### PR TITLE
Prevent public signup from joining arbitrary orgs

### DIFF
--- a/docs/INVITATIONS.md
+++ b/docs/INVITATIONS.md
@@ -2,6 +2,8 @@
 
 SqlOS invitations are organization-membership invites. They are email-bound, one-time, expiring links that only activate membership after the invited email is proven by OTP, trusted SSO, existing login, or invite-backed signup.
 
+Public signup does not treat a caller-supplied `organizationId` as authorization to join an existing tenant. Use invitations or another admin-owned provisioning path when a new user should become a member of an existing organization.
+
 ## Configure Email Delivery
 
 Invitations use the same `ISqlOSAuthEmailSender` delivery abstraction as Email OTP. The ACS sender is configured through Email OTP settings:

--- a/examples/SqlOS.Example.IntegrationTests/SqlOSExampleApiIntegrationTests.cs
+++ b/examples/SqlOS.Example.IntegrationTests/SqlOSExampleApiIntegrationTests.cs
@@ -74,6 +74,47 @@ public sealed class SqlOSExampleApiIntegrationTests
     }
 
     [TestMethod]
+    public async Task PasswordSignupEndpoint_WithExistingOrganizationId_ReturnsFailureAndNoMembership()
+    {
+        var orgResponse = await AdminPostAsync("/sqlos/admin/auth/api/organizations", new
+        {
+            name = $"Signup Target {Guid.NewGuid():N}"
+        });
+        orgResponse.EnsureSuccessStatusCode();
+        var orgJson = JsonDocument.Parse(await orgResponse.Content.ReadAsStringAsync());
+        var organizationId = orgJson.RootElement.GetProperty("id").GetString();
+
+        var existingOrgResponse = await ExampleApiFixture.Client.PostAsJsonAsync("/sqlos/auth/signup", new
+        {
+            displayName = "Org Probe",
+            email = $"org-probe-{Guid.NewGuid():N}@example.com",
+            password = "P@ssword123!",
+            clientId = "example-web",
+            organizationId
+        });
+        existingOrgResponse.StatusCode.Should().Be(System.Net.HttpStatusCode.BadRequest);
+        var existingBody = await existingOrgResponse.Content.ReadAsStringAsync();
+        existingBody.Should().Contain("Joining an existing organization requires an invitation or approved join policy.");
+        existingBody.Should().NotContain(organizationId);
+
+        var unknownOrgResponse = await ExampleApiFixture.Client.PostAsJsonAsync("/sqlos/auth/signup", new
+        {
+            displayName = "Unknown Org Probe",
+            email = $"unknown-org-probe-{Guid.NewGuid():N}@example.com",
+            password = "P@ssword123!",
+            clientId = "example-web",
+            organizationId = $"org_{Guid.NewGuid():N}"
+        });
+        unknownOrgResponse.StatusCode.Should().Be(System.Net.HttpStatusCode.BadRequest);
+        (await unknownOrgResponse.Content.ReadAsStringAsync()).Should().Be(existingBody);
+
+        var membershipsResponse = await ExampleApiFixture.Client.GetAsync($"/sqlos/admin/auth/api/organizations/{organizationId}/memberships");
+        membershipsResponse.EnsureSuccessStatusCode();
+        var membershipsJson = JsonDocument.Parse(await membershipsResponse.Content.ReadAsStringAsync());
+        membershipsJson.RootElement.GetProperty("totalCount").GetInt32().Should().Be(0);
+    }
+
+    [TestMethod]
     public async Task PasswordResetAndRefresh_Work()
     {
         var email = $"reset-{Guid.NewGuid():N}@example.com";

--- a/src/SqlOS/AuthServer/Extensions/EndpointRouteBuilderExtensions.cs
+++ b/src/SqlOS/AuthServer/Extensions/EndpointRouteBuilderExtensions.cs
@@ -1185,7 +1185,7 @@ public static class EndpointRouteBuilderExtensions
                 var redirectUrl = await authorizationServerService.IssueAuthorizationRedirectAsync(
                     authorizationRequest,
                     signup.User,
-                    invitation?.OrganizationId ?? authorizationRequest.OrganizationId ?? signup.Organizations.FirstOrDefault()?.Id,
+                    invitation?.OrganizationId ?? signup.Organizations.FirstOrDefault()?.Id,
                     signup.AuthenticationMethod,
                     context,
                     cancellationToken);
@@ -1483,7 +1483,7 @@ public static class EndpointRouteBuilderExtensions
                 var redirectUrl = await authorizationServerService.IssueAuthorizationRedirectAsync(
                     authorizationRequest,
                     signup.User,
-                    invitation?.OrganizationId ?? authorizationRequest.OrganizationId ?? signupVerification.OrganizationId ?? signup.Organizations.FirstOrDefault()?.Id,
+                    invitation?.OrganizationId ?? signup.Organizations.FirstOrDefault()?.Id,
                     signup.AuthenticationMethod,
                     context,
                     cancellationToken);
@@ -2058,7 +2058,16 @@ public static class EndpointRouteBuilderExtensions
         }
 
         auth.MapPost("/signup", async (SqlOSSignupRequest request, SqlOSAuthService authService, HttpContext httpContext, CancellationToken cancellationToken) =>
-            Results.Ok(await authService.SignUpAsync(request, httpContext, cancellationToken)));
+        {
+            try
+            {
+                return Results.Ok(await authService.SignUpAsync(request, httpContext, cancellationToken));
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.BadRequest(ex.Message);
+            }
+        });
 
         auth.MapPost("/password/login", async (SqlOSPasswordLoginRequest request, SqlOSAuthService authService, HttpContext httpContext, CancellationToken cancellationToken) =>
             Results.Ok(await authService.LoginWithPasswordAsync(request, httpContext, cancellationToken)));

