### PR TITLE
Add password-login throttling and audit

### DIFF
--- a/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerModelConfiguration.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerModelConfiguration.cs
@@ -52,6 +52,30 @@ public static class SqlOSAuthServerModelConfiguration
                 .OnDelete(DeleteBehavior.Restrict);
         });
 
+        modelBuilder.Entity<SqlOSPasswordLoginBucket>(entity =>
+        {
+            entity.ToTable("SqlOSPasswordLoginBuckets", schema, t => t.ExcludeFromMigrations());
+            entity.HasKey(x => x.Id);
+            entity.HasIndex(x => new { x.Scope, x.BucketKey }).IsUnique();
+            entity.HasIndex(x => new { x.NormalizedEmail, x.UpdatedAt });
+            entity.HasIndex(x => new { x.UserId, x.UpdatedAt });
+            entity.HasIndex(x => new { x.IpAddress, x.UpdatedAt });
+            entity.HasIndex(x => new { x.ClientKey, x.UpdatedAt });
+            entity.HasIndex(x => x.LockedUntil);
+            entity.Property(x => x.Scope).HasMaxLength(40);
+            entity.Property(x => x.BucketKey).HasMaxLength(512);
+            entity.Property(x => x.NormalizedEmail).HasMaxLength(320);
+            entity.Property(x => x.UserId).HasMaxLength(64);
+            entity.Property(x => x.ClientKey).HasMaxLength(850);
+            entity.Property(x => x.IpAddress).HasMaxLength(128);
+            entity.Property(x => x.UserAgentHash).HasMaxLength(128);
+            entity.Property(x => x.LockoutReason).HasMaxLength(120);
+            entity.HasOne(x => x.User)
+                .WithMany()
+                .HasForeignKey(x => x.UserId)
+                .OnDelete(DeleteBehavior.Restrict);
+        });
+
         modelBuilder.Entity<SqlOSMembership>(entity =>
         {
             entity.ToTable("SqlOSMemberships", schema, t => t.ExcludeFromMigrations());

--- a/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerOptions.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerOptions.cs
@@ -35,6 +35,7 @@ public class SqlOSAuthServerOptions
     public int DefaultSigningKeyGraceWindowDays { get; set; } = 7;
     public int DefaultSigningKeyRetiredCleanupDays { get; set; } = 30;
     public SqlOSEmailOtpOptions EmailOtp { get; } = new();
+    public SqlOSPasswordLoginAbuseOptions PasswordLogin { get; } = new();
     public SqlOSInvitationOptions Invitations { get; } = new();
     public SqlOSDeviceAuthorizationOptions DeviceAuthorization { get; } = new();
     public SqlOSClientRegistrationOptions ClientRegistration { get; } = new();
@@ -90,6 +91,12 @@ public class SqlOSAuthServerOptions
     public SqlOSAuthServerOptions ConfigureEmailOtp(Action<SqlOSEmailOtpOptions> configure)
     {
         configure(EmailOtp);
+        return this;
+    }
+
+    public SqlOSAuthServerOptions ConfigurePasswordLoginAbuse(Action<SqlOSPasswordLoginAbuseOptions> configure)
+    {
+        configure(PasswordLogin);
         return this;
     }
 
@@ -189,4 +196,15 @@ public class SqlOSAuthServerOptions
         configure?.Invoke(ClientRegistration.Dcr);
         return this;
     }
+}
+
+public sealed class SqlOSPasswordLoginAbuseOptions
+{
+    public bool Enabled { get; set; } = true;
+    public int MaxFailedAttemptsPerAccount { get; set; } = 5;
+    public int MaxFailedAttemptsPerIp { get; set; } = 20;
+    public int MaxFailedAttemptsPerClient { get; set; } = 50;
+    public int MaxFailedAttemptsPerDevice { get; set; } = 20;
+    public TimeSpan FailureWindow { get; set; } = TimeSpan.FromMinutes(15);
+    public TimeSpan LockoutDuration { get; set; } = TimeSpan.FromMinutes(15);
 }

--- a/src/SqlOS/AuthServer/Extensions/EndpointRouteBuilderExtensions.cs
+++ b/src/SqlOS/AuthServer/Extensions/EndpointRouteBuilderExtensions.cs
@@ -723,7 +723,11 @@ public static class EndpointRouteBuilderExtensions
                     email,
                     password,
                     cancellationToken,
-                    allowUnverifiedEmailForInvitation: invitation != null);
+                    allowUnverifiedEmailForInvitation: invitation != null,
+                    httpContext: context,
+                    clientKey: authorizationRequest?.ClientApplication?.ClientId ?? authorizationRequest?.ClientApplicationId,
+                    authorizationRequestId: authorizationRequest?.Id,
+                    surface: authorizationRequest == null ? "hosted_standalone" : "hosted");
                 if (authorizationRequest == null)
                 {
                     var organizationId = authentication.Organizations.FirstOrDefault()?.Id;

--- a/src/SqlOS/AuthServer/Models/SqlOSEntities.cs
+++ b/src/SqlOS/AuthServer/Models/SqlOSEntities.cs
@@ -59,6 +59,28 @@ public sealed class SqlOSCredential
     public SqlOSUser? User { get; set; }
 }
 
