### PR TITLE
Harden dashboard password login against brute force

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Think **WorkOS / AuthKit**, but **self-hosted** and **your database**.
 
 - **Auth Admin** — manage organizations, users, clients, OIDC/SAML connections, security settings, sessions, and audit events
 - **FGA Admin** — manage resources, grants, roles, permissions, and test access decisions
-- **Password-Protected** — optional password auth mode for production deployments
+- **Password-Protected** — optional password auth mode with dashboard-specific throttling
 
 ## Quick Start
 
@@ -107,6 +107,10 @@ Protect the dashboard in production with a password:
 ```csharp
 options.Dashboard.AuthMode = SqlOSDashboardAuthMode.Password;
 options.Dashboard.Password = builder.Configuration["SqlOS:Dashboard:Password"];
+options.Dashboard.LoginThrottling.MaxFailuresPerIp = 5;
+options.Dashboard.LoginThrottling.MaxGlobalFailures = 25;
+options.Dashboard.LoginThrottling.Window = TimeSpan.FromMinutes(5);
+options.Dashboard.LoginThrottling.LockoutDuration = TimeSpan.FromMinutes(5);
 ```
 
 Or via environment variables:
@@ -115,6 +119,8 @@ Or via environment variables:
 SqlOS__Dashboard__AuthMode=Password
 SqlOS__Dashboard__Password=<strong-password>
 ```
+
+`/sqlos` and `/sqlos/admin` are administrative surfaces. Do not expose them directly to the public internet unless they are behind HTTPS, trusted reverse-proxy or edge rate limiting, and a stronger admin access strategy such as a private network, VPN, identity-aware proxy, or admin SSO/MFA. The built-in password mode includes per-IP throttling, global backoff, temporary lockout, and audit events for login, lockout, rate-limit rejection, and logout, but it should not be the only control for a public admin endpoint.
 
 ## Email OTP with Azure Communication Services
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -146,6 +146,11 @@ builder.AddSqlOS<AppDbContext>(options =>
     options.Dashboard.AuthMode = SqlOSDashboardAuthMode.Password;
     options.Dashboard.Password = builder.Configuration["SqlOS:Dashboard:Password"]
         ?? throw new InvalidOperationException("SqlOS dashboard password is not configured.");
+
+    options.Dashboard.LoginThrottling.MaxFailuresPerIp = 5;
+    options.Dashboard.LoginThrottling.MaxGlobalFailures = 25;
+    options.Dashboard.LoginThrottling.Window = TimeSpan.FromMinutes(5);
+    options.Dashboard.LoginThrottling.LockoutDuration = TimeSpan.FromMinutes(5);
 });
 ```
 