--- a/src/SqlOS/AuthServer/Services/SqlOSAuthService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSAuthService.cs
@@ -48,18 +48,16 @@ public sealed class SqlOSAuthService
             throw new InvalidOperationException("Password signup is disabled.");
         }
 
+        SqlOSSignupJoinPolicy.RejectUnauthorizedOrganizationJoin(request.OrganizationId);
+
         var user = await _adminService.CreateUserAsync(new SqlOSCreateUserRequest(request.DisplayName, request.Email, request.Password), cancellationToken);
 
-        string? organizationId = request.OrganizationId;
+        string? organizationId = null;
         if (!string.IsNullOrWhiteSpace(request.OrganizationName))
         {
             var organization = await _adminService.CreateOrganizationAsync(new SqlOSCreateOrganizationRequest(request.OrganizationName, null), cancellationToken);
             organizationId = organization.Id;
             await _adminService.CreateMembershipAsync(organization.Id, new SqlOSCreateMembershipRequest(user.Id, "owner"), cancellationToken);
-        }
-        else if (!string.IsNullOrWhiteSpace(request.OrganizationId))
-        {
-            await _adminService.CreateMembershipAsync(request.OrganizationId, new SqlOSCreateMembershipRequest(user.Id, "member"), cancellationToken);
         }
 
         await _adminService.RecordAuditAsync("user.signup", "user", user.Id, userId: user.Id, organizationId: organizationId, ipAddress: GetIp(httpContext), cancellationToken: cancellationToken);
@@ -978,6 +976,8 @@ public sealed class SqlOSAuthService
             throw new InvalidOperationException("Email sign-in is unavailable.");
         }
 
+        SqlOSSignupJoinPolicy.RejectUnauthorizedOrganizationJoin(organizationId);
+
         var user = await _adminService.CreateUserAsync(
             new SqlOSCreateUserRequest(displayName, email, null),
             cancellationToken);
@@ -989,30 +989,17 @@ public sealed class SqlOSAuthService
         user.DefaultEmail = emailRecord.Email;
         user.UpdatedAt = DateTime.UtcNow;
 
