### PR TITLE
Add Twilio Verify SMS OTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ examples/SqlOS.Example.AppHost           # Aspire orchestration
 - [Configuration](https://sqlos.dev/docs/guides/configuration) — service registration, EF integration, dashboard setup
 - [Auth Page](docs/AUTH_PAGE.md) — hosted OAuth endpoints and branded UI
 - [Email OTP](docs/EMAIL_OTP.md) — passwordless login/signup across hosted, headless, and SDK flows
+- [SMS OTP](docs/SMS_OTP.md) — passwordless phone-code login/signup through Twilio Verify
 - [Email Invitations](docs/INVITATIONS.md) — organization invite links, dashboard, SDK, hosted, and headless flows
 - [Todo Sample](examples/SqlOS.Todo.Api/README.md) — hosted auth, simple FGA, and MCP-oriented protected-resource flows
 - [Client Registration DevEx](docs/CLIENT_REGISTRATION_DEVEX_2026.md) — product vocabulary and onboarding model
@@ -348,6 +349,39 @@ dotnet run --project examples/SqlOS.Todo.Cli -- toggle <todo-id>
 Then open `http://localhost:5080/`.
 
 Use **Email code sign in** or **Email code sign up**. In this mode the Todo app only starts the OAuth request; the SqlOS hosted auth page sends the OTP, verifies the code, creates the account on signup, and redirects back with the authorization code.
+
+## Testing SMS OTP in the Todo Sample
+
+Use a Twilio pay-as-you-go account before testing arbitrary user phone numbers. Twilio trial accounts can only send OTP messages to phone numbers that are already verified on the Twilio account.
+
+Set up Twilio Verify like this:
+
+1. Sign in to the [Twilio Console](https://console.twilio.com/).
+2. On the Console dashboard, open **Account Info**.
+3. Copy **Account SID**. It starts with `AC`.
+4. Click **Show** for **Auth Token**, then copy it. Treat this as a secret.
+5. Open **Verify** in the left navigation, then **Services**.
+6. Click **Create new Service**.
+7. Set the friendly name to `SqlOS Todo Dev`.
+8. Ensure SMS is enabled and the code length is 6 digits.
+9. Save the **Service SID**. It starts with `VA`.
+
+Run the Todo sample from the repo root:
+
+```bash
+TWILIO_ACCOUNT_SID=<account-sid> \
+TWILIO_AUTH_TOKEN=<auth-token> \
+TWILIO_VERIFY_SERVICE_SID=<verify-service-sid> \
+TWILIO_DEFAULT_REGION=US \
+TodoSample__EnablePhoneOtp=true \
+dotnet run --project examples/SqlOS.Todo.AppHost/SqlOS.Todo.AppHost.csproj
+```
+
+Open `http://localhost:5080/`. The home page should show **SMS code sign in** and **SMS code sign up**. `/sample/config` should report `"phoneOtpEnabled": true`.
+
+Start SMS testing from the Todo sample home page, not directly from `/sqlos/auth/login`. A direct AuthPage sign-in creates a SqlOS auth-page session and shows `/sqlos/auth/login?status=signed-in`, but it does not give the Todo SPA an OAuth access token. The Todo app gets its token only when the flow starts at `http://localhost:5080/` and returns through `/callback.html`.
+
+Do not buy or configure a Programmable Messaging phone number for this SqlOS integration. SqlOS calls Twilio Verify v2 with the Verify Service SID and `sms` channel; Verify manages the SMS sender path for the verification message.
 
 ## Running the Example App with Transactional Email
 

--- a/docs/AUTH_PAGE.md
+++ b/docs/AUTH_PAGE.md
@@ -33,7 +33,7 @@ When enabled, SqlOS can also expose:
 - `POST /sqlos/auth/register` for dynamic client registration
 - `GET /sqlos/auth/headless/*` and `POST /sqlos/auth/headless/*` for headless UI flows
 
-Email OTP and invitations are first-class AuthPage flows. Invite acceptance fixes the email to the invited address, runs the same configured credential methods, and only consumes the invitation when the final session or authorization redirect is issued.
+Email OTP, SMS OTP, and invitations are first-class AuthPage flows. Invite acceptance fixes the email to the invited address, runs the same configured credential methods, and only consumes the invitation when the final session or authorization redirect is issued. SMS OTP uses Twilio Verify and remains disabled until configured; see [SMS OTP](SMS_OTP.md).
 
 ## Fastest hosted setup
 

--- a/docs/EXAMPLE_APP.md
+++ b/docs/EXAMPLE_APP.md
@@ -6,6 +6,7 @@ Use it when you want to explore:
 
 - local password login
 - hosted and headless auth UI
+- optional SMS OTP through Twilio Verify
 - Google, Microsoft, Apple, and custom OIDC login
 - org membership
 - organization email invitations
@@ -58,9 +59,10 @@ dotnet run --project examples/SqlOS.Example.AppHost/SqlOS.Example.AppHost.csproj
 4. Open the example web app and sign in through the hosted flow.
 5. Confirm the app shows session and token debug data.
 6. Switch to the headless route and compare the same auth server with app-owned UI.
-7. Optionally configure an OIDC connection and repeat the sign-in flow with provider buttons.
-8. Create and list workspaces through the protected app flow.
-9. Return to the dashboard and validate auth sessions plus FGA resource/grant data.
+7. Optionally enable [SMS OTP](SMS_OTP.md) and repeat sign in or signup with a phone code.
+8. Optionally configure an OIDC connection and repeat the sign-in flow with provider buttons.
+9. Create and list workspaces through the protected app flow.
+10. Return to the dashboard and validate auth sessions plus FGA resource/grant data.
 
 For a customer-tenant SAML walkthrough with Microsoft Entra ID, use:
 

--- a/docs/SMS_OTP.md
+++ b/docs/SMS_OTP.md
@@ -1,0 +1,184 @@
+# SMS OTP
+
+SqlOS SMS OTP provides passwordless phone-code login and signup through Twilio Verify. It is disabled by default and only becomes visible when all runtime Twilio settings are present and `phone_otp` is enabled in AuthPage credentials.
+
+SMS is a lower-assurance credential than passkeys, WebAuthn, TOTP, or hardware-backed MFA. It is vulnerable to SIM swap, number reassignment, carrier delivery failure, and SMS interception. SqlOS does not count `phone_otp` as strong MFA by default, and admin/owner elevation should require a stronger method.
+
+## Twilio Verify
+
+### Todo sample setup
+
+This is the exact setup path for testing SMS OTP in the Todo sample.
+
+1. Sign in to the [Twilio Console](https://console.twilio.com/) and select the account/project that should own the SqlOS Verify traffic.
+2. Upgrade the account before testing arbitrary user phone numbers. Twilio trial accounts can only send SMS/Voice/WhatsApp OTP messages to destination numbers that are already verified on the account, and trial accounts expire after 30 days. That is fine for one developer phone, but it is not enough for open signup testing.
+3. On the Console dashboard, open **Account Info**.
+4. Copy **Account SID**. It starts with `AC`.
+5. Click **Show** for **Auth Token**, then copy it. Treat this as a secret.
+6. Create one Verify Service:
+   - Open **Verify** in the left navigation.
+   - Go to **Services**.
+   - Click **Create new Service**.
+   - Friendly name: `SqlOS Todo Dev`.
+   - Ensure SMS is enabled.
+   - Use a 6-digit code.
+   - Save the **Service SID**. It starts with `VA`.
+7. Run the Todo sample from the repo root:
+
+   ```bash
+   TWILIO_ACCOUNT_SID=<account-sid> \
+   TWILIO_AUTH_TOKEN=<auth-token> \
+   TWILIO_VERIFY_SERVICE_SID=<verify-service-sid> \
+   TWILIO_DEFAULT_REGION=US \
+   TodoSample__EnablePhoneOtp=true \
+   dotnet run --project examples/SqlOS.Todo.AppHost/SqlOS.Todo.AppHost.csproj
+   ```
+
+8. Open `http://localhost:5080/`. The home page should show **SMS code sign in** and **SMS code sign up**. `/sample/config` should report `"phoneOtpEnabled": true`.
+
+Start SMS testing from the Todo sample home page, not directly from `/sqlos/auth/login`. A direct AuthPage sign-in creates a SqlOS auth-page session and shows `/sqlos/auth/login?status=signed-in`, but it does not give the Todo SPA an OAuth access token. The Todo app gets its token only when the flow starts at `http://localhost:5080/` and returns through `/callback.html`.
+
+Do not buy or configure a Programmable Messaging phone number for this SqlOS integration. SqlOS calls Twilio Verify v2 with the Verify Service SID and `sms` channel; Verify manages the SMS sender path for the verification message.
+
+Twilio documents Verify Services as resources that can be created in the Console or API, and service SIDs use the `VA...` format. The Verify API starts SMS OTP delivery by creating a Verification under that Service SID with `channel=sms`; phone numbers must be E.164 at the Twilio boundary. SqlOS normalizes phone input to E.164 before it calls Twilio.
+
+### Setup script
+
+The helper script creates the same Verify Service and prints the same app environment block:
+
+```bash
+TWILIO_ACCOUNT_SID=<account-sid> \
+TWILIO_AUTH_TOKEN=<auth-token> \
+TWILIO_VERIFY_SERVICE_NAME="SqlOS Todo Dev" \
+./scripts/twilio/setup-twilio-verify.sh
+```
+
+If `TWILIO_VERIFY_SERVICE_SID` is already set, the script reuses that service instead of creating a new one.
+
+## SqlOS Configuration
+
+For a normal app, wire the same three Twilio values into `ConfigurePhoneOtp`:
+
+```csharp
+builder.AddSqlOS<AppDbContext>(options =>
+{
+    options.AuthServer.ConfigurePhoneOtp(phone =>
+    {
+        phone.Enabled = builder.Configuration.GetValue<bool>("SqlOS:PhoneOtp:Enabled");
+        phone.TwilioAccountSid = builder.Configuration["SqlOS:PhoneOtp:TwilioAccountSid"];
+        phone.TwilioAuthToken = builder.Configuration["SqlOS:PhoneOtp:TwilioAuthToken"];
+        phone.TwilioVerifyServiceSid = builder.Configuration["SqlOS:PhoneOtp:TwilioVerifyServiceSid"];
+        phone.DefaultRegion = builder.Configuration["SqlOS:PhoneOtp:DefaultRegion"] ?? "US";
+        phone.CountryAllowList = ["US", "CA"];
+        phone.MaxSendsPerPhone = 5;
+        phone.MaxSendsPerIp = 60;
+    });
+
+    options.AuthServer.SeedAuthPage(page =>
+    {
+        page.EnabledCredentialTypes = ["password", "email_otp", "phone_otp"];
+    });
+});
+```
+
+Runtime environment:
+
+```bash
+SqlOS__PhoneOtp__Enabled=true
+SqlOS__PhoneOtp__TwilioAccountSid=<account-sid>
+SqlOS__PhoneOtp__TwilioAuthToken=<auth-token>
+SqlOS__PhoneOtp__TwilioVerifyServiceSid=<verify-service-sid>
+SqlOS__PhoneOtp__DefaultRegion=US
+```
+
+Startup validation fails if `Enabled` is true without `TwilioAccountSid`, `TwilioAuthToken`, and `TwilioVerifyServiceSid`.
+
+## Runtime Behavior
+
+- Phone numbers are parsed and normalized to E.164 before storage or Twilio calls.
+- Stored phone lookup uses a hash; display and challenge phone values are encrypted.
+- Unknown-account login starts return the same public message as known-account starts.
+- Signup rejects an already registered phone before sending another paid Verify challenge.
+- Local rate limits run before provider sends by phone, account, IP, and client.
+- Phone enrollment or phone-number change requires an authenticated session.
+- Audit events are written for challenge start, provider send failure, verification success/failure, throttling, and phone enrollment.
+
+## Hosted AuthPage
+
+Enable `phone_otp` in AuthPage settings. Hosted pages expose:
+
+```text
+GET  /sqlos/auth/login/phone-otp
+POST /sqlos/auth/login/phone-otp/start
+POST /sqlos/auth/login/phone-otp/verify
+GET  /sqlos/auth/signup/phone-otp
+POST /sqlos/auth/signup/phone-otp/start
+POST /sqlos/auth/signup/phone-otp/verify
+```
+
+## Headless UI
+
+Headless browser clients use:
+
+```text
+POST /sqlos/auth/headless/phone-otp/start
+POST /sqlos/auth/headless/phone-otp/verify
+POST /sqlos/auth/headless/signup/phone-otp/start
+POST /sqlos/auth/headless/signup/phone-otp/verify
+```
+
+The `start` responses include raw one-time tokens that SqlOS intentionally cannot return from a later request reload. Keep `challengeToken`, and for signup also `signupToken`, in component state or browser `sessionStorage` until verification.
+
+## SDK Usage
+
+Existing users:
+
+```csharp
+var start = await sqlosAuth.RequestPhoneOtpAsync(
+    new SqlOSPhoneOtpStartRequest("+12025550105", "web", OrganizationId: null),
+    httpContext);
+
+var login = await sqlosAuth.VerifyPhoneOtpAsync(
+    new SqlOSPhoneOtpVerifyRequest(start.ChallengeToken, code),
+    httpContext);
+```
+
+New users:
+
+```csharp
+var start = await sqlosAuth.RequestPhoneOtpSignupAsync(
+    new SqlOSPhoneOtpSignupStartRequest(
+        DisplayName: "Jane Doe",
+        PhoneNumber: "+12025550105",
+        ClientId: "web",
+        OrganizationName: "Example Co",
+        OrganizationId: null,
+        CustomFields: null),
+    httpContext);
+
+var login = await sqlosAuth.VerifyPhoneOtpSignupAsync(
+    new SqlOSPhoneOtpSignupVerifyRequest(start.SignupToken, start.ChallengeToken, code),
+    httpContext);
+```
+
+## Example Apps
+
+Todo sample:
+
+```bash
+TodoSample__EnablePhoneOtp=true
+TWILIO_ACCOUNT_SID=<account-sid>
+TWILIO_AUTH_TOKEN=<auth-token>
+TWILIO_VERIFY_SERVICE_SID=<verify-service-sid>
+```
+
+Retail example:
+
+```bash
+SqlOS__PhoneOtp__Enabled=true
+TWILIO_ACCOUNT_SID=<account-sid>
+TWILIO_AUTH_TOKEN=<auth-token>
+TWILIO_VERIFY_SERVICE_SID=<verify-service-sid>
+```
+
+Both examples also accept the equivalent SqlOS configuration keys: `SqlOS__PhoneOtp__TwilioAccountSid`, `SqlOS__PhoneOtp__TwilioAuthToken`, and `SqlOS__PhoneOtp__TwilioVerifyServiceSid`.

--- a/examples/SqlOS.Example.Api/Program.cs
+++ b/examples/SqlOS.Example.Api/Program.cs
@@ -41,6 +41,15 @@ builder.AddSqlOS<ExampleAppDbContext>(options =>
     var emailFromAddress = builder.Configuration["SqlOS:Email:FromAddress"]
         ?? builder.Configuration["SqlOS:EmailOtp:FromAddress"]
         ?? builder.Configuration["AZURE_EMAIL_SENDER_ADDRESS"];
+    var enablePhoneOtp = builder.Configuration.GetValue<bool>("SqlOS:PhoneOtp:Enabled");
+    var twilioAccountSid = builder.Configuration["SqlOS:PhoneOtp:TwilioAccountSid"]
+        ?? builder.Configuration["TWILIO_ACCOUNT_SID"];
+    var twilioAuthToken = builder.Configuration["SqlOS:PhoneOtp:TwilioAuthToken"]
+        ?? builder.Configuration["TWILIO_AUTH_TOKEN"];
+    var twilioVerifyServiceSid = builder.Configuration["SqlOS:PhoneOtp:TwilioVerifyServiceSid"]
+        ?? builder.Configuration["TWILIO_VERIFY_SERVICE_SID"];
+    var phoneOtpDefaultRegion = builder.Configuration["SqlOS:PhoneOtp:DefaultRegion"]
+        ?? builder.Configuration["TWILIO_DEFAULT_REGION"];
 
     if (Enum.TryParse<SqlOSDashboardAuthMode>(builder.Configuration["SqlOS:Dashboard:AuthMode"], ignoreCase: true, out var authMode))
     {
@@ -74,6 +83,17 @@ builder.AddSqlOS<ExampleAppDbContext>(options =>
         emailOtp.FromAddress = emailFromAddress;
         emailOtp.ApplicationName = "SqlOS Example";
     });
+    auth.ConfigurePhoneOtp(phone =>
+    {
+        phone.Enabled = enablePhoneOtp;
+        phone.TwilioAccountSid = twilioAccountSid;
+        phone.TwilioAuthToken = twilioAuthToken;
+        phone.TwilioVerifyServiceSid = twilioVerifyServiceSid;
+        if (!string.IsNullOrWhiteSpace(phoneOtpDefaultRegion))
+        {
+            phone.DefaultRegion = phoneOtpDefaultRegion;
+        }
+    });
 
     var headlessFrontendUrl = builder.Configuration["SqlOS:HeadlessFrontendUrl"]
         ?? builder.Configuration["ExampleFrontend:Origin"]
@@ -89,7 +109,9 @@ builder.AddSqlOS<ExampleAppDbContext>(options =>
         page.BackgroundColor = "#f8fafc";
         page.Layout = "split";
         page.EnablePasswordSignup = true;
-        page.EnabledCredentialTypes = ["password", "email_otp"];
+        page.EnabledCredentialTypes = enablePhoneOtp
+            ? ["password", "email_otp", "phone_otp"]
+            : ["password", "email_otp"];
     });
     auth.SeedAuthEmails(email =>
     {

--- a/examples/SqlOS.Example.AppHost/Program.cs
+++ b/examples/SqlOS.Example.AppHost/Program.cs
@@ -12,6 +12,16 @@ var emailConnectionString = builder.Configuration["SqlOS:Email:AzureCommunicatio
 var emailFromAddress = builder.Configuration["SqlOS:Email:FromAddress"]
     ?? builder.Configuration["SqlOS:EmailOtp:FromAddress"]
     ?? builder.Configuration["AZURE_EMAIL_SENDER_ADDRESS"];
+var enablePhoneOtp = builder.Configuration["SqlOS:PhoneOtp:Enabled"]
+    ?? builder.Configuration["TodoSample:EnablePhoneOtp"];
+var twilioAccountSid = builder.Configuration["SqlOS:PhoneOtp:TwilioAccountSid"]
+    ?? builder.Configuration["TWILIO_ACCOUNT_SID"];
+var twilioAuthToken = builder.Configuration["SqlOS:PhoneOtp:TwilioAuthToken"]
+    ?? builder.Configuration["TWILIO_AUTH_TOKEN"];
+var twilioVerifyServiceSid = builder.Configuration["SqlOS:PhoneOtp:TwilioVerifyServiceSid"]
+    ?? builder.Configuration["TWILIO_VERIFY_SERVICE_SID"];
+var phoneOtpDefaultRegion = builder.Configuration["SqlOS:PhoneOtp:DefaultRegion"]
+    ?? builder.Configuration["TWILIO_DEFAULT_REGION"];
 var sqlPassword = builder.AddParameter("sql-password", value: "LocalDevPassword123!");
 
 var sql = builder.AddSqlServer("sql", password: sqlPassword, port: 1434)
@@ -41,6 +51,31 @@ if (!string.IsNullOrWhiteSpace(emailConnectionString) && !string.IsNullOrWhiteSp
         .WithEnvironment("SqlOS__EmailOtp__FromAddress", emailFromAddress);
 }
 
+if (!string.IsNullOrWhiteSpace(enablePhoneOtp))
+{
+    api.WithEnvironment("SqlOS__PhoneOtp__Enabled", enablePhoneOtp);
+}
+
+if (!string.IsNullOrWhiteSpace(twilioAccountSid))
+{
+    api.WithEnvironment("SqlOS__PhoneOtp__TwilioAccountSid", twilioAccountSid);
+}
+
+if (!string.IsNullOrWhiteSpace(twilioAuthToken))
+{
+    api.WithEnvironment("SqlOS__PhoneOtp__TwilioAuthToken", twilioAuthToken);
+}
+
+if (!string.IsNullOrWhiteSpace(twilioVerifyServiceSid))
+{
+    api.WithEnvironment("SqlOS__PhoneOtp__TwilioVerifyServiceSid", twilioVerifyServiceSid);
+}
+
+if (!string.IsNullOrWhiteSpace(phoneOtpDefaultRegion))
+{
+    api.WithEnvironment("SqlOS__PhoneOtp__DefaultRegion", phoneOtpDefaultRegion);
+}
+
 var todoApi = builder.AddProject<Projects.SqlOS_Todo_Api>("todo-api")
     .WithReference(todoDatabase)
     .WaitFor(todoDatabase)
@@ -58,6 +93,33 @@ if (!string.IsNullOrWhiteSpace(emailConnectionString) && !string.IsNullOrWhiteSp
         .WithEnvironment("SqlOS__Email__FromAddress", emailFromAddress)
         .WithEnvironment("SqlOS__EmailOtp__AzureCommunicationServicesConnectionString", emailConnectionString)
         .WithEnvironment("SqlOS__EmailOtp__FromAddress", emailFromAddress);
+}
+
+if (!string.IsNullOrWhiteSpace(enablePhoneOtp))
+{
+    todoApi
+        .WithEnvironment("TodoSample__EnablePhoneOtp", enablePhoneOtp)
+        .WithEnvironment("SqlOS__PhoneOtp__Enabled", enablePhoneOtp);
+}
+
+if (!string.IsNullOrWhiteSpace(twilioAccountSid))
+{
+    todoApi.WithEnvironment("SqlOS__PhoneOtp__TwilioAccountSid", twilioAccountSid);
+}
+
+if (!string.IsNullOrWhiteSpace(twilioAuthToken))
+{
+    todoApi.WithEnvironment("SqlOS__PhoneOtp__TwilioAuthToken", twilioAuthToken);
+}
+
+if (!string.IsNullOrWhiteSpace(twilioVerifyServiceSid))
+{
+    todoApi.WithEnvironment("SqlOS__PhoneOtp__TwilioVerifyServiceSid", twilioVerifyServiceSid);
+}
+
+if (!string.IsNullOrWhiteSpace(phoneOtpDefaultRegion))
+{
+    todoApi.WithEnvironment("SqlOS__PhoneOtp__DefaultRegion", phoneOtpDefaultRegion);
 }
 
 builder.AddNpmApp("web", "../SqlOS.Example.Web", "dev")

--- a/examples/SqlOS.Example.Web/components/sqlos-headless-auth-panel.tsx
+++ b/examples/SqlOS.Example.Web/components/sqlos-headless-auth-panel.tsx
@@ -10,10 +10,14 @@ import {
   headlessIdentify,
   headlessPasswordLogin,
   headlessRequestEmailOtp,
+  headlessRequestPhoneOtp,
+  headlessRequestPhoneOtpSignup,
   headlessSelectOrganization,
   headlessSignup,
   headlessStartProvider,
   headlessVerifyEmailOtp,
+  headlessVerifyPhoneOtp,
+  headlessVerifyPhoneOtpSignup,
   type HeadlessViewModel,
   type HeadlessActionResult,
   type HeadlessProvider,
@@ -89,6 +93,7 @@ export function SqlOSHeadlessAuthPanel() {
   const [viewModel, setViewModel] = useState<HeadlessViewModel | null>(null);
 
   const [email, setEmail] = useState(initialEmail);
+  const [phoneNumber, setPhoneNumber] = useState("");
   const [password, setPassword] = useState("");
   const [otpCode, setOtpCode] = useState("");
   const [organizationName, setOrganizationName] = useState("");
@@ -113,6 +118,7 @@ export function SqlOSHeadlessAuthPanel() {
         if (vm.view) setView(vm.view);
         if (vm.error) setError(vm.error);
         if (vm.email) setEmail(vm.email);
+        if (vm.phoneNumber) setPhoneNumber(vm.phoneNumber);
         if (vm.displayName && !firstName && !lastName && initialDisplayName) {
           const [first = "", ...rest] = vm.displayName.split(" ");
           setFirstName(first);
@@ -190,6 +196,7 @@ export function SqlOSHeadlessAuthPanel() {
       if (result.viewModel.view) setView(result.viewModel.view);
       if (result.viewModel.error) setError(result.viewModel.error);
       if (result.viewModel.email) setEmail(result.viewModel.email);
+      if (result.viewModel.phoneNumber) setPhoneNumber(result.viewModel.phoneNumber);
       if (result.viewModel.challengeToken) setOtpCode("");
       setFieldErrors(result.viewModel.fieldErrors ?? {});
     }
@@ -237,6 +244,30 @@ export function SqlOSHeadlessAuthPanel() {
     finally { setLoading(false); }
   };
 
+  const onRequestPhoneOtp = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!requestId) return;
+    setLoading(true); setError(null); setFieldErrors({});
+    try { await handleResult(await headlessRequestPhoneOtp(requestId, phoneNumber)); }
+    catch (err) { setError(err instanceof Error ? err.message : "We could not send a sign-in code."); }
+    finally { setLoading(false); }
+  };
+
+  const onVerifyPhoneOtp = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!requestId) return;
+    const challengeToken = viewModel?.challengeToken;
+    if (!challengeToken) {
+      setError("Request a new sign-in code first.");
+      return;
+    }
+
+    setLoading(true); setError(null); setFieldErrors({});
+    try { await handleResult(await headlessVerifyPhoneOtp(requestId, challengeToken, otpCode)); }
+    catch (err) { setError(err instanceof Error ? err.message : "The sign-in code was rejected."); }
+    finally { setLoading(false); }
+  };
+
   const onSignup = async (event: React.FormEvent) => {
     event.preventDefault();
     if (!requestId) return;
@@ -244,6 +275,38 @@ export function SqlOSHeadlessAuthPanel() {
     try {
       await handleResult(await headlessSignup(requestId, buildDisplayName(firstName, lastName, email), email, password, organizationName, { referralSource, firstName, lastName }));
     } catch (err) { setError(err instanceof Error ? err.message : "Signup failed."); }
+    finally { setLoading(false); }
+  };
+
+  const onRequestPhoneOtpSignup = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!requestId) return;
+    setLoading(true); setError(null); setFieldErrors({});
+    try {
+      await handleResult(await headlessRequestPhoneOtpSignup(
+        requestId,
+        buildDisplayName(firstName, lastName, phoneNumber),
+        phoneNumber,
+        organizationName,
+        { referralSource, firstName, lastName },
+      ));
+    } catch (err) { setError(err instanceof Error ? err.message : "Signup failed."); }
+    finally { setLoading(false); }
+  };
+
+  const onVerifyPhoneOtpSignup = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!requestId) return;
+    const challengeToken = viewModel?.challengeToken;
+    const signupToken = viewModel?.signupToken;
+    if (!challengeToken || !signupToken) {
+      setError("Request a new sign-up code first.");
+      return;
+    }
+
+    setLoading(true); setError(null); setFieldErrors({});
+    try { await handleResult(await headlessVerifyPhoneOtpSignup(requestId, signupToken, challengeToken, otpCode)); }
+    catch (err) { setError(err instanceof Error ? err.message : "The sign-up code was rejected."); }
     finally { setLoading(false); }
   };
 
@@ -264,12 +327,14 @@ export function SqlOSHeadlessAuthPanel() {
     finally { setLoading(false); }
   };
 
-  const isSignup = view === "signup";
+  const isSignup = view === "signup" || view === "phone-otp-signup" || view === "phone-otp-signup-verify";
   const showProviderButtons = (view === "login" || view === "identify" || view === "signup") && (viewModel?.providers?.length ?? 0) > 0;
   const supportsPassword = !!viewModel?.settings?.localPasswordRuntimeEnabled
     && (viewModel?.settings?.enabledCredentialTypes ?? []).includes("password");
   const supportsEmailOtp = !!viewModel?.settings?.emailOtpRuntimeConfigured
     && (viewModel?.settings?.enabledCredentialTypes ?? []).includes("email_otp");
+  const supportsPhoneOtp = !!viewModel?.settings?.phoneOtpRuntimeConfigured
+    && (viewModel?.settings?.enabledCredentialTypes ?? []).includes("phone_otp");
 
   const headline = isSignup ? "Start your free trial" : view === "organization" ? "Choose workspace" : "Welcome back";
   const subtitle = isSignup
@@ -340,6 +405,7 @@ export function SqlOSHeadlessAuthPanel() {
                   <div className="ha-alt">
                     Don&apos;t have an account?{" "}
                     <button type="button" className="ha-link-btn" onClick={() => setView("signup")}>Sign up</button>
+                    {supportsPhoneOtp && <button type="button" className="ha-link-btn" onClick={() => setView("phone-otp")}>Use phone instead</button>}
                   </div>
                 </form>
               )}
@@ -361,6 +427,7 @@ export function SqlOSHeadlessAuthPanel() {
                   <div className="ha-alt">
                     <button type="button" className="ha-link-btn" onClick={() => setView("login")}>Use a different email</button>
                     {supportsEmailOtp && <button type="button" className="ha-link-btn" onClick={() => setView("email-otp")}>Email me a code instead</button>}
+                    {supportsPhoneOtp && <button type="button" className="ha-link-btn" onClick={() => setView("phone-otp")}>Text me a code instead</button>}
                   </div>
                 </form>
               )}
@@ -376,6 +443,7 @@ export function SqlOSHeadlessAuthPanel() {
                   </button>
                   <div className="ha-alt">
                     {supportsPassword && <button type="button" className="ha-link-btn" onClick={() => setView("password")}>Use password instead</button>}
+                    {supportsPhoneOtp && <button type="button" className="ha-link-btn" onClick={() => setView("phone-otp")}>Text me a code instead</button>}
                     <button type="button" className="ha-link-btn" onClick={() => setView("login")}>Use a different email</button>
                   </div>
                 </form>
@@ -393,6 +461,41 @@ export function SqlOSHeadlessAuthPanel() {
                   <div className="ha-alt">
                     <button type="button" className="ha-link-btn" onClick={() => setView("email-otp")}>Send a new code</button>
                     {supportsPassword && <button type="button" className="ha-link-btn" onClick={() => setView("password")}>Use password instead</button>}
+                    {supportsPhoneOtp && <button type="button" className="ha-link-btn" onClick={() => setView("phone-otp")}>Use phone instead</button>}
+                  </div>
+                </form>
+              )}
+
+              {view === "phone-otp" && (
+                <form className="ha-form" onSubmit={onRequestPhoneOtp}>
+                  <div className="ha-field">
+                    <label htmlFor="ha-otp-phone">Phone</label>
+                    <input id="ha-otp-phone" type="tel" value={phoneNumber} onChange={(e) => setPhoneNumber(e.target.value)} placeholder="+1 202 555 0105" autoComplete="tel" required />
+                  </div>
+                  <button type="submit" className="ha-submit" disabled={loading}>
+                    {loading ? "Sending code..." : "Text me a code"}
+                  </button>
+                  <div className="ha-alt">
+                    {supportsPassword && <button type="button" className="ha-link-btn" onClick={() => setView("password")}>Use password instead</button>}
+                    {supportsEmailOtp && <button type="button" className="ha-link-btn" onClick={() => setView("email-otp")}>Use email instead</button>}
+                    <button type="button" className="ha-link-btn" onClick={() => setView("login")}>Use a different email</button>
+                  </div>
+                </form>
+              )}
+
+              {view === "phone-otp-verify" && (
+                <form className="ha-form" onSubmit={onVerifyPhoneOtp}>
+                  <div className="ha-field">
+                    <label htmlFor="ha-phone-otp-code">Code</label>
+                    <input id="ha-phone-otp-code" type="text" value={otpCode} onChange={(e) => setOtpCode(e.target.value)} inputMode="numeric" autoComplete="one-time-code" placeholder="123456" required autoFocus />
+                  </div>
+                  <button type="submit" className="ha-submit" disabled={loading}>
+                    {loading ? "Verifying..." : "Verify code"}
+                  </button>
+                  <div className="ha-alt">
+                    <button type="button" className="ha-link-btn" onClick={() => setView("phone-otp")}>Send a new code</button>
+                    {supportsPassword && <button type="button" className="ha-link-btn" onClick={() => setView("password")}>Use password instead</button>}
+                    {supportsEmailOtp && <button type="button" className="ha-link-btn" onClick={() => setView("email-otp")}>Use email instead</button>}
                   </div>
                 </form>
               )}
@@ -440,6 +543,63 @@ export function SqlOSHeadlessAuthPanel() {
                   <div className="ha-alt">
                     Already have an account?{" "}
                     <button type="button" className="ha-link-btn" onClick={() => setView("login")}>Sign in</button>
+                    {supportsPhoneOtp && <button type="button" className="ha-link-btn" onClick={() => setView("phone-otp-signup")}>Create account with SMS</button>}
+                  </div>
+                </form>
+              )}
+
+              {view === "phone-otp-signup" && (
+                <form className="ha-form" onSubmit={onRequestPhoneOtpSignup}>
+                  <div className="ha-row">
+                    <div className="ha-field">
+                      <label htmlFor="ha-phone-fn">First name</label>
+                      <input id="ha-phone-fn" type="text" value={firstName} onChange={(e) => setFirstName(e.target.value)} placeholder="Taylor" required />
+                      {fieldErrors.firstName && <p className="ha-field-error">{fieldErrors.firstName}</p>}
+                    </div>
+                    <div className="ha-field">
+                      <label htmlFor="ha-phone-ln">Last name</label>
+                      <input id="ha-phone-ln" type="text" value={lastName} onChange={(e) => setLastName(e.target.value)} placeholder="Morgan" required />
+                      {fieldErrors.lastName && <p className="ha-field-error">{fieldErrors.lastName}</p>}
+                    </div>
+                  </div>
+                  <div className="ha-field">
+                    <label htmlFor="ha-phone-org">Organization</label>
+                    <input id="ha-phone-org" type="text" value={organizationName} onChange={(e) => setOrganizationName(e.target.value)} placeholder="Your company name" required />
+                    {fieldErrors.organizationName && <p className="ha-field-error">{fieldErrors.organizationName}</p>}
+                  </div>
+                  <div className="ha-field">
+                    <label htmlFor="ha-su-phone">Phone</label>
+                    <input id="ha-su-phone" type="tel" value={phoneNumber} onChange={(e) => setPhoneNumber(e.target.value)} placeholder="+1 202 555 0105" autoComplete="tel" required />
+                  </div>
+                  <div className="ha-field">
+                    <label htmlFor="ha-phone-ref">How did you hear about us?</label>
+                    <select id="ha-phone-ref" value={referralSource} onChange={(e) => setReferralSource(e.target.value)} required>
+                      <option value="">Select one</option>
+                      {referralOptions.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
+                    </select>
+                    {fieldErrors.referralSource && <p className="ha-field-error">{fieldErrors.referralSource}</p>}
+                  </div>
+                  <button type="submit" className="ha-submit" disabled={loading}>
+                    {loading ? "Sending code..." : "Text me a code"}
+                  </button>
+                  <div className="ha-alt">
+                    <button type="button" className="ha-link-btn" onClick={() => setView("signup")}>Use email and password</button>
+                    <button type="button" className="ha-link-btn" onClick={() => setView("login")}>Sign in</button>
+                  </div>
+                </form>
+              )}
+
+              {view === "phone-otp-signup-verify" && (
+                <form className="ha-form" onSubmit={onVerifyPhoneOtpSignup}>
+                  <div className="ha-field">
+                    <label htmlFor="ha-phone-su-code">Code</label>
+                    <input id="ha-phone-su-code" type="text" value={otpCode} onChange={(e) => setOtpCode(e.target.value)} inputMode="numeric" autoComplete="one-time-code" placeholder="123456" required autoFocus />
+                  </div>
+                  <button type="submit" className="ha-submit" disabled={loading}>
+                    {loading ? "Creating account..." : "Verify and create account"}
+                  </button>
+                  <div className="ha-alt">
+                    <button type="button" className="ha-link-btn" onClick={() => setView("phone-otp-signup")}>Start over</button>
                   </div>
                 </form>
               )}

--- a/examples/SqlOS.Example.Web/lib/sqlos-headless.ts
+++ b/examples/SqlOS.Example.Web/lib/sqlos-headless.ts
@@ -12,8 +12,10 @@ export type HeadlessViewModel = {
   error?: string | null;
   info?: string | null;
   challengeToken?: string | null;
+  signupToken?: string | null;
   pendingToken?: string | null;
   email?: string | null;
+  phoneNumber?: string | null;
   displayName?: string | null;
   uiContext?: Record<string, unknown> | null;
   providers?: HeadlessProvider[];
@@ -46,6 +48,7 @@ export type HeadlessSettings = {
   enabledCredentialTypes?: string[];
   localPasswordRuntimeEnabled?: boolean;
   emailOtpRuntimeConfigured?: boolean;
+  phoneOtpRuntimeConfigured?: boolean;
 };
 
 export type HeadlessActionResult = {
@@ -112,6 +115,14 @@ export async function headlessVerifyEmailOtp(requestId: string, challengeToken: 
   return headlessPost("/email-otp/verify", { requestId, challengeToken, code });
 }
 
+export async function headlessRequestPhoneOtp(requestId: string, phoneNumber: string): Promise<HeadlessActionResult> {
+  return headlessPost("/phone-otp/start", { requestId, phoneNumber });
+}
+
+export async function headlessVerifyPhoneOtp(requestId: string, challengeToken: string, code: string): Promise<HeadlessActionResult> {
+  return headlessPost("/phone-otp/verify", { requestId, challengeToken, code });
+}
+
 export async function headlessSignup(
   requestId: string,
   displayName: string,
@@ -128,6 +139,31 @@ export async function headlessSignup(
     organizationName,
     customFields: customFields ?? {},
   });
+}
+
+export async function headlessRequestPhoneOtpSignup(
+  requestId: string,
+  displayName: string,
+  phoneNumber: string,
+  organizationName: string,
+  customFields?: Record<string, string>,
+): Promise<HeadlessActionResult> {
+  return headlessPost("/signup/phone-otp/start", {
+    requestId,
+    displayName,
+    phoneNumber,
+    organizationName,
+    customFields: customFields ?? {},
+  });
+}
+
+export async function headlessVerifyPhoneOtpSignup(
+  requestId: string,
+  signupToken: string,
+  challengeToken: string,
+  code: string,
+): Promise<HeadlessActionResult> {
+  return headlessPost("/signup/phone-otp/verify", { requestId, signupToken, challengeToken, code });
 }
 
 export async function headlessSelectOrganization(pendingToken: string, organizationId: string): Promise<HeadlessActionResult> {

--- a/examples/SqlOS.Todo.Api/Configuration/TodoSampleOptions.cs
+++ b/examples/SqlOS.Todo.Api/Configuration/TodoSampleOptions.cs
@@ -10,6 +10,7 @@ public sealed class TodoSampleOptions
     public bool EnableDcr { get; set; }
     public string Resource { get; set; } = "http://localhost:5080/api/todos";
     public bool EnableEmailOtp { get; set; }
+    public bool EnablePhoneOtp { get; set; }
     public string LocalClientId { get; set; } = "todo-local";
     public string LocalRedirectUri { get; set; } = "http://localhost:3100/oauth/callback";
     public string EmcyClientId { get; set; } = "todo-mcp-local";

--- a/examples/SqlOS.Todo.Api/Program.cs
+++ b/examples/SqlOS.Todo.Api/Program.cs
@@ -61,6 +61,9 @@ var hostedCallbackUrl = $"{publicOrigin}/callback.html";
 var localClientRedirectUri = sampleConfig.LocalRedirectUri;
 var emcyClientRedirectUri = sampleConfig.EmcyRedirectUri;
 var portableClientUrl = $"{publicOrigin}{sampleConfig.PortableClientPath}";
+var enablePhoneOtp =
+    sampleConfig.EnablePhoneOtp
+    || builder.Configuration.GetValue<bool>("SqlOS:PhoneOtp:Enabled");
 var emcyLocalOrigins = new[]
 {
     new Uri(localClientRedirectUri).GetLeftPart(UriPartial.Authority),
@@ -96,12 +99,34 @@ builder.AddSqlOS<TodoSampleDbContext>(options =>
     var emailFromAddress = builder.Configuration["SqlOS:Email:FromAddress"]
         ?? builder.Configuration["SqlOS:EmailOtp:FromAddress"]
         ?? builder.Configuration["AZURE_EMAIL_SENDER_ADDRESS"];
+    var twilioAccountSid = builder.Configuration["SqlOS:PhoneOtp:TwilioAccountSid"]
+        ?? builder.Configuration["TWILIO_ACCOUNT_SID"];
+    var twilioAuthToken = builder.Configuration["SqlOS:PhoneOtp:TwilioAuthToken"]
+        ?? builder.Configuration["TWILIO_AUTH_TOKEN"];
+    var twilioVerifyServiceSid = builder.Configuration["SqlOS:PhoneOtp:TwilioVerifyServiceSid"]
+        ?? builder.Configuration["TWILIO_VERIFY_SERVICE_SID"];
+    var phoneOtpDefaultRegion = builder.Configuration["SqlOS:PhoneOtp:DefaultRegion"]
+        ?? builder.Configuration["TWILIO_DEFAULT_REGION"];
+    var enabledCredentialTypes = new List<string>();
+    if (sampleConfig.EnableEmailOtp)
+    {
+        enabledCredentialTypes.Add("email_otp");
+    }
+    if (enablePhoneOtp)
+    {
+        enabledCredentialTypes.Add("phone_otp");
+    }
+    if (enabledCredentialTypes.Count == 0)
+    {
+        enabledCredentialTypes.Add("password");
+    }
+    var passwordAuthEnabled = enabledCredentialTypes.Contains("password", StringComparer.OrdinalIgnoreCase);
 
     var auth = options.AuthServer;
     auth.Issuer = builder.Configuration["SqlOS:Issuer"] ?? $"{publicOrigin}/sqlos/auth";
     auth.PublicOrigin = publicOrigin;
     auth.DefaultAudience = sampleConfig.Resource;
-    auth.EnableLocalPasswordAuth = !sampleConfig.EnableEmailOtp;
+    auth.EnableLocalPasswordAuth = passwordAuthEnabled;
     options.ConfigureEmail(email =>
     {
         email.AzureCommunicationServicesConnectionString = emailConnectionString;
@@ -113,19 +138,30 @@ builder.AddSqlOS<TodoSampleDbContext>(options =>
         email.FromAddress = emailFromAddress;
         email.ApplicationName = "SqlOS Todo";
     });
+    auth.ConfigurePhoneOtp(phone =>
+    {
+        phone.Enabled = enablePhoneOtp;
+        phone.TwilioAccountSid = twilioAccountSid;
+        phone.TwilioAuthToken = twilioAuthToken;
+        phone.TwilioVerifyServiceSid = twilioVerifyServiceSid;
+        if (!string.IsNullOrWhiteSpace(phoneOtpDefaultRegion))
+        {
+            phone.DefaultRegion = phoneOtpDefaultRegion;
+        }
+    });
 
     auth.SeedAuthPage(page =>
     {
-        page.PageTitle = sampleConfig.EnableEmailOtp ? "Check your email. Ship the Todo app." : "Ship the Todo app first.";
-        page.PageSubtitle = sampleConfig.EnableEmailOtp
-            ? "Use passwordless email codes for sign in and sign up, then land back in the hosted-first Todo sample."
+        page.PageTitle = sampleConfig.EnableEmailOtp || enablePhoneOtp ? "Check your code. Ship the Todo app." : "Ship the Todo app first.";
+        page.PageSubtitle = sampleConfig.EnableEmailOtp || enablePhoneOtp
+            ? "Use passwordless email or SMS codes for sign in and sign up, then land back in the hosted-first Todo sample."
             : "Start with hosted auth, then graduate to headless and public-client onboarding when you need it.";
         page.PrimaryColor = "#0f172a";
         page.AccentColor = "#2563eb";
         page.BackgroundColor = "#f8fafc";
         page.Layout = "split";
-        page.EnablePasswordSignup = !sampleConfig.EnableEmailOtp;
-        page.EnabledCredentialTypes = sampleConfig.EnableEmailOtp ? ["email_otp"] : ["password"];
+        page.EnablePasswordSignup = passwordAuthEnabled;
+        page.EnabledCredentialTypes = enabledCredentialTypes;
     });
 
     auth.SeedAuthEmails(email =>
@@ -304,6 +340,7 @@ app.MapGet("/sample/config", async (
         },
         headlessEnabled = sample.EnableHeadless,
         emailOtpEnabled = sample.EnableEmailOtp && authPageSettings.EmailOtpRuntimeConfigured,
+        phoneOtpEnabled = enablePhoneOtp && authPageSettings.PhoneOtpRuntimeConfigured,
         dcrEnabled = authOptions.Value.ClientRegistration.Dcr.Enabled,
         cimdEnabled = authOptions.Value.ClientRegistration.Cimd.Enabled,
         allowedScopes = sample.AllowedScopes

--- a/examples/SqlOS.Todo.Api/appsettings.Development.json
+++ b/examples/SqlOS.Todo.Api/appsettings.Development.json
@@ -9,6 +9,7 @@
     "HostedClientName": "Todo Web App",
     "EnableHeadless": false,
     "EnableDcr": false,
+    "EnablePhoneOtp": false,
     "LocalClientId": "todo-local",
     "LocalRedirectUri": "http://localhost:3100/oauth/callback",
     "EmcyClientId": "todo-mcp-local",

--- a/examples/SqlOS.Todo.Api/wwwroot/index.html
+++ b/examples/SqlOS.Todo.Api/wwwroot/index.html
@@ -10,10 +10,10 @@
   <main class="shell">
     <section class="hero">
       <p class="eyebrow">SqlOS Todo Sample</p>
-      <h1>Demo SqlOS AuthPage with passwordless email codes.</h1>
+      <h1>Demo SqlOS AuthPage with passwordless codes.</h1>
       <p class="lede">
         The Todo app only starts OAuth. SqlOS AuthPage owns sign in, sign up,
-        email-code verification, and the redirect back with a resource-bound token.
+        one-time-code verification, and the redirect back with a resource-bound token.
       </p>
       <div class="button-row">
         <button id="hosted-login-button" type="button">Hosted sign in</button>

--- a/examples/SqlOS.Todo.Api/wwwroot/sample.js
+++ b/examples/SqlOS.Todo.Api/wwwroot/sample.js
@@ -36,6 +36,7 @@ async function initIndexPage() {
         resource: config.resource,
         hostedClient: config.hostedClient,
         emailOtpEnabled: config.emailOtpEnabled,
+        phoneOtpEnabled: config.phoneOtpEnabled,
         localClient: config.localClient,
         portableClient: config.portableClient,
         cimdEnabled: config.cimdEnabled,
@@ -49,7 +50,14 @@ async function initIndexPage() {
   const hostedLoginButton = document.getElementById("hosted-login-button");
   const hostedSignupButton = document.getElementById("hosted-signup-button");
 
-  if (config.emailOtpEnabled) {
+  if (config.phoneOtpEnabled) {
+    if (hostedLoginButton) {
+      hostedLoginButton.textContent = config.emailOtpEnabled ? "Code sign in" : "SMS code sign in";
+    }
+    if (hostedSignupButton) {
+      hostedSignupButton.textContent = config.emailOtpEnabled ? "Code sign up" : "SMS code sign up";
+    }
+  } else if (config.emailOtpEnabled) {
     if (hostedLoginButton) {
       hostedLoginButton.textContent = "Email code sign in";
     }
@@ -59,7 +67,7 @@ async function initIndexPage() {
   }
 
   hostedLoginButton?.addEventListener("click", async () => {
-    await startAuthorization(config.emailOtpEnabled ? "email-otp" : "login");
+    await startAuthorization(config.emailOtpEnabled ? "email-otp" : config.phoneOtpEnabled ? "phone-otp" : "login");
   });
 
   hostedSignupButton?.addEventListener("click", async () => {
@@ -305,7 +313,7 @@ async function startAuthorization(view) {
     view
   });
 
-  if (view === "signup" || view === "email-otp") {
+  if (view === "signup" || view === "email-otp" || view === "phone-otp") {
     params.set("prompt", "login");
   }
 

--- a/examples/SqlOS.Todo.AppHost/Program.cs
+++ b/examples/SqlOS.Todo.AppHost/Program.cs
@@ -7,12 +7,22 @@ var todoOrigin = $"http://localhost:{todoPort}";
 var todoResource = $"{todoOrigin}/api/todos";
 var todoIssuer = $"{todoOrigin}/sqlos/auth";
 var todoEnableEmailOtp = builder.Configuration["TodoSample:EnableEmailOtp"];
+var todoEnablePhoneOtp = builder.Configuration["TodoSample:EnablePhoneOtp"]
+    ?? builder.Configuration["SqlOS:PhoneOtp:Enabled"];
 var emailConnectionString = builder.Configuration["SqlOS:Email:AzureCommunicationServicesConnectionString"]
     ?? builder.Configuration["SqlOS:EmailOtp:AzureCommunicationServicesConnectionString"]
     ?? builder.Configuration["AZURE_EMAIL_CONNECTION_STRING"];
 var emailFromAddress = builder.Configuration["SqlOS:Email:FromAddress"]
     ?? builder.Configuration["SqlOS:EmailOtp:FromAddress"]
     ?? builder.Configuration["AZURE_EMAIL_SENDER_ADDRESS"];
+var twilioAccountSid = builder.Configuration["SqlOS:PhoneOtp:TwilioAccountSid"]
+    ?? builder.Configuration["TWILIO_ACCOUNT_SID"];
+var twilioAuthToken = builder.Configuration["SqlOS:PhoneOtp:TwilioAuthToken"]
+    ?? builder.Configuration["TWILIO_AUTH_TOKEN"];
+var twilioVerifyServiceSid = builder.Configuration["SqlOS:PhoneOtp:TwilioVerifyServiceSid"]
+    ?? builder.Configuration["TWILIO_VERIFY_SERVICE_SID"];
+var phoneOtpDefaultRegion = builder.Configuration["SqlOS:PhoneOtp:DefaultRegion"]
+    ?? builder.Configuration["TWILIO_DEFAULT_REGION"];
 var sqlPassword = builder.AddParameter("sql-password", value: "LocalDevPassword123!");
 
 var sql = builder.AddSqlServer("sql", password: sqlPassword, port: 1435)
@@ -37,6 +47,13 @@ if (!string.IsNullOrWhiteSpace(todoEnableEmailOtp))
     todoApi.WithEnvironment("TodoSample__EnableEmailOtp", todoEnableEmailOtp);
 }
 
+if (!string.IsNullOrWhiteSpace(todoEnablePhoneOtp))
+{
+    todoApi
+        .WithEnvironment("TodoSample__EnablePhoneOtp", todoEnablePhoneOtp)
+        .WithEnvironment("SqlOS__PhoneOtp__Enabled", todoEnablePhoneOtp);
+}
+
 if (!string.IsNullOrWhiteSpace(emailConnectionString) && !string.IsNullOrWhiteSpace(emailFromAddress))
 {
     todoApi
@@ -44,6 +61,26 @@ if (!string.IsNullOrWhiteSpace(emailConnectionString) && !string.IsNullOrWhiteSp
         .WithEnvironment("SqlOS__Email__FromAddress", emailFromAddress)
         .WithEnvironment("SqlOS__EmailOtp__AzureCommunicationServicesConnectionString", emailConnectionString)
         .WithEnvironment("SqlOS__EmailOtp__FromAddress", emailFromAddress);
+}
+
+if (!string.IsNullOrWhiteSpace(twilioAccountSid))
+{
+    todoApi.WithEnvironment("SqlOS__PhoneOtp__TwilioAccountSid", twilioAccountSid);
+}
+
+if (!string.IsNullOrWhiteSpace(twilioAuthToken))
+{
+    todoApi.WithEnvironment("SqlOS__PhoneOtp__TwilioAuthToken", twilioAuthToken);
+}
+
+if (!string.IsNullOrWhiteSpace(twilioVerifyServiceSid))
+{
+    todoApi.WithEnvironment("SqlOS__PhoneOtp__TwilioVerifyServiceSid", twilioVerifyServiceSid);
+}
+
+if (!string.IsNullOrWhiteSpace(phoneOtpDefaultRegion))
+{
+    todoApi.WithEnvironment("SqlOS__PhoneOtp__DefaultRegion", phoneOtpDefaultRegion);
 }
 
 builder.Build().Run();

--- a/examples/SqlOS.Todo.IntegrationTests/TodoSampleIntegrationTests.cs
+++ b/examples/SqlOS.Todo.IntegrationTests/TodoSampleIntegrationTests.cs
@@ -26,6 +26,24 @@ public sealed class TodoSampleIntegrationTests
     private const string TodoResource = "https://todo.example.test/api/todos";
 
     [TestMethod]
+    public async Task HostedAuthStandaloneStatus_ShowsSessionStateInsteadOfLoginForm()
+    {
+        await using var factory = TodoApiFixture.CreateFactory();
+        using var client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false
+        });
+
+        var response = await client.GetAsync("/sqlos/auth/login?status=signed-in");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("You are signed in.");
+        html.Should().Contain("href=\"/sqlos/auth/logout\"");
+        html.Should().NotContain("action=\"/sqlos/auth/login/identify\"");
+    }
+
+    [TestMethod]
     public async Task HostedSignup_IssuesResourceBoundToken_AndReadsTodos()
     {
         await using var factory = TodoApiFixture.CreateFactory();
@@ -134,6 +152,72 @@ public sealed class TodoSampleIntegrationTests
         ReadAudience(tokens.AccessToken).Should().Be(TodoResource);
 
         var createResponse = await CreateTodoAsync(client, tokens.AccessToken, "Ship passwordless Todo");
+        var createJson = JsonDocument.Parse(await createResponse.Content.ReadAsStringAsync());
+        createJson.RootElement.GetProperty("resourceId").GetString().Should().StartWith("todo::");
+    }
+
+    [TestMethod]
+    public async Task HostedPhoneOtpSignup_DoesNotIssueTokenUntilCodeIsVerified()
+    {
+        await using var factory = TodoApiFixture.CreateFactory(builder =>
+        {
+            builder.UseSetting("TodoSample:EnablePhoneOtp", "true");
+            builder.UseSetting("SqlOS:PhoneOtp:TwilioAccountSid", "AC00000000000000000000000000000000");
+            builder.UseSetting("SqlOS:PhoneOtp:TwilioAuthToken", "test-token");
+            builder.UseSetting("SqlOS:PhoneOtp:TwilioVerifyServiceSid", "VA00000000000000000000000000000000");
+            builder.ConfigureServices(services =>
+            {
+                services.RemoveAll<ISqlOSOtpDeliveryChannel>();
+                services.AddSingleton<TestOtpDeliveryChannel>();
+                services.AddSingleton<ISqlOSOtpDeliveryChannel>(provider => provider.GetRequiredService<TestOtpDeliveryChannel>());
+            });
+        });
+        using var client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false
+        });
+
+        var authorize = await StartAuthorizationAsync(client, HostedClientId, HostedRedirectUri);
+        authorize.Html.Should().Contain("/sqlos/auth/signup/phone-otp/start");
+        authorize.Html.Should().NotContain("name=\"password\"");
+        var delivery = factory.Services.GetRequiredService<TestOtpDeliveryChannel>();
+        var phoneNumber = "+12025550177";
+
+        var startResponse = await client.PostAsync("/sqlos/auth/signup/phone-otp/start", new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["requestId"] = authorize.RequestId,
+            ["displayName"] = "SMS Hosted User",
+            ["phoneNumber"] = phoneNumber,
+            ["organizationName"] = "SMS Hosted Org"
+        }));
+
+        startResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        startResponse.Headers.Location.Should().BeNull("phone OTP signup must render code verification before issuing an authorization code");
+        delivery.StartRequests.Should().ContainSingle(x => x.PhoneNumber == phoneNumber);
+
+        var verifyHtml = await startResponse.Content.ReadAsStringAsync();
+        verifyHtml.Should().Contain("Verify and create account");
+        var challengeToken = ExtractHiddenInput(verifyHtml, "challengeToken");
+        var signupToken = ExtractHiddenInput(verifyHtml, "signupToken");
+
+        var verifyResponse = await client.PostAsync("/sqlos/auth/signup/phone-otp/verify", new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["requestId"] = authorize.RequestId,
+            ["phoneNumber"] = phoneNumber,
+            ["challengeToken"] = challengeToken,
+            ["signupToken"] = signupToken,
+            ["code"] = TestOtpDeliveryChannel.ApprovedCode
+        }));
+
+        verifyResponse.StatusCode.Should().Be(HttpStatusCode.Redirect);
+        var location = verifyResponse.Headers.Location!.ToString();
+        var authCode = QueryHelpers.ParseQuery(new Uri(location).Query)["code"].ToString();
+        authCode.Should().NotBeNullOrWhiteSpace();
+
+        var tokens = await ExchangeAuthorizationCodeAsync(client, authCode, HostedClientId, HostedRedirectUri, authorize.CodeVerifier);
+        ReadAudience(tokens.AccessToken).Should().Be(TodoResource);
+
+        var createResponse = await CreateTodoAsync(client, tokens.AccessToken, "Ship SMS Todo");
         var createJson = JsonDocument.Parse(await createResponse.Content.ReadAsStringAsync());
         createJson.RootElement.GetProperty("resourceId").GetString().Should().StartWith("todo::");
     }
@@ -613,4 +697,36 @@ public sealed class TodoSampleIntegrationTests
     private sealed record AuthorizationStartResult(string RequestId, string CodeVerifier, Uri? HeadlessRedirect, string? Html);
     private sealed record HostedSignupResult(string Code, string CodeVerifier);
     private sealed record TokenResult(string AccessToken, string RefreshToken, string ClientId);
+
+    private sealed class TestOtpDeliveryChannel : ISqlOSOtpDeliveryChannel
+    {
+        public const string ApprovedCode = "123456";
+        public List<(string PhoneNumber, SqlOSOtpDeliveryContext Context)> StartRequests { get; } = [];
+        public List<(string PhoneNumber, string Code, SqlOSOtpDeliveryContext Context)> CheckRequests { get; } = [];
+
+        public Task<SqlOSOtpDeliveryStartResult> StartAsync(
+            string e164PhoneNumber,
+            SqlOSOtpDeliveryContext context,
+            CancellationToken cancellationToken = default)
+        {
+            StartRequests.Add((e164PhoneNumber, context));
+            return Task.FromResult(new SqlOSOtpDeliveryStartResult(true, "test_verify", $"ve-{StartRequests.Count}", "pending"));
+        }
+
+        public Task<SqlOSOtpDeliveryCheckResult> CheckAsync(
+            string e164PhoneNumber,
+            string code,
+            SqlOSOtpDeliveryContext context,
+            CancellationToken cancellationToken = default)
+        {
+            CheckRequests.Add((e164PhoneNumber, code, context));
+            var approved = string.Equals(code, ApprovedCode, StringComparison.Ordinal);
+            return Task.FromResult(new SqlOSOtpDeliveryCheckResult(
+                approved,
+                "test_verify",
+                $"ve-{CheckRequests.Count}",
+                approved ? "approved" : "denied",
+                approved ? null : "bad_code"));
+        }
+    }
 }

--- a/scripts/twilio/setup-twilio-verify.sh
+++ b/scripts/twilio/setup-twilio-verify.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Create or reuse a Twilio Verify Service for SqlOS phone OTP.
+#
+# Required environment variables:
+#   TWILIO_ACCOUNT_SID
+#   TWILIO_AUTH_TOKEN
+#
+# Optional environment variables:
+#   TWILIO_VERIFY_SERVICE_SID       Reuse this Verify Service instead of creating one.
+#   TWILIO_VERIFY_SERVICE_NAME      Defaults to "SqlOS Auth"
+#   TWILIO_VERIFY_CODE_LENGTH       Defaults to 6
+#
+# Usage:
+#   TWILIO_ACCOUNT_SID=... TWILIO_AUTH_TOKEN=... \
+#   TWILIO_VERIFY_SERVICE_NAME="SqlOS Example" \
+#   ./scripts/twilio/setup-twilio-verify.sh
+
+DRY_RUN=false
+PRINT_SECRETS=false
+YES=false
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/twilio/setup-twilio-verify.sh [options]
+
+Options:
+  --dry-run         Print the Twilio API action without mutating Twilio resources.
+  --print-secrets   Include auth-token values in the printed env block.
+  --yes             Skip confirmation prompts.
+  -h, --help        Show this help.
+
+The script creates a Twilio Verify Service unless TWILIO_VERIFY_SERVICE_SID is already set.
+It prints the SqlOS and sample-app environment variables needed to enable SMS OTP.
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run) DRY_RUN=true ;;
+    --print-secrets) PRINT_SECRETS=true ;;
+    --yes) YES=true ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
+  esac
+  shift
+done
+
+info() { printf '[info] %s\n' "$*" >&2; }
+warn() { printf '[warn] %s\n' "$*" >&2; }
+fail() { printf '[error] %s\n' "$*" >&2; exit 1; }
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "$1 is required but was not found."
+}
+
+require_env() {
+  local name="$1"
+  [ -n "${!name:-}" ] || fail "$name is required."
+}
+
+confirm() {
+  if [ "$YES" = true ] || [ "$DRY_RUN" = true ]; then
+    return
+  fi
+
+  printf 'Create a Twilio Verify Service in account %s? [y/N] ' "$TWILIO_ACCOUNT_SID"
+  read -r answer
+  case "$answer" in
+    y|Y|yes|YES) ;;
+    *) fail "Aborted." ;;
+  esac
+}
+
+twilio_create_verify_service() {
+  local friendly_name="$1"
+  local code_length="$2"
+
+  if [ "$DRY_RUN" = true ]; then
+    printf '[dry-run] curl -fsS -u <twilio-credential> -X POST https://verify.twilio.com/v2/Services --data-urlencode FriendlyName=%q --data-urlencode CodeLength=%q\n' "$friendly_name" "$code_length" >&2
+    printf 'VA_DRY_RUN_VERIFY_SERVICE_SID'
+    return
+  fi
+
+  curl -fsS \
+    -u "$TWILIO_ACCOUNT_SID:$TWILIO_AUTH_TOKEN" \
+    -X POST "https://verify.twilio.com/v2/Services" \
+    --data-urlencode "FriendlyName=$friendly_name" \
+    --data-urlencode "CodeLength=$code_length"
+}
+
+print_sqlos_env() {
+  local service_sid="$1"
+  local auth_token_value="<auth-token>"
+
+  if [ "$PRINT_SECRETS" = true ]; then
+    auth_token_value="${TWILIO_AUTH_TOKEN:-}"
+  fi
+
+  cat <<EOF
+
+SqlOS SMS OTP environment:
+
+SqlOS__PhoneOtp__Enabled=true
+SqlOS__PhoneOtp__TwilioAccountSid=$TWILIO_ACCOUNT_SID
+SqlOS__PhoneOtp__TwilioAuthToken=$auth_token_value
+SqlOS__PhoneOtp__TwilioVerifyServiceSid=$service_sid
+SqlOS__PhoneOtp__DefaultRegion=${TWILIO_DEFAULT_REGION:-US}
+EOF
+
+  cat <<EOF
+
+Todo sample flag:
+
+TodoSample__EnablePhoneOtp=true
+
+Portable TWILIO_* aliases accepted by the examples:
+
+TWILIO_ACCOUNT_SID=$TWILIO_ACCOUNT_SID
+TWILIO_AUTH_TOKEN=$auth_token_value
+TWILIO_VERIFY_SERVICE_SID=$service_sid
+TWILIO_DEFAULT_REGION=${TWILIO_DEFAULT_REGION:-US}
+EOF
+
+  cat <<'EOF'
+
+Use --print-secrets only in a local terminal you trust. Avoid committing these values.
+EOF
+}
+
+main() {
+  require_command curl
+  require_command jq
+  require_env TWILIO_ACCOUNT_SID
+  require_env TWILIO_AUTH_TOKEN
+
+  local service_sid="${TWILIO_VERIFY_SERVICE_SID:-}"
+  local service_name="${TWILIO_VERIFY_SERVICE_NAME:-SqlOS Auth}"
+  local code_length="${TWILIO_VERIFY_CODE_LENGTH:-6}"
+
+  if [ -z "$service_sid" ]; then
+    confirm
+    info "Creating Twilio Verify Service '$service_name'."
+    local response
+    response="$(twilio_create_verify_service "$service_name" "$code_length")"
+    if [ "$DRY_RUN" = true ]; then
+      service_sid="$response"
+    else
+      service_sid="$(printf '%s' "$response" | jq -r '.sid // empty')"
+    fi
+
+    [ -n "$service_sid" ] || fail "Twilio response did not include a Verify Service SID."
+  else
+    info "Using existing Verify Service $service_sid."
+  fi
+
+  print_sqlos_env "$service_sid"
+}
+
+main "$@"