+public sealed class SqlOSPasswordLoginBucket
+{
+    public string Id { get; set; } = string.Empty;
+    public string Scope { get; set; } = string.Empty;
+    public string BucketKey { get; set; } = string.Empty;
+    public string? NormalizedEmail { get; set; }
+    public string? UserId { get; set; }
+    public string? ClientKey { get; set; }
+    public string? IpAddress { get; set; }
+    public string? UserAgentHash { get; set; }
+    public int FailureCount { get; set; }
+    public DateTime? WindowStartedAt { get; set; }
+    public DateTime? LastFailureAt { get; set; }
+    public DateTime? LastSuccessAt { get; set; }
+    public DateTime? LockedUntil { get; set; }
+    public string? LockoutReason { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+
+    public SqlOSUser? User { get; set; }
+}
+
 public sealed class SqlOSMembership
 {
     public string OrganizationId { get; set; } = string.Empty;

--- a/src/SqlOS/AuthServer/Schema/017_PasswordLoginAbuse.sql
+++ b/src/SqlOS/AuthServer/Schema/017_PasswordLoginAbuse.sql
@@ -1,0 +1,48 @@
+IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'SqlOSPasswordLoginBuckets' AND schema_id = SCHEMA_ID('{Schema}'))
+BEGIN
+    CREATE TABLE [{Schema}].[SqlOSPasswordLoginBuckets] (
+        [Id] NVARCHAR(64) NOT NULL PRIMARY KEY,
+        [Scope] NVARCHAR(40) NOT NULL,
+        [BucketKey] NVARCHAR(512) NOT NULL,
+        [NormalizedEmail] NVARCHAR(320) NULL,
+        [UserId] NVARCHAR(64) NULL,
+        [ClientKey] NVARCHAR(850) NULL,
+        [IpAddress] NVARCHAR(128) NULL,
+        [UserAgentHash] NVARCHAR(128) NULL,
+        [FailureCount] INT NOT NULL CONSTRAINT [DF_SqlOSPasswordLoginBuckets_FailureCount] DEFAULT 0,
+        [WindowStartedAt] DATETIME2 NULL,
+        [LastFailureAt] DATETIME2 NULL,
+        [LastSuccessAt] DATETIME2 NULL,
+        [LockedUntil] DATETIME2 NULL,
+        [LockoutReason] NVARCHAR(120) NULL,
+        [CreatedAt] DATETIME2 NOT NULL,
+        [UpdatedAt] DATETIME2 NOT NULL
+    );
+
+    CREATE UNIQUE INDEX [IX_SqlOSPasswordLoginBuckets_Scope_BucketKey]
+        ON [{Schema}].[SqlOSPasswordLoginBuckets]([Scope], [BucketKey]);
+
+    CREATE INDEX [IX_SqlOSPasswordLoginBuckets_NormalizedEmail_UpdatedAt]
+        ON [{Schema}].[SqlOSPasswordLoginBuckets]([NormalizedEmail], [UpdatedAt]);
+
+    CREATE INDEX [IX_SqlOSPasswordLoginBuckets_UserId_UpdatedAt]
+        ON [{Schema}].[SqlOSPasswordLoginBuckets]([UserId], [UpdatedAt]);
+
+    CREATE INDEX [IX_SqlOSPasswordLoginBuckets_IpAddress_UpdatedAt]
+        ON [{Schema}].[SqlOSPasswordLoginBuckets]([IpAddress], [UpdatedAt]);
+
+    CREATE INDEX [IX_SqlOSPasswordLoginBuckets_ClientKey_UpdatedAt]
+        ON [{Schema}].[SqlOSPasswordLoginBuckets]([ClientKey], [UpdatedAt]);
+
+    CREATE INDEX [IX_SqlOSPasswordLoginBuckets_LockedUntil]
+        ON [{Schema}].[SqlOSPasswordLoginBuckets]([LockedUntil]);
+
+    ALTER TABLE [{Schema}].[SqlOSPasswordLoginBuckets]
+        ADD CONSTRAINT [FK_SqlOSPasswordLoginBuckets_Users_UserId]
+            FOREIGN KEY ([UserId]) REFERENCES [{Schema}].[SqlOSUsers]([Id]);
+END
+
+GO
+
+DELETE FROM [{Schema}].[SqlOSSchema];
+INSERT INTO [{Schema}].[SqlOSSchema] ([Version]) VALUES (17);

--- a/src/SqlOS/AuthServer/Services/SqlOSAuthService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSAuthService.cs
@@ -21,6 +21,7 @@ public sealed class SqlOSAuthService
     private readonly SqlOSSettingsService _settingsService;
     private readonly SqlOSEmailOtpService _emailOtpService;
     private readonly SqlOSInvitationService? _invitationService;
+    private readonly SqlOSPasswordLoginAbuseService _passwordLoginAbuseService;
 
     public SqlOSAuthService(
         ISqlOSAuthServerDbContext context,
@@ -29,7 +30,8 @@ public sealed class SqlOSAuthService
         SqlOSCryptoService cryptoService,
         SqlOSSettingsService settingsService,
         SqlOSEmailOtpService emailOtpService,
-        SqlOSInvitationService? invitationService = null)
+        SqlOSInvitationService? invitationService = null,
+        SqlOSPasswordLoginAbuseService? passwordLoginAbuseService = null)
     {
         _context = context;
         _options = options.Value;
@@ -38,6 +40,8 @@ public sealed class SqlOSAuthService
         _settingsService = settingsService;
         _emailOtpService = emailOtpService;
         _invitationService = invitationService;
+        _passwordLoginAbuseService = passwordLoginAbuseService
+            ?? new SqlOSPasswordLoginAbuseService(context, adminService, cryptoService, options);
     }
 
     public async Task<SqlOSLoginResult> SignUpAsync(SqlOSSignupRequest request, HttpContext httpContext, CancellationToken cancellationToken = default)
@@ -76,9 +80,23 @@ public sealed class SqlOSAuthService
         }
 
         var normalizedEmail = SqlOSAdminService.NormalizeEmail(request.Email);
+        var attempt = _passwordLoginAbuseService.CreateAttempt(
+            normalizedEmail,
+            httpContext,
+            clientKey: request.ClientId,
+            surface: "api");
+        await _passwordLoginAbuseService.EnsureAllowedAsync(attempt, cancellationToken);
+
         var email = await _context.Set<SqlOSUserEmail>()
-            .FirstOrDefaultAsync(x => x.NormalizedEmail == normalizedEmail, cancellationToken)
-            ?? throw new InvalidOperationException("Invalid email or password.");
+            .FirstOrDefaultAsync(x => x.NormalizedEmail == normalizedEmail, cancellationToken);
+        if (email == null)
+        {
+            await _passwordLoginAbuseService.RecordFailureAsync(attempt, "unknown_email", cancellationToken);
+            throw new InvalidOperationException(SqlOSPasswordLoginAbuseService.PublicFailureMessage);
+        }
+
+        attempt = attempt with { UserId = email.UserId };
+        await _passwordLoginAbuseService.EnsureAllowedAsync(attempt, cancellationToken);
 
         if (_options.RequireVerifiedEmailForPasswordLogin && !email.IsVerified)
         {
@@ -86,18 +104,24 @@ public sealed class SqlOSAuthService
         }
 
         var credential = await _context.Set<SqlOSCredential>()
-            .FirstOrDefaultAsync(x => x.UserId == email.UserId && x.Type == "password" && x.RevokedAt == null, cancellationToken)
-            ?? throw new InvalidOperationException("Invalid email or password.");
+            .FirstOrDefaultAsync(x => x.UserId == email.UserId && x.Type == "password" && x.RevokedAt == null, cancellationToken);
+        if (credential == null)
+        {
+            await _passwordLoginAbuseService.RecordFailureAsync(attempt, "missing_password_credential", cancellationToken);
+            throw new InvalidOperationException(SqlOSPasswordLoginAbuseService.PublicFailureMessage);
+        }
 
         if (!_cryptoService.VerifyPassword(credential.SecretHash, request.Password))
         {
-            throw new InvalidOperationException("Invalid email or password.");
+            await _passwordLoginAbuseService.RecordFailureAsync(attempt, "invalid_password", cancellationToken);
+            throw new InvalidOperationException(SqlOSPasswordLoginAbuseService.PublicFailureMessage);
         }
 
         credential.LastUsedAt = DateTime.UtcNow;
 
         var user = await _context.Set<SqlOSUser>().FirstAsync(x => x.Id == email.UserId, cancellationToken);
         var client = await _adminService.RequireClientAsync(request.ClientId, null, cancellationToken);
+        await _passwordLoginAbuseService.RecordSuccessAsync(attempt, cancellationToken);
         await _context.SaveChangesAsync(cancellationToken);
         return await FinalizeClientLoginAsync(user, client, request.OrganizationId, "password", httpContext, cancellationToken);
     }

--- a/src/SqlOS/AuthServer/Services/SqlOSAuthorizationServerService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSAuthorizationServerService.cs
@@ -21,6 +21,7 @@ public sealed class SqlOSAuthorizationServerService
     private readonly SqlOSAuthPageSessionService _authPageSessionService;
     private readonly SqlOSAuthServerOptions _options;
     private readonly SqlOSInvitationService? _invitationService;