@@ -158,6 +163,10 @@ if (sessionMinutes is > 0)
     options.Dashboard.SessionLifetime = TimeSpan.FromMinutes(sessionMinutes.Value);
 }
 ```
+
+Password mode records audit events for dashboard login success, login failure, rate-limit rejection, temporary lockout, and logout. Repeated failed attempts from one client IP are locked out with `429 Too Many Requests`; a distributed spike trips the global backoff even when attempts come from different IPs.
+
+`/sqlos` and `/sqlos/admin` should be treated as administrative endpoints. For production, keep them on a trusted network or behind a VPN, identity-aware proxy, or reverse proxy that enforces HTTPS and edge rate limiting. Do not expose them directly to the public internet with only the shared dashboard password; use stronger admin authentication such as SSO/MFA as the deployment strategy when the dashboard must be reachable from outside a trusted network.
 
 ## EF model registration
 

--- a/src/SqlOS/AuthServer/Services/SqlOSAdminService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSAdminService.cs
@@ -1172,6 +1172,7 @@ public sealed class SqlOSAdminService
                 x.OrganizationId,
                 x.SessionId,
                 x.OccurredAt,
+                x.IpAddress,
                 x.DataJson
             })
             .Cast<object>()

--- a/src/SqlOS/Configuration/SqlOSOptions.cs
+++ b/src/SqlOS/Configuration/SqlOSOptions.cs
@@ -31,5 +31,15 @@ public sealed class SqlOSDashboardOptions
     public SqlOSDashboardAuthMode AuthMode { get; set; } = SqlOSDashboardAuthMode.DevelopmentOnly;
     public string? Password { get; set; }
     public TimeSpan SessionLifetime { get; set; } = DefaultSessionLifetime;
+    public SqlOSDashboardLoginThrottlingOptions LoginThrottling { get; } = new();
     public Func<HttpContext, Task<bool>>? AuthorizationCallback { get; set; }
+}
+
+public sealed class SqlOSDashboardLoginThrottlingOptions
+{
+    public bool Enabled { get; set; } = true;
+    public int MaxFailuresPerIp { get; set; } = 5;
+    public int MaxGlobalFailures { get; set; } = 25;
+    public TimeSpan Window { get; set; } = TimeSpan.FromMinutes(5);
+    public TimeSpan LockoutDuration { get; set; } = TimeSpan.FromMinutes(5);
 }

--- a/src/SqlOS/Configuration/SqlOSOptionsValidator.cs
+++ b/src/SqlOS/Configuration/SqlOSOptionsValidator.cs
@@ -31,6 +31,8 @@ internal static class SqlOSOptionsValidator
             errors.Add("Dashboard.SessionLifetime must be greater than zero.");
         }
 
+        ValidateDashboardLoginThrottlingOptions(options.Dashboard.LoginThrottling, errors);
+
         var issuer = ValidateAbsoluteUri(options.AuthServer.Issuer, "AuthServer.Issuer", errors);
         if (issuer != null && authBasePath != null)
         {
@@ -76,6 +78,34 @@ internal static class SqlOSOptionsValidator
         {
             throw new InvalidOperationException(
                 "Invalid SqlOS configuration:" + Environment.NewLine + string.Join(Environment.NewLine, errors.Select(static error => $"- {error}")));
+        }
+    }
+
+    private static void ValidateDashboardLoginThrottlingOptions(SqlOSDashboardLoginThrottlingOptions options, List<string> errors)
+    {
+        if (!options.Enabled)
+        {
+            return;
+        }
+
+        if (options.MaxFailuresPerIp <= 0)
+        {
+            errors.Add("Dashboard.LoginThrottling.MaxFailuresPerIp must be greater than zero.");
+        }
+
+        if (options.MaxGlobalFailures <= 0)
+        {
+            errors.Add("Dashboard.LoginThrottling.MaxGlobalFailures must be greater than zero.");
+        }
+
+        if (options.Window <= TimeSpan.Zero)
+        {
+            errors.Add("Dashboard.LoginThrottling.Window must be greater than zero.");
+        }
+
+        if (options.LockoutDuration <= TimeSpan.Zero)
+        {
+            errors.Add("Dashboard.LoginThrottling.LockoutDuration must be greater than zero.");
         }
     }
 

--- a/src/SqlOS/Dashboard/SqlOSDashboardLoginThrottlingService.cs
+++ b/src/SqlOS/Dashboard/SqlOSDashboardLoginThrottlingService.cs
@@ -1,0 +1,176 @@
+using SqlOS.Configuration;
+
+namespace SqlOS.Dashboard;
+
+public sealed class SqlOSDashboardLoginThrottlingService
+{
+    private const string UnknownClientIp = "unknown";
+    private readonly object _sync = new();
+    private readonly Dictionary<string, FailureBucket> _ipFailures = new(StringComparer.Ordinal);
+    private readonly FailureBucket _globalFailures = new();
+
+    public SqlOSDashboardLoginThrottleRejection? GetRejection(
+        string? clientIp,
+        SqlOSDashboardLoginThrottlingOptions options,
+        DateTimeOffset now)
+    {
+        if (!options.Enabled)
+        {
+            return null;
+        }
+
+        var normalizedIp = NormalizeClientIp(clientIp);
+        lock (_sync)
+        {
+            if (_ipFailures.TryGetValue(normalizedIp, out var ipBucket))
+            {
+                ResetIfExpired(ipBucket, options, now);
+                if (ipBucket.LockedUntil is { } ipLockedUntil && ipLockedUntil > now)
+                {
+                    return new SqlOSDashboardLoginThrottleRejection("ip", ipLockedUntil);
+                }
+
+                if (ipBucket.Count == 0)
+                {
+                    _ipFailures.Remove(normalizedIp);
+                }
+            }
+
+            ResetIfExpired(_globalFailures, options, now);
+            if (_globalFailures.LockedUntil is { } globalLockedUntil && globalLockedUntil > now)
+            {
+                return new SqlOSDashboardLoginThrottleRejection("global", globalLockedUntil);
+            }
+
+            return null;
+        }
+    }
+
+    public SqlOSDashboardLoginLockoutResult RecordFailure(
+        string? clientIp,
+        SqlOSDashboardLoginThrottlingOptions options,
+        DateTimeOffset now)
+    {
+        if (!options.Enabled)
+        {
+            return SqlOSDashboardLoginLockoutResult.None;
+        }
+
+        var normalizedIp = NormalizeClientIp(clientIp);
+        lock (_sync)
+        {
+            var ipBucket = GetActiveIpBucket(normalizedIp, options, now);
+            var perIpLockedUntil = RecordFailure(ipBucket, options.MaxFailuresPerIp, options.LockoutDuration, now);
+
+            ResetIfExpired(_globalFailures, options, now);
+            var globalLockedUntil = RecordFailure(_globalFailures, options.MaxGlobalFailures, options.LockoutDuration, now);
+
+            return new SqlOSDashboardLoginLockoutResult(perIpLockedUntil, globalLockedUntil);
+        }
+    }
+
+    public void RecordSuccess(
+        string? clientIp,
+        SqlOSDashboardLoginThrottlingOptions options,
+        DateTimeOffset now)
+    {
+        if (!options.Enabled)
+        {
+            return;
+        }
+
+        var normalizedIp = NormalizeClientIp(clientIp);
+        lock (_sync)
+        {
+            _ipFailures.Remove(normalizedIp);
+
+            ResetIfExpired(_globalFailures, options, now);
+            if (_globalFailures.LockedUntil is null && _globalFailures.Count > 0)
+            {
+                _globalFailures.Count--;
+                if (_globalFailures.Count == 0)
+                {
+                    _globalFailures.WindowStartedAt = null;
+                }
+            }
+        }
+    }
+
+    private FailureBucket GetActiveIpBucket(
+        string clientIp,
+        SqlOSDashboardLoginThrottlingOptions options,
+        DateTimeOffset now)
+    {
+        if (!_ipFailures.TryGetValue(clientIp, out var bucket))
+        {
+            bucket = new FailureBucket();
+            _ipFailures[clientIp] = bucket;
+            return bucket;
+        }
+
+        ResetIfExpired(bucket, options, now);
+        return bucket;
+    }
+
+    private static DateTimeOffset? RecordFailure(
+        FailureBucket bucket,
+        int threshold,
+        TimeSpan lockoutDuration,
+        DateTimeOffset now)
+    {
+        bucket.WindowStartedAt ??= now;
+        bucket.Count++;
+
+        if (bucket.Count < threshold || bucket.LockedUntil is not null)
+        {
+            return null;
+        }
+
+        bucket.LockedUntil = now.Add(lockoutDuration);
+        return bucket.LockedUntil;
+    }
+
+    private static void ResetIfExpired(
+        FailureBucket bucket,
+        SqlOSDashboardLoginThrottlingOptions options,
+        DateTimeOffset now)
+    {
+        if (bucket.LockedUntil is { } lockedUntil)
+        {
+            if (lockedUntil > now)
+            {
+                return;
+            }
+
+            bucket.Count = 0;
+            bucket.WindowStartedAt = null;
+            bucket.LockedUntil = null;
+            return;
+        }
+
+        if (bucket.WindowStartedAt is { } windowStartedAt && now - windowStartedAt >= options.Window)
+        {
+            bucket.Count = 0;
+            bucket.WindowStartedAt = null;
+        }
+    }
+
+    private static string NormalizeClientIp(string? clientIp)
+        => string.IsNullOrWhiteSpace(clientIp) ? UnknownClientIp : clientIp.Trim();
+
+    private sealed class FailureBucket
+    {
+        public DateTimeOffset? WindowStartedAt { get; set; }
+        public int Count { get; set; }
+        public DateTimeOffset? LockedUntil { get; set; }
+    }
+}
+
+public sealed record SqlOSDashboardLoginThrottleRejection(string Scope, DateTimeOffset RetryAfter);
+
+public sealed record SqlOSDashboardLoginLockoutResult(DateTimeOffset? PerIpLockedUntil, DateTimeOffset? GlobalLockedUntil)
+{
+    public static SqlOSDashboardLoginLockoutResult None { get; } = new(null, null);
+    public bool PerIpLocked => PerIpLockedUntil.HasValue;
+    public bool GlobalLocked => GlobalLockedUntil.HasValue;
+}

--- a/src/SqlOS/Dashboard/SqlOSDashboardMiddleware.cs
+++ b/src/SqlOS/Dashboard/SqlOSDashboardMiddleware.cs
@@ -1,8 +1,10 @@
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
 using System.Text;
 using System.Text.Json;
+using SqlOS.AuthServer.Services;
 using SqlOS.Configuration;
 
 namespace SqlOS.Dashboard;
@@ -19,6 +21,7 @@ public sealed class SqlOSDashboardMiddleware
     private readonly bool _isDevelopment;
     private readonly SqlOSDashboardOptions _options;
     private readonly SqlOSDashboardSessionService _sessionService;
+    private readonly SqlOSDashboardLoginThrottlingService _loginThrottlingService;
     private readonly IFileProvider _fileProvider;
 
     public SqlOSDashboardMiddleware(
@@ -26,13 +29,15 @@ public sealed class SqlOSDashboardMiddleware
         string pathPrefix,
         IHostEnvironment environment,
         SqlOSDashboardOptions options,
-        SqlOSDashboardSessionService sessionService)
+        SqlOSDashboardSessionService sessionService,
+        SqlOSDashboardLoginThrottlingService loginThrottlingService)
     {
         _next = next;
         _pathPrefix = pathPrefix.TrimEnd('/');
         _isDevelopment = environment.IsDevelopment();
         _options = options;
         _sessionService = sessionService;
+        _loginThrottlingService = loginThrottlingService;
         _fileProvider = CreateFileProvider();
     }
 
@@ -144,7 +149,13 @@ public sealed class SqlOSDashboardMiddleware
         if (endpoint.Equals("logout", StringComparison.OrdinalIgnoreCase)
             && HttpMethods.IsPost(context.Request.Method))
         {
+            var clientIp = GetClientIpAddress(context);
             _sessionService.ClearSession(context, _pathPrefix);
+            await RecordDashboardAuditAsync(
+                context,
+                "dashboard.logout",
+                clientIp,
+                new { reason = "operator_requested" });
             context.Response.StatusCode = StatusCodes.Status204NoContent;
             return;
         }
@@ -173,28 +184,129 @@ public sealed class SqlOSDashboardMiddleware
                 return;
             }
 
+            var clientIp = GetClientIpAddress(context);
+            var now = DateTimeOffset.UtcNow;
+            var rejection = _loginThrottlingService.GetRejection(clientIp, _options.LoginThrottling, now);
+            if (rejection != null)
+            {
+                await RecordDashboardAuditAsync(
+                    context,
+                    "dashboard.login.rate-limited",
+                    clientIp,
+                    new
+                    {
+                        scope = rejection.Scope,
+                        retry_after_seconds = GetRetryAfterSeconds(rejection.RetryAfter, now)
+                    });
+                await WriteThrottleResponseAsync(context, rejection, now);
+                return;
+            }
+
             if (!_sessionService.VerifyPassword(_options.Password!, payload.Password))
             {
+                await RecordDashboardAuditAsync(
+                    context,
+                    "dashboard.login.failure",
+                    clientIp,
+                    new { reason = "invalid_password" });
+
+                var lockout = _loginThrottlingService.RecordFailure(clientIp, _options.LoginThrottling, now);
+                if (lockout.PerIpLockedUntil is { } perIpLockedUntil)
+                {
+                    await RecordDashboardAuditAsync(
+                        context,
+                        "dashboard.login.lockout",
+                        clientIp,
+                        new
+                        {
+                            scope = "ip",
+                            retry_after_seconds = GetRetryAfterSeconds(perIpLockedUntil, now)
+                        });
+                }
+
+                if (lockout.GlobalLockedUntil is { } globalLockedUntil)
+                {
+                    await RecordDashboardAuditAsync(
+                        context,
+                        "dashboard.login.lockout",
+                        clientIp,
+                        new
+                        {
+                            scope = "global",
+                            retry_after_seconds = GetRetryAfterSeconds(globalLockedUntil, now)
+                        });
+                }
+
+                context.Response.ContentType = "application/json; charset=utf-8";
                 context.Response.StatusCode = StatusCodes.Status401Unauthorized;
                 await context.Response.WriteAsync("{\"error\":\"Invalid password\"}");
                 return;
             }
 
+            _loginThrottlingService.RecordSuccess(clientIp, _options.LoginThrottling, now);
             var allowInsecureCookie = _isDevelopment && !context.Request.IsHttps;
-            _sessionService.CreateSession(context, _pathPrefix, _options.SessionLifetime, allowInsecureCookie);
-            var expiresAt = _sessionService.GetSessionExpiry(context);
+            var expiresAt = _sessionService.CreateSession(context, _pathPrefix, _options.SessionLifetime, allowInsecureCookie);
+            await RecordDashboardAuditAsync(
+                context,
+                "dashboard.login.success",
+                clientIp,
+                new { expires_at = expiresAt.UtcDateTime });
 
             context.Response.ContentType = "application/json; charset=utf-8";
             await context.Response.WriteAsync(JsonSerializer.Serialize(new
             {
                 authenticated = true,
-                expiresAt = expiresAt?.UtcDateTime
+                expiresAt = expiresAt.UtcDateTime
             }));
             return;
         }
 
         context.Response.StatusCode = StatusCodes.Status404NotFound;
     }
+
+    private static async Task WriteThrottleResponseAsync(
+        HttpContext context,
+        SqlOSDashboardLoginThrottleRejection rejection,
+        DateTimeOffset now)
+    {
+        var retryAfterSeconds = GetRetryAfterSeconds(rejection.RetryAfter, now);
+        context.Response.StatusCode = StatusCodes.Status429TooManyRequests;
+        context.Response.ContentType = "application/json; charset=utf-8";
+        context.Response.Headers.RetryAfter = retryAfterSeconds.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        await context.Response.WriteAsync(JsonSerializer.Serialize(new
+        {
+            error = "Too many dashboard login attempts. Try again later.",
+            scope = rejection.Scope,
+            retryAfterSeconds
+        }));
+    }
+
+    private static async Task RecordDashboardAuditAsync(
+        HttpContext context,
+        string eventType,
+        string clientIp,
+        object? data)
+    {
+        var adminService = context.RequestServices.GetService<SqlOSAdminService>();
+        if (adminService == null)
+        {
+            return;
+        }
+
+        await adminService.RecordAuditAsync(
+            eventType,
+            "dashboard",
+            actorId: null,
+            ipAddress: clientIp,
+            data: data,
+            cancellationToken: context.RequestAborted);
+    }
+
+    private static string GetClientIpAddress(HttpContext context)
+        => context.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+
+    private static int GetRetryAfterSeconds(DateTimeOffset retryAfter, DateTimeOffset now)
+        => Math.Max(1, (int)Math.Ceiling((retryAfter - now).TotalSeconds));
 
     private async Task HandleUnauthorizedRequestAsync(HttpContext context, string relativePath)
     {

--- a/src/SqlOS/Dashboard/SqlOSDashboardSessionService.cs
+++ b/src/SqlOS/Dashboard/SqlOSDashboardSessionService.cs
@@ -62,7 +62,7 @@ public sealed class SqlOSDashboardSessionService
         return true;
     }
 
-    public void CreateSession(
+    public DateTimeOffset CreateSession(
         HttpContext context,
         string cookiePath,
         TimeSpan sessionLifetime,
@@ -81,6 +81,8 @@ public sealed class SqlOSDashboardSessionService
             Path = cookiePath,
             Expires = expiresAt.UtcDateTime
         });
+
+        return expiresAt;
     }
 
     public void ClearSession(HttpContext context, string cookiePath)

--- a/src/SqlOS/Extensions/ServiceCollectionExtensions.cs
+++ b/src/SqlOS/Extensions/ServiceCollectionExtensions.cs
@@ -36,6 +36,7 @@ public static class ServiceCollectionExtensions
         services.AddDataProtection();
         services.AddHttpClient();
         services.AddSingleton<SqlOSDashboardSessionService>();
+        services.AddSingleton<SqlOSDashboardLoginThrottlingService>();
         services.AddSingleton<SqlOSDynamicClientRegistrationRateLimiter>();
 
         services.AddScoped<ISqlOSAuthServerDbContext>(sp => sp.GetRequiredService<TContext>());

--- a/tests/SqlOS.Tests/SqlOSDashboardAuthMiddlewareTests.cs
+++ b/tests/SqlOS.Tests/SqlOSDashboardAuthMiddlewareTests.cs
@@ -1,0 +1,265 @@
+using System.Net;
+using System.Text;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SqlOS.AuthServer.Configuration;
+using SqlOS.AuthServer.Interfaces;
+using SqlOS.AuthServer.Models;
+using SqlOS.AuthServer.Services;
+using SqlOS.Configuration;
+using SqlOS.Dashboard;
+using SqlOS.Tests.Infrastructure;
+
+namespace SqlOS.Tests;
+
+[TestClass]
+public sealed class SqlOSDashboardAuthMiddlewareTests
+{
+    [TestMethod]
+    public async Task DashboardLogin_RepeatedWrongPassword_FromSameIp_IsThrottled()
+    {
+        using var harness = CreateHarness(options =>
+        {
+            options.LoginThrottling.MaxFailuresPerIp = 2;
+            options.LoginThrottling.MaxGlobalFailures = 20;
+        });
+
+        (await harness.PostLoginAsync("wrong-password", "203.0.113.10")).StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+        (await harness.PostLoginAsync("wrong-password", "203.0.113.10")).StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+
+        var throttled = await harness.PostLoginAsync("wrong-password", "203.0.113.10");
+
+        throttled.StatusCode.Should().Be(StatusCodes.Status429TooManyRequests);
+        throttled.Body.Should().Contain("Too many dashboard login attempts");
+        throttled.Body.Should().Contain("ip");
+        throttled.RetryAfter.Should().NotBeNullOrWhiteSpace();
+
+        var auditEvents = await harness.ListAuditEventsAsync();
+        auditEvents.Should().ContainSingle(x =>
+            x.EventType == "dashboard.login.lockout"
+            && x.DataJson != null
+            && x.DataJson.Contains("\"scope\":\"ip\"", StringComparison.Ordinal));
+        auditEvents.Should().ContainSingle(x =>
+            x.EventType == "dashboard.login.rate-limited"
+            && x.DataJson != null
+            && x.DataJson.Contains("\"scope\":\"ip\"", StringComparison.Ordinal));
+    }
+
+    [TestMethod]
+    public async Task DashboardLogin_GlobalFailureSpike_IsThrottled()
+    {
+        using var harness = CreateHarness(options =>
+        {
+            options.LoginThrottling.MaxFailuresPerIp = 10;
+            options.LoginThrottling.MaxGlobalFailures = 2;
+        });
+
+        (await harness.PostLoginAsync("wrong-password", "203.0.113.10")).StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+        (await harness.PostLoginAsync("wrong-password", "203.0.113.11")).StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+
+        var throttled = await harness.PostLoginAsync("wrong-password", "203.0.113.12");
+
+        throttled.StatusCode.Should().Be(StatusCodes.Status429TooManyRequests);
+        throttled.Body.Should().Contain("global");
+
+        var auditEvents = await harness.ListAuditEventsAsync();
+        auditEvents.Should().ContainSingle(x =>
+            x.EventType == "dashboard.login.lockout"
+            && x.DataJson != null
+            && x.DataJson.Contains("\"scope\":\"global\"", StringComparison.Ordinal));
+        auditEvents.Should().ContainSingle(x =>
+            x.EventType == "dashboard.login.rate-limited"
+            && x.DataJson != null
+            && x.DataJson.Contains("\"scope\":\"global\"", StringComparison.Ordinal));
+    }
+
+    [TestMethod]
+    public async Task DashboardLogin_Success_WritesAuditEvent_AndCreatesSessionCookie()
+    {
+        using var harness = CreateHarness();
+
+        var response = await harness.PostLoginAsync("correct-password", "203.0.113.20");
+
+        response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        response.SetCookie.Should().Contain(cookie => cookie.Contains("SqlOS.Dashboard.Session=", StringComparison.Ordinal));
+
+        var auditEvents = await harness.ListAuditEventsAsync();
+        auditEvents.Should().ContainSingle(x =>
+            x.EventType == "dashboard.login.success"
+            && x.ActorType == "dashboard"
+            && x.IpAddress == "203.0.113.20");
+    }
+
+    [TestMethod]
+    public async Task DashboardLogin_Failure_WritesAuditEvent_WithoutPasswordValue()
+    {
+        using var harness = CreateHarness();
+
+        var response = await harness.PostLoginAsync("submitted-secret", "203.0.113.30");
+
+        response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+        var auditEvent = (await harness.ListAuditEventsAsync())
+            .Single(x => x.EventType == "dashboard.login.failure");
+        auditEvent.IpAddress.Should().Be("203.0.113.30");
+        auditEvent.DataJson.Should().Contain("invalid_password");
+        auditEvent.DataJson.Should().NotContain("submitted-secret");
+    }
+
+    [TestMethod]
+    public async Task DashboardLogin_ProductionCookie_IsSecureHttpOnlyAndPathScoped()
+    {
+        using var harness = CreateHarness();
+
+        var response = await harness.PostLoginAsync("correct-password", "203.0.113.40");
+
+        var sessionCookie = response.SetCookie.Single(cookie => cookie.Contains("SqlOS.Dashboard.Session=", StringComparison.Ordinal));
+        var normalizedCookie = sessionCookie.ToLowerInvariant();
+        normalizedCookie.Should().Contain("httponly");
+        normalizedCookie.Should().Contain("secure");
+        normalizedCookie.Should().Contain("path=/sqlos");
+    }
+
+    [TestMethod]
+    public async Task DashboardLogout_WritesAuditEvent_AndClearsSessionCookie()
+    {
+        using var harness = CreateHarness();
+
+        var response = await harness.PostLogoutAsync("203.0.113.50");
+
+        response.StatusCode.Should().Be(StatusCodes.Status204NoContent);
+        response.SetCookie.Should().Contain(cookie => cookie.Contains("SqlOS.Dashboard.Session=", StringComparison.Ordinal));
+
+        var auditEvents = await harness.ListAuditEventsAsync();
+        auditEvents.Should().ContainSingle(x =>
+            x.EventType == "dashboard.logout"
+            && x.ActorType == "dashboard"
+            && x.IpAddress == "203.0.113.50");
+    }
+
+    private static DashboardMiddlewareHarness CreateHarness(Action<SqlOSDashboardOptions>? configure = null)
+    {
+        var dashboardOptions = new SqlOSDashboardOptions
+        {
+            AuthMode = SqlOSDashboardAuthMode.Password,
+            Password = "correct-password"
+        };
+        configure?.Invoke(dashboardOptions);
+
+        var services = new ServiceCollection();
+        var databaseName = Guid.NewGuid().ToString("N");
+        services.AddDataProtection();
+        services.AddDbContext<TestSqlOSInMemoryDbContext>(options =>
+            options.UseInMemoryDatabase(databaseName));
+        services.AddScoped<ISqlOSAuthServerDbContext>(sp => sp.GetRequiredService<TestSqlOSInMemoryDbContext>());
+        services.AddSingleton(Options.Create(new SqlOSAuthServerOptions()));
+        services.AddScoped<SqlOSCryptoService>();
+        services.AddScoped<SqlOSAdminService>();
+        services.AddSingleton<SqlOSDashboardSessionService>();
+        services.AddSingleton<SqlOSDashboardLoginThrottlingService>();
+
+        var provider = services.BuildServiceProvider(validateScopes: true);
+        var middleware = new SqlOSDashboardMiddleware(
+            _ => Task.CompletedTask,
+            "/sqlos",
+            new TestHostEnvironment(),
+            dashboardOptions,
+            provider.GetRequiredService<SqlOSDashboardSessionService>(),
+            provider.GetRequiredService<SqlOSDashboardLoginThrottlingService>());
+
+        return new DashboardMiddlewareHarness(provider, middleware);
+    }
+
+    private sealed class DashboardMiddlewareHarness : IDisposable
+    {
+        private readonly ServiceProvider _services;
+        private readonly SqlOSDashboardMiddleware _middleware;
+
+        public DashboardMiddlewareHarness(ServiceProvider services, SqlOSDashboardMiddleware middleware)
+        {
+            _services = services;
+            _middleware = middleware;
+        }
+
+        public Task<DashboardResponse> PostLoginAsync(string password, string ipAddress)
+            => SendAsync(
+                HttpMethods.Post,
+                "/sqlos/dashboard-auth/login",
+                $$"""{"password":"{{password}}"}""",
+                ipAddress);
+
+        public Task<DashboardResponse> PostLogoutAsync(string ipAddress)
+            => SendAsync(HttpMethods.Post, "/sqlos/dashboard-auth/logout", null, ipAddress);
+
+        public async Task<List<SqlOSAuditEvent>> ListAuditEventsAsync()
+        {
+            using var scope = _services.CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<TestSqlOSInMemoryDbContext>();
+            return await context.Set<SqlOSAuditEvent>()
+                .OrderBy(x => x.OccurredAt)
+                .ToListAsync();
+        }
+
+        private async Task<DashboardResponse> SendAsync(
+            string method,
+            string path,
+            string? body,
+            string ipAddress)
+        {
+            using var scope = _services.CreateScope();
+            var context = new DefaultHttpContext
+            {
+                RequestServices = scope.ServiceProvider
+            };
+            context.Request.Method = method;
+            context.Request.Path = path;
+            context.Request.Scheme = Uri.UriSchemeHttps;
+            context.Connection.RemoteIpAddress = IPAddress.Parse(ipAddress);
+            context.Response.Body = new MemoryStream();
+
+            if (body != null)
+            {
+                var bytes = Encoding.UTF8.GetBytes(body);
+                context.Request.Body = new MemoryStream(bytes);
+                context.Request.ContentLength = bytes.Length;
+                context.Request.ContentType = "application/json";
+            }
+
+            await _middleware.InvokeAsync(context);
+
+            context.Response.Body.Position = 0;
+            using var reader = new StreamReader(context.Response.Body, Encoding.UTF8);
+            var responseBody = await reader.ReadToEndAsync();
+            var setCookie = context.Response.Headers.TryGetValue("Set-Cookie", out var cookies)
+                ? cookies.Select(cookie => cookie ?? string.Empty).ToArray()
+                : Array.Empty<string>();
+            var retryAfter = context.Response.Headers.TryGetValue("Retry-After", out var retryAfterValues)
+                ? retryAfterValues.ToString()
+                : null;
+
+            return new DashboardResponse(context.Response.StatusCode, responseBody, setCookie, retryAfter);
+        }
+
+        public void Dispose()
+            => _services.Dispose();
+    }
+
+    private sealed record DashboardResponse(
+        int StatusCode,
+        string Body,
+        string[] SetCookie,
+        string? RetryAfter);
+
+    private sealed class TestHostEnvironment : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = Environments.Production;
+        public string ApplicationName { get; set; } = "SqlOS.Tests";
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+    }
+}

--- a/tests/SqlOS.Tests/SqlOSOptionsValidationTests.cs
+++ b/tests/SqlOS.Tests/SqlOSOptionsValidationTests.cs
@@ -100,6 +100,20 @@ public sealed class SqlOSOptionsValidationTests
     }
 
     [TestMethod]
+    public void AddSqlOS_Throws_WhenDashboardLoginThrottlingWindowIsNotPositive()
+    {
+        var services = new ServiceCollection();
+
+        Action act = () => services.AddSqlOS<TestSqlOSInMemoryDbContext>(options =>
+        {
+            options.Dashboard.LoginThrottling.Window = TimeSpan.Zero;
+        });
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Dashboard.LoginThrottling.Window must be greater than zero.*");
+    }
+
+    [TestMethod]
     public void AddSqlOS_AllowsValidHeadlessConfiguration()
     {
         var services = new ServiceCollection();

--- a/web/content/docs/authserver/dashboard-overview.mdx
+++ b/web/content/docs/authserver/dashboard-overview.mdx
@@ -15,6 +15,12 @@ Example: `http://localhost:5062/sqlos/`. Protect it with a password in `appsetti
 
 ![Dashboard home](/docs/dashboard-home.png)
 