--- a/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerModelConfiguration.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerModelConfiguration.cs
@@ -41,6 +41,24 @@ public static class SqlOSAuthServerModelConfiguration
                 .OnDelete(DeleteBehavior.Restrict);
         });
 
+        modelBuilder.Entity<SqlOSUserPhoneNumber>(entity =>
+        {
+            entity.ToTable("SqlOSUserPhoneNumbers", schema, t => t.ExcludeFromMigrations());
+            entity.HasKey(x => x.Id);
+            entity.HasIndex(x => x.PhoneNumberHash)
+                .IsUnique()
+                .HasFilter("[RemovedAt] IS NULL");
+            entity.HasIndex(x => new { x.UserId, x.RemovedAt });
+            entity.Property(x => x.PhoneNumber).HasMaxLength(32);
+            entity.Property(x => x.PhoneNumberHash).HasMaxLength(128);
+            entity.Property(x => x.DisplayValueEncrypted).HasMaxLength(2048);
+            entity.Property(x => x.RemovalReason).HasMaxLength(120);
+            entity.HasOne(x => x.User)
+                .WithMany(x => x.PhoneNumbers)
+                .HasForeignKey(x => x.UserId)
+                .OnDelete(DeleteBehavior.Restrict);
+        });
+
         modelBuilder.Entity<SqlOSCredential>(entity =>
         {
             entity.ToTable("SqlOSCredentials", schema, t => t.ExcludeFromMigrations());
@@ -357,6 +375,45 @@ public static class SqlOSAuthServerModelConfiguration
             entity.HasOne(x => x.UserEmail)
                 .WithMany()
                 .HasForeignKey(x => x.UserEmailId)
+                .OnDelete(DeleteBehavior.Restrict);
+            entity.HasOne(x => x.AuthorizationRequest)
+                .WithMany()
+                .HasForeignKey(x => x.AuthorizationRequestId)
+                .OnDelete(DeleteBehavior.Restrict);
+            entity.HasOne(x => x.ClientApplication)
+                .WithMany()
+                .HasForeignKey(x => x.ClientApplicationId)
+                .OnDelete(DeleteBehavior.Restrict);
+        });
+
+        modelBuilder.Entity<SqlOSPhoneOtpChallenge>(entity =>
+        {
+            entity.ToTable("SqlOSPhoneOtpChallenges", schema, t => t.ExcludeFromMigrations());
+            entity.HasKey(x => x.Id);
+            entity.HasIndex(x => x.ChallengeTokenHash).IsUnique();
+            entity.HasIndex(x => new { x.PhoneNumberHash, x.CreatedAt });
+            entity.HasIndex(x => new { x.UserId, x.CreatedAt });
+            entity.HasIndex(x => new { x.IpAddress, x.CreatedAt });
+            entity.HasIndex(x => new { x.ClientApplicationId, x.CreatedAt });
+            entity.Property(x => x.ChallengeTokenHash).HasMaxLength(128);
+            entity.Property(x => x.PhoneNumberHash).HasMaxLength(128);
+            entity.Property(x => x.PhoneNumberEncrypted).HasMaxLength(2048);
+            entity.Property(x => x.MaskedPhoneNumber).HasMaxLength(32);
+            entity.Property(x => x.Purpose).HasMaxLength(32);
+            entity.Property(x => x.Provider).HasMaxLength(40);
+            entity.Property(x => x.ProviderChallengeId).HasMaxLength(128);
+            entity.Property(x => x.ProviderStatus).HasMaxLength(80);
+            entity.Property(x => x.InvalidatedReason).HasMaxLength(120);
+            entity.Property(x => x.IpAddress).HasMaxLength(128);
+            entity.Property(x => x.UserAgent).HasMaxLength(512);
+            entity.Property(x => x.ConsumedAt).IsConcurrencyToken();
+            entity.HasOne(x => x.User)
+                .WithMany()
+                .HasForeignKey(x => x.UserId)
+                .OnDelete(DeleteBehavior.Restrict);
+            entity.HasOne(x => x.UserPhoneNumber)
+                .WithMany()
+                .HasForeignKey(x => x.UserPhoneNumberId)
                 .OnDelete(DeleteBehavior.Restrict);
             entity.HasOne(x => x.AuthorizationRequest)
                 .WithMany()

--- a/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerOptions.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerOptions.cs
@@ -35,6 +35,7 @@ public class SqlOSAuthServerOptions
     public int DefaultSigningKeyGraceWindowDays { get; set; } = 7;
     public int DefaultSigningKeyRetiredCleanupDays { get; set; } = 30;
     public SqlOSEmailOtpOptions EmailOtp { get; } = new();
+    public SqlOSPhoneOtpOptions PhoneOtp { get; } = new();
     public SqlOSPasswordLoginAbuseOptions PasswordLogin { get; } = new();
     public SqlOSInvitationOptions Invitations { get; } = new();
     public SqlOSDeviceAuthorizationOptions DeviceAuthorization { get; } = new();
@@ -91,6 +92,12 @@ public class SqlOSAuthServerOptions
     public SqlOSAuthServerOptions ConfigureEmailOtp(Action<SqlOSEmailOtpOptions> configure)
     {
         configure(EmailOtp);
+        return this;
+    }
+
+    public SqlOSAuthServerOptions ConfigurePhoneOtp(Action<SqlOSPhoneOtpOptions> configure)
+    {
+        configure(PhoneOtp);
         return this;
     }
 

--- a/src/SqlOS/AuthServer/Configuration/SqlOSPhoneOtpOptions.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSPhoneOtpOptions.cs
@@ -1,0 +1,30 @@
+namespace SqlOS.AuthServer.Configuration;
+
+public sealed class SqlOSPhoneOtpOptions
+{
+    public bool Enabled { get; set; }
+    public string? TwilioAccountSid { get; set; }
+    public string? TwilioAuthToken { get; set; }
+    public string? TwilioVerifyServiceSid { get; set; }
+    public string DefaultRegion { get; set; } = "US";
+    public TimeSpan ChallengeLifetime { get; set; } = TimeSpan.FromMinutes(10);
+    public TimeSpan ResendCooldown { get; set; } = TimeSpan.FromSeconds(30);
+    public TimeSpan RateLimitWindow { get; set; } = TimeSpan.FromHours(1);
+    public int MaxSendsPerPhone { get; set; } = 5;
+    public int MaxSendsPerAccount { get; set; } = 5;
+    public int MaxSendsPerIp { get; set; } = 60;
+    public int MaxSendsPerClient { get; set; } = 300;
+    public string[] CountryAllowList { get; set; } = [];
+    public string[] CountryDenyList { get; set; } = [];
+    public bool SatisfiesMfa { get; set; }
+
+    public bool HasTwilioCredentials
+        => !string.IsNullOrWhiteSpace(TwilioAccountSid)
+            && !string.IsNullOrWhiteSpace(TwilioAuthToken);
+
+    public bool HasCompleteTwilioConfiguration
+        => !string.IsNullOrWhiteSpace(TwilioVerifyServiceSid)
+            && HasTwilioCredentials;
+
+    public bool IsConfigured => Enabled && HasCompleteTwilioConfiguration;
+}

--- a/src/SqlOS/AuthServer/Contracts/SqlOSContracts.cs
+++ b/src/SqlOS/AuthServer/Contracts/SqlOSContracts.cs
@@ -456,7 +456,8 @@ public sealed record SqlOSAuthPageSettingsDto(
     bool ManagedByStartupSeed,
     bool HeadlessCapabilityRegistered,
     bool LocalPasswordRuntimeEnabled,
-    bool EmailOtpRuntimeConfigured);
+    bool EmailOtpRuntimeConfigured,
+    bool PhoneOtpRuntimeConfigured = false);
 
 public sealed record SqlOSAuthEmailBrandingSettingsDto(
     string ApplicationName,

--- a/src/SqlOS/AuthServer/Contracts/SqlOSEmailOtpContracts.cs
+++ b/src/SqlOS/AuthServer/Contracts/SqlOSEmailOtpContracts.cs
@@ -45,4 +45,5 @@ public sealed record SqlOSResolvedCredentialSettings(
     string[] EnabledCredentialTypes,
     bool PasswordEnabled,
     bool PasswordSignupEnabled,
-    bool EmailOtpEnabled);
+    bool EmailOtpEnabled,
+    bool PhoneOtpEnabled);

--- a/src/SqlOS/AuthServer/Contracts/SqlOSHeadlessAuthContracts.cs
+++ b/src/SqlOS/AuthServer/Contracts/SqlOSHeadlessAuthContracts.cs
@@ -37,7 +37,8 @@ public sealed record SqlOSHeadlessViewModel(
     IReadOnlyList<SqlOSHeadlessProviderDto> Providers,
     SqlOSEmailInvitationResult? Invitation,
     JsonObject? UiContext,
-    SqlOSHeadlessDeviceAuthorizationDto? DeviceAuthorization = null);
+    SqlOSHeadlessDeviceAuthorizationDto? DeviceAuthorization = null,
+    string? PhoneNumber = null);
 
 public sealed record SqlOSHeadlessActionResult(
     string Type,
@@ -91,6 +92,32 @@ public sealed record SqlOSHeadlessEmailOtpSignupStartRequest(
     string? InvitationToken = null);
 
 public sealed record SqlOSHeadlessEmailOtpSignupVerifyRequest(
+    string RequestId,
+    string SignupToken,
+    string ChallengeToken,
+    string Code,
+    string? InvitationToken = null);
+
+public sealed record SqlOSHeadlessPhoneOtpStartRequest(
+    string RequestId,
+    string PhoneNumber,
+    string? InvitationToken = null);
+
+public sealed record SqlOSHeadlessPhoneOtpVerifyRequest(
+    string RequestId,
+    string ChallengeToken,
+    string Code,
+    string? InvitationToken = null);
+
+public sealed record SqlOSHeadlessPhoneOtpSignupStartRequest(
+    string RequestId,
+    string DisplayName,
+    string PhoneNumber,
+    string? OrganizationName,
+    JsonObject? CustomFields,
+    string? InvitationToken = null);
+
+public sealed record SqlOSHeadlessPhoneOtpSignupVerifyRequest(
     string RequestId,
     string SignupToken,
     string ChallengeToken,

--- a/src/SqlOS/AuthServer/Contracts/SqlOSPhoneOtpContracts.cs
+++ b/src/SqlOS/AuthServer/Contracts/SqlOSPhoneOtpContracts.cs
@@ -1,0 +1,49 @@
+using System.Text.Json.Nodes;
+
+namespace SqlOS.AuthServer.Contracts;
+
+public sealed record SqlOSPhoneOtpStartRequest(
+    string PhoneNumber,
+    string ClientId,
+    string? OrganizationId);
+
+public sealed record SqlOSPhoneOtpSignupStartRequest(
+    string DisplayName,
+    string PhoneNumber,
+    string ClientId,
+    string? OrganizationName,
+    string? OrganizationId,
+    JsonObject? CustomFields);
+
+public sealed record SqlOSPhoneOtpStartResult(
+    string ChallengeToken,
+    string PhoneNumber,
+    string MaskedPhoneNumber,
+    string Message,
+    DateTime ExpiresAt,
+    DateTime NextAllowedSendAt);
+
+public sealed record SqlOSPhoneOtpSignupStartResult(
+    string ChallengeToken,
+    string SignupToken,
+    string PhoneNumber,
+    string MaskedPhoneNumber,
+    string Message,
+    DateTime ExpiresAt,
+    DateTime NextAllowedSendAt);
+
+public sealed record SqlOSPhoneOtpVerifyRequest(
+    string ChallengeToken,
+    string Code);
+
+public sealed record SqlOSPhoneOtpSignupVerifyRequest(
+    string SignupToken,
+    string ChallengeToken,
+    string Code);
+
+public sealed record SqlOSPhoneOtpEnrollmentStartRequest(
+    string PhoneNumber);
+
+public sealed record SqlOSPhoneOtpEnrollmentVerifyRequest(
+    string ChallengeToken,
+    string Code);

--- a/src/SqlOS/AuthServer/Extensions/EndpointRouteBuilderExtensions.cs
+++ b/src/SqlOS/AuthServer/Extensions/EndpointRouteBuilderExtensions.cs
@@ -126,6 +126,8 @@ public static class EndpointRouteBuilderExtensions
                     "signup" => "signup",
                     "password" => "password",
                     "email-otp" => "email-otp",
+                    "phone-otp" => "phone-otp",
+                    "phone-otp-signup" => "phone-otp-signup",
                     _ when invitation != null => "invite",
                     _ => "login"
                 };
@@ -216,6 +218,13 @@ public static class EndpointRouteBuilderExtensions
         {
             var invitationToken = ReadInvitationToken(context);
             var deviceUserCode = ReadDeviceUserCode(context);
+            var statusMode = context.Request.Query["status"].ToString().Trim().ToLowerInvariant() switch
+            {
+                "signed-in" => "signed-in",
+                "signed-up" => "signed-up",
+                "invitation-accepted" => "invitation-accepted",
+                _ => null
+            };
             var invitation = !string.IsNullOrWhiteSpace(invitationToken)
                 ? await invitationService.ResolveEmailInvitationAsync(invitationToken, context, cancellationToken)
                 : null;
@@ -240,7 +249,7 @@ public static class EndpointRouteBuilderExtensions
             }
 
             var page = await BuildAuthPageViewModelAsync(
-                invitation == null ? "login" : "invite",
+                statusMode ?? (invitation == null ? "login" : "invite"),
                 context.Request.Query["request"].ToString(),
                 invitation?.Email ?? context.Request.Query["email"].ToString(),
                 null,
@@ -1018,6 +1027,179 @@ public static class EndpointRouteBuilderExtensions
             }
         });
 