+    private readonly SqlOSPasswordLoginAbuseService _passwordLoginAbuseService;
 
     public SqlOSAuthorizationServerService(
         ISqlOSAuthServerDbContext context,
@@ -30,7 +31,8 @@ public sealed class SqlOSAuthorizationServerService
         SqlOSSettingsService settingsService,
         SqlOSAuthPageSessionService authPageSessionService,
         IOptions<SqlOSAuthServerOptions> options,
-        SqlOSInvitationService? invitationService = null)
+        SqlOSInvitationService? invitationService = null,
+        SqlOSPasswordLoginAbuseService? passwordLoginAbuseService = null)
     {
         _context = context;
         _adminService = adminService;
@@ -40,6 +42,8 @@ public sealed class SqlOSAuthorizationServerService
         _authPageSessionService = authPageSessionService;
         _options = options.Value;
         _invitationService = invitationService;
+        _passwordLoginAbuseService = passwordLoginAbuseService
+            ?? new SqlOSPasswordLoginAbuseService(context, adminService, cryptoService, options);
     }
 
     public async Task<SqlOSAuthorizationServerMetadataDto> GetMetadataAsync(HttpContext httpContext, CancellationToken cancellationToken = default)
@@ -207,7 +211,11 @@ public sealed class SqlOSAuthorizationServerService
         string email,
         string password,
         CancellationToken cancellationToken = default,
-        bool allowUnverifiedEmailForInvitation = false)
+        bool allowUnverifiedEmailForInvitation = false,
+        HttpContext? httpContext = null,
+        string? clientKey = null,
+        string? authorizationRequestId = null,
+        string? surface = null)
     {
         var credentialSettings = await _settingsService.GetResolvedCredentialSettingsAsync(cancellationToken);
         if (!credentialSettings.PasswordEnabled)
@@ -216,9 +224,24 @@ public sealed class SqlOSAuthorizationServerService
         }
 
         var normalizedEmail = SqlOSAdminService.NormalizeEmail(email);
+        var attempt = _passwordLoginAbuseService.CreateAttempt(
+            normalizedEmail,
+            httpContext,
+            clientKey,
+            authorizationRequestId,
+            surface ?? "authorization");
+        await _passwordLoginAbuseService.EnsureAllowedAsync(attempt, cancellationToken);
+
         var emailRecord = await _context.Set<SqlOSUserEmail>()
-            .FirstOrDefaultAsync(x => x.NormalizedEmail == normalizedEmail, cancellationToken)
-            ?? throw new InvalidOperationException("Invalid email or password.");
+            .FirstOrDefaultAsync(x => x.NormalizedEmail == normalizedEmail, cancellationToken);
+        if (emailRecord == null)
+        {
+            await _passwordLoginAbuseService.RecordFailureAsync(attempt, "unknown_email", cancellationToken);
+            throw new InvalidOperationException(SqlOSPasswordLoginAbuseService.PublicFailureMessage);
+        }
+
+        attempt = attempt with { UserId = emailRecord.UserId };
+        await _passwordLoginAbuseService.EnsureAllowedAsync(attempt, cancellationToken);
 
         if (_options.RequireVerifiedEmailForPasswordLogin && !emailRecord.IsVerified && !allowUnverifiedEmailForInvitation)
         {
@@ -226,15 +249,21 @@ public sealed class SqlOSAuthorizationServerService
         }
 
         var credential = await _context.Set<SqlOSCredential>()
-            .FirstOrDefaultAsync(x => x.UserId == emailRecord.UserId && x.Type == "password" && x.RevokedAt == null, cancellationToken)
-            ?? throw new InvalidOperationException("Invalid email or password.");
+            .FirstOrDefaultAsync(x => x.UserId == emailRecord.UserId && x.Type == "password" && x.RevokedAt == null, cancellationToken);
+        if (credential == null)
+        {
+            await _passwordLoginAbuseService.RecordFailureAsync(attempt, "missing_password_credential", cancellationToken);
+            throw new InvalidOperationException(SqlOSPasswordLoginAbuseService.PublicFailureMessage);
+        }
 
         if (!_cryptoService.VerifyPassword(credential.SecretHash, password))
         {
-            throw new InvalidOperationException("Invalid email or password.");
+            await _passwordLoginAbuseService.RecordFailureAsync(attempt, "invalid_password", cancellationToken);
+            throw new InvalidOperationException(SqlOSPasswordLoginAbuseService.PublicFailureMessage);
         }
 
         credential.LastUsedAt = DateTime.UtcNow;
+        await _passwordLoginAbuseService.RecordSuccessAsync(attempt, cancellationToken);
         await _context.SaveChangesAsync(cancellationToken);
 
         var user = await _context.Set<SqlOSUser>().FirstAsync(x => x.Id == emailRecord.UserId, cancellationToken);

--- a/src/SqlOS/AuthServer/Services/SqlOSHeadlessAuthService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSHeadlessAuthService.cs
@@ -410,7 +410,11 @@ public sealed class SqlOSHeadlessAuthService
                 email,
                 request.Password,
                 cancellationToken,
