### PR TITLE
Require expected audience for access token validation

### DIFF
--- a/examples/SqlOS.Example.Api/Endpoints/ExampleAuthEndpoints.cs
+++ b/examples/SqlOS.Example.Api/Endpoints/ExampleAuthEndpoints.cs
@@ -369,7 +369,7 @@ public static class ExampleAuthEndpoints
         ExampleAppDbContext context,
         SqlOSAuthService authService,
         ExampleFgaService fgaService,
-        string? expectedAudience,
+        string expectedAudience,
         CancellationToken cancellationToken)
     {
         if (result.Tokens == null)
@@ -397,7 +397,7 @@ public static class ExampleAuthEndpoints
         ExampleAppDbContext context,
         SqlOSAuthService authService,
         ExampleFgaService fgaService,
-        string? expectedAudience,
+        string expectedAudience,
         CancellationToken cancellationToken)
     {
         var validated = await authService.ValidateAccessTokenAsync(tokens.AccessToken, expectedAudience, cancellationToken)
@@ -412,7 +412,7 @@ public static class ExampleAuthEndpoints
         SqlOSUser user,
         SqlOSAuthService authService,
         ExampleFgaService fgaService,
-        string? expectedAudience,
+        string expectedAudience,
         CancellationToken cancellationToken)
     {
         var validated = await authService.ValidateAccessTokenAsync(tokens.AccessToken, expectedAudience, cancellationToken)

--- a/src/SqlOS/AuthServer/Configuration/SqlOSAccessTokenValidationOptions.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSAccessTokenValidationOptions.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Http;
+
+namespace SqlOS.AuthServer.Configuration;
+
+public sealed class SqlOSAccessTokenValidationOptions
+{
+    public string ExpectedAudience { get; set; } = string.Empty;
+
+    public Func<HttpContext, bool>? ShouldValidate { get; set; }
+
+    public string Realm { get; set; } = "SqlOS API";
+
+    public string? ResourceMetadataUrl { get; set; }
+}

--- a/src/SqlOS/AuthServer/Extensions/SqlOSAccessTokenValidationExtensions.cs
+++ b/src/SqlOS/AuthServer/Extensions/SqlOSAccessTokenValidationExtensions.cs
@@ -1,0 +1,144 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using SqlOS.AuthServer.Configuration;
+using SqlOS.AuthServer.Contracts;
+using SqlOS.AuthServer.Services;
+
+namespace SqlOS.AuthServer.Extensions;
+
+public static class SqlOSAccessTokenValidationExtensions
+{
+    public const string ValidatedTokenItemKey = "SqlOS.AuthServer.ValidatedAccessToken";
+
+    public static IApplicationBuilder UseSqlOSAccessTokenValidation(
+        this IApplicationBuilder app,
+        string expectedAudience)
+        => app.UseSqlOSAccessTokenValidation(options => options.ExpectedAudience = expectedAudience);
+
+    public static IApplicationBuilder UseSqlOSAccessTokenValidation(
+        this IApplicationBuilder app,
+        Action<SqlOSAccessTokenValidationOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(app);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        var options = new SqlOSAccessTokenValidationOptions();
+        configure(options);
+        SqlOSAccessTokenValidationMiddleware.ValidateOptions(options);
+
+        return app.UseMiddleware<SqlOSAccessTokenValidationMiddleware>(options);
+    }
+
+    public static SqlOSValidatedToken? GetSqlOSValidatedToken(this HttpContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        return context.Items.TryGetValue(ValidatedTokenItemKey, out var value)
+            ? value as SqlOSValidatedToken
+            : null;
+    }
+}
+
+public sealed class SqlOSAccessTokenValidationMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly SqlOSAccessTokenValidationOptions _options;
+
+    public SqlOSAccessTokenValidationMiddleware(
+        RequestDelegate next,
+        SqlOSAccessTokenValidationOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(next);
+
+        _next = next;
+        _options = ValidateOptions(options);
+    }
+
+    public async Task InvokeAsync(HttpContext context, SqlOSAuthService authService)
+    {
+        if (_options.ShouldValidate is { } shouldValidate && !shouldValidate(context))
+        {
+            await _next(context);
+            return;
+        }
+
+        var authorization = context.Request.Headers.Authorization.ToString();
+        if (!authorization.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+        {
+            await WriteUnauthorizedAsync(context, "A bearer access token is required.");
+            return;
+        }
+
+        var rawToken = authorization["Bearer ".Length..].Trim();
+        if (string.IsNullOrWhiteSpace(rawToken))
+        {
+            await WriteUnauthorizedAsync(context, "A bearer access token is required.");
+            return;
+        }
+
+        var validated = await authService.ValidateAccessTokenAsync(
+            rawToken,
+            _options.ExpectedAudience,
+            context.RequestAborted);
+
+        if (validated == null)
+        {
+            await WriteUnauthorizedAsync(context, "The bearer access token is invalid, expired, revoked, or was not minted for this resource.");
+            return;
+        }
+
+        context.User = validated.Principal;
+        context.Items[SqlOSAccessTokenValidationExtensions.ValidatedTokenItemKey] = validated;
+
+        await _next(context);
+    }
+
+    internal static SqlOSAccessTokenValidationOptions ValidateOptions(SqlOSAccessTokenValidationOptions? options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (string.IsNullOrWhiteSpace(options.ExpectedAudience))
+        {
+            throw new InvalidOperationException("SqlOS access-token validation requires a non-empty expected audience.");
+        }
+
+        options.ExpectedAudience = options.ExpectedAudience.Trim();
+        options.Realm = string.IsNullOrWhiteSpace(options.Realm) ? "SqlOS API" : options.Realm.Trim();
+        options.ResourceMetadataUrl = string.IsNullOrWhiteSpace(options.ResourceMetadataUrl)
+            ? null
+            : options.ResourceMetadataUrl.Trim();
+
+        return options;
+    }
+
+    private async Task WriteUnauthorizedAsync(HttpContext context, string description)
+    {
+        context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+        context.Response.Headers.WWWAuthenticate = BuildChallenge(description);
+        await context.Response.WriteAsJsonAsync(new
+        {
+            error = "invalid_token",
+            error_description = description
+        });
+    }
+
+    private string BuildChallenge(string description)
+    {
+        var parts = new List<string>
+        {
+            $"Bearer realm=\"{EscapeHeaderValue(_options.Realm)}\"",
+            "error=\"invalid_token\"",
+            $"error_description=\"{EscapeHeaderValue(description)}\""
+        };
+
+        if (!string.IsNullOrWhiteSpace(_options.ResourceMetadataUrl))
+        {
+            parts.Add($"resource_metadata=\"{EscapeHeaderValue(_options.ResourceMetadataUrl!)}\"");
+        }
+
+        return string.Join(", ", parts);
+    }
+
+    private static string EscapeHeaderValue(string value)
+        => value.Replace("\\", "\\\\", StringComparison.Ordinal).Replace("\"", "\\\"", StringComparison.Ordinal);
+}

--- a/src/SqlOS/AuthServer/Services/SqlOSAuthService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSAuthService.cs
@@ -827,14 +827,17 @@ public sealed class SqlOSAuthService
         await _adminService.RecordAuditAsync("user.email-verified", "user", email.UserId, userId: email.UserId, cancellationToken: cancellationToken);
     }
 