+## Production exposure
+
+`/sqlos` and `/sqlos/admin` are administrative endpoints for users, organizations, memberships, clients, OIDC/SAML connections, security settings, sessions, audit events, and FGA data. In production, keep them on a trusted network or place them behind HTTPS, reverse-proxy or edge rate limiting, and an admin access layer such as VPN, identity-aware proxy, SSO, or MFA.
+
+Password mode includes dashboard-specific per-IP throttling, global backoff for distributed failures, temporary lockout, and audit events for login success, login failure, rate-limit rejection, lockout, and logout. Treat those built-in controls as a baseline, not as the only protection for a publicly reachable admin surface.
+
 ## Auth Server pages
 
 | Page | URL | What you can do |


### PR DESCRIPTION
## Summary
- add configurable dashboard login throttling with per-IP lockout and global backoff
- audit dashboard login success, failure, rate-limit rejection, lockout, and logout events
- document production exposure guidance for `/sqlos` and `/sqlos/admin`

## Tests
- `dotnet test tests/SqlOS.Tests/SqlOS.Tests.csproj`
- `dotnet test tests/SqlOS.Tests/SqlOS.Tests.csproj --configuration Release`
- `./scripts/build.sh`
- `./scripts/docs-check.sh`
- `./scripts/unit-tests.sh`

Closes #27
