### PR TITLE
Enhance headless authentication features and update to version 3.3.0

### DIFF
--- a/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerOptions.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerOptions.cs
@@ -97,7 +97,7 @@ public class SqlOSAuthServerOptions
     public SqlOSAuthServerOptions SeedOwnedWebApp(string clientId, string name, params string[] redirectUris)
         => SeedBrowserClient(clientId, name, redirectUris);
 
-    public SqlOSAuthServerOptions SeedOwnedNativeApp(string clientId, string name, params string[] redirectUris)
+    public SqlOSAuthServerOptions SeedOwnedNativeApp(string clientId, string name, bool allowNativeHeadlessAuth = false, params string[] redirectUris)
         => SeedClient(client =>
         {
             client.ClientId = clientId;
@@ -110,6 +110,7 @@ public class SqlOSAuthServerOptions
             client.ClientType = "public_pkce";
             client.RequirePkce = true;
             client.IsFirstParty = true;
+            client.AllowNativeHeadlessAuth = allowNativeHeadlessAuth;
         });
 
     public SqlOSAuthServerOptions EnablePortableMcpClients(Action<SqlOSClientRegistrationOptions>? configure = null)

--- a/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerSeedOptions.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerSeedOptions.cs
@@ -24,5 +24,6 @@ public sealed class SqlOSClientSeedOptions
     public List<string> AllowedScopes { get; set; } = [];
     public List<string> RedirectUris { get; set; } = [];
     public bool IsFirstParty { get; set; }
+    public bool AllowNativeHeadlessAuth { get; set; }
     public bool IsActive { get; set; } = true;
 }

--- a/src/SqlOS/AuthServer/Configuration/SqlOSHeadlessAuthOptions.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSHeadlessAuthOptions.cs
@@ -6,6 +6,7 @@ namespace SqlOS.AuthServer.Configuration;
 
 public sealed class SqlOSHeadlessAuthOptions
 {
+    public bool EnableApi { get; set; } = true;
     public string? HeadlessApiBasePath { get; set; }
     public Func<SqlOSHeadlessUiRouteContext, string>? BuildUiUrl { get; set; }
     public Func<SqlOSHeadlessSignupHookContext, CancellationToken, Task>? OnHeadlessSignupAsync { get; set; }

--- a/src/SqlOS/AuthServer/Contracts/SqlOSContracts.cs
+++ b/src/SqlOS/AuthServer/Contracts/SqlOSContracts.cs
@@ -107,6 +107,7 @@ public sealed record SqlOSCreateClientRequest(
     List<string>? AllowedScopes = null,
     bool RequirePkce = true,
     bool IsFirstParty = false,
+    bool AllowNativeHeadlessAuth = false,
     string ClientType = "public_pkce");
 
 public sealed record SqlOSDynamicClientRegistrationRequest

--- a/src/SqlOS/AuthServer/Contracts/SqlOSHeadlessAuthContracts.cs
+++ b/src/SqlOS/AuthServer/Contracts/SqlOSHeadlessAuthContracts.cs
@@ -31,6 +31,21 @@ public sealed record SqlOSHeadlessActionResult(
     string? RedirectUrl,
     SqlOSHeadlessViewModel? ViewModel);
 
+public sealed record SqlOSHeadlessStartRequest(
+    string ResponseType,
+    string ClientId,
+    string RedirectUri,
+    string State,
+    string? Scope,
+    string? CodeChallenge,
+    string? CodeChallengeMethod,
+    string? Resource,
+    string? LoginHint,
+    string? Prompt,
+    string? Nonce,
+    string? View,
+    JsonObject? UiContext);
+
 public sealed record SqlOSHeadlessIdentifyRequest(
     string RequestId,
     string Email);

--- a/src/SqlOS/AuthServer/Extensions/EndpointRouteBuilderExtensions.cs
+++ b/src/SqlOS/AuthServer/Extensions/EndpointRouteBuilderExtensions.cs
@@ -72,7 +72,7 @@ public static class EndpointRouteBuilderExtensions
                         context.Request.Query["login_hint"].ToString(),
                         prompt,
                         context.Request.Query["nonce"].ToString(),
-                        headlessAuthService.IsEnabled ? "headless" : "hosted",
+                        headlessAuthService.IsBrowserUiEnabled ? "headless" : "hosted",
                         context.Request.Query["ui_context"].ToString()),
                     cancellationToken);
                 var requestedView = string.Equals(context.Request.Query["view"], "signup", StringComparison.OrdinalIgnoreCase)
