### PR TITLE
chore(web): bump @emcy/docs to ^0.2.1

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,7 +8,7 @@
       "name": "web",
       "version": "0.1.0",
       "dependencies": {
-        "@emcy/docs": "^0.1.0",
+        "@emcy/docs": "^0.2.1",
         "@mdx-js/loader": "^3.1.1",
         "@mdx-js/react": "^3.1.1",
         "@next/mdx": "^16.1.6",
@@ -357,9 +357,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@emcy/docs": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@emcy/docs/-/docs-0.1.0.tgz",
-      "integrity": "sha512-03RhI9GYJRpFtfLpJmN0GUH9yStwfoeWEUq8fVPKLbbTkFZFLZqWGwC532P/YQtK7FzjUsqp3m9Djn4NAd1iow==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@emcy/docs/-/docs-0.2.1.tgz",
+      "integrity": "sha512-fnXNK/i5J4TsP4sRpNFE8e7hhzJiFEncRW6ruQ7gOwKbncD1bAN/sonF6Fi+eYQGpAeWAzKbwajr7ru/rh4Y6Q==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-accordion": "^1.2.12",

--- a/web/package.json
+++ b/web/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@emcy/docs": "^0.1.0",
+    "@emcy/docs": "^0.2.1",
     "@mdx-js/loader": "^3.1.1",
     "@mdx-js/react": "^3.1.1",
     "@next/mdx": "^16.1.6",


### PR DESCRIPTION
## Summary
- Bumps the `@emcy/docs` dependency in the web app from `^0.1.0` to `^0.2.1`.
- Refreshes `package-lock.json` via `npm install` so installs stay reproducible.

## Test plan
- [ ] `npm ci` in `web/` succeeds on CI.
- [ ] Web app builds and docs-related routes still render as expected locally if you use them.

Made with [Cursor](https://cursor.com)