-        var selectedOrganizationId = organizationId;
         if (!string.IsNullOrWhiteSpace(organizationName))
         {
             var createdOrganization = await _adminService.CreateOrganizationAsync(
                 new SqlOSCreateOrganizationRequest(organizationName, null),
                 cancellationToken);
-            selectedOrganizationId = createdOrganization.Id;
             await _adminService.CreateMembershipAsync(createdOrganization.Id, new SqlOSCreateMembershipRequest(user.Id, "owner"), cancellationToken);
-        }
-        else if (!string.IsNullOrWhiteSpace(organizationId))
-        {
-            await _adminService.CreateMembershipAsync(organizationId, new SqlOSCreateMembershipRequest(user.Id, "member"), cancellationToken);
         }
 
         await _context.SaveChangesAsync(cancellationToken);
 
         var organizations = await _adminService.GetUserOrganizationsAsync(user.Id, cancellationToken);
-        if (!string.IsNullOrWhiteSpace(selectedOrganizationId) && organizations.All(x => x.Id != selectedOrganizationId))
-        {
-            organizations = organizations
-                .Concat([new SqlOSOrganizationOption(selectedOrganizationId, selectedOrganizationId, selectedOrganizationId, "member")])
-                .ToList();
-        }
-
         return new SqlOSPasswordAuthenticationResult(user, organizations, "email_otp");
     }
 

--- a/src/SqlOS/AuthServer/Services/SqlOSAuthorizationServerService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSAuthorizationServerService.cs
@@ -256,31 +256,21 @@ public sealed class SqlOSAuthorizationServerService
             throw new InvalidOperationException("Password signup is disabled.");
         }
 
+        SqlOSSignupJoinPolicy.RejectUnauthorizedOrganizationJoin(organizationId);
+
         var user = await _adminService.CreateUserAsync(
             new SqlOSCreateUserRequest(displayName, email, password),
             cancellationToken);
 
-        var selectedOrganizationId = organizationId;
         if (!string.IsNullOrWhiteSpace(organizationName))
         {
             var createdOrganization = await _adminService.CreateOrganizationAsync(
                 new SqlOSCreateOrganizationRequest(organizationName, null),
                 cancellationToken);
-            selectedOrganizationId = createdOrganization.Id;
             await _adminService.CreateMembershipAsync(createdOrganization.Id, new SqlOSCreateMembershipRequest(user.Id, "owner"), cancellationToken);
-        }
-        else if (!string.IsNullOrWhiteSpace(organizationId))
-        {
-            await _adminService.CreateMembershipAsync(organizationId, new SqlOSCreateMembershipRequest(user.Id, "member"), cancellationToken);
         }
 
         var organizations = await _adminService.GetUserOrganizationsAsync(user.Id, cancellationToken);
-        if (!string.IsNullOrWhiteSpace(selectedOrganizationId) && organizations.All(x => x.Id != selectedOrganizationId))
-        {
-            organizations = organizations
-                .Concat([new SqlOSOrganizationOption(selectedOrganizationId, selectedOrganizationId, selectedOrganizationId, "member")])
-                .ToList();
-        }
 
         return new SqlOSPasswordAuthenticationResult(user, organizations, "password");
     }
@@ -298,6 +288,8 @@ public sealed class SqlOSAuthorizationServerService
             throw new InvalidOperationException("Email sign-in is unavailable.");
         }
 
+        SqlOSSignupJoinPolicy.RejectUnauthorizedOrganizationJoin(organizationId);
+
         var user = await _adminService.CreateUserAsync(
             new SqlOSCreateUserRequest(displayName, email, null),
             cancellationToken);
@@ -309,29 +301,17 @@ public sealed class SqlOSAuthorizationServerService
         user.DefaultEmail = emailRecord.Email;
         user.UpdatedAt = DateTime.UtcNow;
 
-        var selectedOrganizationId = organizationId;
         if (!string.IsNullOrWhiteSpace(organizationName))
         {
             var createdOrganization = await _adminService.CreateOrganizationAsync(
                 new SqlOSCreateOrganizationRequest(organizationName, null),
                 cancellationToken);
-            selectedOrganizationId = createdOrganization.Id;
             await _adminService.CreateMembershipAsync(createdOrganization.Id, new SqlOSCreateMembershipRequest(user.Id, "owner"), cancellationToken);
-        }
-        else if (!string.IsNullOrWhiteSpace(organizationId))
-        {
-            await _adminService.CreateMembershipAsync(organizationId, new SqlOSCreateMembershipRequest(user.Id, "member"), cancellationToken);
         }
 
         await _context.SaveChangesAsync(cancellationToken);
 
         var organizations = await _adminService.GetUserOrganizationsAsync(user.Id, cancellationToken);