+        auth.MapGet("/login/phone-otp", async (
+            HttpContext context,
+            SqlOSAuthorizationServerService authorizationServerService,
+            SqlOSHeadlessAuthService headlessAuthService,
+            CancellationToken cancellationToken) =>
+        {
+            var deviceUserCode = ReadDeviceUserCode(context);
+            var phoneNumber = context.Request.Query["phoneNumber"].ToString();
+            if (headlessAuthService.IsBrowserUiEnabled)
+            {
+                var uiContext = SqlOSHeadlessAuthService.ParseUiContext(context.Request.Query["ui_context"].ToString()) ?? new JsonObject();
+                if (!string.IsNullOrWhiteSpace(deviceUserCode))
+                {
+                    uiContext["deviceUserCode"] = deviceUserCode;
+                }
+
+                return Results.Redirect(headlessAuthService.BuildStandaloneUiUrl(
+                    context,
+                    "phone-otp",
+                    context.Request.Query["request"].ToString(),
+                    email: null,
+                    uiContext));
+            }
+
+            var page = await BuildAuthPageViewModelAsync(
+                "phone-otp",
+                context.Request.Query["request"].ToString(),
+                email: null,
+                error: null,
+                displayName: null,
+                pendingToken: null,
+                authPrefix,
+                authorizationServerService,
+                cancellationToken,
+                deviceUserCode: deviceUserCode,
+                phoneNumber: phoneNumber);
+            return Html(page);
+        });
+
+        auth.MapPost("/login/phone-otp/start", async (
+            HttpContext context,
+            SqlOSAuthorizationServerService authorizationServerService,
+            SqlOSPhoneOtpService phoneOtpService,
+            CancellationToken cancellationToken) =>
+        {
+            var form = await context.Request.ReadFormAsync(cancellationToken);
+            var requestId = form["requestId"].ToString();
+            var phoneNumber = form["phoneNumber"].ToString();
+            var deviceUserCode = ReadDeviceUserCode(context, form);
+
+            try
+            {
+                var authorizationRequest = await authorizationServerService.TryGetActiveAuthorizationRequestAsync(requestId, cancellationToken);
+                var challenge = await phoneOtpService.StartForAuthorizationRequestAsync(
+                    authorizationRequest,
+                    phoneNumber,
+                    context,
+                    cancellationToken);
+
+                var page = await BuildAuthPageViewModelAsync(
+                    "phone-otp-verify",
+                    requestId,
+                    email: null,
+                    error: null,
+                    displayName: null,
+                    pendingToken: null,
+                    authPrefix,
+                    authorizationServerService,
+                    cancellationToken,
+                    info: challenge.Message,
+                    challengeToken: challenge.ChallengeToken,
+                    deviceUserCode: deviceUserCode,
+                    phoneNumber: challenge.PhoneNumber);
+                return Html(page);
+            }
+            catch (InvalidOperationException ex)
+            {
+                var page = await BuildAuthPageViewModelAsync(
+                    "phone-otp",
+                    requestId,
+                    email: null,
+                    error: ex.Message,
+                    displayName: null,
+                    pendingToken: null,
+                    authPrefix,
+                    authorizationServerService,
+                    cancellationToken,
+                    deviceUserCode: deviceUserCode,
+                    phoneNumber: phoneNumber);
+                return Html(page, StatusCodes.Status400BadRequest);
+            }
+        });
+
+        auth.MapPost("/login/phone-otp/verify", async (
+            HttpContext context,
+            SqlOSAuthorizationServerService authorizationServerService,
+            SqlOSPhoneOtpService phoneOtpService,
+            SqlOSAuthPageSessionService authPageSessionService,
+            CancellationToken cancellationToken) =>
+        {
+            var form = await context.Request.ReadFormAsync(cancellationToken);
+            var requestId = form["requestId"].ToString();
+            var phoneNumber = form["phoneNumber"].ToString();
+            var challengeToken = form["challengeToken"].ToString();
+            var code = form["code"].ToString();
+            var deviceUserCode = ReadDeviceUserCode(context, form);
+
+            try
+            {
+                var authorizationRequest = await authorizationServerService.TryGetActiveAuthorizationRequestAsync(requestId, cancellationToken);
+                var verification = await phoneOtpService.VerifyAsync(
+                    new SqlOSPhoneOtpVerifyRequest(challengeToken, code),
+                    authorizationRequest?.Id,
+                    requireAuthorizationRequestMatch: true,
+                    cancellationToken);
+
+                if (authorizationRequest == null)
+                {
+                    var organizationId = verification.Organizations.FirstOrDefault()?.Id;
+                    await authPageSessionService.SignInAsync(
+                        context,
+                        verification.User,
+                        organizationId,
+                        verification.AuthenticationMethod,
+                        cancellationToken);
+                    return RedirectAfterStandaloneSignIn(authPrefix, "signed-in", deviceUserCode);
+                }
+
+                var completion = await authorizationServerService.CompleteAuthorizationRequestLoginAsync(
+                    authorizationRequest,
+                    verification.User,
+                    verification.AuthenticationMethod,
+                    context,
+                    cancellationToken);
+
+                if (completion.RequiresOrganizationSelection)
+                {
+                    var organizationPage = await BuildAuthPageViewModelAsync(
+                        "organization",
+                        requestId,
+                        email: null,
+                        error: null,
+                        displayName: null,
+                        pendingToken: completion.PendingToken,
+                        authPrefix,
+                        authorizationServerService,
+                        cancellationToken,
+                        completion.Organizations,
+                        phoneNumber: phoneNumber);
+                    return Html(organizationPage);
+                }
+
+                return Results.Redirect(completion.RedirectUrl!);
+            }
+            catch (InvalidOperationException ex)
+            {
+                var page = await BuildAuthPageViewModelAsync(
+                    "phone-otp-verify",
+                    requestId,
+                    email: null,
+                    error: ex.Message,
+                    displayName: null,
+                    pendingToken: null,
+                    authPrefix,
+                    authorizationServerService,
+                    cancellationToken,
+                    challengeToken: challengeToken,
+                    deviceUserCode: deviceUserCode,
+                    phoneNumber: phoneNumber);
+                return Html(page, StatusCodes.Status400BadRequest);
+            }
+        });
+
         auth.MapPost("/login/select-organization", async (
             HttpContext context,
             SqlOSAuthorizationServerService authorizationServerService,
@@ -1112,6 +1294,61 @@ public static class EndpointRouteBuilderExtensions
                 invitationToken: invitationToken,
                 invitation: invitation,
                 deviceUserCode: deviceUserCode);
+            return Html(page);
+        });
+
+        auth.MapGet("/signup/phone-otp", async (
+            HttpContext context,
+            SqlOSAuthorizationServerService authorizationServerService,
+            SqlOSHeadlessAuthService headlessAuthService,
+            SqlOSInvitationService invitationService,
+            CancellationToken cancellationToken) =>
+        {
+            var invitationToken = ReadInvitationToken(context);
+            var deviceUserCode = ReadDeviceUserCode(context);
+            var invitation = !string.IsNullOrWhiteSpace(invitationToken)
+                ? await invitationService.ResolveEmailInvitationAsync(invitationToken, context, cancellationToken)
+                : null;
+            var phoneNumber = context.Request.Query["phoneNumber"].ToString();
+
+            if (headlessAuthService.IsBrowserUiEnabled)
+            {
+                var uiContext = SqlOSHeadlessAuthService.ParseUiContext(context.Request.Query["ui_context"].ToString()) ?? new JsonObject();
+                if (!string.IsNullOrWhiteSpace(invitationToken))
+                {
+                    uiContext["invitationToken"] = invitationToken;
+                }
+                if (!string.IsNullOrWhiteSpace(deviceUserCode))
+                {
+                    uiContext["deviceUserCode"] = deviceUserCode;
+                }
+                if (!string.IsNullOrWhiteSpace(phoneNumber))
+                {
+                    uiContext["phoneNumber"] = phoneNumber;
+                }
+
+                return Results.Redirect(headlessAuthService.BuildStandaloneUiUrl(
+                    context,
+                    "phone-otp-signup",
+                    context.Request.Query["request"].ToString(),
+                    email: null,
+                    uiContext));
+            }
+
+            var page = await BuildAuthPageViewModelAsync(
+                "phone-otp-signup",
+                context.Request.Query["request"].ToString(),
+                email: null,
+                error: null,
+                displayName: context.Request.Query["displayName"].ToString(),
+                pendingToken: null,
+                authPrefix,
+                authorizationServerService,
+                cancellationToken,
+                invitationToken: invitationToken,
+                invitation: invitation,
+                deviceUserCode: deviceUserCode,
+                phoneNumber: phoneNumber);
             return Html(page);
         });
 