@@ -101,7 +101,7 @@ public static class EndpointRouteBuilderExtensions
                         cancellationToken));
                 }
 
-                if (headlessAuthService.IsEnabled)
+                if (headlessAuthService.IsBrowserUiEnabled)
                 {
                     return Results.Redirect(headlessAuthService.BuildUiUrl(
                         context,
@@ -129,7 +129,7 @@ public static class EndpointRouteBuilderExtensions
             }
             catch (InvalidOperationException ex)
             {
-                if (headlessAuthService.IsEnabled)
+                if (headlessAuthService.IsBrowserUiEnabled)
                 {
                     return Results.Redirect(headlessAuthService.BuildStandaloneUiUrl(
                         context,
@@ -160,7 +160,7 @@ public static class EndpointRouteBuilderExtensions
             SqlOSHeadlessAuthService headlessAuthService,
             CancellationToken cancellationToken) =>
         {
-            if (headlessAuthService.IsEnabled)
+            if (headlessAuthService.IsBrowserUiEnabled)
             {
                 return Results.Redirect(headlessAuthService.BuildStandaloneUiUrl(
                     context,
@@ -367,7 +367,7 @@ public static class EndpointRouteBuilderExtensions
             SqlOSHeadlessAuthService headlessAuthService,
             CancellationToken cancellationToken) =>
         {
-            if (headlessAuthService.IsEnabled)
+            if (headlessAuthService.IsBrowserUiEnabled)
             {
                 return Results.Redirect(headlessAuthService.BuildStandaloneUiUrl(
                     context,
@@ -447,6 +447,72 @@ public static class EndpointRouteBuilderExtensions
         var headless = endpoints.MapGroup(resolvedHeadlessPath);
         headless.ExcludeFromDescription();
 
+        headless.MapPost("/start", async (
+            SqlOSHeadlessStartRequest request,
+            HttpContext context,
+            SqlOSAuthorizationServerService authorizationServerService,
+            SqlOSHeadlessAuthService headlessAuthService,
+            CancellationToken cancellationToken) =>
+        {
+            if (!headlessAuthService.IsApiEnabled)
+            {
+                return Results.NotFound();
+            }
+
+            try
+            {
+                await headlessAuthService.EnsureNativeHeadlessClientAllowedAsync(
+                    request.ClientId,
+                    request.RedirectUri,
+                    cancellationToken);
+
+                var authorizationRequest = await authorizationServerService.CreateAuthorizationRequestAsync(
+                    new SqlOSAuthorizeRequestInput(
+                        request.ResponseType,
+                        request.ClientId,
+                        request.RedirectUri,
+                        request.State,
+                        request.Scope,
+                        request.CodeChallenge,
+                        request.CodeChallengeMethod,
+                        request.Resource,
+                        request.LoginHint,
+                        request.Prompt,
+                        request.Nonce,
+                        "headless",
+                        SqlOSHeadlessAuthService.NormalizeUiContext(request.UiContext)),
+                    cancellationToken);
+
+                if (string.Equals(request.Prompt, "none", StringComparison.Ordinal))
+                {
+                    return Results.Ok(new SqlOSHeadlessActionResult(
+                        "redirect",
+                        await authorizationServerService.BuildAuthorizationErrorRedirectAsync(
+                            authorizationRequest,
+                            "login_required",
+                            "The user is not signed in.",
+                            cancellationToken),
+                        null));
+                }
+
+                return Results.Ok(new SqlOSHeadlessActionResult(
+                    "view",
+                    null,
+                    await headlessAuthService.GetRequestAsync(
+                        authorizationRequest.Id,
+                        request.View,
+                        error: null,
+                        pendingToken: null,
+                        email: authorizationRequest.LoginHintEmail,
+                        displayName: null,
+                        cancellationToken)));
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.BadRequest(new { message = ex.Message });
+            }
+        });
+
         headless.MapGet("/requests/{requestId}", async (
             string requestId,
             string? view,
@@ -457,7 +523,7 @@ public static class EndpointRouteBuilderExtensions
             SqlOSHeadlessAuthService headlessAuthService,
             CancellationToken cancellationToken) =>
         {
-            if (!headlessAuthService.IsEnabled)
+            if (!headlessAuthService.IsApiEnabled)
             {
                 return Results.NotFound();
             }
@@ -484,7 +550,7 @@ public static class EndpointRouteBuilderExtensions
             SqlOSHeadlessAuthService headlessAuthService,
             CancellationToken cancellationToken) =>
         {
-            if (!headlessAuthService.IsEnabled)
+            if (!headlessAuthService.IsApiEnabled)
             {
                 return Results.NotFound();
             }
@@ -505,7 +571,7 @@ public static class EndpointRouteBuilderExtensions
             SqlOSHeadlessAuthService headlessAuthService,
             CancellationToken cancellationToken) =>
         {
-            if (!headlessAuthService.IsEnabled)
+            if (!headlessAuthService.IsApiEnabled)
             {
                 return Results.NotFound();
             }
@@ -526,7 +592,7 @@ public static class EndpointRouteBuilderExtensions
             SqlOSHeadlessAuthService headlessAuthService,
             CancellationToken cancellationToken) =>
         {
-            if (!headlessAuthService.IsEnabled)
+            if (!headlessAuthService.IsApiEnabled)
             {
                 return Results.NotFound();
             }
@@ -547,7 +613,7 @@ public static class EndpointRouteBuilderExtensions
             SqlOSHeadlessAuthService headlessAuthService,
             CancellationToken cancellationToken) =>
         {
-            if (!headlessAuthService.IsEnabled)
+            if (!headlessAuthService.IsApiEnabled)
             {
                 return Results.NotFound();
             }
@@ -568,7 +634,7 @@ public static class EndpointRouteBuilderExtensions
             SqlOSHeadlessAuthService headlessAuthService,
             CancellationToken cancellationToken) =>
         {
-            if (!headlessAuthService.IsEnabled)
+            if (!headlessAuthService.IsApiEnabled)
             {
                 return Results.NotFound();
             }
@@ -1030,6 +1096,7 @@ public static class EndpointRouteBuilderExtensions
                     client.ClientId,
                     client.Name,
                     client.Audience,
+                    client.AllowNativeHeadlessAuth,
                     RedirectUris = SqlOSAdminService.DeserializeJsonList(client.RedirectUrisJson),
                     client.IsActive,
                     client.CreatedAt

--- a/src/SqlOS/AuthServer/Models/SqlOSEntities.cs
+++ b/src/SqlOS/AuthServer/Models/SqlOSEntities.cs
@@ -219,6 +219,7 @@ public sealed class SqlOSClientApplication
     public bool RequirePkce { get; set; } = true;
     public string AllowedScopesJson { get; set; } = "[]";
     public bool IsFirstParty { get; set; }
+    public bool AllowNativeHeadlessAuth { get; set; }
     public string RedirectUrisJson { get; set; } = "[]";
     public string? MetadataDocumentUrl { get; set; }
     public string? ClientUri { get; set; }

--- a/src/SqlOS/AuthServer/Schema/005_AuthPageAndOauthSurface.sql
+++ b/src/SqlOS/AuthServer/Schema/005_AuthPageAndOauthSurface.sql
@@ -57,6 +57,14 @@ END
 
 GO
 
+IF COL_LENGTH('{Schema}.SqlOSClientApplications', 'AllowNativeHeadlessAuth') IS NULL
+BEGIN
+    ALTER TABLE [{Schema}].[SqlOSClientApplications]
+    ADD [AllowNativeHeadlessAuth] BIT NOT NULL CONSTRAINT [DF_SqlOSClientApplications_AllowNativeHeadlessAuth] DEFAULT 0;
+END
+
+GO
+
 IF COL_LENGTH('{Schema}.SqlOSAuthorizationRequests', 'OrganizationId') IS NOT NULL
 AND EXISTS (
     SELECT 1

--- a/src/SqlOS/AuthServer/Schema/011_NativeHeadlessAuth.sql
+++ b/src/SqlOS/AuthServer/Schema/011_NativeHeadlessAuth.sql
@@ -1,0 +1,10 @@
+IF COL_LENGTH('{Schema}.SqlOSClientApplications', 'AllowNativeHeadlessAuth') IS NULL
+BEGIN
+    ALTER TABLE [{Schema}].[SqlOSClientApplications]
+    ADD [AllowNativeHeadlessAuth] BIT NOT NULL CONSTRAINT [DF_SqlOSClientApplications_AllowNativeHeadlessAuth] DEFAULT 0;
+END
+
+GO
+
+DELETE FROM [{Schema}].[SqlOSSchema];
+INSERT INTO [{Schema}].[SqlOSSchema] ([Version]) VALUES (11);

--- a/src/SqlOS/AuthServer/Services/SqlOSAdminService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSAdminService.cs
@@ -95,6 +95,7 @@ public sealed class SqlOSAdminService
                     ResponseTypesJson = JsonSerializer.Serialize(new[] { "code" }),
                     RequirePkce = normalized.RequirePkce,
                     AllowedScopesJson = JsonSerializer.Serialize(normalized.AllowedScopes),
+                    AllowNativeHeadlessAuth = normalized.AllowNativeHeadlessAuth,
                     RedirectUrisJson = JsonSerializer.Serialize(normalized.RedirectUris),
                     CreatedAt = DateTime.UtcNow,
                     IsFirstParty = normalized.IsFirstParty,
@@ -117,6 +118,7 @@ public sealed class SqlOSAdminService
                 : existing.ResponseTypesJson;
             existing.RequirePkce = normalized.RequirePkce;
             existing.AllowedScopesJson = JsonSerializer.Serialize(normalized.AllowedScopes);
+            existing.AllowNativeHeadlessAuth = normalized.AllowNativeHeadlessAuth;
             existing.RedirectUrisJson = JsonSerializer.Serialize(normalized.RedirectUris);
             existing.IsFirstParty = normalized.IsFirstParty;
             if (existing.DisabledAt != null)
@@ -276,6 +278,7 @@ public sealed class SqlOSAdminService
             RequirePkce = normalized.RequirePkce,
             AllowedScopesJson = JsonSerializer.Serialize(normalized.AllowedScopes),
             IsFirstParty = normalized.IsFirstParty,
+            AllowNativeHeadlessAuth = normalized.AllowNativeHeadlessAuth,
             RedirectUrisJson = JsonSerializer.Serialize(normalized.RedirectUris),
             CreatedAt = DateTime.UtcNow,
             IsActive = true
@@ -818,6 +821,7 @@ public sealed class SqlOSAdminService
             item.TokenEndpointAuthMethod,
             item.RequirePkce,
             item.IsFirstParty,
+            item.AllowNativeHeadlessAuth,
             item.RedirectUris,
             item.GrantTypes,
             item.ResponseTypes,
@@ -1519,6 +1523,7 @@ public sealed class SqlOSAdminService
             seed.AllowedScopes,
             seed.RequirePkce,
             seed.IsFirstParty,
+            seed.AllowNativeHeadlessAuth,
             seed.ClientType,
             seed.IsActive);
 
@@ -1542,6 +1547,7 @@ public sealed class SqlOSAdminService
             client.TokenEndpointAuthMethod,
             client.RequirePkce,
             client.IsFirstParty,
+            client.AllowNativeHeadlessAuth,
             redirectUris,
             grantTypes,
             responseTypes,
@@ -1706,6 +1712,7 @@ public sealed class SqlOSAdminService
             request.AllowedScopes,
             request.RequirePkce,
             request.IsFirstParty,
+            request.AllowNativeHeadlessAuth,
             request.ClientType,
             true);
 
@@ -1718,6 +1725,7 @@ public sealed class SqlOSAdminService
         IEnumerable<string>? allowedScopes,
         bool requirePkce,
         bool isFirstParty,
+        bool allowNativeHeadlessAuth,
         string? clientType,
         bool isActive)
     {
@@ -1756,6 +1764,7 @@ public sealed class SqlOSAdminService
             normalizedClientType,
             requirePkce,
             isFirstParty,
+            allowNativeHeadlessAuth,
             isActive);
     }
 
@@ -1793,6 +1802,7 @@ public sealed class SqlOSAdminService
         string TokenEndpointAuthMethod,
         bool RequirePkce,
         bool IsFirstParty,
+        bool AllowNativeHeadlessAuth,
         List<string> RedirectUris,
         List<string> GrantTypes,
         List<string> ResponseTypes,
@@ -1846,5 +1856,6 @@ public sealed class SqlOSAdminService
         string ClientType,
         bool RequirePkce,
         bool IsFirstParty,
+        bool AllowNativeHeadlessAuth,
         bool IsActive);
 }

--- a/src/SqlOS/AuthServer/Services/SqlOSHeadlessAuthService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSHeadlessAuthService.cs
@@ -41,7 +41,9 @@ public sealed class SqlOSHeadlessAuthService
         _options = options.Value;
     }
 
-    public bool IsEnabled => _options.Headless.BuildUiUrl != null;
+    public bool IsApiEnabled => _options.Headless.EnableApi;
+    public bool IsBrowserUiEnabled => _options.Headless.BuildUiUrl != null;
+    public bool IsEnabled => IsBrowserUiEnabled;
 
     public string GetHeadlessApiBasePath() => _options.Headless.ResolveApiBasePath(_options.BasePath);
 
@@ -71,9 +73,9 @@ public sealed class SqlOSHeadlessAuthService
         string? displayName,
         JsonObject? uiContext)
     {
-        if (!IsEnabled)
+        if (!IsBrowserUiEnabled)
         {
-            throw new InvalidOperationException("Headless auth mode is not enabled.");
+            throw new InvalidOperationException("Headless browser handoff is not enabled.");
         }
 
         if (_options.Headless.BuildUiUrl == null)
@@ -104,7 +106,7 @@ public sealed class SqlOSHeadlessAuthService
         CancellationToken cancellationToken = default)
     {
         var authorizationRequest = await _authorizationServerService.TryGetActiveAuthorizationRequestAsync(authorizationRequestId, cancellationToken);
-        if (authorizationRequest == null || !IsHeadlessRequest(authorizationRequest))
+        if (authorizationRequest == null || !IsHeadlessRequest(authorizationRequest) || !IsBrowserUiEnabled)
         {
             return null;
         }
@@ -420,6 +422,37 @@ public sealed class SqlOSHeadlessAuthService
 
     public static bool IsHeadlessRequest(SqlOSAuthorizationRequest authorizationRequest)
         => string.Equals(authorizationRequest.PresentationMode, "headless", StringComparison.OrdinalIgnoreCase);
+
+    public static string? NormalizeUiContext(JsonObject? uiContext)
+        => uiContext?.ToJsonString();
+
+    public async Task EnsureNativeHeadlessClientAllowedAsync(
+        string clientId,
+        string redirectUri,
+        CancellationToken cancellationToken = default)
+    {
+        var client = await _adminService.RequireClientAsync(clientId, redirectUri, cancellationToken);
+
+        if (!IsApiEnabled)
+        {
+            throw new InvalidOperationException("Native headless auth is not enabled.");
+        }
+
+        if (!client.IsFirstParty)
+        {
+            throw new InvalidOperationException("Native headless auth is only available to first-party clients.");
+        }
+
+        if (!client.RequirePkce || !string.Equals(client.ClientType, "public_pkce", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException("Native headless auth requires a PKCE public client.");
+        }
+
+        if (!client.AllowNativeHeadlessAuth)
+        {
+            throw new InvalidOperationException("This client is not allowed to start native headless auth.");
+        }
+    }
 
     public static JsonObject? ParseUiContext(string? json)
     {

--- a/src/SqlOS/Configuration/SqlOSOptionsValidator.cs
+++ b/src/SqlOS/Configuration/SqlOSOptionsValidator.cs
@@ -80,20 +80,18 @@ internal static class SqlOSOptionsValidator
 
     private static void ValidateHeadlessOptions(SqlOSHeadlessAuthOptions options, List<string> errors)
     {
-        var headlessEnabled = options.BuildUiUrl != null;
-
         if (!string.IsNullOrWhiteSpace(options.HeadlessApiBasePath))
         {
             ValidateRootPath(options.HeadlessApiBasePath, "AuthServer.Headless.HeadlessApiBasePath", errors);
-            if (!headlessEnabled)
+            if (!options.EnableApi)
             {
-                errors.Add("AuthServer.Headless.HeadlessApiBasePath requires AuthServer.Headless.BuildUiUrl.");
+                errors.Add("AuthServer.Headless.HeadlessApiBasePath requires AuthServer.Headless.EnableApi.");
             }
         }
 
-        if (options.OnHeadlessSignupAsync != null && !headlessEnabled)
+        if (options.OnHeadlessSignupAsync != null && !options.EnableApi)
         {
-            errors.Add("AuthServer.Headless.OnHeadlessSignupAsync requires AuthServer.Headless.BuildUiUrl.");
+            errors.Add("AuthServer.Headless.OnHeadlessSignupAsync requires AuthServer.Headless.EnableApi.");
         }
     }
 

--- a/src/SqlOS/SqlOS.csproj
+++ b/src/SqlOS/SqlOS.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>SqlOS</PackageId>
-    <Version>3.2.0</Version>
+    <Version>3.3.0</Version>
     <Authors>Ross Slaney</Authors>
     <Description>Embedded auth server and fine-grained authorization runtime for .NET + SQL Server + EF Core.</Description>
     <PackageTags>authentication;authorization;fga;saml;jwt;sessions;efcore;sqlserver</PackageTags>

--- a/tests/SqlOS.IntegrationTests/HeadlessAuthIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/HeadlessAuthIntegrationTests.cs
@@ -267,7 +267,34 @@ public sealed class HeadlessAuthIntegrationTests
         session.AuthenticationMethod.Should().Be("password");
     }
 
-    private static async Task<HeadlessFixture> CreateFixtureAsync(Action<SqlOSHeadlessAuthOptions>? configureHeadless = null)
+    [TestMethod]
+    public async Task EnsureNativeHeadlessClientAllowedAsync_RejectsClientWithoutOptIn()
+    {
+        await using var fixture = await CreateFixtureAsync();
+
+        var act = async () => await fixture.HeadlessAuthService.EnsureNativeHeadlessClientAllowedAsync(
+            fixture.ClientId,
+            fixture.RedirectUri);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("This client is not allowed to start native headless auth.");
+    }
+
+    [TestMethod]
+    public async Task EnsureNativeHeadlessClientAllowedAsync_AllowsFirstPartyOptedInClient()
+    {
+        await using var fixture = await CreateFixtureAsync(allowNativeHeadlessAuth: true);
+
+        var act = async () => await fixture.HeadlessAuthService.EnsureNativeHeadlessClientAllowedAsync(
+            fixture.ClientId,
+            fixture.RedirectUri);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    private static async Task<HeadlessFixture> CreateFixtureAsync(
+        Action<SqlOSHeadlessAuthOptions>? configureHeadless = null,
+        bool allowNativeHeadlessAuth = false)
     {
         var context = CreateContext();
         var clientId = $"headless-{Guid.NewGuid():N}";
@@ -279,6 +306,7 @@ public sealed class HeadlessAuthIntegrationTests
             BasePath = AspireFixture.Options.BasePath
         };
         optionsValue.SeedBrowserClient(clientId, $"Headless Test {clientId}", redirectUri);
+        optionsValue.ClientSeeds[0].AllowNativeHeadlessAuth = allowNativeHeadlessAuth;
         optionsValue.UseHeadlessAuthPage(headless =>
         {
             headless.BuildUiUrl = ctx =>

--- a/tests/SqlOS.Tests/SqlOSOptionsValidationTests.cs
+++ b/tests/SqlOS.Tests/SqlOSOptionsValidationTests.cs
@@ -56,7 +56,7 @@ public sealed class SqlOSOptionsValidationTests
     }
 
     [TestMethod]
-    public void AddSqlOS_Throws_WhenHeadlessApiBasePathIsSetWithoutBuildUiUrl()
+    public void AddSqlOS_AllowsHeadlessApiBasePathWithoutBuildUiUrl()
     {
         var services = new ServiceCollection();
 
@@ -65,8 +65,22 @@ public sealed class SqlOSOptionsValidationTests
             options.AuthServer.Headless.HeadlessApiBasePath = "/sqlos/auth/custom-headless";
         });
 
+        act.Should().NotThrow();
+    }
+
+    [TestMethod]
+    public void AddSqlOS_Throws_WhenHeadlessApiBasePathIsSetButHeadlessApiIsDisabled()
+    {
+        var services = new ServiceCollection();
+
+        Action act = () => services.AddSqlOS<TestSqlOSInMemoryDbContext>(options =>
+        {
+            options.AuthServer.Headless.EnableApi = false;
+            options.AuthServer.Headless.HeadlessApiBasePath = "/sqlos/auth/custom-headless";
+        });
+
         act.Should().Throw<InvalidOperationException>()
-            .WithMessage("*AuthServer.Headless.HeadlessApiBasePath requires AuthServer.Headless.BuildUiUrl.*");
+            .WithMessage("*AuthServer.Headless.HeadlessApiBasePath requires AuthServer.Headless.EnableApi.*");
     }
 
     [TestMethod]


### PR DESCRIPTION
This pull request introduces support for native headless authentication in the SQL OS Auth Server, including API endpoints and configuration options to enable or restrict this feature per client. It adds a new `AllowNativeHeadlessAuth` property to client models, seed options, and database schema, and exposes a dedicated `/headless/start` API endpoint for initiating headless auth flows. The changes also refactor how headless API and UI features are toggled, providing more granular control.

**Native Headless Authentication Support**

* Added `AllowNativeHeadlessAuth` property to client models (`SqlOSClientApplication`), seed options (`SqlOSClientSeedOptions`), creation requests (`SqlOSCreateClientRequest`), and admin views to track and configure client eligibility for native headless authentication. [[1]](diffhunk://#diff-50cfc44b4f6e24d923576196971de0740386f0042c9fe3d281e4c93b7d8b4127R222) [[2]](diffhunk://#diff-fe0cd91686c973b0a588e133c623e0a9fcf912410542b53f5ff4d4f11c7d41a5R27) [[3]](diffhunk://#diff-c7b51216628ee1951a5d51fb48106a4ed612ca9437def9771e378da621e7495eR110) [[4]](diffhunk://#diff-06330174ffb7b54b2f88ec41410f8ab348d4fa1375bb1034cade0bf867bd0f9dR98) [[5]](diffhunk://#diff-06330174ffb7b54b2f88ec41410f8ab348d4fa1375bb1034cade0bf867bd0f9dR121) [[6]](diffhunk://#diff-06330174ffb7b54b2f88ec41410f8ab348d4fa1375bb1034cade0bf867bd0f9dR281) [[7]](diffhunk://#diff-06330174ffb7b54b2f88ec41410f8ab348d4fa1375bb1034cade0bf867bd0f9dR824) [[8]](diffhunk://#diff-06330174ffb7b54b2f88ec41410f8ab348d4fa1375bb1034cade0bf867bd0f9dR1526) [[9]](diffhunk://#diff-06330174ffb7b54b2f88ec41410f8ab348d4fa1375bb1034cade0bf867bd0f9dR1550) [[10]](diffhunk://#diff-22e44834fcbc5c5e256746b9169ca4ead6277fe26d1e83ef7b00e5443d3c3f4dL100-R100) [[11]](diffhunk://#diff-22e44834fcbc5c5e256746b9169ca4ead6277fe26d1e83ef7b00e5443d3c3f4dR113) [[12]](diffhunk://#diff-b8a795edf22d3ac809c0d59d14fdcd26f3205eaf34116ccf0fce1b2c5a948388R1099)

* Updated database schema to add the `AllowNativeHeadlessAuth` column to the `SqlOSClientApplications` table, with migration scripts for both incremental and idempotent schema updates. [[1]](diffhunk://#diff-0381423c833c34df9b8e37a085ff66735b06a7934d74fc4a34d74ec3753ae6dcR60-R67) [[2]](diffhunk://#diff-8505488a7fc45309886d106c1c3568e5740a93e50d1f4c9604dffe1c91606c91R1-R10)

**Headless API and Endpoint Enhancements**

* Introduced a new `/headless/start` API endpoint (`SqlOSHeadlessStartRequest`) for initiating native headless authentication flows, including validation of client permissions and improved error handling. [[1]](diffhunk://#diff-b8a795edf22d3ac809c0d59d14fdcd26f3205eaf34116ccf0fce1b2c5a948388R450-R515) [[2]](diffhunk://#diff-3cb4a413755a21d539190793b5a2f7e7074b20572533b8e8eebe66f4bbed6388R34-R48)

* Refactored headless API/UI feature toggles: replaced checks for `IsEnabled` with more granular `IsApiEnabled` and `IsBrowserUiEnabled` flags, and updated all relevant endpoints to use these new properties for controlling access. [[1]](diffhunk://#diff-3ef3ab439f286af734365d44c597133f4474940274349e18f627067c7231ba51R9) [[2]](diffhunk://#diff-b8a795edf22d3ac809c0d59d14fdcd26f3205eaf34116ccf0fce1b2c5a948388L75-R75) [[3]](diffhunk://#diff-b8a795edf22d3ac809c0d59d14fdcd26f3205eaf34116ccf0fce1b2c5a948388L104-R104) [[4]](diffhunk://#diff-b8a795edf22d3ac809c0d59d14fdcd26f3205eaf34116ccf0fce1b2c5a948388L132-R132) [[5]](diffhunk://#diff-b8a795edf22d3ac809c0d59d14fdcd26f3205eaf34116ccf0fce1b2c5a948388L163-R163) [[6]](diffhunk://#diff-b8a795edf22d3ac809c0d59d14fdcd26f3205eaf34116ccf0fce1b2c5a948388L370-R370) [[7]](diffhunk://#diff-b8a795edf22d3ac809c0d59d14fdcd26f3205eaf34116ccf0fce1b2c5a948388L460-R526) [[8]](diffhunk://#diff-b8a795edf22d3ac809c0d59d14fdcd26f3205eaf34116ccf0fce1b2c5a948388L487-R553) [[9]](diffhunk://#diff-b8a795edf22d3ac809c0d59d14fdcd26f3205eaf34116ccf0fce1b2c5a948388L508-R574) [[10]](diffhunk://#diff-b8a795edf22d3ac809c0d59d14fdcd26f3205eaf34116ccf0fce1b2c5a948388L529-R595) [[11]](diffhunk://#diff-b8a795edf22d3ac809c0d59d14fdcd26f3205eaf34116ccf0fce1b2c5a948388L550-R616) [[12]](diffhunk://#diff-b8a795edf22d3ac809c0d59d14fdcd26f3205eaf34116ccf0fce1b2c5a948388L571-R637)

**Client Seeding and Admin Improvements**

* Updated client seeding, normalization, and admin endpoints to handle the new `AllowNativeHeadlessAuth` property, ensuring correct persistence and display in admin tools. [[1]](diffhunk://#diff-06330174ffb7b54b2f88ec41410f8ab348d4fa1375bb1034cade0bf867bd0f9dR98) [[2]](diffhunk://#diff-06330174ffb7b54b2f88ec41410f8ab348d4fa1375bb1034cade0bf867bd0f9dR121) [[3]](diffhunk://#diff-06330174ffb7b54b2f88ec41410f8ab348d4fa1375bb1034cade0bf867bd0f9dR281) [[4]](diffhunk://#diff-06330174ffb7b54b2f88ec41410f8ab348d4fa1375bb1034cade0bf867bd0f9dR824) [[5]](diffhunk://#diff-06330174ffb7b54b2f88ec41410f8ab348d4fa1375bb1034cade0bf867bd0f9dR1526) [[6]](diffhunk://#diff-06330174ffb7b54b2f88ec41410f8ab348d4fa1375bb1034cade0bf867bd0f9dR1550) [[7]](diffhunk://#diff-b8a795edf22d3ac809c0d59d14fdcd26f3205eaf34116ccf0fce1b2c5a948388R1099)

These changes collectively enable secure, configurable support for native headless authentication flows, while improving the flexibility and maintainability of headless authentication features in the codebase.