-                allowUnverifiedEmailForInvitation: !string.IsNullOrWhiteSpace(authorizationRequest.InvitationId));
+                allowUnverifiedEmailForInvitation: !string.IsNullOrWhiteSpace(authorizationRequest.InvitationId),
+                httpContext: httpContext,
+                clientKey: authorizationRequest.ClientApplication?.ClientId ?? authorizationRequest.ClientApplicationId,
+                authorizationRequestId: authorizationRequest.Id,
+                surface: "headless");
             var completion = await _authorizationServerService.CompleteAuthorizationRequestLoginAsync(
                 authorizationRequest,
                 authentication.User,

--- a/src/SqlOS/AuthServer/Services/SqlOSPasswordLoginAbuseService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSPasswordLoginAbuseService.cs
@@ -1,0 +1,371 @@
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using SqlOS.AuthServer.Configuration;
+using SqlOS.AuthServer.Interfaces;
+using SqlOS.AuthServer.Models;
+
+namespace SqlOS.AuthServer.Services;
+
+public sealed class SqlOSPasswordLoginAbuseService
+{
+    public const string PublicFailureMessage = "Invalid email or password.";
+
+    private readonly ISqlOSAuthServerDbContext _context;
+    private readonly SqlOSAdminService _adminService;
+    private readonly SqlOSCryptoService _cryptoService;
+    private readonly SqlOSPasswordLoginAbuseOptions _options;
+
+    public SqlOSPasswordLoginAbuseService(
+        ISqlOSAuthServerDbContext context,
+        SqlOSAdminService adminService,
+        SqlOSCryptoService cryptoService,
+        IOptions<SqlOSAuthServerOptions> options)
+    {
+        _context = context;
+        _adminService = adminService;
+        _cryptoService = cryptoService;
+        _options = options.Value.PasswordLogin;
+    }
+
+    public SqlOSPasswordLoginAttempt CreateAttempt(
+        string normalizedEmail,
+        HttpContext? httpContext,
+        string? clientKey = null,
+        string? authorizationRequestId = null,
+        string? surface = null,
+        string? userId = null)
+    {
+        var userAgent = httpContext?.Request.Headers.UserAgent.ToString();
+        return new SqlOSPasswordLoginAttempt(
+            normalizedEmail,
+            userId,
+            NormalizeClientKey(clientKey),
+            authorizationRequestId,
+            string.IsNullOrWhiteSpace(surface) ? "unknown" : surface.Trim(),
+            NormalizeIpAddress(httpContext),
+            HashUserAgent(userAgent));
+    }
+
+    public async Task EnsureAllowedAsync(SqlOSPasswordLoginAttempt attempt, CancellationToken cancellationToken = default)
+    {
+        if (!_options.Enabled)
+        {
+            return;
+        }
+
+        var now = DateTime.UtcNow;
+        foreach (var identity in GetBucketIdentities(attempt, includeUserBucket: true))
+        {
+            var bucket = await FindBucketAsync(identity, cancellationToken);
+            if (bucket == null)
+            {
+                continue;
+            }
+
+            if (ResetExpired(bucket, now))
+            {
+                await _context.SaveChangesAsync(cancellationToken);
+            }
+
+            if (bucket.LockedUntil is { } lockedUntil && lockedUntil > now)
+            {
+                await RecordPasswordAuditAsync(
+                    "password.login.rate_limit_rejected",
+                    attempt,
+                    data: new
+                    {
+                        scope = bucket.Scope,
+                        retryAfter = lockedUntil,
+                        failureCount = bucket.FailureCount,
+                        reason = bucket.LockoutReason ?? "active_lockout"
+                    },
+                    cancellationToken);
+                throw new InvalidOperationException(PublicFailureMessage);
+            }
+        }
+    }
+
+    public async Task RecordFailureAsync(
+        SqlOSPasswordLoginAttempt attempt,
+        string failureReason,
+        CancellationToken cancellationToken = default)
+    {
+        if (!_options.Enabled)
+        {
+            await RecordPasswordAuditAsync(
+                "password.login.failed",
+                attempt,
+                data: new { failureReason },
+                cancellationToken);
+            return;
+        }
+
+        var now = DateTime.UtcNow;
+        var newlyLocked = new List<SqlOSPasswordLoginBucket>();
+
+        foreach (var identity in GetBucketIdentities(attempt, includeUserBucket: true))
+        {
+            var bucket = await GetOrCreateBucketAsync(identity, attempt, now, cancellationToken);
+            ResetExpired(bucket, now);
+
+            bucket.FailureCount++;
+            bucket.WindowStartedAt ??= now;
+            bucket.LastFailureAt = now;
+            bucket.UpdatedAt = now;
+            bucket.NormalizedEmail ??= attempt.NormalizedEmail;
+            bucket.UserId ??= attempt.UserId;
+            bucket.ClientKey ??= attempt.ClientKey;
+            bucket.IpAddress ??= attempt.IpAddress;
+            bucket.UserAgentHash ??= attempt.UserAgentHash;
+
+            if (bucket.FailureCount >= identity.Threshold && bucket.LockedUntil == null)
+            {
+                bucket.LockedUntil = now.Add(_options.LockoutDuration);
+                bucket.LockoutReason = "failed_attempt_threshold";
+                newlyLocked.Add(bucket);
+            }
+        }
+
+        await RecordPasswordAuditAsync(
+            "password.login.failed",
+            attempt,
+            data: new
+            {
+                failureReason,
+                lockedScopes = newlyLocked.Select(static x => x.Scope).ToArray()
+            },
+            cancellationToken);
+
+        foreach (var bucket in newlyLocked.Where(static x => x.Scope is "email" or "user"))
+        {
+            await RecordPasswordAuditAsync(
+                "password.login.locked",
+                attempt,
+                data: new
+                {
+                    scope = bucket.Scope,
+                    retryAfter = bucket.LockedUntil,
+                    failureCount = bucket.FailureCount
+                },
+                cancellationToken);
+        }
+
+        foreach (var bucket in newlyLocked.Where(static x => x.Scope is "ip" or "client" or "device"))
+        {
+            await RecordPasswordAuditAsync(
+                "password.login.suspicious_pattern",
+                attempt,
+                data: new
+                {
+                    scope = bucket.Scope,
+                    retryAfter = bucket.LockedUntil,
+                    failureCount = bucket.FailureCount
+                },
+                cancellationToken);
+        }
+    }
+
+    public async Task RecordSuccessAsync(SqlOSPasswordLoginAttempt attempt, CancellationToken cancellationToken = default)
+    {
+        if (_options.Enabled)
+        {
+            var now = DateTime.UtcNow;
+            foreach (var identity in GetAccountBucketIdentities(attempt))
+            {
+                var bucket = await FindBucketAsync(identity, cancellationToken);
+                if (bucket == null)
+                {
+                    continue;
+                }
+
+                bucket.FailureCount = 0;
+                bucket.WindowStartedAt = null;
+                bucket.LockedUntil = null;
+                bucket.LockoutReason = null;
+                bucket.LastSuccessAt = now;
+                bucket.UpdatedAt = now;
+            }
+        }
+
+        await RecordPasswordAuditAsync(
+            "password.login.succeeded",
+            attempt,
+            data: new { resetScopes = GetAccountBucketIdentities(attempt).Select(static x => x.Scope).ToArray() },
+            cancellationToken);
+    }
+
+    private async Task<SqlOSPasswordLoginBucket?> FindBucketAsync(
+        PasswordBucketIdentity identity,
+        CancellationToken cancellationToken)
+        => await _context.Set<SqlOSPasswordLoginBucket>()
+            .FirstOrDefaultAsync(
+                x => x.Scope == identity.Scope && x.BucketKey == identity.Key,
+                cancellationToken);
+
+    private async Task<SqlOSPasswordLoginBucket> GetOrCreateBucketAsync(
+        PasswordBucketIdentity identity,
+        SqlOSPasswordLoginAttempt attempt,
+        DateTime now,
+        CancellationToken cancellationToken)
+    {
+        var bucket = await FindBucketAsync(identity, cancellationToken);
+        if (bucket != null)
+        {
+            return bucket;
+        }
+
+        bucket = new SqlOSPasswordLoginBucket
+        {
+            Id = _cryptoService.GenerateId("plb"),
+            Scope = identity.Scope,
+            BucketKey = identity.Key,
+            NormalizedEmail = attempt.NormalizedEmail,
+            UserId = attempt.UserId,
+            ClientKey = attempt.ClientKey,
+            IpAddress = attempt.IpAddress,
+            UserAgentHash = attempt.UserAgentHash,
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+        _context.Set<SqlOSPasswordLoginBucket>().Add(bucket);
+        return bucket;
+    }
+
+    private IEnumerable<PasswordBucketIdentity> GetBucketIdentities(
+        SqlOSPasswordLoginAttempt attempt,
+        bool includeUserBucket)
+    {
+        foreach (var identity in GetAccountBucketIdentities(attempt, includeUserBucket))
+        {
+            yield return identity;
+        }
+
+        if (!string.IsNullOrWhiteSpace(attempt.IpAddress) && _options.MaxFailedAttemptsPerIp > 0)
+        {
+            yield return new PasswordBucketIdentity("ip", attempt.IpAddress, _options.MaxFailedAttemptsPerIp);
+        }
+
+        if (!string.IsNullOrWhiteSpace(attempt.ClientKey) && _options.MaxFailedAttemptsPerClient > 0)
+        {
+            yield return new PasswordBucketIdentity("client", attempt.ClientKey, _options.MaxFailedAttemptsPerClient);
+        }
+
+        if (!string.IsNullOrWhiteSpace(attempt.UserAgentHash) && _options.MaxFailedAttemptsPerDevice > 0)
+        {
+            yield return new PasswordBucketIdentity("device", attempt.UserAgentHash, _options.MaxFailedAttemptsPerDevice);
+        }
+    }
+
+    private IEnumerable<PasswordBucketIdentity> GetAccountBucketIdentities(
+        SqlOSPasswordLoginAttempt attempt,
+        bool includeUserBucket = true)
+    {
+        if (!string.IsNullOrWhiteSpace(attempt.NormalizedEmail) && _options.MaxFailedAttemptsPerAccount > 0)
+        {
+            yield return new PasswordBucketIdentity("email", attempt.NormalizedEmail, _options.MaxFailedAttemptsPerAccount);
+        }
+
+        if (includeUserBucket && !string.IsNullOrWhiteSpace(attempt.UserId) && _options.MaxFailedAttemptsPerAccount > 0)
+        {
+            yield return new PasswordBucketIdentity("user", attempt.UserId, _options.MaxFailedAttemptsPerAccount);
+        }
+    }
+
+    private bool ResetExpired(SqlOSPasswordLoginBucket bucket, DateTime now)
+    {
+        if (bucket.LockedUntil is { } lockedUntil)
+        {
+            if (lockedUntil > now)
+            {
+                return false;
+            }
+
+            ResetBucket(bucket, now);
+            return true;
+        }
+
+        if (bucket.WindowStartedAt is { } windowStartedAt && now - windowStartedAt >= _options.FailureWindow)
+        {
+            ResetBucket(bucket, now);
+            return true;
+        }
+
+        return false;
+    }
+
+    private static void ResetBucket(SqlOSPasswordLoginBucket bucket, DateTime now)
+    {
+        bucket.FailureCount = 0;
+        bucket.WindowStartedAt = null;
+        bucket.LockedUntil = null;
+        bucket.LockoutReason = null;
+        bucket.UpdatedAt = now;
+    }
+
+    private async Task RecordPasswordAuditAsync(
+        string eventType,
+        SqlOSPasswordLoginAttempt attempt,
+        object? data,
+        CancellationToken cancellationToken)
+        => await _adminService.RecordAuditAsync(
+            eventType,
+            eventType == "password.login.succeeded" && attempt.UserId != null ? "user" : "system",
+            eventType == "password.login.succeeded" ? attempt.UserId : null,
+            userId: attempt.UserId,
+            ipAddress: attempt.IpAddress,
+            data: new
+            {
+                attempt.NormalizedEmail,
+                maskedEmail = MaskEmail(attempt.NormalizedEmail),
+                attempt.ClientKey,
+                attempt.AuthorizationRequestId,
+                attempt.Surface,
+                attempt.UserAgentHash,
+                details = data
+            },
+            cancellationToken: cancellationToken);
+
+    private static string? NormalizeIpAddress(HttpContext? httpContext)
+        => httpContext?.Connection.RemoteIpAddress?.ToString();
+
+    private static string? NormalizeClientKey(string? clientKey)
+        => string.IsNullOrWhiteSpace(clientKey) ? null : clientKey.Trim();
+
+    private static string? HashUserAgent(string? userAgent)
+    {
+        if (string.IsNullOrWhiteSpace(userAgent))
+        {
+            return null;
+        }
+
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(userAgent.Trim())));
+    }
+
+    private static string MaskEmail(string normalizedEmail)
+    {
+        var atIndex = normalizedEmail.IndexOf('@');
+        if (atIndex <= 1 || atIndex == normalizedEmail.Length - 1)
+        {
+            return normalizedEmail;
+        }
+
+        var local = normalizedEmail[..atIndex];
+        var domain = normalizedEmail[(atIndex + 1)..];
+        var visibleCount = Math.Min(2, local.Length);
+        return $"{local[..visibleCount]}***@{domain}";
+    }
+
+    private sealed record PasswordBucketIdentity(string Scope, string Key, int Threshold);
+}
+
+public sealed record SqlOSPasswordLoginAttempt(
+    string NormalizedEmail,
+    string? UserId,
+    string? ClientKey,
+    string? AuthorizationRequestId,
+    string Surface,
+    string? IpAddress,
+    string? UserAgentHash);