@@ -1527,6 +1764,198 @@ public static class EndpointRouteBuilderExtensions
             }
         });
 
+        auth.MapPost("/signup/phone-otp/start", async (
+            HttpContext context,
+            SqlOSAuthorizationServerService authorizationServerService,
+            SqlOSPhoneOtpService phoneOtpService,
+            SqlOSInvitationService invitationService,
+            CancellationToken cancellationToken) =>
+        {
+            var form = await context.Request.ReadFormAsync(cancellationToken);
+            var requestId = form["requestId"].ToString();
+            var displayName = form["displayName"].ToString();
+            var phoneNumber = form["phoneNumber"].ToString();
+            var organizationName = form["organizationName"].ToString();
+            var invitationToken = ReadInvitationToken(context, form);
+            var deviceUserCode = ReadDeviceUserCode(context, form);
+
+            try
+            {
+                var authorizationRequest = await authorizationServerService.TryGetActiveAuthorizationRequestAsync(requestId, cancellationToken);
+                var invitation = await BindInvitationIfPresentAsync(invitationService, authorizationRequest, invitationToken, cancellationToken)
+                    ?? await ResolveStandaloneInvitationAsync(invitationService, authorizationRequest, invitationToken, context, cancellationToken);
+                if (invitation != null)
+                {
+                    throw new InvalidOperationException("Phone signup is not available for email invitations.");
+                }
+
+                var signup = await phoneOtpService.StartSignupForAuthorizationRequestAsync(
+                    authorizationRequest,
+                    displayName,
+                    phoneNumber,
+                    organizationName,
+                    customFields: null,
+                    context,
+                    cancellationToken);
+
+                var page = await BuildAuthPageViewModelAsync(
+                    "phone-otp-signup-verify",
+                    requestId,
+                    email: null,
+                    error: null,
+                    displayName: displayName,
+                    pendingToken: null,
+                    authPrefix,
+                    authorizationServerService,
+                    cancellationToken,
+                    info: signup.Message,
+                    challengeToken: signup.ChallengeToken,
+                    signupToken: signup.SignupToken,
+                    invitationToken: invitationToken,
+                    deviceUserCode: deviceUserCode,
+                    phoneNumber: signup.PhoneNumber);
+                return Html(page);
+            }
+            catch (InvalidOperationException ex)
+            {
+                var page = await BuildAuthPageViewModelAsync(
+                    "phone-otp-signup",
+                    requestId,
+                    email: null,
+                    error: ex.Message,
+                    displayName: displayName,
+                    pendingToken: null,
+                    authPrefix,
+                    authorizationServerService,
+                    cancellationToken,
+                    invitationToken: invitationToken,
+                    invitationService: invitationService,
+                    deviceUserCode: deviceUserCode,
+                    phoneNumber: phoneNumber);
+                return Html(page, StatusCodes.Status400BadRequest);
+            }
+        });
+
+        auth.MapPost("/signup/phone-otp/verify", async (
+            HttpContext context,
+            SqlOSAuthorizationServerService authorizationServerService,
+            SqlOSAuthPageSessionService authPageSessionService,
+            SqlOSPhoneOtpService phoneOtpService,
+            ISqlOSAuthServerDbContext dbContext,
+            SqlOSInvitationService invitationService,
+            SqlOSAdminService adminService,
+            CancellationToken cancellationToken) =>
+        {
+            var form = await context.Request.ReadFormAsync(cancellationToken);
+            var requestId = form["requestId"].ToString();
+            var phoneNumber = form["phoneNumber"].ToString();
+            var signupToken = form["signupToken"].ToString();
+            var challengeToken = form["challengeToken"].ToString();
+            var code = form["code"].ToString();
+            var invitationToken = ReadInvitationToken(context, form);
+            var deviceUserCode = ReadDeviceUserCode(context, form);
+            IDbContextTransaction? transaction = null;
+
+            try
+            {
+                if (SupportsDatabaseTransactions(dbContext))
+                {
+                    transaction = await dbContext.Database.BeginTransactionAsync(cancellationToken);
+                }
+
+                var authorizationRequest = await authorizationServerService.TryGetActiveAuthorizationRequestAsync(requestId, cancellationToken);
+                var invitation = await BindInvitationIfPresentAsync(invitationService, authorizationRequest, invitationToken, cancellationToken)
+                    ?? await ResolveStandaloneInvitationAsync(invitationService, authorizationRequest, invitationToken, context, cancellationToken);
+                if (invitation != null)
+                {
+                    throw new InvalidOperationException("Phone signup is not available for email invitations.");
+                }
+
+                var signupVerification = await phoneOtpService.VerifySignupAsync(
+                    new SqlOSPhoneOtpSignupVerifyRequest(signupToken, challengeToken, code),
+                    authorizationRequest?.Id,
+                    requireAuthorizationRequestMatch: true,
+                    cancellationToken);
+
+                var signup = await authorizationServerService.SignUpWithPhoneOtpAsync(
+                    signupVerification.DisplayName,
+                    signupVerification.PhoneNumber,
+                    signupVerification.OrganizationName,
+                    authorizationRequest?.OrganizationId ?? signupVerification.OrganizationId,
+                    cancellationToken);
+
+                if (authorizationRequest == null)
+                {
+                    var organizationId = signup.Organizations.FirstOrDefault()?.Id;
+                    await authPageSessionService.SignInAsync(context, signup.User, organizationId, signup.AuthenticationMethod, cancellationToken);
+                    await phoneOtpService.ConsumeSignupTokenAsync(signupVerification.SignupToken, cancellationToken);
+                    await adminService.RecordAuditAsync(
+                        "user.signup.phone_otp",
+                        "user",
+                        signup.User.Id,
+                        userId: signup.User.Id,
+                        organizationId: organizationId,
+                        ipAddress: context.Connection.RemoteIpAddress?.ToString(),
+                        cancellationToken: cancellationToken);
+                    if (transaction != null)
+                    {
+                        await transaction.CommitAsync(cancellationToken);
+                    }
+
+                    return RedirectAfterStandaloneSignIn(authPrefix, "signed-up", deviceUserCode);
+                }
+
+                var redirectUrl = await authorizationServerService.IssueAuthorizationRedirectAsync(
+                    authorizationRequest,
+                    signup.User,
+                    signup.Organizations.FirstOrDefault()?.Id,
+                    signup.AuthenticationMethod,
+                    context,
+                    cancellationToken);
+
+                await phoneOtpService.ConsumeSignupTokenAsync(signupVerification.SignupToken, cancellationToken);
+                await adminService.RecordAuditAsync(
+                    "user.signup.phone_otp",
+                    "user",
+                    signup.User.Id,
+                    userId: signup.User.Id,
+                    organizationId: signup.Organizations.FirstOrDefault()?.Id,
+                    ipAddress: context.Connection.RemoteIpAddress?.ToString(),
+                    cancellationToken: cancellationToken);
+                if (transaction != null)
+                {
+                    await transaction.CommitAsync(cancellationToken);
+                }
+
+                return Results.Redirect(redirectUrl);
+            }
+            catch (InvalidOperationException ex)
+            {
+                if (transaction != null)
+                {
+                    await transaction.RollbackAsync(cancellationToken);
+                }
+
+                var page = await BuildAuthPageViewModelAsync(
+                    "phone-otp-signup-verify",
+                    requestId,
+                    email: null,
+                    error: ex.Message,
+                    displayName: null,
+                    pendingToken: null,
+                    authPrefix,
+                    authorizationServerService,
+                    cancellationToken,
+                    challengeToken: challengeToken,
+                    signupToken: signupToken,
+                    invitationToken: invitationToken,
+                    invitationService: invitationService,
+                    deviceUserCode: deviceUserCode,
+                    phoneNumber: phoneNumber);
+                return Html(page, StatusCodes.Status400BadRequest);
+            }
+        });
+
         var headless = endpoints.MapGroup(resolvedHeadlessPath);
         headless.ExcludeFromDescription();
 
@@ -1858,6 +2287,90 @@ public static class EndpointRouteBuilderExtensions
             try
             {
                 return Results.Ok(await headlessAuthService.SignUpWithInvitationAsync(context, request, cancellationToken));
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.BadRequest(ex.Message);
+            }
+        });
+
+        headless.MapPost("/phone-otp/start", async (
+            SqlOSHeadlessPhoneOtpStartRequest request,
+            HttpContext context,
+            SqlOSHeadlessAuthService headlessAuthService,
+            CancellationToken cancellationToken) =>
+        {
+            if (!headlessAuthService.IsApiEnabled)
+            {
+                return Results.NotFound();
+            }
+
+            try
+            {
+                return Results.Ok(await headlessAuthService.RequestPhoneOtpAsync(context, request, cancellationToken));
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.BadRequest(ex.Message);
+            }
+        });
+
+        headless.MapPost("/phone-otp/verify", async (
+            SqlOSHeadlessPhoneOtpVerifyRequest request,
+            HttpContext context,
+            SqlOSHeadlessAuthService headlessAuthService,
+            CancellationToken cancellationToken) =>
+        {
+            if (!headlessAuthService.IsApiEnabled)
+            {
+                return Results.NotFound();
+            }
+
+            try
+            {
+                return Results.Ok(await headlessAuthService.VerifyPhoneOtpAsync(context, request, cancellationToken));
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.BadRequest(ex.Message);
+            }
+        });
+
+        headless.MapPost("/signup/phone-otp/start", async (
+            SqlOSHeadlessPhoneOtpSignupStartRequest request,
+            HttpContext context,
+            SqlOSHeadlessAuthService headlessAuthService,
+            CancellationToken cancellationToken) =>
+        {
+            if (!headlessAuthService.IsApiEnabled)
+            {
+                return Results.NotFound();
+            }
+
+            try
+            {
+                return Results.Ok(await headlessAuthService.RequestPhoneOtpSignupAsync(context, request, cancellationToken));
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.BadRequest(ex.Message);
+            }
+        });
+
+        headless.MapPost("/signup/phone-otp/verify", async (
+            SqlOSHeadlessPhoneOtpSignupVerifyRequest request,
+            HttpContext context,
+            SqlOSHeadlessAuthService headlessAuthService,
+            CancellationToken cancellationToken) =>
+        {
+            if (!headlessAuthService.IsApiEnabled)
+            {
+                return Results.NotFound();
+            }
+
+            try
+            {
+                return Results.Ok(await headlessAuthService.VerifyPhoneOtpSignupAsync(context, request, cancellationToken));
             }
             catch (InvalidOperationException ex)
             {
@@ -3063,7 +3576,8 @@ public static class EndpointRouteBuilderExtensions
         SqlOSEmailInvitationResult? invitation = null,
         SqlOSInvitationService? invitationService = null,
         string? deviceUserCode = null,
-        SqlOSDeviceAuthorizationResolveResult? deviceAuthorization = null)
+        SqlOSDeviceAuthorizationResolveResult? deviceAuthorization = null,
+        string? phoneNumber = null)
     {
         var settings = await authorizationServerService.GetAuthPageSettingsAsync(cancellationToken);
         var isDeviceView = string.Equals(mode, "device", StringComparison.OrdinalIgnoreCase)
@@ -3124,7 +3638,8 @@ public static class EndpointRouteBuilderExtensions
             invitationToken,
             invitation,
             effectiveDeviceUserCode,
-            deviceAuthorization);
+            deviceAuthorization,
+            phoneNumber);
     }
 
     private static string ResolvePreferredLocalView(SqlOSResolvedCredentialSettings credentialSettings)
@@ -3132,6 +3647,11 @@ public static class EndpointRouteBuilderExtensions
         if (credentialSettings.EmailOtpEnabled)
         {
             return "email-otp";
+        }
+
+        if (credentialSettings.PhoneOtpEnabled)
+        {
+            return "phone-otp";
         }
 
         if (credentialSettings.PasswordEnabled)

--- a/src/SqlOS/AuthServer/Interfaces/ISqlOSOtpDeliveryChannel.cs
+++ b/src/SqlOS/AuthServer/Interfaces/ISqlOSOtpDeliveryChannel.cs
@@ -1,0 +1,36 @@
+namespace SqlOS.AuthServer.Interfaces;
+
+public interface ISqlOSOtpDeliveryChannel
+{
+    Task<SqlOSOtpDeliveryStartResult> StartAsync(
+        string e164PhoneNumber,
+        SqlOSOtpDeliveryContext context,
+        CancellationToken cancellationToken = default);
+
+    Task<SqlOSOtpDeliveryCheckResult> CheckAsync(
+        string e164PhoneNumber,
+        string code,
+        SqlOSOtpDeliveryContext context,
+        CancellationToken cancellationToken = default);
+}
+
+public sealed record SqlOSOtpDeliveryContext(
+    string Purpose,
+    string? ClientApplicationId,
+    string? AuthorizationRequestId,
+    string? IpAddress,
+    string? UserAgent);
+
+public sealed record SqlOSOtpDeliveryStartResult(
+    bool Accepted,
+    string Provider,
+    string? ProviderChallengeId,
+    string? ProviderStatus,
+    string? SanitizedError = null);
+
+public sealed record SqlOSOtpDeliveryCheckResult(
+    bool Approved,
+    string Provider,
+    string? ProviderChallengeId,
+    string? ProviderStatus,
+    string? SanitizedError = null);

--- a/src/SqlOS/AuthServer/Models/SqlOSEntities.cs
+++ b/src/SqlOS/AuthServer/Models/SqlOSEntities.cs
@@ -25,6 +25,7 @@ public sealed class SqlOSUser
     public DateTime UpdatedAt { get; set; }
 
     public ICollection<SqlOSUserEmail> Emails { get; set; } = new List<SqlOSUserEmail>();
+    public ICollection<SqlOSUserPhoneNumber> PhoneNumbers { get; set; } = new List<SqlOSUserPhoneNumber>();
     public ICollection<SqlOSCredential> Credentials { get; set; } = new List<SqlOSCredential>();
     public ICollection<SqlOSMembership> Memberships { get; set; } = new List<SqlOSMembership>();
     public ICollection<SqlOSExternalIdentity> ExternalIdentities { get; set; } = new List<SqlOSExternalIdentity>();
@@ -41,6 +42,25 @@ public sealed class SqlOSUserEmail
     public bool IsVerified { get; set; }
     public DateTime? VerifiedAt { get; set; }
     public DateTime CreatedAt { get; set; }
+
+    public SqlOSUser? User { get; set; }
+}
+
+public sealed class SqlOSUserPhoneNumber
+{
+    public string Id { get; set; } = string.Empty;
+    public string UserId { get; set; } = string.Empty;
+    public string PhoneNumber { get; set; } = string.Empty;
+    public string PhoneNumberHash { get; set; } = string.Empty;
+    public string? DisplayValueEncrypted { get; set; }
+    public bool IsPrimary { get; set; }
+    public bool IsVerified { get; set; }
+    public DateTime? VerifiedAt { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+    public DateTime? LastUsedAt { get; set; }
+    public DateTime? RemovedAt { get; set; }
+    public string? RemovalReason { get; set; }
 
     public SqlOSUser? User { get; set; }
 }
@@ -425,6 +445,39 @@ public sealed class SqlOSEmailOtpChallenge
 
     public SqlOSUser? User { get; set; }
     public SqlOSUserEmail? UserEmail { get; set; }
+    public SqlOSAuthorizationRequest? AuthorizationRequest { get; set; }
+    public SqlOSClientApplication? ClientApplication { get; set; }
+}
+
+public sealed class SqlOSPhoneOtpChallenge
+{
+    public string Id { get; set; } = string.Empty;
+    public string ChallengeTokenHash { get; set; } = string.Empty;
+    public string PhoneNumberHash { get; set; } = string.Empty;
+    public string PhoneNumberEncrypted { get; set; } = string.Empty;
+    public string MaskedPhoneNumber { get; set; } = string.Empty;
+    public string Purpose { get; set; } = "login";
+    public string? UserId { get; set; }
+    public string? UserPhoneNumberId { get; set; }
+    public string? AuthorizationRequestId { get; set; }
+    public string? ClientApplicationId { get; set; }
+    public string? RequestedOrganizationId { get; set; }
+    public bool ProviderStarted { get; set; }
+    public string Provider { get; set; } = "twilio_verify";
+    public string? ProviderChallengeId { get; set; }
+    public string? ProviderStatus { get; set; }
+    public int AttemptCount { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime ExpiresAt { get; set; }
+    public DateTime LastSentAt { get; set; }
+    public DateTime? ConsumedAt { get; set; }
+    public DateTime? InvalidatedAt { get; set; }
+    public string? InvalidatedReason { get; set; }
+    public string? IpAddress { get; set; }
+    public string? UserAgent { get; set; }
+
+    public SqlOSUser? User { get; set; }
+    public SqlOSUserPhoneNumber? UserPhoneNumber { get; set; }
     public SqlOSAuthorizationRequest? AuthorizationRequest { get; set; }
     public SqlOSClientApplication? ClientApplication { get; set; }
 }

--- a/src/SqlOS/AuthServer/Schema/018_PhoneOtp.sql
+++ b/src/SqlOS/AuthServer/Schema/018_PhoneOtp.sql
@@ -1,0 +1,97 @@
+IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'SqlOSUserPhoneNumbers' AND schema_id = SCHEMA_ID('{Schema}'))
+BEGIN
+    CREATE TABLE [{Schema}].[SqlOSUserPhoneNumbers] (
+        [Id] NVARCHAR(64) NOT NULL PRIMARY KEY,
+        [UserId] NVARCHAR(64) NOT NULL,
+        [PhoneNumber] NVARCHAR(32) NOT NULL,
+        [PhoneNumberHash] NVARCHAR(128) NOT NULL,
+        [DisplayValueEncrypted] NVARCHAR(2048) NULL,
+        [IsPrimary] BIT NOT NULL CONSTRAINT [DF_SqlOSUserPhoneNumbers_IsPrimary] DEFAULT 0,
+        [IsVerified] BIT NOT NULL CONSTRAINT [DF_SqlOSUserPhoneNumbers_IsVerified] DEFAULT 0,
+        [VerifiedAt] DATETIME2 NULL,
+        [CreatedAt] DATETIME2 NOT NULL,
+        [UpdatedAt] DATETIME2 NOT NULL,
+        [LastUsedAt] DATETIME2 NULL,
+        [RemovedAt] DATETIME2 NULL,
+        [RemovalReason] NVARCHAR(120) NULL
+    );
+
+    CREATE UNIQUE INDEX [IX_SqlOSUserPhoneNumbers_PhoneNumberHash]
+        ON [{Schema}].[SqlOSUserPhoneNumbers]([PhoneNumberHash])
+        WHERE [RemovedAt] IS NULL;
+
+    CREATE INDEX [IX_SqlOSUserPhoneNumbers_UserId_RemovedAt]
+        ON [{Schema}].[SqlOSUserPhoneNumbers]([UserId], [RemovedAt]);
+
+    ALTER TABLE [{Schema}].[SqlOSUserPhoneNumbers]
+        ADD CONSTRAINT [FK_SqlOSUserPhoneNumbers_Users_UserId]
+            FOREIGN KEY ([UserId]) REFERENCES [{Schema}].[SqlOSUsers]([Id]);
+END
+
+GO
+
+IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'SqlOSPhoneOtpChallenges' AND schema_id = SCHEMA_ID('{Schema}'))
+BEGIN
+    CREATE TABLE [{Schema}].[SqlOSPhoneOtpChallenges] (
+        [Id] NVARCHAR(64) NOT NULL PRIMARY KEY,
+        [ChallengeTokenHash] NVARCHAR(128) NOT NULL,
+        [PhoneNumberHash] NVARCHAR(128) NOT NULL,
+        [PhoneNumberEncrypted] NVARCHAR(2048) NOT NULL,
+        [MaskedPhoneNumber] NVARCHAR(32) NOT NULL,
+        [Purpose] NVARCHAR(32) NOT NULL,
+        [UserId] NVARCHAR(64) NULL,
+        [UserPhoneNumberId] NVARCHAR(64) NULL,
+        [AuthorizationRequestId] NVARCHAR(64) NULL,
+        [ClientApplicationId] NVARCHAR(64) NULL,
+        [RequestedOrganizationId] NVARCHAR(64) NULL,
+        [ProviderStarted] BIT NOT NULL CONSTRAINT [DF_SqlOSPhoneOtpChallenges_ProviderStarted] DEFAULT 0,
+        [Provider] NVARCHAR(40) NOT NULL,
+        [ProviderChallengeId] NVARCHAR(128) NULL,
+        [ProviderStatus] NVARCHAR(80) NULL,
+        [AttemptCount] INT NOT NULL CONSTRAINT [DF_SqlOSPhoneOtpChallenges_AttemptCount] DEFAULT 0,
+        [CreatedAt] DATETIME2 NOT NULL,
+        [ExpiresAt] DATETIME2 NOT NULL,
+        [LastSentAt] DATETIME2 NOT NULL,
+        [ConsumedAt] DATETIME2 NULL,
+        [InvalidatedAt] DATETIME2 NULL,
+        [InvalidatedReason] NVARCHAR(120) NULL,
+        [IpAddress] NVARCHAR(128) NULL,
+        [UserAgent] NVARCHAR(512) NULL
+    );
+
+    CREATE UNIQUE INDEX [IX_SqlOSPhoneOtpChallenges_ChallengeTokenHash]
+        ON [{Schema}].[SqlOSPhoneOtpChallenges]([ChallengeTokenHash]);
+
+    CREATE INDEX [IX_SqlOSPhoneOtpChallenges_PhoneNumberHash_CreatedAt]
+        ON [{Schema}].[SqlOSPhoneOtpChallenges]([PhoneNumberHash], [CreatedAt]);
+
+    CREATE INDEX [IX_SqlOSPhoneOtpChallenges_UserId_CreatedAt]
+        ON [{Schema}].[SqlOSPhoneOtpChallenges]([UserId], [CreatedAt]);
+
+    CREATE INDEX [IX_SqlOSPhoneOtpChallenges_IpAddress_CreatedAt]
+        ON [{Schema}].[SqlOSPhoneOtpChallenges]([IpAddress], [CreatedAt]);
+
+    CREATE INDEX [IX_SqlOSPhoneOtpChallenges_ClientApplicationId_CreatedAt]
+        ON [{Schema}].[SqlOSPhoneOtpChallenges]([ClientApplicationId], [CreatedAt]);
+
+    ALTER TABLE [{Schema}].[SqlOSPhoneOtpChallenges]
+        ADD CONSTRAINT [FK_SqlOSPhoneOtpChallenges_Users_UserId]
+            FOREIGN KEY ([UserId]) REFERENCES [{Schema}].[SqlOSUsers]([Id]);
+
+    ALTER TABLE [{Schema}].[SqlOSPhoneOtpChallenges]
+        ADD CONSTRAINT [FK_SqlOSPhoneOtpChallenges_UserPhoneNumbers_UserPhoneNumberId]
+            FOREIGN KEY ([UserPhoneNumberId]) REFERENCES [{Schema}].[SqlOSUserPhoneNumbers]([Id]);
+
+    ALTER TABLE [{Schema}].[SqlOSPhoneOtpChallenges]
+        ADD CONSTRAINT [FK_SqlOSPhoneOtpChallenges_AuthorizationRequests_AuthorizationRequestId]
+            FOREIGN KEY ([AuthorizationRequestId]) REFERENCES [{Schema}].[SqlOSAuthorizationRequests]([Id]);
+
+    ALTER TABLE [{Schema}].[SqlOSPhoneOtpChallenges]
+        ADD CONSTRAINT [FK_SqlOSPhoneOtpChallenges_ClientApplications_ClientApplicationId]
+            FOREIGN KEY ([ClientApplicationId]) REFERENCES [{Schema}].[SqlOSClientApplications]([Id]);
+END
+
+GO
+
+DELETE FROM [{Schema}].[SqlOSSchema];
+INSERT INTO [{Schema}].[SqlOSSchema] ([Version]) VALUES (18);

--- a/src/SqlOS/AuthServer/Services/SqlOSAdminService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSAdminService.cs
@@ -66,6 +66,20 @@ public sealed class SqlOSAdminService
         await _context.SaveChangesAsync(cancellationToken);
     }
 