-        if (!string.IsNullOrWhiteSpace(selectedOrganizationId) && organizations.All(x => x.Id != selectedOrganizationId))
-        {
-            organizations = organizations
-                .Concat([new SqlOSOrganizationOption(selectedOrganizationId, selectedOrganizationId, selectedOrganizationId, "member")])
-                .ToList();
-        }
 
         return new SqlOSPasswordAuthenticationResult(user, organizations, "email_otp");
     }

--- a/src/SqlOS/AuthServer/Services/SqlOSEmailOtpService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSEmailOtpService.cs
@@ -99,6 +99,11 @@ public sealed class SqlOSEmailOtpService
             throw new InvalidOperationException("An account already exists for this email. Sign in with an email code instead.");
         }
 
+        if (string.IsNullOrWhiteSpace(authorizationRequest?.InvitationId))
+        {
+            SqlOSSignupJoinPolicy.RejectUnauthorizedOrganizationJoin(authorizationRequest?.OrganizationId);
+        }
+
         if (authorizationRequest != null)
         {
             authorizationRequest.LoginHintEmail = trimmedEmail;
@@ -119,7 +124,7 @@ public sealed class SqlOSEmailOtpService
             "email_otp_signup",
             userId: null,
             clientApplicationId: authorizationRequest?.ClientApplicationId,
-            organizationId: authorizationRequest?.OrganizationId,
+            organizationId: null,
             payload: new EmailOtpSignupPayload(
                 _cryptoService.HashToken(challenge.ChallengeToken),
                 authorizationRequest?.Id,
@@ -128,8 +133,8 @@ public sealed class SqlOSEmailOtpService
                 trimmedDisplayName,
                 trimmedEmail,
                 string.IsNullOrWhiteSpace(organizationName) ? null : organizationName.Trim(),
-                authorizationRequest?.OrganizationId,
-                customFields),
+                OrganizationId: null,
+                CustomFields: customFields),
             lifetime: _options.ChallengeLifetime,
             cancellationToken);
 
@@ -174,11 +179,13 @@ public sealed class SqlOSEmailOtpService
             throw new InvalidOperationException("An account already exists for this email. Sign in with an email code instead.");
         }
 
+        SqlOSSignupJoinPolicy.RejectUnauthorizedOrganizationJoin(request.OrganizationId);
+
         var challenge = await CreateChallengeAsync(
             trimmedEmail,
             authorizationRequestId: null,
             clientApplicationId: client.Id,
-            requestedOrganizationId: request.OrganizationId,
+            requestedOrganizationId: null,
             httpContext,
             cancellationToken,
             sendWhenNoUser: true,
@@ -188,7 +195,7 @@ public sealed class SqlOSEmailOtpService
             "email_otp_signup",
             userId: null,
             clientApplicationId: client.Id,
-            organizationId: request.OrganizationId,
+            organizationId: null,
             payload: new EmailOtpSignupPayload(
                 _cryptoService.HashToken(challenge.ChallengeToken),
                 AuthorizationRequestId: null,
@@ -197,7 +204,7 @@ public sealed class SqlOSEmailOtpService
                 DisplayName: trimmedDisplayName,
                 Email: trimmedEmail,
                 OrganizationName: string.IsNullOrWhiteSpace(request.OrganizationName) ? null : request.OrganizationName.Trim(),
-                OrganizationId: request.OrganizationId,
+                OrganizationId: null,
                 CustomFields: request.CustomFields),
             lifetime: _options.ChallengeLifetime,
             cancellationToken);

--- a/src/SqlOS/AuthServer/Services/SqlOSHeadlessAuthService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSHeadlessAuthService.cs
@@ -693,8 +693,6 @@ public sealed class SqlOSHeadlessAuthService
                 cancellationToken);
 
             var selectedOrganizationId = boundInvitation?.OrganizationId