-    public Task<SqlOSValidatedToken?> ValidateAccessTokenAsync(string rawToken, CancellationToken cancellationToken = default)
-        => _cryptoService.ValidateAccessTokenAsync(rawToken, cancellationToken);
-
     public Task<SqlOSValidatedToken?> ValidateAccessTokenAsync(
         string rawToken,
-        string? expectedAudience,
+        string expectedAudience,
         CancellationToken cancellationToken = default)
         => _cryptoService.ValidateAccessTokenAsync(rawToken, expectedAudience, cancellationToken);
+
+    [Obsolete("This method does not validate the JWT aud claim and must only be used for token introspection or diagnostics. Resource servers must call ValidateAccessTokenAsync(rawToken, expectedAudience, cancellationToken).", false)]
+    public Task<SqlOSValidatedToken?> ValidateAccessTokenWithoutAudienceForIntrospectionOnlyAsync(
+        string rawToken,
+        CancellationToken cancellationToken = default)
+        => _cryptoService.ValidateAccessTokenWithoutAudienceForIntrospectionOnlyAsync(rawToken, cancellationToken);
 
     public async Task<SqlOSTokenResponse> CreateSessionTokensForUserAsync(
         SqlOSUser user,

--- a/src/SqlOS/AuthServer/Services/SqlOSCryptoService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSCryptoService.cs
@@ -287,13 +287,29 @@ public sealed class SqlOSCryptoService
         return new JwtSecurityTokenHandler().WriteToken(token);
     }
 