+    public async Task CleanupExpiredPhoneOtpChallengesAsync(CancellationToken cancellationToken = default)
+    {
+        var expired = await _context.Set<SqlOSPhoneOtpChallenge>()
+            .Where(x => x.ExpiresAt < DateTime.UtcNow || x.ConsumedAt != null || x.InvalidatedAt != null)
+            .ToListAsync(cancellationToken);
+        if (expired.Count == 0)
+        {
+            return;
+        }
+
+        _context.Set<SqlOSPhoneOtpChallenge>().RemoveRange(expired);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+
     public async Task CleanupExpiredRefreshTokensAsync(CancellationToken cancellationToken = default)
     {
         var expired = await _context.Set<SqlOSRefreshToken>()

--- a/src/SqlOS/AuthServer/Services/SqlOSAuthPageRenderer.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSAuthPageRenderer.cs
@@ -51,10 +51,13 @@ public static class SqlOSAuthPageRenderer
             && SupportsCredentialType(model.Settings.EnabledCredentialTypes, "password");
         var supportsEmailOtp = model.Settings.EmailOtpRuntimeConfigured
             && SupportsCredentialType(model.Settings.EnabledCredentialTypes, "email_otp");
+        var supportsPhoneOtp = model.Settings.PhoneOtpRuntimeConfigured
+            && SupportsCredentialType(model.Settings.EnabledCredentialTypes, "phone_otp");
         var supportsPasswordSignup = supportsPassword && model.Settings.EnablePasswordSignup;
         var supportsEmailOtpSignup = supportsEmailOtp;
+        var supportsPhoneOtpSignup = model.Invitation == null && supportsPhoneOtp;
         var supportsInvitationSignup = model.Invitation != null && supportsEmailOtpSignup;
-        var supportsSignup = supportsPasswordSignup || supportsEmailOtpSignup;
+        var supportsSignup = supportsPasswordSignup || supportsEmailOtpSignup || supportsPhoneOtpSignup;
         var signupLink = supportsSignup
             ? $"<a class=\"secondary-link\" href=\"{Html(AuthPath(model, "/signup", model.AuthorizationRequestId))}\">Get started</a>"
             : string.Empty;
@@ -65,7 +68,14 @@ public static class SqlOSAuthPageRenderer
         var emailOtpLink = supportsEmailOtp
             ? $"<a class=\"secondary-link\" href=\"{Html(AuthPathWithQuery(model, "/login/email-otp", model.AuthorizationRequestId, ("email", model.Email)))}\">Use an email code instead</a>"
             : string.Empty;
+        var phoneOtpLink = supportsPhoneOtp
+            ? $"<a class=\"secondary-link\" href=\"{Html(AuthPathWithQuery(model, "/login/phone-otp", model.AuthorizationRequestId, ("phoneNumber", model.PhoneNumber)))}\">Use a phone code instead</a>"
+            : string.Empty;
+        var phoneOtpSignupLink = supportsPhoneOtpSignup
+            ? $"<a class=\"secondary-link\" href=\"{Html(AuthPathWithQuery(model, "/signup/phone-otp", model.AuthorizationRequestId, ("phoneNumber", model.PhoneNumber)))}\">Create account with phone code</a>"
+            : string.Empty;
         var signInAgainLink = $"<a class=\"secondary-link\" href=\"{Html(AuthPath(model, "/login"))}\">Sign in again</a>";
+        var signOutLink = $"<a class=\"secondary-link\" href=\"{Html(AuthPath(model, "/logout"))}\">Sign out</a>";
         var errorMarkup = BuildCallout("error", model.Error);
         var infoMarkup = BuildCallout("info", model.Info);
         var invitationMarkup = RenderInvitationSummary(model.Invitation);
@@ -123,6 +133,7 @@ public static class SqlOSAuthPageRenderer
                 {{RenderPrimaryAction("Create account", "Creating account")}}
                 </form>
                 {{RenderProvidersSection(model)}}
+                {{RenderFooterLinks(phoneOtpSignupLink)}}
                 {{RenderFooterPrompt("Already have an account?", loginLink)}}
                 """
             : supportsEmailOtpSignup
@@ -143,6 +154,29 @@ public static class SqlOSAuthPageRenderer
                       </label>
                       {{organizationField}}
                       {{RenderPrimaryAction("Email me a code", "Sending code")}}
+                    </form>
+                    {{RenderProvidersSection(model)}}
+                    {{RenderFooterLinks(phoneOtpSignupLink)}}
+                    {{RenderFooterPrompt("Already have an account?", loginLink)}}
+                    """
+            : supportsPhoneOtpSignup
+                ? $$"""
+                    {{RenderPanelIntro("Create account", "Verify your phone with a one-time code to create your account.")}}
+                    <form class="auth-form" method="post" action="{{Html(AuthPath(model, "/signup/phone-otp/start"))}}">
+                      {{requestIdInput}}
+                      {{invitationTokenInput}}
+                      {{deviceUserCodeInput}}
+                      <input type="hidden" name="mode" value="{{encodedMode}}" />
+                      <label class="field">
+                        <span>Display name</span>
+                        <input name="displayName" value="{{Html(model.DisplayName ?? string.Empty)}}" placeholder="Jane Doe" autocomplete="name" required />
+                      </label>
+                      <label class="field">
+                        <span>Phone</span>
+                        <input name="phoneNumber" type="tel" value="{{Html(model.PhoneNumber ?? string.Empty)}}" placeholder="+1 202 555 0105" autocomplete="tel" required />
+                      </label>
+                      {{organizationField}}
+                      {{RenderPrimaryAction("Text me a code", "Sending code")}}
                     </form>
                     {{RenderProvidersSection(model)}}
                     {{RenderFooterPrompt("Already have an account?", loginLink)}}
@@ -268,6 +302,7 @@ public static class SqlOSAuthPageRenderer
                   {{RenderPrimaryAction("Continue", "Signing in")}}
                 </form>
                 {{(string.IsNullOrWhiteSpace(emailOtpLink) ? string.Empty : RenderFooterLinks(emailOtpLink))}}
+                {{(string.IsNullOrWhiteSpace(phoneOtpLink) ? string.Empty : RenderFooterLinks(phoneOtpLink))}}
                 {{RenderProvidersSection(model)}}
                 {{RenderFooterPrompt("Don't have an account?", signupLink)}}
                 """,
@@ -283,8 +318,80 @@ public static class SqlOSAuthPageRenderer
                   </label>
                   {{RenderPrimaryAction("Email me a code", "Sending code")}}
                 </form>
-                {{RenderFooterLinks(string.Join(string.Empty, new[] { passwordLink, signupLink }.Where(link => !string.IsNullOrWhiteSpace(link))))}}
+                {{RenderFooterLinks(string.Join(string.Empty, new[] { passwordLink, phoneOtpLink, signupLink }.Where(link => !string.IsNullOrWhiteSpace(link))))}}
                 {{RenderProvidersSection(model)}}
+                """,
+            "phone-otp" => $$"""
+                {{RenderPanelIntro("Phone Code", "Get a one-time code sent to your phone.")}}
+                <form class="auth-form" method="post" action="{{Html(AuthPath(model, "/login/phone-otp/start"))}}">
+                  {{requestIdInput}}
+                  {{invitationTokenInput}}
+                  {{deviceUserCodeInput}}
+                  <label class="field">
+                    <span>Phone</span>
+                    <input name="phoneNumber" type="tel" value="{{Html(model.PhoneNumber ?? string.Empty)}}" placeholder="+1 202 555 0105" autocomplete="tel" required />
+                  </label>
+                  {{RenderPrimaryAction("Text me a code", "Sending code")}}
+                </form>
+                {{RenderFooterLinks(string.Join(string.Empty, new[] { passwordLink, emailOtpLink, signupLink }.Where(link => !string.IsNullOrWhiteSpace(link))))}}
+                {{RenderProvidersSection(model)}}
+                """,
+            "phone-otp-verify" => $$"""
+                {{RenderPanelIntro("Enter Code", "Use the one-time code we sent to your phone.")}}
+                <form class="auth-form" method="post" action="{{Html(AuthPath(model, "/login/phone-otp/verify"))}}">
+                  {{requestIdInput}}
+                  {{invitationTokenInput}}
+                  {{deviceUserCodeInput}}
+                  <input type="hidden" name="challengeToken" value="{{Html(model.ChallengeToken ?? string.Empty)}}" />
+                  <input type="hidden" name="phoneNumber" value="{{Html(model.PhoneNumber ?? string.Empty)}}" />
+                  <label class="field">
+                    <span>Code</span>
+                    <input name="code" inputmode="numeric" autocomplete="one-time-code" placeholder="123456" required autofocus />
+                  </label>
+                  {{RenderPrimaryAction("Verify code", "Verifying code")}}
+                </form>
+                {{RenderFooterLinks(string.Join(string.Empty, new[] {
+                    $"<a class=\"secondary-link\" href=\"{Html(AuthPathWithQuery(model, "/login/phone-otp", model.AuthorizationRequestId, ("phoneNumber", model.PhoneNumber)))}\">Send a new code</a>",
+                    passwordLink,
+                    emailOtpLink
+                }.Where(link => !string.IsNullOrWhiteSpace(link))))}}
+                """,
+            "phone-otp-signup" => $$"""
+                {{RenderPanelIntro("Create account", "Verify your phone with a one-time code to create your account.")}}
+                <form class="auth-form" method="post" action="{{Html(AuthPath(model, "/signup/phone-otp/start"))}}">
+                  {{requestIdInput}}
+                  {{invitationTokenInput}}
+                  {{deviceUserCodeInput}}
+                  <input type="hidden" name="mode" value="{{encodedMode}}" />
+                  <label class="field">
+                    <span>Display name</span>
+                    <input name="displayName" value="{{Html(model.DisplayName ?? string.Empty)}}" placeholder="Jane Doe" autocomplete="name" required />
+                  </label>
+                  <label class="field">
+                    <span>Phone</span>
+                    <input name="phoneNumber" type="tel" value="{{Html(model.PhoneNumber ?? string.Empty)}}" placeholder="+1 202 555 0105" autocomplete="tel" required />
+                  </label>
+                  {{organizationField}}
+                  {{RenderPrimaryAction("Text me a code", "Sending code")}}
+                </form>
+                {{RenderFooterPrompt("Already have an account?", loginLink)}}
+                """,
+            "phone-otp-signup-verify" => $$"""
+                {{RenderPanelIntro("Enter Code", "Use the one-time code we sent to your phone to create your account.")}}
+                <form class="auth-form" method="post" action="{{Html(AuthPath(model, "/signup/phone-otp/verify"))}}">
+                  {{requestIdInput}}
+                  {{invitationTokenInput}}
+                  {{deviceUserCodeInput}}
+                  <input type="hidden" name="signupToken" value="{{Html(model.SignupToken ?? string.Empty)}}" />
+                  <input type="hidden" name="challengeToken" value="{{Html(model.ChallengeToken ?? string.Empty)}}" />
+                  <input type="hidden" name="phoneNumber" value="{{Html(model.PhoneNumber ?? string.Empty)}}" />
+                  <label class="field">
+                    <span>Code</span>
+                    <input name="code" inputmode="numeric" autocomplete="one-time-code" placeholder="123456" required autofocus />
+                  </label>
+                  {{RenderPrimaryAction("Verify and create account", "Verifying code")}}
+                </form>
+                {{RenderFooterLinks($"<a class=\"secondary-link\" href=\"{Html(AuthPathWithQuery(model, "/signup/phone-otp", model.AuthorizationRequestId, ("phoneNumber", model.PhoneNumber)))}\">Start over</a>")}}
                 """,
             "email-otp-verify" => $$"""
                 {{RenderPanelIntro("Enter Code", "Use the one-time code we sent to your email address.")}}
@@ -302,7 +409,8 @@ public static class SqlOSAuthPageRenderer
                 </form>
                 {{RenderFooterLinks(string.Join(string.Empty, new[] {
                     $"<a class=\"secondary-link\" href=\"{Html(AuthPathWithQuery(model, "/login/email-otp", model.AuthorizationRequestId, ("email", model.Email)))}\">Send a new code</a>",
-                    passwordLink
+                    passwordLink,
+                    phoneOtpLink
                 }.Where(link => !string.IsNullOrWhiteSpace(link))))}}
                 """,
             "email-otp-signup-verify" => $$"""
@@ -340,6 +448,36 @@ public static class SqlOSAuthPageRenderer
                 </div>
                 {{RenderFooterLinks(signInAgainLink)}}
                 """,
+            "signed-in" => $$"""
+                <div class="state-card">
+                  <span class="state-icon">OK</span>
+                  <div class="state-copy">
+                    <strong>You are signed in.</strong>
+                    <p>Your SqlOS auth session is active. Return to the application that sent you here to continue.</p>
+                  </div>
+                </div>
+                {{RenderFooterLinks(signOutLink)}}
+                """,
+            "signed-up" => $$"""
+                <div class="state-card">
+                  <span class="state-icon">OK</span>
+                  <div class="state-copy">
+                    <strong>Your account is ready.</strong>
+                    <p>Your SqlOS auth session is active. Return to the application that sent you here to continue.</p>
+                  </div>
+                </div>
+                {{RenderFooterLinks(signOutLink)}}
+                """,
+            "invitation-accepted" => $$"""
+                <div class="state-card">
+                  <span class="state-icon">OK</span>
+                  <div class="state-copy">
+                    <strong>Invitation accepted.</strong>
+                    <p>Your SqlOS auth session is active. Return to the application that sent you here to continue.</p>
+                  </div>
+                </div>
+                {{RenderFooterLinks(signOutLink)}}
+                """,
             _ => $$"""
                 <form class="auth-form" method="post" action="{{Html(AuthPath(model, "/login/identify"))}}" data-flow-kind="hrd">
                   {{requestIdInput}}
@@ -356,6 +494,7 @@ public static class SqlOSAuthPageRenderer
                   </div>
                 </form>
                 {{RenderProvidersSection(model)}}
+                {{RenderFooterLinks(string.Join(string.Empty, new[] { phoneOtpLink, emailOtpLink }.Where(link => !string.IsNullOrWhiteSpace(link))))}}
                 {{RenderFooterPrompt("Don't have an account?", signupLink)}}
                 """
         };
@@ -1292,6 +1431,7 @@ public sealed record SqlOSAuthPageViewModel(
     string? InvitationToken = null,
     SqlOSEmailInvitationResult? Invitation = null,
     string? DeviceUserCode = null,
-    SqlOSDeviceAuthorizationResolveResult? DeviceAuthorization = null);
+    SqlOSDeviceAuthorizationResolveResult? DeviceAuthorization = null,
+    string? PhoneNumber = null);
 
 public sealed record SqlOSAuthPageProviderLink(string ConnectionId, string DisplayName, string Url, string? LogoDataUrl = null);

--- a/src/SqlOS/AuthServer/Services/SqlOSAuthService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSAuthService.cs
@@ -24,6 +24,7 @@ public sealed class SqlOSAuthService
     private readonly SqlOSCryptoService _cryptoService;
     private readonly SqlOSSettingsService _settingsService;
     private readonly SqlOSEmailOtpService _emailOtpService;
+    private readonly SqlOSPhoneOtpService? _phoneOtpService;
     private readonly SqlOSInvitationService? _invitationService;
     private readonly SqlOSPasswordLoginAbuseService _passwordLoginAbuseService;
     private readonly ISqlOSTransactionalEmailService? _transactionalEmailService;
@@ -37,7 +38,8 @@ public sealed class SqlOSAuthService
         SqlOSEmailOtpService emailOtpService,
         SqlOSInvitationService? invitationService = null,
         SqlOSPasswordLoginAbuseService? passwordLoginAbuseService = null,
-        ISqlOSTransactionalEmailService? transactionalEmailService = null)
+        ISqlOSTransactionalEmailService? transactionalEmailService = null,
+        SqlOSPhoneOtpService? phoneOtpService = null)
     {
         _context = context;
         _options = options.Value;
@@ -45,6 +47,7 @@ public sealed class SqlOSAuthService
         _cryptoService = cryptoService;
         _settingsService = settingsService;
         _emailOtpService = emailOtpService;
+        _phoneOtpService = phoneOtpService;
         _invitationService = invitationService;
         _passwordLoginAbuseService = passwordLoginAbuseService
             ?? new SqlOSPasswordLoginAbuseService(context, adminService, cryptoService, options);
@@ -144,6 +147,18 @@ public sealed class SqlOSAuthService
         HttpContext? httpContext = null,
         CancellationToken cancellationToken = default)
         => await _emailOtpService.StartSignupForClientAsync(request, httpContext, cancellationToken);
+
+    public async Task<SqlOSPhoneOtpStartResult> RequestPhoneOtpAsync(
+        SqlOSPhoneOtpStartRequest request,
+        HttpContext? httpContext = null,
+        CancellationToken cancellationToken = default)
+        => await RequirePhoneOtpService().StartForClientAsync(request, httpContext, cancellationToken);
+
+    public async Task<SqlOSPhoneOtpSignupStartResult> RequestPhoneOtpSignupAsync(
+        SqlOSPhoneOtpSignupStartRequest request,
+        HttpContext? httpContext = null,
+        CancellationToken cancellationToken = default)
+        => await RequirePhoneOtpService().StartSignupForClientAsync(request, httpContext, cancellationToken);
 
     public async Task<SqlOSEmailInvitationResult> CreateEmailInvitationAsync(
         SqlOSCreateEmailInvitationRequest request,
@@ -312,6 +327,111 @@ public sealed class SqlOSAuthService
             verification.AuthenticationMethod,
             httpContext,
             cancellationToken);
+    }
+
+    public async Task<SqlOSLoginResult> VerifyPhoneOtpAsync(
+        SqlOSPhoneOtpVerifyRequest request,
+        HttpContext httpContext,
+        CancellationToken cancellationToken = default)
+    {
+        var verification = await RequirePhoneOtpService().VerifyAsync(request, cancellationToken);
+        if (verification.Challenge.ClientApplicationId == null)
+        {
+            throw new InvalidOperationException("The sign-in code is invalid or expired.");
+        }
+
+        var client = await _context.Set<SqlOSClientApplication>()
+            .FirstAsync(x => x.Id == verification.Challenge.ClientApplicationId, cancellationToken);
+
+        return await FinalizeClientLoginAsync(
+            verification.User,
+            client,
+            verification.Challenge.RequestedOrganizationId,
+            verification.AuthenticationMethod,
+            httpContext,
+            cancellationToken);
+    }
+
+    public async Task<SqlOSLoginResult> VerifyPhoneOtpSignupAsync(
+        SqlOSPhoneOtpSignupVerifyRequest request,
+        HttpContext httpContext,
+        CancellationToken cancellationToken = default)
+    {
+        IDbContextTransaction? transaction = null;
+        SqlOSPasswordAuthenticationResult? signup = null;
+        SqlOSPhoneOtpSignupVerificationResult? verification = null;
+
+        try
+        {
+            if (SupportsDatabaseTransactions())
+            {
+                transaction = await _context.Database.BeginTransactionAsync(cancellationToken);
+            }
+
+            verification = await RequirePhoneOtpService().VerifySignupAsync(
+                request,
+                expectedAuthorizationRequestId: null,
+                requireAuthorizationRequestMatch: false,
+                cancellationToken);
+
+            if (string.IsNullOrWhiteSpace(verification.ClientApplicationId))
+            {
+                throw new InvalidOperationException("The sign-in code is invalid or expired.");
+            }
+
+            var client = await _context.Set<SqlOSClientApplication>()
+                .FirstAsync(x => x.Id == verification.ClientApplicationId, cancellationToken);
+
+            signup = await CreatePhoneOtpSignupUserAsync(
+                verification.DisplayName,
+                verification.PhoneNumber,
+                verification.OrganizationName,
+                verification.OrganizationId,
+                cancellationToken);
+
+            var selectedOrganizationId = verification.OrganizationId ?? signup.Organizations.FirstOrDefault()?.Id;
+            var result = await FinalizeClientLoginAsync(
+                signup.User,
+                client,
+                selectedOrganizationId,
+                signup.AuthenticationMethod,
+                httpContext,
+                cancellationToken);
+
+            await RequirePhoneOtpService().ConsumeSignupTokenAsync(verification.SignupToken, cancellationToken);
+            await _adminService.RecordAuditAsync(
+                "user.signup.phone_otp",
+                "user",
+                signup.User.Id,
+                userId: signup.User.Id,
+                organizationId: selectedOrganizationId,
+                ipAddress: GetIp(httpContext),
+                cancellationToken: cancellationToken);
+
+            if (transaction != null)
+            {
+                await transaction.CommitAsync(cancellationToken);
+            }
+
+            return result;
+        }
+        catch
+        {
+            if (transaction != null)
+            {
+                await transaction.RollbackAsync(cancellationToken);
+            }
+            else
+            {
+                await CleanupNonTransactionalSignupArtifactsAsync(
+                    signup,
+                    verification?.OrganizationId,
+                    verification?.OrganizationName,
+                    cancellationToken);
+            }
+
+            throw;
+        }
     }
 
     public async Task<SqlOSLoginResult> VerifyEmailOtpSignupAsync(
@@ -1200,6 +1320,44 @@ public sealed class SqlOSAuthService
         return new SqlOSPasswordAuthenticationResult(user, organizations, "email_otp");
     }
 
+    private async Task<SqlOSPasswordAuthenticationResult> CreatePhoneOtpSignupUserAsync(
+        string displayName,
+        string phoneNumber,
+        string? organizationName,
+        string? organizationId,
+        CancellationToken cancellationToken)
+    {
+        var credentialSettings = await _settingsService.GetResolvedCredentialSettingsAsync(cancellationToken);
+        if (!credentialSettings.PhoneOtpEnabled)
+        {
+            throw new InvalidOperationException("Phone sign-in is unavailable.");
+        }
+
+        SqlOSSignupJoinPolicy.RejectUnauthorizedOrganizationJoin(organizationId);
+
+        var user = new SqlOSUser
+        {
+            Id = _cryptoService.GenerateId("usr"),
+            DisplayName = displayName,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+        _context.Set<SqlOSUser>().Add(user);
+        await _context.SaveChangesAsync(cancellationToken);
+        await RequirePhoneOtpService().AddVerifiedPhoneNumberAsync(user, phoneNumber, cancellationToken);
+
+        if (!string.IsNullOrWhiteSpace(organizationName))
+        {
+            var createdOrganization = await _adminService.CreateOrganizationAsync(
+                new SqlOSCreateOrganizationRequest(organizationName, null),
+                cancellationToken);
+            await _adminService.CreateMembershipAsync(createdOrganization.Id, new SqlOSCreateMembershipRequest(user.Id, "owner"), cancellationToken);
+        }
+
+        var organizations = await _adminService.GetUserOrganizationsAsync(user.Id, cancellationToken);
+        return new SqlOSPasswordAuthenticationResult(user, organizations, "phone_otp");
+    }
+
     private async Task<SqlOSPasswordAuthenticationResult> CreateInvitationSignupUserAsync(
         string displayName,
         string email,
@@ -1258,11 +1416,22 @@ public sealed class SqlOSAuthService
             .FirstOrDefaultAsync(x => x.Id == signup.User.Id, cancellationToken);
         if (user != null)
         {
+            var phoneNumbers = await _context.Set<SqlOSUserPhoneNumber>()
+                .Where(x => x.UserId == user.Id)
+                .ToListAsync(cancellationToken);
+            if (phoneNumbers.Count > 0)
+            {
+                _context.Set<SqlOSUserPhoneNumber>().RemoveRange(phoneNumbers);
+            }
+
             _context.Set<SqlOSUser>().Remove(user);
         }
 
         await _context.SaveChangesAsync(cancellationToken);
     }
+
+    private SqlOSPhoneOtpService RequirePhoneOtpService()
+        => _phoneOtpService ?? throw new InvalidOperationException("Phone OTP service is not registered.");
 
     private async Task<SqlOSLoginResult> FinalizeClientLoginAsync(
         SqlOSUser user,

--- a/src/SqlOS/AuthServer/Services/SqlOSAuthorizationServerService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSAuthorizationServerService.cs
@@ -345,6 +345,67 @@ public sealed class SqlOSAuthorizationServerService
         return new SqlOSPasswordAuthenticationResult(user, organizations, "email_otp");
     }
 
+    public async Task<SqlOSPasswordAuthenticationResult> SignUpWithPhoneOtpAsync(
+        string displayName,
+        string phoneNumber,
+        string? organizationName,
+        string? organizationId,
+        CancellationToken cancellationToken = default)
+    {
+        var credentialSettings = await _settingsService.GetResolvedCredentialSettingsAsync(cancellationToken);
+        if (!credentialSettings.PhoneOtpEnabled)
+        {
+            throw new InvalidOperationException("Phone sign-in is unavailable.");
+        }
+
+        SqlOSSignupJoinPolicy.RejectUnauthorizedOrganizationJoin(organizationId);
+
+        var phoneHash = _cryptoService.HashToken(phoneNumber);
+        var existingPhone = await _context.Set<SqlOSUserPhoneNumber>()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(x => x.PhoneNumberHash == phoneHash && x.RemovedAt == null, cancellationToken);
+        if (existingPhone != null)
+        {
+            throw new InvalidOperationException("An account already exists for this phone number. Sign in with a phone code instead.");
+        }
+
+        var now = DateTime.UtcNow;
+        var user = new SqlOSUser
+        {
+            Id = _cryptoService.GenerateId("usr"),
+            DisplayName = displayName,
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+        _context.Set<SqlOSUser>().Add(user);
+        _context.Set<SqlOSUserPhoneNumber>().Add(new SqlOSUserPhoneNumber
+        {
+            Id = _cryptoService.GenerateId("phn"),
+            UserId = user.Id,
+            PhoneNumber = phoneNumber,
+            PhoneNumberHash = phoneHash,
+            DisplayValueEncrypted = _cryptoService.ProtectSecret(phoneNumber),
+            IsPrimary = true,
+            IsVerified = true,
+            VerifiedAt = now,
+            CreatedAt = now,
+            UpdatedAt = now
+        });
+
+        if (!string.IsNullOrWhiteSpace(organizationName))
+        {
+            var createdOrganization = await _adminService.CreateOrganizationAsync(
+                new SqlOSCreateOrganizationRequest(organizationName, null),
+                cancellationToken);
+            await _adminService.CreateMembershipAsync(createdOrganization.Id, new SqlOSCreateMembershipRequest(user.Id, "owner"), cancellationToken);
+        }
+
+        await _context.SaveChangesAsync(cancellationToken);
+
+        var organizations = await _adminService.GetUserOrganizationsAsync(user.Id, cancellationToken);
+        return new SqlOSPasswordAuthenticationResult(user, organizations, "phone_otp");
+    }
+
     public async Task<SqlOSPasswordAuthenticationResult> SignUpWithInvitationAsync(
         string displayName,
         string email,

--- a/src/SqlOS/AuthServer/Services/SqlOSHeadlessAuthService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSHeadlessAuthService.cs
@@ -20,6 +20,7 @@ public sealed class SqlOSHeadlessAuthService
     private readonly SqlOSSamlService _samlService;
     private readonly SqlOSSettingsService _settingsService;
     private readonly SqlOSEmailOtpService _emailOtpService;
+    private readonly SqlOSPhoneOtpService? _phoneOtpService;
     private readonly SqlOSInvitationService? _invitationService;
     private readonly SqlOSDeviceAuthorizationService? _deviceAuthorizationService;
     private readonly SqlOSAuthPageSessionService? _authPageSessionService;
@@ -37,7 +38,8 @@ public sealed class SqlOSHeadlessAuthService
         IOptions<SqlOSAuthServerOptions> options,
         SqlOSInvitationService? invitationService = null,
         SqlOSDeviceAuthorizationService? deviceAuthorizationService = null,
-        SqlOSAuthPageSessionService? authPageSessionService = null)
+        SqlOSAuthPageSessionService? authPageSessionService = null,
+        SqlOSPhoneOtpService? phoneOtpService = null)
     {
         _context = context;
         _adminService = adminService;
@@ -47,6 +49,7 @@ public sealed class SqlOSHeadlessAuthService
         _samlService = samlService;
         _settingsService = settingsService;
         _emailOtpService = emailOtpService;
+        _phoneOtpService = phoneOtpService;
         _invitationService = invitationService;
         _deviceAuthorizationService = deviceAuthorizationService;
         _authPageSessionService = authPageSessionService;
@@ -796,6 +799,274 @@ public sealed class SqlOSHeadlessAuthService
                 organizationSelection: null,
                 challengeToken: request.ChallengeToken,
                 signupToken: request.SignupToken,
+            cancellationToken: cancellationToken));
+        }
+    }
+
+    public async Task<SqlOSHeadlessActionResult> RequestPhoneOtpAsync(
+        HttpContext httpContext,
+        SqlOSHeadlessPhoneOtpStartRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var authorizationRequest = await _authorizationServerService.GetRequiredAuthorizationRequestAsync(request.RequestId, cancellationToken);
+
+        try
+        {
+            var challenge = await RequirePhoneOtpService().StartForAuthorizationRequestAsync(
+                authorizationRequest,
+                request.PhoneNumber,
+                httpContext,
+                cancellationToken);
+
+            return View(await BuildViewModelAsync(
+                authorizationRequest,
+                "phone-otp-verify",
+                error: null,
+                pendingToken: null,
+                email: null,
+                displayName: null,
+                fieldErrors: null,
+                organizationSelection: null,
+                info: challenge.Message,
+                challengeToken: challenge.ChallengeToken,
+                phoneNumber: challenge.PhoneNumber,
+                cancellationToken: cancellationToken));
+        }
+        catch (InvalidOperationException ex)
+        {
+            return View(await BuildViewModelAsync(
+                authorizationRequest,
+                "phone-otp",
+                ex.Message,
+                pendingToken: null,
+                email: null,
+                displayName: null,
+                fieldErrors: null,
+                organizationSelection: null,
+                phoneNumber: request.PhoneNumber,
+                cancellationToken: cancellationToken));
+        }
+    }
+
+    public async Task<SqlOSHeadlessActionResult> VerifyPhoneOtpAsync(
+        HttpContext httpContext,
+        SqlOSHeadlessPhoneOtpVerifyRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var authorizationRequest = await _authorizationServerService.GetRequiredAuthorizationRequestAsync(request.RequestId, cancellationToken);
+
+        try
+        {
+            var verification = await RequirePhoneOtpService().VerifyAsync(
+                new SqlOSPhoneOtpVerifyRequest(request.ChallengeToken, request.Code),
+                authorizationRequest.Id,
+                requireAuthorizationRequestMatch: true,
+                cancellationToken);
+
+            var completion = await _authorizationServerService.CompleteAuthorizationRequestLoginAsync(
+                authorizationRequest,
+                verification.User,
+                verification.AuthenticationMethod,
+                httpContext,
+                cancellationToken);
+
+            if (completion.RequiresOrganizationSelection)
+            {
+                return View(await BuildViewModelAsync(
+                    authorizationRequest,
+                    "organization",
+                    error: null,
+                    pendingToken: completion.PendingToken,
+                    email: null,
+                    displayName: null,
+                    fieldErrors: null,
+                    organizationSelection: completion.Organizations,
+                    info: null,
+                    challengeToken: null,
+                    cancellationToken: cancellationToken));
+            }
+
+            return Redirect(completion.RedirectUrl!);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return View(await BuildViewModelAsync(
+                authorizationRequest,
+                "phone-otp-verify",
+                ex.Message,
+                pendingToken: null,
+                email: null,
+                displayName: null,
+                fieldErrors: null,
+                organizationSelection: null,
+                challengeToken: request.ChallengeToken,
+                cancellationToken: cancellationToken));
+        }
+    }
+
+    public async Task<SqlOSHeadlessActionResult> RequestPhoneOtpSignupAsync(
+        HttpContext httpContext,
+        SqlOSHeadlessPhoneOtpSignupStartRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var authorizationRequest = await _authorizationServerService.GetRequiredAuthorizationRequestAsync(request.RequestId, cancellationToken);
+        await BindInvitationIfPresentAsync(authorizationRequest, request.InvitationToken, cancellationToken);
+
+        try
+        {
+            if (await GetBoundInvitationOrNullAsync(authorizationRequest, cancellationToken) != null)
+            {
+                throw new InvalidOperationException("Phone signup is not available for email invitations.");
+            }
+
+            var signup = await RequirePhoneOtpService().StartSignupForAuthorizationRequestAsync(
+                authorizationRequest,
+                request.DisplayName,
+                request.PhoneNumber,
+                request.OrganizationName,
+                request.CustomFields,
+                httpContext,
+                cancellationToken);
+
+            return View(await BuildViewModelAsync(
+                authorizationRequest,
+                "phone-otp-signup-verify",
+                error: null,
+                pendingToken: null,
+                email: null,
+                displayName: request.DisplayName,
+                fieldErrors: null,
+                organizationSelection: null,
+                info: signup.Message,
+                challengeToken: signup.ChallengeToken,
+                signupToken: signup.SignupToken,
+                phoneNumber: signup.PhoneNumber,
+                cancellationToken: cancellationToken));
+        }
+        catch (InvalidOperationException ex)
+        {
+            return View(await BuildViewModelAsync(
+                authorizationRequest,
+                "phone-otp-signup",
+                ex.Message,
+                pendingToken: null,
+                email: null,
+                displayName: request.DisplayName,
+                fieldErrors: null,
+                organizationSelection: null,
+                phoneNumber: request.PhoneNumber,
+                cancellationToken: cancellationToken));
+        }
+    }
+
+    public async Task<SqlOSHeadlessActionResult> VerifyPhoneOtpSignupAsync(
+        HttpContext httpContext,
+        SqlOSHeadlessPhoneOtpSignupVerifyRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var authorizationRequest = await _authorizationServerService.GetRequiredAuthorizationRequestAsync(request.RequestId, cancellationToken);
+        await BindInvitationIfPresentAsync(authorizationRequest, request.InvitationToken, cancellationToken);
+        IDbContextTransaction? transaction = null;
+        SqlOSPasswordAuthenticationResult? signup = null;
+        SqlOSPhoneOtpSignupVerificationResult? verification = null;
+
+        try
+        {
+            if (SupportsDatabaseTransactions())
+            {
+                transaction = await _context.Database.BeginTransactionAsync(cancellationToken);
+            }
+
+            if (await GetBoundInvitationOrNullAsync(authorizationRequest, cancellationToken) != null)
+            {
+                throw new InvalidOperationException("Phone signup is not available for email invitations.");
+            }
+
+            verification = await RequirePhoneOtpService().VerifySignupAsync(
+                new SqlOSPhoneOtpSignupVerifyRequest(request.SignupToken, request.ChallengeToken, request.Code),
+                authorizationRequest.Id,
+                requireAuthorizationRequestMatch: true,
+                cancellationToken);
+
+            signup = await _authorizationServerService.SignUpWithPhoneOtpAsync(
+                verification.DisplayName,
+                verification.PhoneNumber,
+                verification.OrganizationName,
+                authorizationRequest.OrganizationId ?? verification.OrganizationId,
+                cancellationToken);
+
+            var selectedOrganizationId = signup.Organizations.FirstOrDefault()?.Id;
+            SqlOSOrganization? organization = null;
+            if (!string.IsNullOrWhiteSpace(selectedOrganizationId))
+            {
+                organization = await _context.Set<SqlOSOrganization>()
+                    .FirstOrDefaultAsync(x => x.Id == selectedOrganizationId, cancellationToken);
+            }
+
+            if (_options.Headless.OnHeadlessSignupAsync != null)
+            {
+                await _options.Headless.OnHeadlessSignupAsync(
+                    new SqlOSHeadlessSignupHookContext(
+                        httpContext,
+                        authorizationRequest,
+                        signup.User,
+                        organization,
+                        verification.CustomFields ?? new JsonObject()),
+                    cancellationToken);
+            }
+
+            var redirectUrl = await _authorizationServerService.IssueAuthorizationRedirectAsync(
+                authorizationRequest,
+                signup.User,
+                selectedOrganizationId,
+                signup.AuthenticationMethod,
+                httpContext,
+                cancellationToken);
+
+            await RequirePhoneOtpService().ConsumeSignupTokenAsync(verification.SignupToken, cancellationToken);
+            await _adminService.RecordAuditAsync(
+                "user.signup.phone_otp",
+                "user",
+                signup.User.Id,
+                userId: signup.User.Id,
+                organizationId: selectedOrganizationId,
+                ipAddress: httpContext.Connection.RemoteIpAddress?.ToString(),
+                cancellationToken: cancellationToken);
+
+            if (transaction != null)
+            {
+                await transaction.CommitAsync(cancellationToken);
+            }
+
+            return Redirect(redirectUrl);
+        }
+        catch (InvalidOperationException ex)
+        {
+            if (transaction != null)
+            {
+                await transaction.RollbackAsync(cancellationToken);
+            }
+            else
+            {
+                await CleanupNonTransactionalSignupArtifactsAsync(
+                    signup,
+                    authorizationRequest.OrganizationId ?? verification?.OrganizationId,
+                    verification?.OrganizationName,
+                    cancellationToken);
+            }
+
+            return View(await BuildViewModelAsync(
+                authorizationRequest,
+                "phone-otp-signup-verify",
+                ex.Message,
+                pendingToken: null,
+                email: null,
+                displayName: null,
+                fieldErrors: null,
+                organizationSelection: null,
+                challengeToken: request.ChallengeToken,
+                signupToken: request.SignupToken,
+                phoneNumber: verification?.PhoneNumber,
                 cancellationToken: cancellationToken));
         }
     }
@@ -1097,6 +1368,7 @@ public sealed class SqlOSHeadlessAuthService
         string? info = null,
         string? challengeToken = null,
         string? signupToken = null,
+        string? phoneNumber = null,
         CancellationToken cancellationToken = default)
     {
         var settings = await _settingsService.GetAuthPageSettingsAsync(cancellationToken);
@@ -1131,7 +1403,8 @@ public sealed class SqlOSHeadlessAuthService
             providers,
             await GetBoundInvitationOrNullAsync(authorizationRequest, cancellationToken),
             ParseUiContext(authorizationRequest.UiContextJson),
-            DeviceAuthorization: deviceAuthorization);
+            DeviceAuthorization: deviceAuthorization,
+            PhoneNumber: phoneNumber);
     }
 
     public static bool IsHeadlessRequest(SqlOSAuthorizationRequest authorizationRequest)
@@ -1196,37 +1469,32 @@ public sealed class SqlOSHeadlessAuthService
     }
 
     public static string NormalizeView(string? requestedView)
-        => string.Equals(requestedView, "signup", StringComparison.OrdinalIgnoreCase)
-            ? "signup"
-            : string.Equals(requestedView, "password", StringComparison.OrdinalIgnoreCase)
-                ? "password"
-                : string.Equals(requestedView, "email-otp", StringComparison.OrdinalIgnoreCase)
-                    ? "email-otp"
-                    : string.Equals(requestedView, "email-otp-verify", StringComparison.OrdinalIgnoreCase)
-                        ? "email-otp-verify"
-                        : string.Equals(requestedView, "email-otp-signup-verify", StringComparison.OrdinalIgnoreCase)
-                            ? "email-otp-signup-verify"
-                            : string.Equals(requestedView, "invite", StringComparison.OrdinalIgnoreCase)
-                                ? "invite"
-                                : string.Equals(requestedView, "invite-login", StringComparison.OrdinalIgnoreCase)
-                                    ? "invite-login"
-                                    : string.Equals(requestedView, "invite-email-otp-verify", StringComparison.OrdinalIgnoreCase)
-                                        ? "invite-email-otp-verify"
-                                        : string.Equals(requestedView, "invite-accepted", StringComparison.OrdinalIgnoreCase)
-                                            ? "invite-accepted"
-                                            : string.Equals(requestedView, "device", StringComparison.OrdinalIgnoreCase)
-                                                ? "device"
-                                                : string.Equals(requestedView, "device-approve", StringComparison.OrdinalIgnoreCase)
-                                                    ? "device-approve"
-                                                    : string.Equals(requestedView, "device-approved", StringComparison.OrdinalIgnoreCase)
-                                                        ? "device-approved"
-                                                        : string.Equals(requestedView, "device-denied", StringComparison.OrdinalIgnoreCase)
-                                                            ? "device-denied"
-                                                            : string.Equals(requestedView, "organization", StringComparison.OrdinalIgnoreCase)
-                                                                ? "organization"
-                                                                : string.Equals(requestedView, "logged-out", StringComparison.OrdinalIgnoreCase)
-                                                                    ? "logged-out"
-                                                                    : "login";
+    {
+        var normalized = requestedView?.Trim().ToLowerInvariant();
+        return normalized switch
+        {
+            "signup" => "signup",
+            "password" => "password",
+            "email-otp" => "email-otp",
+            "email-otp-verify" => "email-otp-verify",
+            "email-otp-signup-verify" => "email-otp-signup-verify",
+            "phone-otp" => "phone-otp",
+            "phone-otp-verify" => "phone-otp-verify",
+            "phone-otp-signup" => "phone-otp-signup",
+            "phone-otp-signup-verify" => "phone-otp-signup-verify",
+            "invite" => "invite",
+            "invite-login" => "invite-login",
+            "invite-email-otp-verify" => "invite-email-otp-verify",
+            "invite-accepted" => "invite-accepted",
+            "device" => "device",
+            "device-approve" => "device-approve",
+            "device-approved" => "device-approved",
+            "device-denied" => "device-denied",
+            "organization" => "organization",
+            "logged-out" => "logged-out",
+            _ => "login"
+        };
+    }
 
     private static SqlOSHeadlessActionResult Redirect(string url)
         => new("redirect", url, null);
@@ -1241,6 +1509,11 @@ public sealed class SqlOSHeadlessAuthService
             return "email-otp";
         }
 
+        if (credentialSettings.PhoneOtpEnabled)
+        {
+            return "phone-otp";
+        }
+
         if (credentialSettings.PasswordEnabled)
         {
             return "password";
@@ -1251,6 +1524,9 @@ public sealed class SqlOSHeadlessAuthService
 
     private bool SupportsDatabaseTransactions()
         => !string.Equals(_context.Database.ProviderName, "Microsoft.EntityFrameworkCore.InMemory", StringComparison.Ordinal);
+
+    private SqlOSPhoneOtpService RequirePhoneOtpService()
+        => _phoneOtpService ?? throw new InvalidOperationException("Phone OTP service is not registered.");
 
     private async Task BindInvitationIfPresentAsync(
         SqlOSAuthorizationRequest authorizationRequest,
@@ -1439,6 +1715,14 @@ public sealed class SqlOSHeadlessAuthService
             .FirstOrDefaultAsync(x => x.Id == signup.User.Id, cancellationToken);
         if (user != null)
         {
+            var phoneNumbers = await _context.Set<SqlOSUserPhoneNumber>()
+                .Where(x => x.UserId == user.Id)
+                .ToListAsync(cancellationToken);
+            if (phoneNumbers.Count > 0)
+            {
+                _context.Set<SqlOSUserPhoneNumber>().RemoveRange(phoneNumbers);
+            }
+
             _context.Set<SqlOSUser>().Remove(user);
         }
 

--- a/src/SqlOS/AuthServer/Services/SqlOSMfaPolicyService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSMfaPolicyService.cs
@@ -1,0 +1,35 @@
+using Microsoft.Extensions.Options;
+using SqlOS.AuthServer.Configuration;
+
+namespace SqlOS.AuthServer.Services;
+
+public sealed class SqlOSMfaPolicyService
+{
+    private readonly SqlOSAuthServerOptions _options;
+
+    public SqlOSMfaPolicyService(IOptions<SqlOSAuthServerOptions> options)
+    {
+        _options = options.Value;
+    }
+
+    public bool SatisfiesStrongMfa(string? authenticationMethod)
+    {
+        if (string.IsNullOrWhiteSpace(authenticationMethod))
+        {
+            return false;
+        }
+
+        if (string.Equals(authenticationMethod, "phone_otp", StringComparison.OrdinalIgnoreCase))
+        {
+            return _options.PhoneOtp.SatisfiesMfa;
+        }
+
+        return string.Equals(authenticationMethod, "totp", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(authenticationMethod, "passkey", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(authenticationMethod, "webauthn", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public bool SatisfiesAdminOwnerStrongMfa(string? authenticationMethod)
+        => !string.Equals(authenticationMethod, "phone_otp", StringComparison.OrdinalIgnoreCase)
+            && SatisfiesStrongMfa(authenticationMethod);
+}

--- a/src/SqlOS/AuthServer/Services/SqlOSPhoneOtpService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSPhoneOtpService.cs
@@ -1,0 +1,934 @@
+using System.Text.Json.Nodes;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.Options;
+using PhoneNumbers;
+using SqlOS.AuthServer.Configuration;
+using SqlOS.AuthServer.Contracts;
+using SqlOS.AuthServer.Interfaces;
+using SqlOS.AuthServer.Models;
+
+namespace SqlOS.AuthServer.Services;
+
+public sealed class SqlOSPhoneOtpService
+{
+    private const string PublicInvalidMessage = "The sign-in code is invalid or expired.";
+    private const string PublicStartMessage = "If an account exists for that phone number, check your messages for a sign-in code.";
+    private readonly ISqlOSAuthServerDbContext _context;
+    private readonly SqlOSAdminService _adminService;
+    private readonly SqlOSCryptoService _cryptoService;
+    private readonly SqlOSSettingsService _settingsService;
+    private readonly ISqlOSOtpDeliveryChannel _deliveryChannel;
+    private readonly SqlOSPhoneOtpOptions _options;
+    private readonly PhoneNumberUtil _phoneNumberUtil = PhoneNumberUtil.GetInstance();
+
+    public SqlOSPhoneOtpService(
+        ISqlOSAuthServerDbContext context,
+        SqlOSAdminService adminService,
+        SqlOSCryptoService cryptoService,
+        SqlOSSettingsService settingsService,
+        ISqlOSOtpDeliveryChannel deliveryChannel,
+        IOptions<SqlOSAuthServerOptions> options)
+    {
+        _context = context;
+        _adminService = adminService;
+        _cryptoService = cryptoService;
+        _settingsService = settingsService;
+        _deliveryChannel = deliveryChannel;
+        _options = options.Value.PhoneOtp;
+    }
+
+    public bool IsRuntimeConfigured => _options.IsConfigured;
+
+    public async Task<SqlOSPhoneOtpStartResult> StartForAuthorizationRequestAsync(
+        SqlOSAuthorizationRequest? authorizationRequest,
+        string phoneNumber,
+        HttpContext? httpContext = null,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsurePhoneOtpEnabledAsync(cancellationToken);
+
+        return await CreateChallengeAsync(
+            phoneNumber,
+            authorizationRequestId: authorizationRequest?.Id,
+            clientApplicationId: authorizationRequest?.ClientApplicationId,
+            requestedOrganizationId: null,
+            userId: null,
+            userPhoneNumberId: null,
+            sendWhenNoUser: false,
+            purpose: "login",
+            httpContext,
+            cancellationToken);
+    }
+
+    public async Task<SqlOSPhoneOtpStartResult> StartForClientAsync(
+        SqlOSPhoneOtpStartRequest request,
+        HttpContext? httpContext = null,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsurePhoneOtpEnabledAsync(cancellationToken);
+
+        var client = await _adminService.RequireClientAsync(request.ClientId, null, cancellationToken);
+        return await CreateChallengeAsync(
+            request.PhoneNumber,
+            authorizationRequestId: null,
+            clientApplicationId: client.Id,
+            requestedOrganizationId: request.OrganizationId,
+            userId: null,
+            userPhoneNumberId: null,
+            sendWhenNoUser: false,
+            purpose: "login",
+            httpContext,
+            cancellationToken);
+    }
+
+    public async Task<SqlOSPhoneOtpSignupStartResult> StartSignupForAuthorizationRequestAsync(
+        SqlOSAuthorizationRequest? authorizationRequest,
+        string displayName,
+        string phoneNumber,
+        string? organizationName,
+        JsonObject? customFields = null,
+        HttpContext? httpContext = null,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsurePhoneOtpEnabledAsync(cancellationToken);
+
+        var trimmedDisplayName = RequireText(displayName, "Display name is required.");
+        SqlOSSignupJoinPolicy.RejectUnauthorizedOrganizationJoin(authorizationRequest?.OrganizationId);
+        var normalizedPhoneNumber = await EnsurePhoneNumberAvailableForSignupAsync(phoneNumber, cancellationToken);
+
+        var challenge = await CreateChallengeAsync(
+            normalizedPhoneNumber,
+            authorizationRequestId: authorizationRequest?.Id,
+            clientApplicationId: authorizationRequest?.ClientApplicationId,
+            requestedOrganizationId: null,
+            userId: null,
+            userPhoneNumberId: null,
+            sendWhenNoUser: true,
+            purpose: "signup",
+            httpContext,
+            cancellationToken);
+
+        var signupToken = await _cryptoService.CreateTemporaryTokenAsync(
+            "phone_otp_signup",
+            userId: null,
+            clientApplicationId: authorizationRequest?.ClientApplicationId,
+            organizationId: null,
+            payload: new PhoneOtpSignupPayload(
+                _cryptoService.HashToken(challenge.ChallengeToken),
+                authorizationRequest?.Id,
+                authorizationRequest?.ClientApplication?.ClientId,
+                authorizationRequest?.ClientApplicationId,
+                trimmedDisplayName,
+                challenge.PhoneNumber,
+                string.IsNullOrWhiteSpace(organizationName) ? null : organizationName.Trim(),
+                authorizationRequest?.OrganizationId,
+                customFields),
+            lifetime: _options.ChallengeLifetime,
+            cancellationToken);
+
+        return new SqlOSPhoneOtpSignupStartResult(
+            challenge.ChallengeToken,
+            signupToken,
+            challenge.PhoneNumber,
+            challenge.MaskedPhoneNumber,
+            challenge.Message,
+            challenge.ExpiresAt,
+            challenge.NextAllowedSendAt);
+    }
+
+    public async Task<SqlOSPhoneOtpSignupStartResult> StartSignupForClientAsync(
+        SqlOSPhoneOtpSignupStartRequest request,
+        HttpContext? httpContext = null,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsurePhoneOtpEnabledAsync(cancellationToken);
+
+        var client = await _adminService.RequireClientAsync(request.ClientId, null, cancellationToken);
+        var trimmedDisplayName = RequireText(request.DisplayName, "Display name is required.");
+        SqlOSSignupJoinPolicy.RejectUnauthorizedOrganizationJoin(request.OrganizationId);
+        var normalizedPhoneNumber = await EnsurePhoneNumberAvailableForSignupAsync(request.PhoneNumber, cancellationToken);
+
+        var challenge = await CreateChallengeAsync(
+            normalizedPhoneNumber,
+            authorizationRequestId: null,
+            clientApplicationId: client.Id,
+            requestedOrganizationId: null,
+            userId: null,
+            userPhoneNumberId: null,
+            sendWhenNoUser: true,
+            purpose: "signup",
+            httpContext,
+            cancellationToken);
+
+        var signupToken = await _cryptoService.CreateTemporaryTokenAsync(
+            "phone_otp_signup",
+            userId: null,
+            clientApplicationId: client.Id,
+            organizationId: request.OrganizationId,
+            payload: new PhoneOtpSignupPayload(
+                _cryptoService.HashToken(challenge.ChallengeToken),
+                AuthorizationRequestId: null,
+                ClientId: client.ClientId,
+                ClientApplicationId: client.Id,
+                DisplayName: trimmedDisplayName,
+                PhoneNumber: challenge.PhoneNumber,
+                OrganizationName: string.IsNullOrWhiteSpace(request.OrganizationName) ? null : request.OrganizationName.Trim(),
+                OrganizationId: request.OrganizationId,
+                CustomFields: request.CustomFields),
+            lifetime: _options.ChallengeLifetime,
+            cancellationToken);
+
+        return new SqlOSPhoneOtpSignupStartResult(
+            challenge.ChallengeToken,
+            signupToken,
+            challenge.PhoneNumber,
+            challenge.MaskedPhoneNumber,
+            challenge.Message,
+            challenge.ExpiresAt,
+            challenge.NextAllowedSendAt);
+    }
+
+    public async Task<SqlOSPhoneOtpStartResult> StartEnrollmentAsync(
+        SqlOSUser? authenticatedUser,
+        string phoneNumber,
+        HttpContext? httpContext = null,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsurePhoneOtpEnabledAsync(cancellationToken);
+        if (authenticatedUser == null)
+        {
+            throw new InvalidOperationException("Sign in before changing phone numbers.");
+        }
+
+        return await CreateChallengeAsync(
+            phoneNumber,
+            authorizationRequestId: null,
+            clientApplicationId: null,
+            requestedOrganizationId: null,
+            userId: authenticatedUser.Id,
+            userPhoneNumberId: null,
+            sendWhenNoUser: true,
+            purpose: "enrollment",
+            httpContext,
+            cancellationToken);
+    }
+
+    public async Task<SqlOSUserPhoneNumber> VerifyEnrollmentAsync(
+        SqlOSUser? authenticatedUser,
+        SqlOSPhoneOtpEnrollmentVerifyRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsurePhoneOtpEnabledAsync(cancellationToken);
+        if (authenticatedUser == null)
+        {
+            throw new InvalidOperationException("Sign in before changing phone numbers.");
+        }
+
+        var challenge = await VerifyChallengeAsync(
+            new SqlOSPhoneOtpVerifyRequest(request.ChallengeToken, request.Code),
+            expectedAuthorizationRequestId: null,
+            requireAuthorizationRequestMatch: false,
+            expectedPurpose: "enrollment",
+            cancellationToken);
+
+        if (!string.Equals(challenge.UserId, authenticatedUser.Id, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(PublicInvalidMessage);
+        }
+
+        var phoneNumber = UnprotectPhoneNumber(challenge.PhoneNumberEncrypted);
+        var record = await AddVerifiedPhoneNumberAsync(authenticatedUser, phoneNumber, cancellationToken);
+        await RecordPhoneOtpAuditAsync(
+            "phone_otp.phone_added",
+            challenge.MaskedPhoneNumber,
+            "enrollment",
+            challenge.IpAddress,
+            new { userId = authenticatedUser.Id, phoneNumberId = record.Id },
+            cancellationToken);
+        return record;
+    }
+
+    public async Task<SqlOSPhoneOtpVerificationResult> VerifyAsync(
+        SqlOSPhoneOtpVerifyRequest request,
+        CancellationToken cancellationToken = default)
+        => await VerifyAsync(
+            request,
+            expectedAuthorizationRequestId: null,
+            requireAuthorizationRequestMatch: false,
+            cancellationToken);
+
+    public async Task<SqlOSPhoneOtpVerificationResult> VerifyAsync(
+        SqlOSPhoneOtpVerifyRequest request,
+        string? expectedAuthorizationRequestId,
+        bool requireAuthorizationRequestMatch,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsurePhoneOtpEnabledAsync(cancellationToken);
+
+        var challenge = await VerifyChallengeAsync(
+            request,
+            expectedAuthorizationRequestId,
+            requireAuthorizationRequestMatch,
+            expectedPurpose: "login",
+            cancellationToken);
+
+        if (challenge.User == null || !challenge.User.IsActive)
+        {
+            throw new InvalidOperationException(PublicInvalidMessage);
+        }
+
+        if (challenge.UserPhoneNumber != null)
+        {
+            challenge.UserPhoneNumber.LastUsedAt = DateTime.UtcNow;
+            challenge.UserPhoneNumber.UpdatedAt = DateTime.UtcNow;
+        }
+
+        challenge.User.UpdatedAt = DateTime.UtcNow;
+        await _context.SaveChangesAsync(cancellationToken);
+
+        var organizations = await _adminService.GetUserOrganizationsAsync(challenge.User.Id, cancellationToken);
+        return new SqlOSPhoneOtpVerificationResult(challenge, challenge.User, organizations, "phone_otp");
+    }
+
+    public async Task<SqlOSPhoneOtpSignupVerificationResult> VerifySignupAsync(
+        SqlOSPhoneOtpSignupVerifyRequest request,
+        string? expectedAuthorizationRequestId,
+        bool requireAuthorizationRequestMatch,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsurePhoneOtpEnabledAsync(cancellationToken);
+
+        var signupToken = request.SignupToken?.Trim()
+            ?? throw new InvalidOperationException(PublicInvalidMessage);
+        var token = await _cryptoService.FindTemporaryTokenAsync("phone_otp_signup", signupToken, cancellationToken)
+            ?? throw new InvalidOperationException(PublicInvalidMessage);
+        var payload = _cryptoService.DeserializePayload<PhoneOtpSignupPayload>(token)
+            ?? throw new InvalidOperationException(PublicInvalidMessage);
+
+        if (requireAuthorizationRequestMatch)
+        {
+            if (string.IsNullOrWhiteSpace(expectedAuthorizationRequestId))
+            {
+                if (!string.IsNullOrWhiteSpace(payload.AuthorizationRequestId))
+                {
+                    throw new InvalidOperationException(PublicInvalidMessage);
+                }
+            }
+            else if (!string.Equals(payload.AuthorizationRequestId, expectedAuthorizationRequestId, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(PublicInvalidMessage);
+            }
+        }
+
+        var rawChallengeToken = request.ChallengeToken?.Trim()
+            ?? throw new InvalidOperationException(PublicInvalidMessage);
+        if (!string.Equals(payload.ChallengeTokenHash, _cryptoService.HashToken(rawChallengeToken), StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(PublicInvalidMessage);
+        }
+
+        var challenge = await VerifyChallengeAsync(
+            new SqlOSPhoneOtpVerifyRequest(rawChallengeToken, request.Code),
+            expectedAuthorizationRequestId,
+            requireAuthorizationRequestMatch,
+            expectedPurpose: "signup",
+            cancellationToken);
+
+        if (challenge.User != null)
+        {
+            throw new InvalidOperationException("An account already exists for this phone number. Sign in with a phone code instead.");
+        }
+
+        var existingPhone = await _context.Set<SqlOSUserPhoneNumber>()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(x => x.PhoneNumberHash == challenge.PhoneNumberHash && x.RemovedAt == null, cancellationToken);
+        if (existingPhone != null)
+        {
+            throw new InvalidOperationException("An account already exists for this phone number. Sign in with a phone code instead.");
+        }
+
+        return new SqlOSPhoneOtpSignupVerificationResult(
+            signupToken,
+            token.ClientApplicationId ?? payload.ClientApplicationId,
+            payload.ClientId,
+            payload.DisplayName,
+            payload.PhoneNumber,
+            payload.OrganizationName,
+            token.OrganizationId ?? payload.OrganizationId,
+            payload.CustomFields);
+    }
+
+    public async Task ConsumeSignupTokenAsync(
+        string signupToken,
+        CancellationToken cancellationToken = default)
+    {
+        var rawSignupToken = signupToken?.Trim()
+            ?? throw new InvalidOperationException(PublicInvalidMessage);
+        _ = await _cryptoService.ConsumeTemporaryTokenAsync("phone_otp_signup", rawSignupToken, cancellationToken)
+            ?? throw new InvalidOperationException(PublicInvalidMessage);
+    }
+
+    public async Task<SqlOSUserPhoneNumber> AddVerifiedPhoneNumberAsync(
+        SqlOSUser user,
+        string e164PhoneNumber,
+        CancellationToken cancellationToken = default)
+    {
+        var phoneHash = _cryptoService.HashToken(e164PhoneNumber);
+        var existing = await _context.Set<SqlOSUserPhoneNumber>()
+            .FirstOrDefaultAsync(x => x.PhoneNumberHash == phoneHash && x.RemovedAt == null, cancellationToken);
+        if (existing != null && !string.Equals(existing.UserId, user.Id, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("An account already exists for this phone number.");
+        }
+
+        var now = DateTime.UtcNow;
+        if (existing != null)
+        {
+            existing.IsVerified = true;
+            existing.VerifiedAt ??= now;
+            existing.PhoneNumber = e164PhoneNumber;
+            existing.DisplayValueEncrypted = _cryptoService.ProtectSecret(e164PhoneNumber);
+            existing.UpdatedAt = now;
+            await _context.SaveChangesAsync(cancellationToken);
+            return existing;
+        }
+
+        var hasActivePhone = await _context.Set<SqlOSUserPhoneNumber>()
+            .AnyAsync(x => x.UserId == user.Id && x.RemovedAt == null, cancellationToken);
+        var record = new SqlOSUserPhoneNumber
+        {
+            Id = _cryptoService.GenerateId("phn"),
+            UserId = user.Id,
+            PhoneNumber = e164PhoneNumber,
+            PhoneNumberHash = phoneHash,
+            DisplayValueEncrypted = _cryptoService.ProtectSecret(e164PhoneNumber),
+            IsPrimary = !hasActivePhone,
+            IsVerified = true,
+            VerifiedAt = now,
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+        _context.Set<SqlOSUserPhoneNumber>().Add(record);
+        await _context.SaveChangesAsync(cancellationToken);
+        return record;
+    }
+
+    private async Task<SqlOSPhoneOtpChallenge> VerifyChallengeAsync(
+        SqlOSPhoneOtpVerifyRequest request,
+        string? expectedAuthorizationRequestId,
+        bool requireAuthorizationRequestMatch,
+        string expectedPurpose,
+        CancellationToken cancellationToken)
+    {
+        var rawChallengeToken = request.ChallengeToken?.Trim()
+            ?? throw new InvalidOperationException(PublicInvalidMessage);
+        var normalizedCode = NormalizeCode(request.Code);
+        var challengeHash = _cryptoService.HashToken(rawChallengeToken);
+        var challenge = await _context.Set<SqlOSPhoneOtpChallenge>()
+            .Include(x => x.User)
+            .Include(x => x.UserPhoneNumber)
+            .Include(x => x.AuthorizationRequest)
+            .ThenInclude(x => x!.ClientApplication)
+            .Include(x => x.ClientApplication)
+            .FirstOrDefaultAsync(x => x.ChallengeTokenHash == challengeHash, cancellationToken)
+            ?? throw new InvalidOperationException(PublicInvalidMessage);
+
+        if (!IsChallengeActive(challenge)
+            || !string.Equals(challenge.Purpose, expectedPurpose, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(PublicInvalidMessage);
+        }
+
+        if (requireAuthorizationRequestMatch)
+        {
+            if (string.IsNullOrWhiteSpace(expectedAuthorizationRequestId))
+            {
+                if (!string.IsNullOrWhiteSpace(challenge.AuthorizationRequestId))
+                {
+                    throw new InvalidOperationException(PublicInvalidMessage);
+                }
+            }
+            else if (!string.Equals(challenge.AuthorizationRequestId, expectedAuthorizationRequestId, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(PublicInvalidMessage);
+            }
+        }
+
+        if (!challenge.ProviderStarted)
+        {
+            await RejectChallengeAsync(challenge, "not_started", cancellationToken);
+            throw new InvalidOperationException(PublicInvalidMessage);
+        }
+
+        var phoneNumber = UnprotectPhoneNumber(challenge.PhoneNumberEncrypted);
+        var check = await _deliveryChannel.CheckAsync(
+            phoneNumber,
+            normalizedCode,
+            new SqlOSOtpDeliveryContext(
+                challenge.Purpose,
+                challenge.ClientApplicationId,
+                challenge.AuthorizationRequestId,
+                challenge.IpAddress,
+                challenge.UserAgent),
+            cancellationToken);
+
+        challenge.AttemptCount++;
+        challenge.ProviderStatus = check.ProviderStatus;
+        if (!string.IsNullOrWhiteSpace(check.ProviderChallengeId))
+        {
+            challenge.ProviderChallengeId = check.ProviderChallengeId;
+        }
+
+        if (!check.Approved)
+        {
+            await RejectChallengeAsync(challenge, check.SanitizedError ?? check.ProviderStatus ?? "provider_rejected", cancellationToken);
+            throw new InvalidOperationException(PublicInvalidMessage);
+        }
+
+        challenge.ConsumedAt = DateTime.UtcNow;
+
+        try
+        {
+            await _context.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            throw new InvalidOperationException(PublicInvalidMessage);
+        }
+
+        await RecordPhoneOtpAuditAsync(
+            "phone_otp.verify_succeeded",
+            challenge.MaskedPhoneNumber,
+            challenge.Purpose,
+            challenge.IpAddress,
+            new
+            {
+                challenge.UserId,
+                challenge.ClientApplicationId,
+                challenge.AuthorizationRequestId,
+                providerStatus = check.ProviderStatus
+            },
+            cancellationToken);
+
+        return challenge;
+    }
+
+    private async Task RejectChallengeAsync(
+        SqlOSPhoneOtpChallenge challenge,
+        string reason,
+        CancellationToken cancellationToken)
+    {
+        challenge.InvalidatedAt = DateTime.UtcNow;
+        challenge.InvalidatedReason = reason.Length > 120 ? reason[..120] : reason;
+        await _context.SaveChangesAsync(cancellationToken);
+        await RecordPhoneOtpAuditAsync(
+            "phone_otp.verify_failed",
+            challenge.MaskedPhoneNumber,
+            challenge.Purpose,
+            challenge.IpAddress,
+            new
+            {
+                challenge.ClientApplicationId,
+                challenge.AuthorizationRequestId,
+                reason = challenge.InvalidatedReason
+            },
+            cancellationToken);
+    }
+
+    private async Task<SqlOSPhoneOtpStartResult> CreateChallengeAsync(
+        string phoneNumber,
+        string? authorizationRequestId,
+        string? clientApplicationId,
+        string? requestedOrganizationId,
+        string? userId,
+        string? userPhoneNumberId,
+        bool sendWhenNoUser,
+        string purpose,
+        HttpContext? httpContext,
+        CancellationToken cancellationToken)
+    {
+        var normalized = NormalizePhoneNumber(phoneNumber);
+        var now = DateTime.UtcNow;
+        var ipAddress = httpContext?.Connection.RemoteIpAddress?.ToString();
+        var phoneHash = _cryptoService.HashToken(normalized.E164);
+        var maskedPhone = MaskPhoneNumber(normalized.E164);
+
+        var phoneRecord = await _context.Set<SqlOSUserPhoneNumber>()
+            .Include(x => x.User)
+            .FirstOrDefaultAsync(x => x.PhoneNumberHash == phoneHash && x.RemovedAt == null && x.IsVerified, cancellationToken);
+
+        var effectiveUserId = userId ?? phoneRecord?.UserId;
+        var effectiveUserPhoneNumberId = userPhoneNumberId ?? phoneRecord?.Id;
+        await EnsureSendAllowedAsync(
+            phoneHash,
+            effectiveUserId,
+            clientApplicationId,
+            requestedOrganizationId,
+            purpose,
+            maskedPhone,
+            ipAddress,
+            now,
+            cancellationToken);
+
+        var recentChallenges = await _context.Set<SqlOSPhoneOtpChallenge>()
+            .Where(x => x.PhoneNumberHash == phoneHash && x.CreatedAt >= now.Subtract(_options.RateLimitWindow))
+            .OrderByDescending(x => x.CreatedAt)
+            .ToListAsync(cancellationToken);
+
+        var latestContextChallenge = recentChallenges
+            .FirstOrDefault(x => string.Equals(x.AuthorizationRequestId, authorizationRequestId, StringComparison.Ordinal)
+                && string.Equals(x.ClientApplicationId, clientApplicationId, StringComparison.Ordinal)
+                && string.Equals(x.RequestedOrganizationId, requestedOrganizationId, StringComparison.Ordinal)
+                && string.Equals(x.Purpose, purpose, StringComparison.Ordinal)
+                && x.InvalidatedAt == null);
+
+        if (latestContextChallenge != null && latestContextChallenge.LastSentAt > now.Subtract(_options.ResendCooldown))
+        {
+            throw new InvalidOperationException($"Wait {(int)Math.Ceiling(_options.ResendCooldown.TotalSeconds)} seconds before requesting another code.");
+        }
+
+        var activeChallenges = await _context.Set<SqlOSPhoneOtpChallenge>()
+            .Where(x => x.PhoneNumberHash == phoneHash
+                && x.ConsumedAt == null
+                && x.InvalidatedAt == null
+                && x.ExpiresAt > now
+                && x.AuthorizationRequestId == authorizationRequestId
+                && x.ClientApplicationId == clientApplicationId
+                && x.RequestedOrganizationId == requestedOrganizationId
+                && x.Purpose == purpose)
+            .ToListAsync(cancellationToken);
+
+        foreach (var activeChallenge in activeChallenges)
+        {
+            activeChallenge.InvalidatedAt = now;
+            activeChallenge.InvalidatedReason = "superseded";
+        }
+
+        var rawChallengeToken = _cryptoService.GenerateOpaqueToken();
+        var challenge = new SqlOSPhoneOtpChallenge
+        {
+            Id = _cryptoService.GenerateId("potp"),
+            ChallengeTokenHash = _cryptoService.HashToken(rawChallengeToken),
+            PhoneNumberHash = phoneHash,
+            PhoneNumberEncrypted = _cryptoService.ProtectSecret(normalized.E164),
+            MaskedPhoneNumber = maskedPhone,
+            Purpose = purpose,
+            UserId = effectiveUserId,
+            UserPhoneNumberId = effectiveUserPhoneNumberId,
+            AuthorizationRequestId = authorizationRequestId,
+            ClientApplicationId = clientApplicationId,
+            RequestedOrganizationId = requestedOrganizationId,
+            ProviderStarted = false,
+            Provider = "twilio_verify",
+            AttemptCount = 0,
+            CreatedAt = now,
+            ExpiresAt = now.Add(_options.ChallengeLifetime),
+            LastSentAt = now,
+            IpAddress = ipAddress,
+            UserAgent = httpContext?.Request.Headers.UserAgent.ToString()
+        };
+
+        _context.Set<SqlOSPhoneOtpChallenge>().Add(challenge);
+        await _context.SaveChangesAsync(cancellationToken);
+
+        var shouldSend = (phoneRecord?.User != null && phoneRecord.User.IsActive) || sendWhenNoUser;
+        if (shouldSend)
+        {
+            var delivery = await _deliveryChannel.StartAsync(
+                normalized.E164,
+                new SqlOSOtpDeliveryContext(purpose, clientApplicationId, authorizationRequestId, ipAddress, challenge.UserAgent),
+                cancellationToken);
+
+            if (!delivery.Accepted)
+            {
+                challenge.InvalidatedAt = DateTime.UtcNow;
+                challenge.InvalidatedReason = "delivery_failed";
+                challenge.ProviderStatus = delivery.ProviderStatus;
+                await _context.SaveChangesAsync(cancellationToken);
+                await RecordPhoneOtpAuditAsync(
+                    "phone_otp.send_failed",
+                    maskedPhone,
+                    purpose,
+                    ipAddress,
+                    new { clientApplicationId, requestedOrganizationId, providerStatus = delivery.ProviderStatus },
+                    cancellationToken);
+                throw new InvalidOperationException("We couldn't send a sign-in code right now.");
+            }
+
+            challenge.ProviderStarted = true;
+            challenge.Provider = delivery.Provider;
+            challenge.ProviderChallengeId = delivery.ProviderChallengeId;
+            challenge.ProviderStatus = delivery.ProviderStatus;
+            await _context.SaveChangesAsync(cancellationToken);
+        }
+
+        await RecordPhoneOtpAuditAsync(
+            "phone_otp.challenge_started",
+            maskedPhone,
+            purpose,
+            ipAddress,
+            new
+            {
+                clientApplicationId,
+                authorizationRequestId,
+                requestedOrganizationId,
+                sent = shouldSend
+            },
+            cancellationToken);
+
+        return new SqlOSPhoneOtpStartResult(
+            rawChallengeToken,
+            normalized.E164,
+            maskedPhone,
+            purpose == "signup"
+                ? $"Check {maskedPhone} for a sign-up code."
+                : purpose == "enrollment"
+                    ? $"Check {maskedPhone} for a phone verification code."
+                    : PublicStartMessage,
+            challenge.ExpiresAt,
+            challenge.LastSentAt.Add(_options.ResendCooldown));
+    }
+
+    private async Task EnsureSendAllowedAsync(
+        string phoneHash,
+        string? userId,
+        string? clientApplicationId,
+        string? requestedOrganizationId,
+        string purpose,
+        string maskedPhone,
+        string? ipAddress,
+        DateTime now,
+        CancellationToken cancellationToken)
+    {
+        var since = now.Subtract(_options.RateLimitWindow);
+        var phoneCount = await _context.Set<SqlOSPhoneOtpChallenge>()
+            .CountAsync(x => x.PhoneNumberHash == phoneHash && x.CreatedAt >= since, cancellationToken);
+        if (phoneCount >= _options.MaxSendsPerPhone)
+        {
+            await RecordRateLimitAuditAsync("phone", maskedPhone, purpose, ipAddress, clientApplicationId, requestedOrganizationId, cancellationToken);
+            throw new InvalidOperationException("Too many sign-in code requests. Try again later.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(userId))
+        {
+            var accountCount = await _context.Set<SqlOSPhoneOtpChallenge>()
+                .CountAsync(x => x.UserId == userId && x.CreatedAt >= since, cancellationToken);
+            if (accountCount >= _options.MaxSendsPerAccount)
+            {
+                await RecordRateLimitAuditAsync("account", maskedPhone, purpose, ipAddress, clientApplicationId, requestedOrganizationId, cancellationToken);
+                throw new InvalidOperationException("Too many sign-in code requests. Try again later.");
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(ipAddress))
+        {
+            var ipCount = await _context.Set<SqlOSPhoneOtpChallenge>()
+                .CountAsync(x => x.IpAddress == ipAddress && x.CreatedAt >= since, cancellationToken);
+            if (ipCount >= _options.MaxSendsPerIp)
+            {
+                await RecordRateLimitAuditAsync("ip", maskedPhone, purpose, ipAddress, clientApplicationId, requestedOrganizationId, cancellationToken);
+                throw new InvalidOperationException("Too many sign-in code requests. Try again later.");
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(clientApplicationId))
+        {
+            var clientCount = await _context.Set<SqlOSPhoneOtpChallenge>()
+                .CountAsync(x => x.ClientApplicationId == clientApplicationId && x.CreatedAt >= since, cancellationToken);
+            if (clientCount >= _options.MaxSendsPerClient)
+            {
+                await RecordRateLimitAuditAsync("client", maskedPhone, purpose, ipAddress, clientApplicationId, requestedOrganizationId, cancellationToken);
+                throw new InvalidOperationException("Too many sign-in code requests. Try again later.");
+            }
+        }
+    }
+
+    private async Task RecordRateLimitAuditAsync(
+        string limit,
+        string maskedPhone,
+        string purpose,
+        string? ipAddress,
+        string? clientApplicationId,
+        string? requestedOrganizationId,
+        CancellationToken cancellationToken)
+        => await RecordPhoneOtpAuditAsync(
+            "phone_otp.rate_limit_rejected",
+            maskedPhone,
+            purpose,
+            ipAddress,
+            new { limit, clientApplicationId, requestedOrganizationId },
+            cancellationToken);
+
+    private async Task<string> EnsurePhoneNumberAvailableForSignupAsync(
+        string phoneNumber,
+        CancellationToken cancellationToken)
+    {
+        var normalized = NormalizePhoneNumber(phoneNumber);
+        var phoneHash = _cryptoService.HashToken(normalized.E164);
+        var existingPhone = await _context.Set<SqlOSUserPhoneNumber>()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(x => x.PhoneNumberHash == phoneHash && x.RemovedAt == null, cancellationToken);
+        if (existingPhone != null)
+        {
+            throw new InvalidOperationException("An account already exists for this phone number. Sign in with a phone code instead.");
+        }
+
+        return normalized.E164;
+    }
+
+    private async Task EnsurePhoneOtpEnabledAsync(CancellationToken cancellationToken)
+    {
+        var settings = await _settingsService.GetResolvedCredentialSettingsAsync(cancellationToken);
+        if (!settings.PhoneOtpEnabled)
+        {
+            throw new InvalidOperationException("Phone sign-in is unavailable.");
+        }
+    }
+
+    private NormalizedPhoneNumber NormalizePhoneNumber(string phoneNumber)
+    {
+        var trimmed = RequireText(phoneNumber, "Phone number is required.");
+        try
+        {
+            var parsed = _phoneNumberUtil.Parse(trimmed, string.IsNullOrWhiteSpace(_options.DefaultRegion) ? null : _options.DefaultRegion.Trim().ToUpperInvariant());
+            if (!_phoneNumberUtil.IsValidNumber(parsed))
+            {
+                throw new InvalidOperationException("Phone number is invalid.");
+            }
+
+            var region = _phoneNumberUtil.GetRegionCodeForNumber(parsed)?.ToUpperInvariant();
+            if (!IsCountryAllowed(region))
+            {
+                throw new InvalidOperationException("Phone number country is not allowed.");
+            }
+
+            return new NormalizedPhoneNumber(
+                _phoneNumberUtil.Format(parsed, PhoneNumberFormat.E164),
+                region);
+        }
+        catch (NumberParseException ex)
+        {
+            throw new InvalidOperationException("Phone number is invalid.", ex);
+        }
+    }
+
+    private bool IsCountryAllowed(string? region)
+    {
+        if (string.IsNullOrWhiteSpace(region))
+        {
+            return false;
+        }
+
+        var denied = NormalizeCountryList(_options.CountryDenyList);
+        if (denied.Contains(region, StringComparer.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var allowed = NormalizeCountryList(_options.CountryAllowList);
+        return allowed.Length == 0 || allowed.Contains(region, StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static string[] NormalizeCountryList(IEnumerable<string>? values)
+        => (values ?? Array.Empty<string>())
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .Select(static value => value.Trim().ToUpperInvariant())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+    private string UnprotectPhoneNumber(string protectedPhoneNumber)
+        => _cryptoService.UnprotectSecret(protectedPhoneNumber);
+
+    private static bool IsChallengeActive(SqlOSPhoneOtpChallenge challenge)
+        => challenge.ConsumedAt == null
+            && challenge.InvalidatedAt == null
+            && challenge.ExpiresAt > DateTime.UtcNow;
+
+    private static string NormalizeCode(string? value)
+    {
+        var normalized = new string((value ?? string.Empty)
+            .Where(char.IsDigit)
+            .ToArray());
+
+        if (string.IsNullOrWhiteSpace(normalized))
+        {
+            throw new InvalidOperationException(PublicInvalidMessage);
+        }
+
+        return normalized;
+    }
+
+    private static string MaskPhoneNumber(string e164PhoneNumber)
+    {
+        if (e164PhoneNumber.Length <= 5)
+        {
+            return e164PhoneNumber;
+        }
+
+        var prefix = e164PhoneNumber[..Math.Min(2, e164PhoneNumber.Length)];
+        var suffix = e164PhoneNumber[^Math.Min(4, e164PhoneNumber.Length)..];
+        return $"{prefix}{new string('*', Math.Max(3, e164PhoneNumber.Length - prefix.Length - suffix.Length))}{suffix}";
+    }
+
+    private static string RequireText(string? value, string message)
+    {
+        var trimmed = value?.Trim();
+        if (string.IsNullOrWhiteSpace(trimmed))
+        {
+            throw new InvalidOperationException(message);
+        }
+
+        return trimmed;
+    }
+
+    private async Task RecordPhoneOtpAuditAsync(
+        string eventType,
+        string maskedPhone,
+        string purpose,
+        string? ipAddress,
+        object? data,
+        CancellationToken cancellationToken)
+        => await _adminService.RecordAuditAsync(
+            eventType,
+            "system",
+            null,
+            ipAddress: ipAddress,
+            data: new
+            {
+                purpose,
+                maskedPhone,
+                details = data
+            },
+            cancellationToken: cancellationToken);
+
+    private sealed record NormalizedPhoneNumber(string E164, string? Region);
+
+    private sealed record PhoneOtpSignupPayload(
+        string ChallengeTokenHash,
+        string? AuthorizationRequestId,
+        string? ClientId,
+        string? ClientApplicationId,
+        string DisplayName,
+        string PhoneNumber,
+        string? OrganizationName,
+        string? OrganizationId,
+        JsonObject? CustomFields);
+}
+
+public sealed record SqlOSPhoneOtpVerificationResult(
+    SqlOSPhoneOtpChallenge Challenge,
+    SqlOSUser User,
+    IReadOnlyList<SqlOSOrganizationOption> Organizations,
+    string AuthenticationMethod);
+
+public sealed record SqlOSPhoneOtpSignupVerificationResult(
+    string SignupToken,
+    string? ClientApplicationId,
+    string? ClientId,
+    string DisplayName,
+    string PhoneNumber,
+    string? OrganizationName,
+    string? OrganizationId,
+    JsonObject? CustomFields);

--- a/src/SqlOS/AuthServer/Services/SqlOSSettingsService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSSettingsService.cs
@@ -237,7 +237,8 @@ public sealed class SqlOSSettingsService
             _options.AuthPageSeed != null,
             _options.Headless.BuildUiUrl != null,
             _options.EnableLocalPasswordAuth,
-            IsAuthEmailRuntimeConfigured);
+            IsAuthEmailRuntimeConfigured,
+            _options.PhoneOtp.IsConfigured);
     }
 
     private bool IsAuthEmailRuntimeConfigured
@@ -328,17 +329,20 @@ public sealed class SqlOSSettingsService
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .Where(value =>
                 (string.Equals(value, "password", StringComparison.OrdinalIgnoreCase) && settings.LocalPasswordRuntimeEnabled)
-                || (string.Equals(value, "email_otp", StringComparison.OrdinalIgnoreCase) && settings.EmailOtpRuntimeConfigured))
+                || (string.Equals(value, "email_otp", StringComparison.OrdinalIgnoreCase) && settings.EmailOtpRuntimeConfigured)
+                || (string.Equals(value, "phone_otp", StringComparison.OrdinalIgnoreCase) && settings.PhoneOtpRuntimeConfigured))
             .ToArray();
 
         var passwordEnabled = effectiveTypes.Contains("password", StringComparer.OrdinalIgnoreCase);
         var emailOtpEnabled = effectiveTypes.Contains("email_otp", StringComparer.OrdinalIgnoreCase);
+        var phoneOtpEnabled = effectiveTypes.Contains("phone_otp", StringComparer.OrdinalIgnoreCase);
 
         return new SqlOSResolvedCredentialSettings(
             effectiveTypes,
             passwordEnabled,
             passwordEnabled && settings.EnablePasswordSignup,
-            emailOtpEnabled);
+            emailOtpEnabled,
+            phoneOtpEnabled);
     }
 
     private static string[] DeserializeCredentialTypes(string json)

--- a/src/SqlOS/AuthServer/Services/SqlOSTwilioVerifyOtpChannel.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSTwilioVerifyOtpChannel.cs
@@ -1,0 +1,104 @@
+using Microsoft.Extensions.Options;
+using SqlOS.AuthServer.Configuration;
+using SqlOS.AuthServer.Interfaces;
+using Twilio.Clients;
+using Twilio.Exceptions;
+using Twilio.Rest.Verify.V2.Service;
+
+namespace SqlOS.AuthServer.Services;
+
+public sealed class SqlOSTwilioVerifyOtpChannel : ISqlOSOtpDeliveryChannel
+{
+    private const string ProviderName = "twilio_verify";
+    private readonly SqlOSPhoneOtpOptions _options;
+
+    public SqlOSTwilioVerifyOtpChannel(IOptions<SqlOSAuthServerOptions> options)
+    {
+        _options = options.Value.PhoneOtp;
+    }
+
+    public async Task<SqlOSOtpDeliveryStartResult> StartAsync(
+        string e164PhoneNumber,
+        SqlOSOtpDeliveryContext context,
+        CancellationToken cancellationToken = default)
+    {
+        EnsureConfigured();
+
+        try
+        {
+            var request = new CreateVerificationOptions(
+                _options.TwilioVerifyServiceSid!.Trim(),
+                e164PhoneNumber,
+                "sms");
+
+            var verification = await VerificationResource.CreateAsync(request, CreateClient());
+            return new SqlOSOtpDeliveryStartResult(
+                Accepted: true,
+                ProviderName,
+                verification.Sid,
+                verification.Status?.ToString());
+        }
+        catch (ApiException ex)
+        {
+            return new SqlOSOtpDeliveryStartResult(
+                Accepted: false,
+                ProviderName,
+                ProviderChallengeId: null,
+                ProviderStatus: ex.Code.ToString(),
+                SanitizedError: "Twilio Verify rejected the send request.");
+        }
+    }
+
+    public async Task<SqlOSOtpDeliveryCheckResult> CheckAsync(
+        string e164PhoneNumber,
+        string code,
+        SqlOSOtpDeliveryContext context,
+        CancellationToken cancellationToken = default)
+    {
+        EnsureConfigured();
+
+        try
+        {
+            var request = new CreateVerificationCheckOptions(_options.TwilioVerifyServiceSid!.Trim())
+            {
+                To = e164PhoneNumber,
+                Code = code
+            };
+
+            var check = await VerificationCheckResource.CreateAsync(request, CreateClient());
+            var approved = check.Valid == true
+                || string.Equals(check.Status?.ToString(), "approved", StringComparison.OrdinalIgnoreCase);
+            return new SqlOSOtpDeliveryCheckResult(
+                approved,
+                ProviderName,
+                check.Sid,
+                check.Status?.ToString());
+        }
+        catch (ApiException ex)
+        {
+            return new SqlOSOtpDeliveryCheckResult(
+                Approved: false,
+                ProviderName,
+                ProviderChallengeId: null,
+                ProviderStatus: ex.Code.ToString(),
+                SanitizedError: "Twilio Verify rejected the check request.");
+        }
+    }
+
+    private ITwilioRestClient CreateClient()
+    {
+        var accountSid = _options.TwilioAccountSid!.Trim();
+        return new TwilioRestClient(
+            accountSid,
+            _options.TwilioAuthToken!.Trim(),
+            accountSid);
+    }
+
+    private void EnsureConfigured()
+    {
+        if (!_options.IsConfigured)
+        {
+            throw new InvalidOperationException("Phone OTP is enabled but Twilio Verify is not configured.");
+        }
+    }
+}

--- a/src/SqlOS/Configuration/SqlOSOptionsValidator.cs
+++ b/src/SqlOS/Configuration/SqlOSOptionsValidator.cs
@@ -73,6 +73,7 @@ internal static class SqlOSOptionsValidator
 
         ValidateHeadlessOptions(options.AuthServer.Headless, errors);
         ValidateEmailOtpOptions(options.AuthServer.EmailOtp, errors);
+        ValidatePhoneOtpOptions(options.AuthServer.PhoneOtp, errors);
         ValidateEmailOptions(options.Email, errors);
         ValidatePasswordLoginAbuseOptions(options.AuthServer.PasswordLogin, errors);
         ValidateClientRegistrationOptions(options.AuthServer, errors);
@@ -248,6 +249,75 @@ internal static class SqlOSOptionsValidator
         if (string.IsNullOrWhiteSpace(options.ApplicationName))
         {
             errors.Add("AuthServer.EmailOtp.ApplicationName is required.");
+        }
+    }
+
+    private static void ValidatePhoneOtpOptions(SqlOSPhoneOtpOptions options, List<string> errors)
+    {
+        if (options.Enabled && !options.HasCompleteTwilioConfiguration)
+        {
+            errors.Add("AuthServer.PhoneOtp requires TwilioAccountSid, TwilioAuthToken, and TwilioVerifyServiceSid when Enabled is true.");
+        }
+
+        if (options.ChallengeLifetime <= TimeSpan.Zero)
+        {
+            errors.Add("AuthServer.PhoneOtp.ChallengeLifetime must be greater than zero.");
+        }
+
+        if (options.ResendCooldown < TimeSpan.Zero)
+        {
+            errors.Add("AuthServer.PhoneOtp.ResendCooldown must be zero or greater.");
+        }
+
+        if (options.RateLimitWindow <= TimeSpan.Zero)
+        {
+            errors.Add("AuthServer.PhoneOtp.RateLimitWindow must be greater than zero.");
+        }
+
+        if (options.MaxSendsPerPhone <= 0)
+        {
+            errors.Add("AuthServer.PhoneOtp.MaxSendsPerPhone must be greater than zero.");
+        }
+
+        if (options.MaxSendsPerAccount <= 0)
+        {
+            errors.Add("AuthServer.PhoneOtp.MaxSendsPerAccount must be greater than zero.");
+        }
+
+        if (options.MaxSendsPerIp <= 0)
+        {
+            errors.Add("AuthServer.PhoneOtp.MaxSendsPerIp must be greater than zero.");
+        }
+
+        if (options.MaxSendsPerClient <= 0)
+        {
+            errors.Add("AuthServer.PhoneOtp.MaxSendsPerClient must be greater than zero.");
+        }
+
+        if (string.IsNullOrWhiteSpace(options.DefaultRegion))
+        {
+            errors.Add("AuthServer.PhoneOtp.DefaultRegion is required.");
+        }
+
+        ValidateCountryList(options.CountryAllowList, "AuthServer.PhoneOtp.CountryAllowList", errors);
+        ValidateCountryList(options.CountryDenyList, "AuthServer.PhoneOtp.CountryDenyList", errors);
+    }
+
+    private static void ValidateCountryList(IEnumerable<string>? values, string name, List<string> errors)
+    {
+        foreach (var value in values ?? Array.Empty<string>())
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                continue;
+            }
+
+            var trimmed = value.Trim();
+            if (trimmed.Length != 2 || !trimmed.All(char.IsLetter))
+            {
+                errors.Add($"{name} values must be ISO 3166-1 alpha-2 country codes.");
+                return;
+            }
         }
     }
 

--- a/src/SqlOS/Extensions/ServiceCollectionExtensions.cs
+++ b/src/SqlOS/Extensions/ServiceCollectionExtensions.cs
@@ -57,6 +57,9 @@ public static class ServiceCollectionExtensions
         services.AddScoped<ISqlOSTransactionalEmailService, SqlOSTransactionalEmailService>();
         services.AddScoped<SqlOSEmailAdminService>();
         services.AddScoped<SqlOSEmailOtpService>();
+        services.AddSingleton<ISqlOSOtpDeliveryChannel, SqlOSTwilioVerifyOtpChannel>();
+        services.AddScoped<SqlOSPhoneOtpService>();
+        services.AddScoped<SqlOSMfaPolicyService>();
         services.AddScoped<SqlOSPasswordLoginAbuseService>();
         services.AddScoped<SqlOSInvitationService>();
         services.AddScoped<SqlOSDeviceAuthorizationService>();

--- a/src/SqlOS/Services/SqlOSBootstrapper.cs
+++ b/src/SqlOS/Services/SqlOSBootstrapper.cs
@@ -58,6 +58,7 @@ public sealed class SqlOSBootstrapper
         await _adminService.UpsertSeededClientsAsync(cancellationToken);
         await _adminService.CleanupExpiredTemporaryTokensAsync(cancellationToken);
         await _adminService.CleanupExpiredEmailOtpChallengesAsync(cancellationToken);
+        await _adminService.CleanupExpiredPhoneOtpChallengesAsync(cancellationToken);
         await _adminService.CleanupExpiredRefreshTokensAsync(cancellationToken);
         await _adminService.CleanupStaleDynamicClientsAsync(cancellationToken);
 

--- a/src/SqlOS/SqlOS.csproj
+++ b/src/SqlOS/SqlOS.csproj
@@ -29,11 +29,13 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Communication.Email" Version="1.1.0" />
+    <PackageReference Include="libphonenumber-csharp" Version="9.0.31" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.0" />
+    <PackageReference Include="Twilio" Version="7.14.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SqlOS/SqlOS.csproj
+++ b/src/SqlOS/SqlOS.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>SqlOS</PackageId>
-    <Version>3.8.0</Version>
+    <Version>3.9.0</Version>
     <Authors>Ross Slaney</Authors>
     <Description>Embedded auth server and fine-grained authorization runtime for .NET + SQL Server + EF Core.</Description>
     <PackageTags>authentication;authorization;fga;saml;jwt;sessions;efcore;sqlserver</PackageTags>

--- a/tests/SqlOS.IntegrationTests/SchemaInitializerIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/SchemaInitializerIntegrationTests.cs
@@ -26,6 +26,7 @@ public sealed class SchemaInitializerIntegrationTests
                      "SqlOSOrganizations",
                      "SqlOSUsers",
                      "SqlOSUserEmails",
+                     "SqlOSUserPhoneNumbers",
                      "SqlOSCredentials",
                      "SqlOSPasswordLoginBuckets",
                      "SqlOSMemberships",
@@ -37,6 +38,7 @@ public sealed class SchemaInitializerIntegrationTests
                      "SqlOSSigningKeys",
                      "SqlOSTemporaryTokens",
                      "SqlOSAuditEvents",
+                     "SqlOSPhoneOtpChallenges",
                      "SqlOSSchema"
                  })
         {

--- a/tests/SqlOS.Tests/SqlOSAuthPageRendererTests.cs
+++ b/tests/SqlOS.Tests/SqlOSAuthPageRendererTests.cs
@@ -78,6 +78,22 @@ public sealed class SqlOSAuthPageRendererTests
     }
 
     [TestMethod]
+    public void RenderPage_StandaloneStatusModes_DoNotShowLoginForm()
+    {
+        var signedInHtml = SqlOSAuthPageRenderer.RenderPage(CreateModel(mode: "signed-in"));
+        var signedUpHtml = SqlOSAuthPageRenderer.RenderPage(CreateModel(mode: "signed-up"));
+        var invitationHtml = SqlOSAuthPageRenderer.RenderPage(CreateModel(mode: "invitation-accepted"));
+
+        signedInHtml.Should().Contain("You are signed in.");
+        signedUpHtml.Should().Contain("Your account is ready.");
+        invitationHtml.Should().Contain("Invitation accepted.");
+        signedInHtml.Should().Contain("href=\"/sqlos/auth/logout\"");
+        signedInHtml.Should().NotContain("action=\"/sqlos/auth/login/identify\"");
+        signedUpHtml.Should().NotContain("action=\"/sqlos/auth/login/identify\"");
+        invitationHtml.Should().NotContain("action=\"/sqlos/auth/login/identify\"");
+    }
+
+    [TestMethod]
     public void RenderPage_StackedLayout_UsesConfiguredBrandingWithoutSecondaryPanel()
     {
         var settings = new SqlOSAuthPageSettingsDto(

--- a/tests/SqlOS.Tests/SqlOSPhoneOtpServiceTests.cs
+++ b/tests/SqlOS.Tests/SqlOSPhoneOtpServiceTests.cs
@@ -1,0 +1,414 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Net;
+using SqlOS.AuthServer.Configuration;
+using SqlOS.AuthServer.Contracts;
+using SqlOS.AuthServer.Interfaces;
+using SqlOS.AuthServer.Models;
+using SqlOS.AuthServer.Services;
+using SqlOS.Extensions;
+using SqlOS.Tests.Infrastructure;
+
+namespace SqlOS.Tests;
+
+[TestClass]
+public sealed class SqlOSPhoneOtpServiceTests
+{
+    [TestMethod]
+    public async Task PhoneOtp_Start_ReturnsGenericResponseForUnknownPhoneOrAccount()
+    {
+        using var harness = await PhoneOtpHarness.CreateAsync(options =>
+        {
+            options.PhoneOtp.ResendCooldown = TimeSpan.Zero;
+        });
+
+        var unknown = await harness.Service.StartForClientAsync(
+            new SqlOSPhoneOtpStartRequest("+12025550100", "test-client", null),
+            CreateHttpContext("203.0.113.10"));
+
+        var user = await harness.CreateUserWithPhoneAsync("+12025550101");
+        user.Should().NotBeNull();
+
+        var known = await harness.Service.StartForClientAsync(
+            new SqlOSPhoneOtpStartRequest("+12025550101", "test-client", null),
+            CreateHttpContext("203.0.113.11"));
+
+        unknown.Message.Should().Be(known.Message);
+        unknown.Message.Should().Be("If an account exists for that phone number, check your messages for a sign-in code.");
+        harness.Channel.StartRequests.Should().ContainSingle(x => x.PhoneNumber == "+12025550101");
+    }
+
+    [TestMethod]
+    public async Task PhoneOtp_Start_NormalizesPhoneNumbersToE164()
+    {
+        using var harness = await PhoneOtpHarness.CreateAsync();
+        await harness.CreateUserWithPhoneAsync("+12025550105");
+
+        var start = await harness.Service.StartForClientAsync(
+            new SqlOSPhoneOtpStartRequest("(202) 555-0105", "test-client", null),
+            CreateHttpContext("203.0.113.12"));
+
+        start.PhoneNumber.Should().Be("+12025550105");
+        harness.Channel.StartRequests.Should().ContainSingle(x => x.PhoneNumber == "+12025550105");
+    }
+
+    [TestMethod]
+    public async Task PhoneOtp_Start_RateLimitsByPhoneAccountIpAndClient()
+    {
+        using var byPhone = await PhoneOtpHarness.CreateAsync(options =>
+        {
+            options.PhoneOtp.ResendCooldown = TimeSpan.Zero;
+            options.PhoneOtp.MaxSendsPerPhone = 1;
+        });
+        await byPhone.CreateUserWithPhoneAsync("+12025550110");
+        await byPhone.Service.StartForClientAsync(new SqlOSPhoneOtpStartRequest("+12025550110", "test-client", null));
+        var phoneAct = async () => await byPhone.Service.StartForClientAsync(new SqlOSPhoneOtpStartRequest("+12025550110", "test-client", null));
+        await phoneAct.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Too many sign-in code requests. Try again later.");
+        byPhone.Channel.StartRequests.Should().HaveCount(1);
+
+        using var byAccount = await PhoneOtpHarness.CreateAsync(options =>
+        {
+            options.PhoneOtp.ResendCooldown = TimeSpan.Zero;
+            options.PhoneOtp.MaxSendsPerAccount = 1;
+        });
+        var accountUser = await byAccount.CreateUserWithPhoneAsync("+12025550111");
+        await byAccount.Service.AddVerifiedPhoneNumberAsync(accountUser, "+12025550112");
+        await byAccount.Service.StartForClientAsync(new SqlOSPhoneOtpStartRequest("+12025550111", "test-client", null));
+        var accountAct = async () => await byAccount.Service.StartForClientAsync(new SqlOSPhoneOtpStartRequest("+12025550112", "test-client", null));
+        await accountAct.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Too many sign-in code requests. Try again later.");
+
+        using var byIp = await PhoneOtpHarness.CreateAsync(options =>
+        {
+            options.PhoneOtp.ResendCooldown = TimeSpan.Zero;
+            options.PhoneOtp.MaxSendsPerIp = 1;
+        });
+        await byIp.CreateUserWithPhoneAsync("+12025550113");
+        await byIp.CreateUserWithPhoneAsync("+12025550114");
+        await byIp.Service.StartForClientAsync(
+            new SqlOSPhoneOtpStartRequest("+12025550113", "test-client", null),
+            CreateHttpContext("203.0.113.20"));
+        var ipAct = async () => await byIp.Service.StartForClientAsync(
+            new SqlOSPhoneOtpStartRequest("+12025550114", "test-client", null),
+            CreateHttpContext("203.0.113.20"));
+        await ipAct.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Too many sign-in code requests. Try again later.");
+
+        using var byClient = await PhoneOtpHarness.CreateAsync(options =>
+        {
+            options.PhoneOtp.ResendCooldown = TimeSpan.Zero;
+            options.PhoneOtp.MaxSendsPerClient = 1;
+        });
+        await byClient.CreateUserWithPhoneAsync("+12025550115");
+        await byClient.CreateUserWithPhoneAsync("+12025550116");
+        await byClient.Service.StartForClientAsync(new SqlOSPhoneOtpStartRequest("+12025550115", "test-client", null));
+        var clientAct = async () => await byClient.Service.StartForClientAsync(new SqlOSPhoneOtpStartRequest("+12025550116", "test-client", null));
+        await clientAct.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Too many sign-in code requests. Try again later.");
+    }
+
+    [TestMethod]
+    public async Task PhoneOtp_Start_RejectsBlockedCountryOrInvalidPhone()
+    {
+        using var blocked = await PhoneOtpHarness.CreateAsync(options =>
+        {
+            options.PhoneOtp.CountryDenyList = ["US"];
+        });
+
+        var blockedAct = async () => await blocked.Service.StartForClientAsync(
+            new SqlOSPhoneOtpStartRequest("+12025550121", "test-client", null));
+        await blockedAct.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Phone number country is not allowed.");
+
+        using var invalid = await PhoneOtpHarness.CreateAsync();
+        var invalidAct = async () => await invalid.Service.StartForClientAsync(
+            new SqlOSPhoneOtpStartRequest("not-a-phone", "test-client", null));
+        await invalidAct.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Phone number is invalid.");
+    }
+
+    [TestMethod]
+    public async Task PhoneOtp_Verify_ValidCode_AuthenticatesWhenPolicyAllows()
+    {
+        using var harness = await PhoneOtpHarness.CreateAsync(options =>
+        {
+            options.PhoneOtp.SatisfiesMfa = true;
+        });
+        var user = await harness.CreateUserWithPhoneAsync("+12025550130");
+        var start = await harness.Service.StartForClientAsync(new SqlOSPhoneOtpStartRequest("+12025550130", "test-client", null));
+
+        var result = await harness.Service.VerifyAsync(new SqlOSPhoneOtpVerifyRequest(start.ChallengeToken, "123456"));
+
+        result.User.Id.Should().Be(user.Id);
+        result.AuthenticationMethod.Should().Be("phone_otp");
+        new SqlOSMfaPolicyService(harness.Options).SatisfiesStrongMfa(result.AuthenticationMethod).Should().BeTrue();
+    }
+
+    [TestMethod]
+    public async Task PhoneOtp_Verify_InvalidCode_IsRejected()
+    {
+        using var harness = await PhoneOtpHarness.CreateAsync();
+        await harness.CreateUserWithPhoneAsync("+12025550131");
+        var start = await harness.Service.StartForClientAsync(new SqlOSPhoneOtpStartRequest("+12025550131", "test-client", null));
+
+        var act = async () => await harness.Service.VerifyAsync(new SqlOSPhoneOtpVerifyRequest(start.ChallengeToken, "000000"));
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("The sign-in code is invalid or expired.");
+        harness.Channel.CheckRequests.Should().ContainSingle(x => x.Code == "000000");
+    }
+
+    [TestMethod]
+    public async Task PhoneOtp_Verify_ExpiredOrReplayedCode_IsRejected()
+    {
+        using var expired = await PhoneOtpHarness.CreateAsync();
+        await expired.CreateUserWithPhoneAsync("+12025550132");
+        var expiredStart = await expired.Service.StartForClientAsync(new SqlOSPhoneOtpStartRequest("+12025550132", "test-client", null));
+        var expiredChallengeHash = expired.Crypto.HashToken(expiredStart.ChallengeToken);
+        var expiredChallenge = await expired.Context.Set<SqlOSPhoneOtpChallenge>()
+            .SingleAsync(x => x.ChallengeTokenHash == expiredChallengeHash);
+        expiredChallenge.ExpiresAt = DateTime.UtcNow.AddMinutes(-1);
+        await expired.Context.SaveChangesAsync();
+
+        var expiredAct = async () => await expired.Service.VerifyAsync(new SqlOSPhoneOtpVerifyRequest(expiredStart.ChallengeToken, "123456"));
+        await expiredAct.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("The sign-in code is invalid or expired.");
+        expired.Channel.CheckRequests.Should().BeEmpty();
+
+        using var replayed = await PhoneOtpHarness.CreateAsync();
+        await replayed.CreateUserWithPhoneAsync("+12025550133");
+        var replayStart = await replayed.Service.StartForClientAsync(new SqlOSPhoneOtpStartRequest("+12025550133", "test-client", null));
+        await replayed.Service.VerifyAsync(new SqlOSPhoneOtpVerifyRequest(replayStart.ChallengeToken, "123456"));
+
+        var replayAct = async () => await replayed.Service.VerifyAsync(new SqlOSPhoneOtpVerifyRequest(replayStart.ChallengeToken, "123456"));
+        await replayAct.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("The sign-in code is invalid or expired.");
+    }
+
+    [TestMethod]
+    public void MfaPolicy_SmsOtp_DoesNotSatisfyStrongMfaByDefault()
+    {
+        var policy = new SqlOSMfaPolicyService(Options.Create(new SqlOSAuthServerOptions()));
+
+        policy.SatisfiesStrongMfa("phone_otp").Should().BeFalse();
+        policy.SatisfiesAdminOwnerStrongMfa("phone_otp").Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void MfaPolicy_SmsOtp_SatisfiesMfaOnlyWhenExplicitlyAllowed()
+    {
+        var options = new SqlOSAuthServerOptions();
+        options.PhoneOtp.SatisfiesMfa = true;
+        var policy = new SqlOSMfaPolicyService(Options.Create(options));
+
+        policy.SatisfiesStrongMfa("phone_otp").Should().BeTrue();
+        policy.SatisfiesAdminOwnerStrongMfa("phone_otp").Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void PhoneOtp_Disabled_ByDefault_And_StartupValidationFailsWhenMisconfigured()
+    {
+        new SqlOSAuthServerOptions().PhoneOtp.IsConfigured.Should().BeFalse();
+
+        var services = new ServiceCollection();
+        Action act = () => services.AddSqlOS<TestSqlOSInMemoryDbContext>(options =>
+        {
+            options.AuthServer.PhoneOtp.Enabled = true;
+        });
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*AuthServer.PhoneOtp requires TwilioAccountSid, TwilioAuthToken, and TwilioVerifyServiceSid*");
+    }
+
+    [TestMethod]
+    public async Task PhoneChange_RequiresAuthenticatedSession()
+    {
+        using var harness = await PhoneOtpHarness.CreateAsync();
+
+        var startAct = async () => await harness.Service.StartEnrollmentAsync(null, "+12025550140");
+        await startAct.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Sign in before changing phone numbers.");
+
+        var verifyAct = async () => await harness.Service.VerifyEnrollmentAsync(
+            null,
+            new SqlOSPhoneOtpEnrollmentVerifyRequest("challenge", "123456"));
+        await verifyAct.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Sign in before changing phone numbers.");
+    }
+
+    [TestMethod]
+    public async Task PhoneOtp_Audit_WritesSendVerifyFailureAndThrottleEvents()
+    {
+        var rejectChannel = new FakeOtpDeliveryChannel { RejectStarts = true };
+        using var sendFailed = await PhoneOtpHarness.CreateAsync(
+            options => options.PhoneOtp.ResendCooldown = TimeSpan.Zero,
+            rejectChannel);
+        await sendFailed.CreateUserWithPhoneAsync("+12025550150");
+        var sendAct = async () => await sendFailed.Service.StartForClientAsync(
+            new SqlOSPhoneOtpStartRequest("+12025550150", "test-client", null),
+            CreateHttpContext("203.0.113.50"));
+        await sendAct.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("We couldn't send a sign-in code right now.");
+
+        using var verifyFailed = await PhoneOtpHarness.CreateAsync();
+        await verifyFailed.CreateUserWithPhoneAsync("+12025550151");
+        var start = await verifyFailed.Service.StartForClientAsync(
+            new SqlOSPhoneOtpStartRequest("+12025550151", "test-client", null),
+            CreateHttpContext("203.0.113.51"));
+        var verifyAct = async () => await verifyFailed.Service.VerifyAsync(new SqlOSPhoneOtpVerifyRequest(start.ChallengeToken, "999999"));
+        await verifyAct.Should().ThrowAsync<InvalidOperationException>();
+
+        using var throttled = await PhoneOtpHarness.CreateAsync(options =>
+        {
+            options.PhoneOtp.ResendCooldown = TimeSpan.Zero;
+            options.PhoneOtp.MaxSendsPerPhone = 1;
+        });
+        await throttled.CreateUserWithPhoneAsync("+12025550152");
+        await throttled.Service.StartForClientAsync(
+            new SqlOSPhoneOtpStartRequest("+12025550152", "test-client", null),
+            CreateHttpContext("203.0.113.52"));
+        var throttleAct = async () => await throttled.Service.StartForClientAsync(
+            new SqlOSPhoneOtpStartRequest("+12025550152", "test-client", null),
+            CreateHttpContext("203.0.113.52"));
+        await throttleAct.Should().ThrowAsync<InvalidOperationException>();
+
+        var sendAuditTypes = await sendFailed.ListAuditTypesAsync();
+        var verifyAuditTypes = await verifyFailed.ListAuditTypesAsync();
+        var throttleAuditTypes = await throttled.ListAuditTypesAsync();
+        sendAuditTypes.Should().Contain("phone_otp.send_failed");
+        verifyAuditTypes.Should().Contain("phone_otp.verify_failed");
+        throttleAuditTypes.Should().Contain("phone_otp.rate_limit_rejected");
+    }
+
+    private static DefaultHttpContext CreateHttpContext(string? ipAddress = null)
+    {
+        var context = new DefaultHttpContext();
+        if (!string.IsNullOrWhiteSpace(ipAddress))
+        {
+            context.Connection.RemoteIpAddress = IPAddress.Parse(ipAddress);
+        }
+
+        context.Request.Headers.UserAgent = "SqlOSPhoneOtpTests";
+        return context;
+    }
+
+    private sealed class PhoneOtpHarness : IDisposable
+    {
+        public required TestSqlOSInMemoryDbContext Context { get; init; }
+        public required SqlOSAdminService Admin { get; init; }
+        public required SqlOSCryptoService Crypto { get; init; }
+        public required SqlOSPhoneOtpService Service { get; init; }
+        public required IOptions<SqlOSAuthServerOptions> Options { get; init; }
+        public required FakeOtpDeliveryChannel Channel { get; init; }
+
+        public static async Task<PhoneOtpHarness> CreateAsync(
+            Action<SqlOSAuthServerOptions>? configure = null,
+            FakeOtpDeliveryChannel? channel = null)
+        {
+            var context = new TestSqlOSInMemoryDbContext(
+                new DbContextOptionsBuilder<TestSqlOSInMemoryDbContext>()
+                    .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+                    .Options);
+
+            var authOptions = new SqlOSAuthServerOptions();
+            authOptions.EnableLocalPasswordAuth = false;
+            authOptions.SeedBrowserClient("test-client", "Test Client", "https://client.example.test/callback");
+            authOptions.SeedAuthPage(page =>
+            {
+                page.EnabledCredentialTypes = ["phone_otp"];
+                page.EnablePasswordSignup = false;
+            });
+            authOptions.ConfigurePhoneOtp(phone =>
+            {
+                phone.Enabled = true;
+                phone.TwilioAccountSid = "AC00000000000000000000000000000000";
+                phone.TwilioAuthToken = "test-token";
+                phone.TwilioVerifyServiceSid = "VA00000000000000000000000000000000";
+                phone.ResendCooldown = TimeSpan.Zero;
+            });
+            configure?.Invoke(authOptions);
+
+            var options = Microsoft.Extensions.Options.Options.Create(authOptions);
+            var emailSender = new TestAuthEmailSender();
+            var crypto = new SqlOSCryptoService(context, options, new EphemeralDataProtectionProvider());
+            var admin = new SqlOSAdminService(context, options, crypto);
+            var settings = new SqlOSSettingsService(context, options, emailSender);
+            var fakeChannel = channel ?? new FakeOtpDeliveryChannel();
+            var phoneOtp = new SqlOSPhoneOtpService(context, admin, crypto, settings, fakeChannel, options);
+
+            await crypto.EnsureActiveSigningKeyAsync();
+            await admin.UpsertSeededClientsAsync();
+            await settings.UpsertSeededAuthPageSettingsAsync();
+
+            return new PhoneOtpHarness
+            {
+                Context = context,
+                Admin = admin,
+                Crypto = crypto,
+                Service = phoneOtp,
+                Options = options,
+                Channel = fakeChannel
+            };
+        }
+
+        public async Task<SqlOSUser> CreateUserWithPhoneAsync(string phoneNumber)
+        {
+            var user = await Admin.CreateUserAsync(new SqlOSCreateUserRequest(
+                $"Phone User {Guid.NewGuid():N}",
+                $"phone-{Guid.NewGuid():N}@example.com",
+                "P@ssword123!"));
+            await Service.AddVerifiedPhoneNumberAsync(user, phoneNumber);
+            return user;
+        }
+
+        public async Task<string[]> ListAuditTypesAsync()
+            => await Context.Set<SqlOSAuditEvent>()
+                .OrderBy(x => x.OccurredAt)
+                .Select(x => x.EventType)
+                .ToArrayAsync();
+
+        public void Dispose()
+            => Context.Dispose();
+    }
+
+    private sealed class FakeOtpDeliveryChannel : ISqlOSOtpDeliveryChannel
+    {
+        public List<(string PhoneNumber, SqlOSOtpDeliveryContext Context)> StartRequests { get; } = [];
+        public List<(string PhoneNumber, string Code, SqlOSOtpDeliveryContext Context)> CheckRequests { get; } = [];
+        public string ApprovedCode { get; set; } = "123456";
+        public bool RejectStarts { get; set; }
+
+        public Task<SqlOSOtpDeliveryStartResult> StartAsync(
+            string e164PhoneNumber,
+            SqlOSOtpDeliveryContext context,
+            CancellationToken cancellationToken = default)
+        {
+            StartRequests.Add((e164PhoneNumber, context));
+            return Task.FromResult(RejectStarts
+                ? new SqlOSOtpDeliveryStartResult(false, "test_verify", null, "failed", "provider_unavailable")
+                : new SqlOSOtpDeliveryStartResult(true, "test_verify", $"ve-{StartRequests.Count}", "pending"));
+        }
+
+        public Task<SqlOSOtpDeliveryCheckResult> CheckAsync(
+            string e164PhoneNumber,
+            string code,
+            SqlOSOtpDeliveryContext context,
+            CancellationToken cancellationToken = default)
+        {
+            CheckRequests.Add((e164PhoneNumber, code, context));
+            var approved = string.Equals(code, ApprovedCode, StringComparison.Ordinal);
+            return Task.FromResult(new SqlOSOtpDeliveryCheckResult(
+                approved,
+                "test_verify",
+                $"ve-{CheckRequests.Count}",
+                approved ? "approved" : "denied",
+                approved ? null : "bad_code"));
+        }
+    }
+}


### PR DESCRIPTION
Closes #42.

## Summary
- Add disabled-by-default SMS OTP with Twilio Verify, E.164 normalization, country controls, local throttles, generic public responses, audit events, and non-strong MFA policy by default.
- Add hosted AuthPage and headless API flows for phone OTP login/signup, plus Todo and retail example wiring.
- Add Twilio Verify setup script and SMS OTP docs using the single supported setup: Account SID, Auth Token, and Verify Service SID.
- Clarify standalone AuthPage success states so `/sqlos/auth/login?status=signed-in` shows an explicit signed-in state instead of the email input form.

## Validation
- `dotnet build SqlOS.sln`
- `dotnet test SqlOS.sln --no-build`
- `dotnet test tests/SqlOS.Tests/SqlOS.Tests.csproj --no-build --filter "FullyQualifiedName~SqlOSPhoneOtpServiceTests|FullyQualifiedName~SqlOSAuthPageRendererTests"`
- `dotnet test examples/SqlOS.Todo.IntegrationTests/SqlOS.Todo.IntegrationTests.csproj --no-build --filter "FullyQualifiedName~HostedAuthStandaloneStatus_ShowsSessionStateInsteadOfLoginForm|FullyQualifiedName~HostedPhoneOtpSignup_DoesNotIssueTokenUntilCodeIsVerified"`
- `./scripts/docs-check.sh`
- Local Todo AppHost run with real Twilio Verify credentials: `/sample/config` returned `phoneOtpEnabled: true`, hosted SMS signup start returned the phone-code verification form, the local challenge stored `providerStatus=pending`, and the SMS was received.
- Local browser reload of `/sqlos/auth/login?status=signed-in` showed the explicit signed-in state with no login form.