-                ?? authorizationRequest.OrganizationId
-                ?? verification.OrganizationId
                 ?? signup.Organizations.FirstOrDefault()?.Id;
             SqlOSOrganization? organization = null;
             if (!string.IsNullOrWhiteSpace(selectedOrganizationId))
@@ -966,7 +964,6 @@ public sealed class SqlOSHeadlessAuthService
                 cancellationToken);
 
             var selectedOrganizationId = boundInvitation?.OrganizationId
-                ?? authorizationRequest.OrganizationId
                 ?? signup.Organizations.FirstOrDefault()?.Id;
             SqlOSOrganization? organization = null;
             if (!string.IsNullOrWhiteSpace(selectedOrganizationId))

--- a/src/SqlOS/AuthServer/Services/SqlOSSignupJoinPolicy.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSSignupJoinPolicy.cs
@@ -1,0 +1,15 @@
+namespace SqlOS.AuthServer.Services;
+
+internal static class SqlOSSignupJoinPolicy
+{
+    public const string UnauthorizedOrganizationJoinMessage =
+        "Joining an existing organization requires an invitation or approved join policy.";
+
+    public static void RejectUnauthorizedOrganizationJoin(string? organizationId)
+    {
+        if (!string.IsNullOrWhiteSpace(organizationId))
+        {
+            throw new InvalidOperationException(UnauthorizedOrganizationJoinMessage);
+        }
+    }
+}

