### PR TITLE
Release 3.1.0

### DIFF
--- a/src/SqlOS/SqlOS.csproj
+++ b/src/SqlOS/SqlOS.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>SqlOS</PackageId>
-    <Version>3.0.0</Version>
+    <Version>3.1.0</Version>
     <Authors>Ross Slaney</Authors>
     <Description>Embedded auth server and fine-grained authorization runtime for .NET + SQL Server + EF Core.</Description>
     <PackageTags>authentication;authorization;fga;saml;jwt;sessions;efcore;sqlserver</PackageTags>


### PR DESCRIPTION
## Summary
- Move the local 3.1.0 version bump off `main` and onto the dedicated `release/3.1.0` branch.
- Update `src/SqlOS/SqlOS.csproj` so the package version is set to `3.1.0` for the release branch.

## Test plan
- [ ] Not run locally; change is limited to the project version metadata.

Made with [Cursor](https://cursor.com)