--- a/src/SqlOS/Configuration/SqlOSOptionsValidator.cs
+++ b/src/SqlOS/Configuration/SqlOSOptionsValidator.cs
@@ -72,6 +72,7 @@ internal static class SqlOSOptionsValidator
 
         ValidateHeadlessOptions(options.AuthServer.Headless, errors);
         ValidateEmailOtpOptions(options.AuthServer.EmailOtp, errors);
+        ValidatePasswordLoginAbuseOptions(options.AuthServer.PasswordLogin, errors);
         ValidateClientRegistrationOptions(options.AuthServer, errors);
 
         if (errors.Count > 0)
@@ -123,6 +124,44 @@ internal static class SqlOSOptionsValidator
         if (options.OnHeadlessSignupAsync != null && !options.EnableApi)
         {
             errors.Add("AuthServer.Headless.OnHeadlessSignupAsync requires AuthServer.Headless.EnableApi.");
+        }
+    }
+
+    private static void ValidatePasswordLoginAbuseOptions(SqlOSPasswordLoginAbuseOptions options, List<string> errors)
+    {
+        if (!options.Enabled)
+        {
+            return;
+        }
+
+        if (options.MaxFailedAttemptsPerAccount <= 0)
+        {
+            errors.Add("AuthServer.PasswordLogin.MaxFailedAttemptsPerAccount must be greater than zero.");
+        }
+
+        if (options.MaxFailedAttemptsPerIp <= 0)
+        {
+            errors.Add("AuthServer.PasswordLogin.MaxFailedAttemptsPerIp must be greater than zero.");
+        }
+
+        if (options.MaxFailedAttemptsPerClient <= 0)
+        {
+            errors.Add("AuthServer.PasswordLogin.MaxFailedAttemptsPerClient must be greater than zero.");
+        }
+
+        if (options.MaxFailedAttemptsPerDevice <= 0)
+        {
+            errors.Add("AuthServer.PasswordLogin.MaxFailedAttemptsPerDevice must be greater than zero.");
+        }
+
+        if (options.FailureWindow <= TimeSpan.Zero)
+        {
+            errors.Add("AuthServer.PasswordLogin.FailureWindow must be greater than zero.");
+        }
+
+        if (options.LockoutDuration <= TimeSpan.Zero)
+        {
+            errors.Add("AuthServer.PasswordLogin.LockoutDuration must be greater than zero.");
         }
     }
 

--- a/src/SqlOS/Extensions/ServiceCollectionExtensions.cs
+++ b/src/SqlOS/Extensions/ServiceCollectionExtensions.cs
@@ -48,6 +48,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<SqlOSSettingsService>();
         services.AddSingleton<ISqlOSAuthEmailSender, SqlOSAcsAuthEmailSender>();
         services.AddScoped<SqlOSEmailOtpService>();
+        services.AddScoped<SqlOSPasswordLoginAbuseService>();
         services.AddScoped<SqlOSInvitationService>();
         services.AddScoped<SqlOSDeviceAuthorizationService>();
         services.AddScoped<SqlOSCimdClientService>();

--- a/tests/SqlOS.IntegrationTests/HeadlessAuthIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/HeadlessAuthIntegrationTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
+using System.Net;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
@@ -666,9 +667,56 @@ public sealed class HeadlessAuthIntegrationTests
         await act.Should().NotThrowAsync();
     }
 