-    public async Task<SqlOSValidatedToken?> ValidateAccessTokenAsync(string rawToken, CancellationToken cancellationToken = default)
-        => await ValidateAccessTokenAsync(rawToken, expectedAudience: null, cancellationToken);
-
     public async Task<SqlOSValidatedToken?> ValidateAccessTokenAsync(
         string rawToken,
-        string? expectedAudience,
+        string expectedAudience,
         CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(expectedAudience))
+        {
+            throw new ArgumentException("An expected audience is required when validating an access token for a resource server.", nameof(expectedAudience));
+        }
+
+        return await ValidateAccessTokenCoreAsync(rawToken, expectedAudience.Trim(), validateAudience: true, cancellationToken);
+    }
+
+    internal async Task<SqlOSValidatedToken?> ValidateAccessTokenWithoutAudienceForIntrospectionOnlyAsync(
+        string rawToken,
+        CancellationToken cancellationToken = default)
+        => await ValidateAccessTokenCoreAsync(rawToken, expectedAudience: null, validateAudience: false, cancellationToken);
+
+    private async Task<SqlOSValidatedToken?> ValidateAccessTokenCoreAsync(
+        string rawToken,
+        string? expectedAudience,
+        bool validateAudience,
+        CancellationToken cancellationToken)
     {
         var keys = await GetValidationSigningKeysAsync(cancellationToken: cancellationToken);
         if (keys.Count == 0)
@@ -313,8 +329,8 @@ public sealed class SqlOSCryptoService
             {
                 ValidateIssuer = true,
                 ValidIssuer = _options.Issuer,
-                ValidateAudience = !string.IsNullOrWhiteSpace(expectedAudience),
-                ValidAudience = expectedAudience,
+                ValidateAudience = validateAudience,
+                ValidAudience = validateAudience ? expectedAudience : null,
                 ValidateIssuerSigningKey = true,
                 IssuerSigningKeys = securityKeys,
                 ValidateLifetime = true,

--- a/tests/SqlOS.Tests/SqlOSResourceBindingTests.cs
+++ b/tests/SqlOS.Tests/SqlOSResourceBindingTests.cs
@@ -1,11 +1,14 @@
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using FluentAssertions;
 using SqlOS.AuthServer.Configuration;
 using SqlOS.AuthServer.Contracts;
+using SqlOS.AuthServer.Extensions;
 using SqlOS.AuthServer.Models;
 using SqlOS.AuthServer.Services;
 using SqlOS.Tests.Infrastructure;
@@ -15,6 +18,135 @@ namespace SqlOS.Tests;
 [TestClass]
 public sealed class SqlOSResourceBindingTests
 {
+    [TestMethod]
+    public void ValidateAccessTokenAsync_RequiresExpectedAudience_ForPublicApi()
+    {
+        var publicValidatorTypes = new[]
+        {
+            typeof(SqlOSAuthService),
+            typeof(SqlOSCryptoService)
+        };
+
+        foreach (var validatorType in publicValidatorTypes)
+        {
+            var overloads = validatorType
+                .GetMethods(System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public)
+                .Where(method => method.Name == nameof(SqlOSAuthService.ValidateAccessTokenAsync))
+                .ToList();
+
+            overloads.Should().NotBeEmpty();
+            overloads.Should().OnlyContain(method =>
+                method.GetParameters().Any(parameter =>
+                    parameter.Name == "expectedAudience"
+                    && parameter.ParameterType == typeof(string)));
+        }
+    }
+
+    [TestMethod]
+    public async Task ValidateAccessTokenWithoutAudienceForIntrospectionOnly_AllowsSignatureAndLifetimeButIsExplicitlyNamed()
+    {
+        using var context = CreateContext();
+        var (options, _, auth) = CreateAuthHarness(context);
+        var user = await SeedUserAsync(context);
+        var client = await SeedClientAsync(context, options.Value, "introspection-client", "https://client.example.test/callback", "https://api-a.example.test");
+
+        var tokens = await auth.CreateSessionTokensForUserAsync(
+            user,
+            client,
+            null,
+            "password",
+            "test-agent",
+            "127.0.0.1");
+
+        var wrongAudience = await auth.ValidateAccessTokenAsync(tokens.AccessToken, "https://api-b.example.test");
+        wrongAudience.Should().BeNull();
+
+#pragma warning disable CS0618
+        var introspected = await auth.ValidateAccessTokenWithoutAudienceForIntrospectionOnlyAsync(tokens.AccessToken);
+#pragma warning restore CS0618
+
+        introspected.Should().NotBeNull();
+        introspected!.Audience.Should().Be("https://api-a.example.test");
+
+        var method = typeof(SqlOSAuthService).GetMethod(
+            nameof(SqlOSAuthService.ValidateAccessTokenWithoutAudienceForIntrospectionOnlyAsync),
+            [typeof(string), typeof(CancellationToken)]);
+        method.Should().NotBeNull();
+        method!.GetCustomAttributes(typeof(ObsoleteAttribute), inherit: false).Should().NotBeEmpty();
+    }
+
+    [TestMethod]
+    public async Task ResourceServerMiddleware_RejectsTokenForDifferentAudience()
+    {
+        using var context = CreateContext();
+        var (options, _, auth) = CreateAuthHarness(context);
+        var user = await SeedUserAsync(context);
+        var client = await SeedClientAsync(context, options.Value, "middleware-client", "https://client.example.test/callback", "https://api-a.example.test");
+
+        var tokens = await auth.CreateSessionTokensForUserAsync(
+            user,
+            client,
+            null,
+            "password",
+            "test-agent",
+            "127.0.0.1");
+
+        var nextCalled = false;
+        var middleware = new SqlOSAccessTokenValidationMiddleware(
+            _ =>
+            {
+                nextCalled = true;
+                return Task.CompletedTask;
+            },
+            new SqlOSAccessTokenValidationOptions
+            {
+                ExpectedAudience = "https://api-b.example.test"
+            });
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers.Authorization = $"Bearer {tokens.AccessToken}";
+
+        await middleware.InvokeAsync(httpContext, auth);
+
+        nextCalled.Should().BeFalse();
+        httpContext.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+        httpContext.GetSqlOSValidatedToken().Should().BeNull();
+    }
+
+    [TestMethod]
+    public void ResourceServerMiddleware_FailsClosed_WhenAudienceNotConfigured()
+    {
+        var constructMiddleware = () => new SqlOSAccessTokenValidationMiddleware(
+            _ => Task.CompletedTask,
+            new SqlOSAccessTokenValidationOptions());
+
+        constructMiddleware.Should().Throw<InvalidOperationException>()
+            .WithMessage("*expected audience*");
+
+        var app = new ApplicationBuilder(new ServiceCollection().BuildServiceProvider());
+        var configurePipeline = () => app.UseSqlOSAccessTokenValidation("");
+
+        configurePipeline.Should().Throw<InvalidOperationException>()
+            .WithMessage("*expected audience*");
+    }
+
+    [TestMethod]
+    public void DocsExamples_DoNotUseNoAudienceValidationOverload()
+    {
+        var docsRoot = Path.Combine(FindRepoRoot(), "web", "content", "docs");
+        var unsafeValidationCall = new System.Text.RegularExpressions.Regex(
+            @"ValidateAccessTokenAsync\s*\((?<arguments>[\s\S]*?)\);",
+            System.Text.RegularExpressions.RegexOptions.Multiline);
+
+        var offenders = Directory
+            .EnumerateFiles(docsRoot, "*.mdx", SearchOption.AllDirectories)
+            .Where(path => HasNoAudienceValidationExample(File.ReadAllText(path), unsafeValidationCall))
+            .Select(path => Path.GetRelativePath(FindRepoRoot(), path))
+            .ToList();
+
+        offenders.Should().BeEmpty("resource-server docs must pass an expected audience to ValidateAccessTokenAsync");
+    }
+
     [TestMethod]
     public async Task CreateSessionTokensForUserAsync_UsesResourceAsAudience()
     {
@@ -304,5 +436,41 @@ public sealed class SqlOSResourceBindingTests
             .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
             .Options;
         return new TestSqlOSInMemoryDbContext(options);
+    }
+
+    private static string FindRepoRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null && !File.Exists(Path.Combine(directory.FullName, "SqlOS.sln")))
+        {
+            directory = directory.Parent;
+        }
+
+        return directory?.FullName ?? throw new DirectoryNotFoundException("Could not find the SqlOS repository root.");
+    }
+
+    private static bool HasNoAudienceValidationExample(
+        string markdown,
+        System.Text.RegularExpressions.Regex validationCall)
+    {
+        foreach (System.Text.RegularExpressions.Match match in validationCall.Matches(markdown))
+        {
+            var arguments = match.Groups["arguments"].Value
+                .Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+
+            if (arguments.Length == 1)
+            {
+                return true;
+            }
+
+            if (arguments.Length == 2
+                && (string.Equals(arguments[1], "ct", StringComparison.Ordinal)
+                    || string.Equals(arguments[1], "cancellationToken", StringComparison.Ordinal)))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/web/content/docs/authserver/sessions-and-tokens.mdx
+++ b/web/content/docs/authserver/sessions-and-tokens.mdx
@@ -28,7 +28,8 @@ After login, you receive:
 Access tokens are RS256-signed JWTs containing user, session, client, and organization claims. Validate them server-side:
 
 ```csharp
-var validated = await authService.ValidateAccessTokenAsync(rawToken, ct);
+var expectedAudience = "https://api.example.com";
+var validated = await authService.ValidateAccessTokenAsync(rawToken, expectedAudience, ct);
 
 if (validated == null)
     return Results.Unauthorized();

--- a/web/content/docs/authserver/token-validation.mdx
+++ b/web/content/docs/authserver/token-validation.mdx
@@ -5,7 +5,26 @@ order: 5.0
 section: authserver
 ---
 
-Access tokens are RS256 JWTs. Validate on the server for each API call.
+Access tokens are RS256 JWTs. Validate on the server for each API call and always require the audience for the API that will process the token.
+
+## Resource-server middleware
+
+```csharp
+using SqlOS.AuthServer.Extensions;
+
+app.UseSqlOSAccessTokenValidation(options =>
+{
+    options.ExpectedAudience = "https://api.example.com";
+    options.ShouldValidate = http => http.Request.Path.StartsWithSegments("/api");
+});
+```
+
+The middleware rejects requests at startup if `ExpectedAudience` is empty. On successful authentication it sets `HttpContext.User` and stores the `SqlOSValidatedToken` on the current request:
+
+```csharp
+var validated = httpContext.GetSqlOSValidatedToken();
+var userId = validated?.UserId;
+```
 
 ## Validate with the SDK
 
@@ -14,8 +33,11 @@ var bearerToken = httpContext.Request.Headers.Authorization.ToString();
 if (!bearerToken.StartsWith("Bearer "))
     return Results.Unauthorized();
 
+var expectedAudience = "https://api.example.com";
 var validated = await authService.ValidateAccessTokenAsync(
-    bearerToken["Bearer ".Length..].Trim(), ct);
+    bearerToken["Bearer ".Length..].Trim(),
+    expectedAudience,
+    ct);
 
 if (validated == null)
     return Results.Unauthorized();
@@ -30,7 +52,7 @@ var orgId = validated.OrganizationId;
 The example app uses middleware to extract the subject ID from multiple auth methods:
 
 ```csharp
-public static string? GetSubjectId(this HttpContext http)
+public static string? GetSubjectId(this HttpContext http, string expectedAudience)
 {
     // Bearer JWT
     var auth = http.Request.Headers.Authorization.ToString();
@@ -39,7 +61,7 @@ public static string? GetSubjectId(this HttpContext http)
         var token = auth["Bearer ".Length..].Trim();
         var validated = http.RequestServices
             .GetRequiredService<SqlOSAuthService>()
-            .ValidateAccessTokenAsync(token, ct).Result;
+            .ValidateAccessTokenAsync(token, expectedAudience, ct).Result;
         return validated?.UserId;
     }
 
@@ -54,6 +76,8 @@ public static string? GetSubjectId(this HttpContext http)
     return null;
 }
 ```
+
+`ValidateAccessTokenWithoutAudienceForIntrospectionOnlyAsync` exists only for diagnostics and token introspection flows that do not authenticate a protected API request. It validates issuer, signature, lifetime, and session state, but it intentionally does not validate `aud`.
 
 ## JWKS for external validation
 

--- a/web/content/docs/reference/authserver-api.mdx
+++ b/web/content/docs/reference/authserver-api.mdx
@@ -392,10 +392,12 @@ await authService.LogoutAllAsync(userId);
 
 ### ValidateAccessTokenAsync
 
-Validate a JWT access token and extract the claims principal.
+Validate a JWT access token for a protected resource server and extract the claims principal. The expected audience is required so a token minted for another API cannot be accepted by this API.
 
 ```csharp
-var validated = await authService.ValidateAccessTokenAsync(rawToken);
+var validated = await authService.ValidateAccessTokenAsync(
+    rawToken,
+    expectedAudience: "https://api.example.com");
 if (validated is null)
     return Results.Unauthorized();
 
@@ -408,6 +410,7 @@ var orgId = validated.OrganizationId;
 | Name | Type | Description |
 |------|------|-------------|
 | `rawToken` | `string` | The raw JWT access token string. |
+| `expectedAudience` | `string` | The required JWT `aud` value for this resource server. |
 
 **Returns**
 
@@ -420,6 +423,15 @@ var orgId = validated.OrganizationId;
 | `UserId` | `string?` | The authenticated user's ID. |
 | `OrganizationId` | `string?` | The organization from the token. |
 | `ClientId` | `string?` | The client application ID. |
+| `Audience` | `string?` | The JWT audience claim. |
+
+---
+
+### ValidateAccessTokenWithoutAudienceForIntrospectionOnlyAsync
+
+Validates issuer, signature, lifetime, and session state without validating the JWT `aud` claim. This method is obsolete and is only for diagnostics or token introspection flows that do not authenticate a protected API request.
+
+Resource servers must use `ValidateAccessTokenAsync(rawToken, expectedAudience, cancellationToken)`.
 
 ---
 
@@ -1175,7 +1187,8 @@ public sealed record SqlOSValidatedToken(
     string SessionId,
     string? UserId,
     string? OrganizationId,
-    string? ClientId);
+    string? ClientId,
+    string? Audience);
 ```
 
 ### SqlOSOrganizationOption

--- a/web/content/docs/reference/sdk-reference.mdx
+++ b/web/content/docs/reference/sdk-reference.mdx
@@ -74,8 +74,11 @@ var tokens = await authService.ExchangeCodeAsync(
 var tokens = await authService.RefreshAsync(
     new SqlOSRefreshRequest(refreshToken, organizationId), ct);
 
-// Validate access token
-var validated = await authService.ValidateAccessTokenAsync(rawToken, ct);
+// Validate access token for a protected resource server
+var validated = await authService.ValidateAccessTokenAsync(
+    rawToken,
+    expectedAudience: "https://api.example.com",
+    ct);
 
 // Logout
 await authService.LogoutAsync(refreshToken, sessionId, ct);


### PR DESCRIPTION
## Summary
- require an expected audience on public ValidateAccessTokenAsync resource-server validation paths
- add an obsolete, explicitly named no-audience introspection helper
- add SqlOS access-token middleware that fails closed without configured audience and rejects wrong-audience tokens
- update docs/examples to pass expected audience and add regression coverage for API shape, middleware behavior, and docs snippets

Fixes #28

## Tests
- dotnet test tests/SqlOS.Tests/SqlOS.Tests.csproj --no-restore
- dotnet test SqlOS.sln --no-restore