### PR TITLE
Release 3.2.0

### DIFF
--- a/src/SqlOS/SqlOS.csproj
+++ b/src/SqlOS/SqlOS.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>SqlOS</PackageId>
-    <Version>3.1.0</Version>
+    <Version>3.2.0</Version>
     <Authors>Ross Slaney</Authors>
     <Description>Embedded auth server and fine-grained authorization runtime for .NET + SQL Server + EF Core.</Description>
     <PackageTags>authentication;authorization;fga;saml;jwt;sessions;efcore;sqlserver</PackageTags>


### PR DESCRIPTION
## Summary

Bumps SqlOS package version from 3.1.0 to 3.2.0 for the refresh token rotation grace window release.

## Changes since 3.1.0

- **#19** — Refresh token rotation grace window (closes #18). Concurrent refresh requests with the same refresh token now share the same new token pair instead of triggering false-positive replay detection. Matches the industry-standard pattern shipped by Okta, Auth0, WorkOS, and Ory. Strictly atomic across multiple app instances via EF Core optimistic concurrency on `ConsumedAt`.

## Test plan

- [x] All 91 unit tests pass
- [x] All 42 integration tests pass (including new multi-instance race test against real SQL Server)
- [x] CI green on the underlying feature PR
- [ ] Post-merge: tag `v3.2.0` and create GitHub release
- [ ] Post-merge: bump consumers (emcy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)