+    [TestMethod]
+    public async Task HeadlessPasswordLogin_UsesSameThrottleStateAsApiLogin()
+    {
+        await using var fixture = await CreateFixtureAsync(configureOptions: options =>
+        {
+            options.PasswordLogin.MaxFailedAttemptsPerAccount = 1;
+            options.PasswordLogin.LockoutDuration = TimeSpan.FromMinutes(10);
+        });
+        var user = await fixture.AdminService.CreateUserAsync(new SqlOSCreateUserRequest(
+            "Headless Lockout",
+            $"headless-lockout-{Guid.NewGuid():N}@example.com",
+            "P@ssword123!"));
+
+        var apiFailure = async () => await fixture.AuthService.LoginWithPasswordAsync(
+            new SqlOSPasswordLoginRequest(user.DefaultEmail!, "wrong-password", fixture.ClientId, null),
+            CreateHttpContext("203.0.113.70"));
+        await apiFailure.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage(SqlOSPasswordLoginAbuseService.PublicFailureMessage);
+
+        var authorizationRequest = await fixture.AuthorizationServerService.CreateAuthorizationRequestAsync(
+            new SqlOSAuthorizeRequestInput(
+                "code",
+                fixture.ClientId,
+                fixture.RedirectUri,
+                "headless-lockout",
+                "openid profile email",
+                "challenge-headless-lockout",
+                "S256",
+                null,
+                user.DefaultEmail,
+                null,
+                null,
+                "headless",
+                null));
+
+        var headlessResult = await fixture.HeadlessAuthService.PasswordLoginAsync(
+            CreateHttpContext("203.0.113.70"),
+            new SqlOSHeadlessPasswordLoginRequest(
+                authorizationRequest.Id,
+                user.DefaultEmail!,
+                "P@ssword123!"));
+
+        headlessResult.Type.Should().Be("view");
+        headlessResult.ViewModel!.Error.Should().Be(SqlOSPasswordLoginAbuseService.PublicFailureMessage);
+    }
+
     private static async Task<HeadlessFixture> CreateFixtureAsync(
         Action<SqlOSHeadlessAuthOptions>? configureHeadless = null,
-        bool allowNativeHeadlessAuth = false)
+        bool allowNativeHeadlessAuth = false,
+        Action<SqlOSAuthServerOptions>? configureOptions = null)
     {
         var context = CreateContext();
         var clientId = $"headless-{Guid.NewGuid():N}";
@@ -692,6 +740,7 @@ public sealed class HeadlessAuthIntegrationTests
                 $"https://app.example.test/authorize?request={Uri.EscapeDataString(ctx.RequestId ?? string.Empty)}&view={Uri.EscapeDataString(ctx.View)}";
         });
         configureHeadless?.Invoke(optionsValue.Headless);
+        configureOptions?.Invoke(optionsValue);
 
         var options = Options.Create(optionsValue);
         var crypto = new SqlOSCryptoService(context, options);
@@ -701,7 +750,16 @@ public sealed class HeadlessAuthIntegrationTests
         var authPageSessionService = new SqlOSAuthPageSessionService(context, crypto, settings);
         var emailOtp = new SqlOSEmailOtpService(context, admin, crypto, settings, emailSender, options);
         var invitationService = new SqlOSInvitationService(context, admin, crypto, emailSender, settings, options);
-        var authService = new SqlOSAuthService(context, options, admin, crypto, settings, emailOtp, invitationService);
+        var passwordAbuse = new SqlOSPasswordLoginAbuseService(context, admin, crypto, options);
+        var authService = new SqlOSAuthService(
+            context,
+            options,
+            admin,
+            crypto,
+            settings,
+            emailOtp,
+            invitationService,
+            passwordAbuse);
         var authorizationServerService = new SqlOSAuthorizationServerService(
             context,
             admin,
@@ -710,7 +768,8 @@ public sealed class HeadlessAuthIntegrationTests
             settings,
             authPageSessionService,
             options,
-            invitationService);
+            invitationService,
+            passwordAbuse);
         var discovery = new SqlOSHomeRealmDiscoveryService(context);
         var oidcAuthService = new SqlOSOidcAuthService(
             context,
@@ -743,7 +802,7 @@ public sealed class HeadlessAuthIntegrationTests
         await admin.UpsertSeededClientsAsync();
         await settings.UpsertSeededAuthPageSettingsAsync();
 
-        return new HeadlessFixture(context, clientId, redirectUri, admin, authorizationServerService, headlessAuthService, authPageSessionService, emailSender, invitationService);
+        return new HeadlessFixture(context, clientId, redirectUri, admin, authService, authorizationServerService, headlessAuthService, authPageSessionService, emailSender, invitationService);
     }
 
     private static TestSqlOSDbContext CreateContext()
@@ -759,6 +818,14 @@ public sealed class HeadlessAuthIntegrationTests
         var context = new DefaultHttpContext();
         context.Request.Scheme = "https";
         context.Request.Host = new HostString("tests");
+        return context;
+    }
+
+    private static DefaultHttpContext CreateHttpContext(string ipAddress)
+    {
+        var context = CreateHttpContext();
+        context.Connection.RemoteIpAddress = IPAddress.Parse(ipAddress);
+        context.Request.Headers.UserAgent = "SqlOSTest";
         return context;
     }
 
@@ -819,6 +886,7 @@ public sealed class HeadlessAuthIntegrationTests
         string ClientId,
         string RedirectUri,
         SqlOSAdminService AdminService,
+        SqlOSAuthService AuthService,
         SqlOSAuthorizationServerService AuthorizationServerService,
         SqlOSHeadlessAuthService HeadlessAuthService,
         SqlOSAuthPageSessionService AuthPageSessionService,

--- a/tests/SqlOS.IntegrationTests/SchemaInitializerIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/SchemaInitializerIntegrationTests.cs
@@ -27,6 +27,7 @@ public sealed class SchemaInitializerIntegrationTests
                      "SqlOSUsers",
                      "SqlOSUserEmails",
                      "SqlOSCredentials",
+                     "SqlOSPasswordLoginBuckets",
                      "SqlOSMemberships",
                      "SqlOSSsoConnections",
                      "SqlOSExternalIdentities",

--- a/tests/SqlOS.Tests/SqlOSAuthServiceTests.cs
+++ b/tests/SqlOS.Tests/SqlOSAuthServiceTests.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Net;
 using System.Text.RegularExpressions;
 using SqlOS.AuthServer.Configuration;
 using SqlOS.AuthServer.Contracts;
@@ -48,6 +49,207 @@ public sealed class SqlOSAuthServiceTests
         result.PendingAuthToken.Should().NotBeNullOrWhiteSpace();
         result.Tokens.Should().BeNull();
         result.Organizations.Should().HaveCount(2);