--- a/tests/SqlOS.IntegrationTests/HeadlessAuthIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/HeadlessAuthIntegrationTests.cs
@@ -17,6 +17,9 @@ namespace SqlOS.IntegrationTests;
 [TestClass]
 public sealed class HeadlessAuthIntegrationTests
 {
+    private const string UnauthorizedOrganizationJoinMessage =
+        "Joining an existing organization requires an invitation or approved join policy.";
+
     [TestMethod]
     public async Task CreateAuthorizationRequestAsync_PersistsHeadlessPresentationAndUiContext()
     {
@@ -165,6 +168,55 @@ public sealed class HeadlessAuthIntegrationTests
 
         (await fixture.Context.Set<SqlOSUserEmail>().CountAsync(x => x.Email == email)).Should().Be(1);
         (await fixture.Context.Set<SqlOSOrganization>().CountAsync(x => x.Name == organizationName)).Should().Be(1);
+    }
+
+    [TestMethod]
+    public async Task HeadlessSignup_WithAuthorizationRequestOrganizationId_WithoutPolicy_DoesNotCreateMembership()
+    {
+        await using var fixture = await CreateFixtureAsync();
+        var existingOrganization = await fixture.AdminService.CreateOrganizationAsync(
+            new SqlOSCreateOrganizationRequest($"Headless Existing {Guid.NewGuid():N}", null));
+
+        var authorizationRequest = await fixture.AuthorizationServerService.CreateAuthorizationRequestAsync(
+            new SqlOSAuthorizeRequestInput(
+                "code",
+                fixture.ClientId,
+                fixture.RedirectUri,
+                "state-org-probe",
+                "openid profile email",
+                "challenge-org-probe",
+                "S256",
+                null,
+                null,
+                null,
+                null,
+                "headless",
+                null));
+        authorizationRequest.OrganizationId = existingOrganization.Id;
+        authorizationRequest.ResolvedOrganizationId = existingOrganization.Id;
+        await fixture.Context.SaveChangesAsync();
+
+        var email = $"headless-probe-{Guid.NewGuid():N}@example.com";
+        var result = await fixture.HeadlessAuthService.SignUpAsync(
+            CreateHttpContext(),
+            new SqlOSHeadlessSignupRequest(
+                authorizationRequest.Id,
+                "Headless Probe",
+                email,
+                "P@ssword123!",
+                OrganizationName: null,
+                CustomFields: new JsonObject()));
+
+        result.Type.Should().Be("view");
+        result.ViewModel.Should().NotBeNull();
+        result.ViewModel!.View.Should().Be("signup");
+        result.ViewModel.Error.Should().Be(UnauthorizedOrganizationJoinMessage);
+
+        (await fixture.Context.Set<SqlOSUserEmail>().CountAsync(x => x.Email == email)).Should().Be(0);
+        (await fixture.Context.Set<SqlOSMembership>()
+            .CountAsync(x => x.OrganizationId == existingOrganization.Id)).Should().Be(0);
+        (await fixture.Context.Set<SqlOSAuthorizationCode>()
+            .CountAsync(x => x.AuthorizationRequestId == authorizationRequest.Id)).Should().Be(0);
     }
 
     [TestMethod]

--- a/tests/SqlOS.Tests/SqlOSAuthServiceTests.cs
+++ b/tests/SqlOS.Tests/SqlOSAuthServiceTests.cs
@@ -16,6 +16,9 @@ namespace SqlOS.Tests;
 [TestClass]
 public sealed class SqlOSAuthServiceTests
 {
+    private const string UnauthorizedOrganizationJoinMessage =
+        "Joining an existing organization requires an invitation or approved join policy.";
+
     [TestMethod]
     public async Task LoginWithMultipleOrganizations_ReturnsPendingAuthToken()
     {
@@ -45,6 +48,68 @@ public sealed class SqlOSAuthServiceTests
         result.PendingAuthToken.Should().NotBeNullOrWhiteSpace();
         result.Tokens.Should().BeNull();
         result.Organizations.Should().HaveCount(2);
+    }
+
+    [TestMethod]
+    public async Task SignUpAsync_WithExistingOrganizationId_WithoutInvitation_DoesNotCreateMembership()
+    {
+        var harness = await TestHarness.CreateAsync();
+        var existingOrganization = await harness.Admin.CreateOrganizationAsync(
+            new SqlOSCreateOrganizationRequest($"Existing {Guid.NewGuid():N}", null));
+        var email = $"attacker-{Guid.NewGuid():N}@example.com";
+
+        var act = async () => await harness.Auth.SignUpAsync(
+            new SqlOSSignupRequest(
+                "Mallory",
+                email,
+                "P@ssword123!",
+                OrganizationName: null,
+                ClientId: "test-client",
+                OrganizationId: existingOrganization.Id),
+            new DefaultHttpContext());
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage(UnauthorizedOrganizationJoinMessage);
+
+        (await harness.Context.Set<SqlOSMembership>()
+            .CountAsync(x => x.OrganizationId == existingOrganization.Id)).Should().Be(0);
+        (await harness.Context.Set<SqlOSUserEmail>()
+            .CountAsync(x => x.NormalizedEmail == SqlOSAdminService.NormalizeEmail(email))).Should().Be(0);
+    }
+
+    [TestMethod]
+    public async Task PublicSignup_UnknownOrgAndExistingOrg_ReturnUniformPublicFailure()
+    {
+        var harness = await TestHarness.CreateAsync();
+        var existingOrganization = await harness.Admin.CreateOrganizationAsync(
+            new SqlOSCreateOrganizationRequest($"Uniform {Guid.NewGuid():N}", null));
+
+        var existingAct = async () => await harness.Auth.SignUpAsync(
+                new SqlOSSignupRequest(
+                    "Existing Org Probe",
+                    $"existing-probe-{Guid.NewGuid():N}@example.com",
+                    "P@ssword123!",
+                    OrganizationName: null,
+                    ClientId: "test-client",
+                    OrganizationId: existingOrganization.Id),
+                new DefaultHttpContext());
+
+        var unknownAct = async () => await harness.Auth.SignUpAsync(
+                new SqlOSSignupRequest(
+                    "Unknown Org Probe",
+                    $"unknown-probe-{Guid.NewGuid():N}@example.com",
+                    "P@ssword123!",
+                    OrganizationName: null,
+                    ClientId: "test-client",
+                    OrganizationId: $"org_{Guid.NewGuid():N}"),
+                new DefaultHttpContext());
+
+        var existingFailure = await existingAct.Should().ThrowAsync<InvalidOperationException>();
+        var unknownFailure = await unknownAct.Should().ThrowAsync<InvalidOperationException>();
+
+        existingFailure.Which.Message.Should().Be(UnauthorizedOrganizationJoinMessage);
+        unknownFailure.Which.Message.Should().Be(existingFailure.Which.Message);
+        existingFailure.Which.Message.Should().NotContain(existingOrganization.Id);
     }
 
     [TestMethod]
@@ -97,6 +162,35 @@ public sealed class SqlOSAuthServiceTests
         start.SignupToken.Should().NotBeNullOrWhiteSpace();
         harness.EmailSender.Messages.Should().ContainSingle();
         harness.EmailSender.Messages.Single().To.Should().Be("new-user@example.com");
+    }
+
+    [TestMethod]
+    public async Task EmailOtpSignup_WithExistingOrganizationId_WithoutPolicy_DoesNotCreateChallengeOrMembership()
+    {
+        var harness = await EmailOtpHarness.CreateAsync();
+        var existingOrganization = await harness.Admin.CreateOrganizationAsync(
+            new SqlOSCreateOrganizationRequest($"OTP Existing {Guid.NewGuid():N}", null));
+        var email = $"otp-attacker-{Guid.NewGuid():N}@example.com";
+
+        var act = async () => await harness.Auth.RequestEmailOtpSignupAsync(
+            new SqlOSEmailOtpSignupStartRequest(
+                "OTP Mallory",
+                email,
+                "test-client",
+                OrganizationName: null,
+                OrganizationId: existingOrganization.Id,
+                CustomFields: null),
+            new DefaultHttpContext());
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage(UnauthorizedOrganizationJoinMessage);
+
+        harness.EmailSender.Messages.Should().BeEmpty();
+        (await harness.Context.Set<SqlOSEmailOtpChallenge>().CountAsync(x => x.Email == email)).Should().Be(0);
+        (await harness.Context.Set<SqlOSUserEmail>()
+            .CountAsync(x => x.NormalizedEmail == SqlOSAdminService.NormalizeEmail(email))).Should().Be(0);
+        (await harness.Context.Set<SqlOSMembership>()
+            .CountAsync(x => x.OrganizationId == existingOrganization.Id)).Should().Be(0);
     }
 
     [TestMethod]

--- a/web/content/docs/authserver/invitations.mdx
+++ b/web/content/docs/authserver/invitations.mdx
@@ -7,6 +7,8 @@ section: authserver
 
 Email invitations are organization membership invites. An invite is bound to one email address, one organization, and one role. It can be accepted once before it expires.
 
+Public signup requests cannot join an existing organization by sending an `organizationId`. Invitations are the built-in explicit join path for email-bound membership, and acceptance is where the membership is created.
+
 ## What an invite does
 
 When a user accepts an invite, SqlOS:

--- a/web/content/docs/authserver/organizations.mdx
+++ b/web/content/docs/authserver/organizations.mdx
@@ -44,7 +44,7 @@ When you set a primary domain, AuthServer uses it for [home realm discovery](/do
 
 ## Create a membership
 
-Users join organizations through memberships. Each membership has a role.
+Users join organizations through memberships. Each membership has a role. Public signup does not accept an `organizationId` as permission to join an existing organization; use an invitation, trusted SSO/SCIM provisioning, or an admin-owned workflow to create memberships for existing tenants.
 
 ```csharp
 var membership = await adminService.CreateMembershipAsync(new CreateMembershipRequest


### PR DESCRIPTION
## Summary
- reject caller-supplied organization IDs in public password and email OTP signup paths before creating users, signup tokens, sessions, or memberships
- stop hosted/headless signup redirects from falling back to authorizationRequest organization IDs without an invitation-backed join
- document invitations/admin provisioning as the safe existing-organization join paths

## Tests
- dotnet build SqlOS.sln --no-restore
- dotnet test tests/SqlOS.Tests/SqlOS.Tests.csproj --no-build
- dotnet test tests/SqlOS.IntegrationTests/SqlOS.IntegrationTests.csproj --no-build --filter "HeadlessSignup_WithAuthorizationRequestOrganizationId_WithoutPolicy_DoesNotCreateMembership"
- dotnet test examples/SqlOS.Example.IntegrationTests/SqlOS.Example.IntegrationTests.csproj --no-build --filter "PasswordSignupEndpoint_WithExistingOrganizationId_ReturnsFailureAndNoMembership"

Fixes #25