+    }
+
+    [TestMethod]
+    public async Task LoginWithPasswordAsync_RepeatedFailures_LocksAccountOrBacksOff()
+    {
+        var harness = await TestHarness.CreateAsync(configure: options =>
+        {
+            options.PasswordLogin.MaxFailedAttemptsPerAccount = 2;
+            options.PasswordLogin.LockoutDuration = TimeSpan.FromMinutes(10);
+        });
+        var user = await harness.Admin.CreateUserAsync(new SqlOSCreateUserRequest(
+            "Lockout User",
+            $"lockout-{Guid.NewGuid():N}@example.com",
+            "P@ssword123!"));
+
+        for (var attempt = 0; attempt < 2; attempt++)
+        {
+            var act = async () => await harness.Auth.LoginWithPasswordAsync(
+                new SqlOSPasswordLoginRequest(user.DefaultEmail!, "wrong-password", "test-client", null),
+                CreatePasswordHttpContext("203.0.113.10"));
+
+            await act.Should().ThrowAsync<InvalidOperationException>()
+                .WithMessage(SqlOSPasswordLoginAbuseService.PublicFailureMessage);
+        }
+
+        var lockedAct = async () => await harness.Auth.LoginWithPasswordAsync(
+            new SqlOSPasswordLoginRequest(user.DefaultEmail!, "P@ssword123!", "test-client", null),
+            CreatePasswordHttpContext("203.0.113.10"));
+
+        await lockedAct.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage(SqlOSPasswordLoginAbuseService.PublicFailureMessage);
+
+        var emailBucket = await harness.Context.Set<SqlOSPasswordLoginBucket>()
+            .SingleAsync(x => x.Scope == "email" && x.BucketKey == SqlOSAdminService.NormalizeEmail(user.DefaultEmail!));
+        emailBucket.LockedUntil.Should().BeAfter(DateTime.UtcNow);
+    }
+
+    [TestMethod]
+    public async Task AuthenticatePasswordAsync_UnknownEmailAndWrongPassword_ReturnUniformPublicFailure()
+    {
+        var harness = await TestHarness.CreateAsync();
+        var user = await harness.Admin.CreateUserAsync(new SqlOSCreateUserRequest(
+            "Uniform User",
+            $"uniform-{Guid.NewGuid():N}@example.com",
+            "P@ssword123!"));
+
+        var unknownAct = async () => await harness.Authorization.AuthenticatePasswordAsync(
+            $"unknown-{Guid.NewGuid():N}@example.com",
+            "anything",
+            cancellationToken: default,
+            httpContext: CreatePasswordHttpContext("203.0.113.20"),
+            clientKey: "test-client",
+            surface: "hosted");
+        var wrongAct = async () => await harness.Authorization.AuthenticatePasswordAsync(
+            user.DefaultEmail!,
+            "wrong-password",
+            cancellationToken: default,
+            httpContext: CreatePasswordHttpContext("203.0.113.21"),
+            clientKey: "test-client",
+            surface: "hosted");
+
+        var unknownFailure = await unknownAct.Should().ThrowAsync<InvalidOperationException>();
+        var wrongFailure = await wrongAct.Should().ThrowAsync<InvalidOperationException>();
+
+        unknownFailure.Which.Message.Should().Be(SqlOSPasswordLoginAbuseService.PublicFailureMessage);
+        wrongFailure.Which.Message.Should().Be(unknownFailure.Which.Message);
+    }
+
+    [TestMethod]
+    public async Task PasswordLogin_PerIpLimit_BlocksPasswordSprayAcrossAccounts()
+    {
+        var harness = await TestHarness.CreateAsync(configure: options =>
+        {
+            options.PasswordLogin.MaxFailedAttemptsPerAccount = 10;
+            options.PasswordLogin.MaxFailedAttemptsPerIp = 2;
+            options.PasswordLogin.LockoutDuration = TimeSpan.FromMinutes(10);
+        });
+        var users = new[]
+        {
+            await harness.Admin.CreateUserAsync(new SqlOSCreateUserRequest("Spray One", $"spray-1-{Guid.NewGuid():N}@example.com", "P@ssword123!")),
+            await harness.Admin.CreateUserAsync(new SqlOSCreateUserRequest("Spray Two", $"spray-2-{Guid.NewGuid():N}@example.com", "P@ssword123!")),
+            await harness.Admin.CreateUserAsync(new SqlOSCreateUserRequest("Spray Three", $"spray-3-{Guid.NewGuid():N}@example.com", "P@ssword123!"))
+        };
+
+        foreach (var user in users.Take(2))
+        {
+            var fail = async () => await harness.Auth.LoginWithPasswordAsync(
+                new SqlOSPasswordLoginRequest(user.DefaultEmail!, "wrong-password", "test-client", null),
+                CreatePasswordHttpContext("203.0.113.30"));
+
+            await fail.Should().ThrowAsync<InvalidOperationException>()
+                .WithMessage(SqlOSPasswordLoginAbuseService.PublicFailureMessage);
+        }
+
+        var blocked = async () => await harness.Auth.LoginWithPasswordAsync(
+            new SqlOSPasswordLoginRequest(users[2].DefaultEmail!, "P@ssword123!", "test-client", null),
+            CreatePasswordHttpContext("203.0.113.30"));
+
+        await blocked.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage(SqlOSPasswordLoginAbuseService.PublicFailureMessage);
+
+        var ipBucket = await harness.Context.Set<SqlOSPasswordLoginBucket>()
+            .SingleAsync(x => x.Scope == "ip" && x.BucketKey == "203.0.113.30");
+        ipBucket.LockedUntil.Should().BeAfter(DateTime.UtcNow);
+    }
+
+    [TestMethod]
+    public async Task HostedPasswordLogin_UsesSameThrottleStateAsApiLogin()
+    {
+        var harness = await TestHarness.CreateAsync(configure: options =>
+        {
+            options.PasswordLogin.MaxFailedAttemptsPerAccount = 1;
+            options.PasswordLogin.LockoutDuration = TimeSpan.FromMinutes(10);
+        });
+        var user = await harness.Admin.CreateUserAsync(new SqlOSCreateUserRequest(
+            "Hosted Shared",
+            $"hosted-shared-{Guid.NewGuid():N}@example.com",
+            "P@ssword123!"));
+
+        var apiFailure = async () => await harness.Auth.LoginWithPasswordAsync(
+            new SqlOSPasswordLoginRequest(user.DefaultEmail!, "wrong-password", "test-client", null),
+            CreatePasswordHttpContext("203.0.113.40"));
+        await apiFailure.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage(SqlOSPasswordLoginAbuseService.PublicFailureMessage);
+
+        var hostedSuccessBypass = async () => await harness.Authorization.AuthenticatePasswordAsync(
+            user.DefaultEmail!,
+            "P@ssword123!",
+            cancellationToken: default,
+            httpContext: CreatePasswordHttpContext("203.0.113.40"),
+            clientKey: "test-client",
+            surface: "hosted");
+
+        await hostedSuccessBypass.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage(SqlOSPasswordLoginAbuseService.PublicFailureMessage);
+    }
+
+    [TestMethod]
+    public async Task PasswordLogin_SuccessAfterFailures_RecordsSuccessAndResetsOrDecaysCounters()
+    {
+        var harness = await TestHarness.CreateAsync(configure: options =>
+        {
+            options.PasswordLogin.MaxFailedAttemptsPerAccount = 3;
+        });
+        var user = await harness.Admin.CreateUserAsync(new SqlOSCreateUserRequest(
+            "Reset User",
+            $"reset-{Guid.NewGuid():N}@example.com",
+            "P@ssword123!"));
+
+        var failure = async () => await harness.Auth.LoginWithPasswordAsync(
+            new SqlOSPasswordLoginRequest(user.DefaultEmail!, "wrong-password", "test-client", null),
+            CreatePasswordHttpContext("203.0.113.50"));
+        await failure.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage(SqlOSPasswordLoginAbuseService.PublicFailureMessage);
+
+        var success = await harness.Auth.LoginWithPasswordAsync(
+            new SqlOSPasswordLoginRequest(user.DefaultEmail!, "P@ssword123!", "test-client", null),
+            CreatePasswordHttpContext("203.0.113.50"));
+        success.Tokens.Should().NotBeNull();
+
+        var emailBucket = await harness.Context.Set<SqlOSPasswordLoginBucket>()
+            .SingleAsync(x => x.Scope == "email" && x.BucketKey == SqlOSAdminService.NormalizeEmail(user.DefaultEmail!));
+        emailBucket.FailureCount.Should().Be(0);
+        emailBucket.LockedUntil.Should().BeNull();
+        emailBucket.LastSuccessAt.Should().NotBeNull();
+
+        (await harness.Context.Set<SqlOSAuditEvent>()
+            .AnyAsync(x => x.EventType == "password.login.succeeded" && x.UserId == user.Id)).Should().BeTrue();
+    }
+
+    [TestMethod]
+    public async Task PasswordLogin_LockoutAndFailure_WriteAuditEvents()
+    {
+        var harness = await TestHarness.CreateAsync(configure: options =>
+        {
+            options.PasswordLogin.MaxFailedAttemptsPerAccount = 1;
+            options.PasswordLogin.LockoutDuration = TimeSpan.FromMinutes(10);
+        });
+        var user = await harness.Admin.CreateUserAsync(new SqlOSCreateUserRequest(
+            "Audit User",
+            $"audit-{Guid.NewGuid():N}@example.com",
+            "P@ssword123!"));
+
+        var failure = async () => await harness.Auth.LoginWithPasswordAsync(
+            new SqlOSPasswordLoginRequest(user.DefaultEmail!, "wrong-password", "test-client", null),
+            CreatePasswordHttpContext("203.0.113.60"));
+        await failure.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage(SqlOSPasswordLoginAbuseService.PublicFailureMessage);
+
+        var rejected = async () => await harness.Auth.LoginWithPasswordAsync(
+            new SqlOSPasswordLoginRequest(user.DefaultEmail!, "P@ssword123!", "test-client", null),
+            CreatePasswordHttpContext("203.0.113.60"));
+        await rejected.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage(SqlOSPasswordLoginAbuseService.PublicFailureMessage);
+
+        var eventTypes = await harness.Context.Set<SqlOSAuditEvent>()
+            .Select(x => x.EventType)
+            .ToListAsync();
+        eventTypes.Should().Contain("password.login.failed");
+        eventTypes.Should().Contain("password.login.locked");
+        eventTypes.Should().Contain("password.login.rate_limit_rejected");
     }
 
     [TestMethod]
@@ -709,6 +911,14 @@ public sealed class SqlOSAuthServiceTests
         return new TestSqlOSInMemoryDbContext(options);
     }
 
+    private static DefaultHttpContext CreatePasswordHttpContext(string ipAddress)
+    {
+        var context = new DefaultHttpContext();
+        context.Connection.RemoteIpAddress = IPAddress.Parse(ipAddress);
+        context.Request.Headers.UserAgent = "SqlOSTest";
+        return context;
+    }
+
     private static string GetLatestCode(TestAuthEmailSender sender, string email)
     {
         var message = sender.Messages.Last(x => string.Equals(x.To, email, StringComparison.OrdinalIgnoreCase));
@@ -774,11 +984,14 @@ public sealed class SqlOSAuthServiceTests
     {
         public required TestSqlOSInMemoryDbContext Context { get; init; }
         public required SqlOSAuthService Auth { get; init; }
+        public required SqlOSAuthorizationServerService Authorization { get; init; }
         public required SqlOSAdminService Admin { get; init; }
         public required SqlOSCryptoService Crypto { get; init; }
         public required SqlOSAuthServerOptions Options { get; init; }
 
-        public static async Task<TestHarness> CreateAsync(int graceWindowSeconds = 30)
+        public static async Task<TestHarness> CreateAsync(
+            int graceWindowSeconds = 30,
+            Action<SqlOSAuthServerOptions>? configure = null)
         {
             var context = new TestSqlOSInMemoryDbContext(
                 new DbContextOptionsBuilder<TestSqlOSInMemoryDbContext>()
@@ -790,6 +1003,7 @@ public sealed class SqlOSAuthServiceTests
                 RefreshTokenGraceWindowSeconds = graceWindowSeconds
             };
             authOptions.SeedBrowserClient("test-client", "Test Client", "https://client.example.test/callback");
+            configure?.Invoke(authOptions);
             var options = Microsoft.Extensions.Options.Options.Create(authOptions);
 
             // Inject a real ephemeral data protection provider so the
@@ -799,7 +1013,25 @@ public sealed class SqlOSAuthServiceTests
             var emailSender = new TestAuthEmailSender();
             var settings = new SqlOSSettingsService(context, options, emailSender);
             var emailOtp = new SqlOSEmailOtpService(context, admin, crypto, settings, emailSender, options);
-            var auth = new SqlOSAuthService(context, options, admin, crypto, settings, emailOtp);
+            var passwordAbuse = new SqlOSPasswordLoginAbuseService(context, admin, crypto, options);
+            var auth = new SqlOSAuthService(
+                context,
+                options,
+                admin,
+                crypto,
+                settings,
+                emailOtp,
+                passwordLoginAbuseService: passwordAbuse);
+            var authPageSession = new SqlOSAuthPageSessionService(context, crypto, settings);
+            var authorization = new SqlOSAuthorizationServerService(
+                context,
+                admin,
+                auth,
+                crypto,
+                settings,
+                authPageSession,
+                options,
+                passwordLoginAbuseService: passwordAbuse);
 
             await crypto.EnsureActiveSigningKeyAsync();
             await admin.UpsertSeededClientsAsync();
@@ -808,6 +1040,7 @@ public sealed class SqlOSAuthServiceTests
             {
                 Context = context,
                 Auth = auth,
+                Authorization = authorization,
                 Admin = admin,
                 Crypto = crypto,
                 Options = authOptions

--- a/web/content/docs/authserver/password-login.mdx
+++ b/web/content/docs/authserver/password-login.mdx
@@ -109,3 +109,23 @@ builder.AddSqlOS<AppDbContext>(options =>
     options.AuthServer.RequireVerifiedEmailForPasswordLogin = true;
 });
 ```
+
+Configure password-login abuse controls:
+
+```csharp
+builder.AddSqlOS<AppDbContext>(options =>
+{
+    options.AuthServer.ConfigurePasswordLoginAbuse(password =>
+    {
+        password.MaxFailedAttemptsPerAccount = 5;
+        password.MaxFailedAttemptsPerIp = 20;
+        password.MaxFailedAttemptsPerClient = 50;
+        password.FailureWindow = TimeSpan.FromMinutes(15);
+        password.LockoutDuration = TimeSpan.FromMinutes(15);
+    });
+});
+```
+
+SqlOS stores password-login throttle state in `SqlOSPasswordLoginBuckets`. Failed password attempts count against the normalized email, user ID when known, source IP, client, and user-agent fingerprint. Account buckets reset after a successful password login. IP, client, and device buckets expire through the configured failure window so one successful login cannot clear a password-spray pattern.
+
+Unknown-email, wrong-password, locked-account, and rate-limited password attempts return the same public failure message. Operators can distinguish them internally through `SqlOSAuditEvents` entries such as `password.login.failed`, `password.login.locked`, `password.login.rate_limit_rejected`, `password.login.suspicious_pattern`, and `password.login.succeeded`.


### PR DESCRIPTION
## Summary
- add durable password-login buckets for account, IP, client, and user-agent fingerprint throttling
- enforce shared password abuse controls in API, hosted authorization, and headless password flows
- add audit events for password login failures, lockouts, rate-limit rejections, suspicious patterns, and successes
- add schema migration and password-login docs for configuration and operator behavior

Closes #26.

## Validation
- dotnet test
- npm run lint --prefix web
- npm run build --prefix web