### PR TITLE
Add first-class password reset emails

### DIFF
--- a/examples/SqlOS.Example.IntegrationTests/SqlOSExampleApiIntegrationTests.cs
+++ b/examples/SqlOS.Example.IntegrationTests/SqlOSExampleApiIntegrationTests.cs
@@ -122,8 +122,22 @@ public sealed class SqlOSExampleApiIntegrationTests
     [TestMethod]
     public async Task PasswordResetAndRefresh_Work()
     {
+        using var factory = ExampleApiFixture.CreateFactory(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                services.RemoveAll<ISqlOSEmailSender>();
+                services.AddSingleton<CapturingTransactionalEmailSender>();
+                services.AddSingleton<ISqlOSEmailSender>(sp => sp.GetRequiredService<CapturingTransactionalEmailSender>());
+            });
+        });
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false
+        });
+        var sender = factory.Services.GetRequiredService<CapturingTransactionalEmailSender>();
         var email = $"reset-{Guid.NewGuid():N}@example.com";
-        var signupResponse = await ExampleApiFixture.Client.PostAsJsonAsync("/sqlos/auth/signup", new
+        var signupResponse = await client.PostAsJsonAsync("/sqlos/auth/signup", new
         {
             displayName = "Reset User",
             email,
@@ -137,26 +151,28 @@ public sealed class SqlOSExampleApiIntegrationTests
         var refreshToken = tokens.GetProperty("refreshToken").GetString();
         var organizationId = tokens.GetProperty("organizationId").GetString();
 
-        var refreshResponse = await ExampleApiFixture.Client.PostAsJsonAsync("/sqlos/auth/token/refresh", new
+        var refreshResponse = await client.PostAsJsonAsync("/sqlos/auth/token/refresh", new
         {
             refreshToken,
             organizationId
         });
         refreshResponse.EnsureSuccessStatusCode();
 
-        var forgotResponse = await ExampleApiFixture.Client.PostAsJsonAsync("/sqlos/auth/password/forgot", new { email });
+        var forgotResponse = await client.PostAsJsonAsync("/sqlos/auth/password/forgot", new { email, clientId = "example-web" });
         forgotResponse.EnsureSuccessStatusCode();
         var forgotJson = JsonDocument.Parse(await forgotResponse.Content.ReadAsStringAsync());
-        var resetToken = forgotJson.RootElement.GetProperty("token").GetString();
+        forgotJson.RootElement.TryGetProperty("token", out _).Should().BeFalse();
+        sender.Messages.Should().ContainSingle();
+        var resetToken = ExtractResetToken(sender.Messages.Single().TextBody);
 
-        var resetResponse = await ExampleApiFixture.Client.PostAsJsonAsync("/sqlos/auth/password/reset", new
+        var resetResponse = await client.PostAsJsonAsync("/sqlos/auth/password/reset", new
         {
             token = resetToken,
             newPassword = "NewPassword123!"
         });
         resetResponse.EnsureSuccessStatusCode();
 
-        var loginResponse = await ExampleApiFixture.Client.PostAsJsonAsync("/sqlos/auth/password/login", new
+        var loginResponse = await client.PostAsJsonAsync("/sqlos/auth/password/login", new
         {
             email,
             password = "NewPassword123!",
@@ -650,6 +666,13 @@ public sealed class SqlOSExampleApiIntegrationTests
             Content = JsonContent.Create(body)
         };
         return await ExampleApiFixture.Client.SendAsync(request);
+    }
+
+    private static string ExtractResetToken(string textBody)
+    {
+        var match = System.Text.RegularExpressions.Regex.Match(textBody, @"token=([A-Za-z0-9_-]+)");
+        match.Success.Should().BeTrue();
+        return match.Groups[1].Value;
     }
 
     private static string BuildSignedSamlResponse(

--- a/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerModelConfiguration.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerModelConfiguration.cs
@@ -356,6 +356,7 @@ public static class SqlOSAuthServerModelConfiguration
             entity.HasKey(x => x.Id);
             entity.HasIndex(x => x.TokenHash).IsUnique();
             entity.Property(x => x.Purpose).HasMaxLength(80);
+            entity.Property(x => x.ConsumedAt).IsConcurrencyToken();
         });
 
         modelBuilder.Entity<SqlOSAuditEvent>(entity =>

--- a/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerOptions.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerOptions.cs
@@ -37,6 +37,7 @@ public class SqlOSAuthServerOptions
     public int DefaultSigningKeyRetiredCleanupDays { get; set; } = 30;
     public SqlOSEmailOtpOptions EmailOtp { get; } = new();
     public SqlOSPhoneOtpOptions PhoneOtp { get; } = new();
+    public SqlOSPasswordResetOptions PasswordReset { get; } = new();
     public SqlOSPasswordLoginAbuseOptions PasswordLogin { get; } = new();
     public SqlOSInvitationOptions Invitations { get; } = new();
     public SqlOSDeviceAuthorizationOptions DeviceAuthorization { get; } = new();
@@ -171,6 +172,12 @@ public class SqlOSAuthServerOptions
     public SqlOSAuthServerOptions ConfigurePhoneOtp(Action<SqlOSPhoneOtpOptions> configure)
     {
         configure(PhoneOtp);
+        return this;
+    }
+
+    public SqlOSAuthServerOptions ConfigurePasswordReset(Action<SqlOSPasswordResetOptions> configure)
+    {
+        configure(PasswordReset);
         return this;
     }
 

--- a/src/SqlOS/AuthServer/Configuration/SqlOSPasswordResetOptions.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSPasswordResetOptions.cs
@@ -1,0 +1,36 @@
+using Microsoft.AspNetCore.Http;
+using SqlOS.AuthServer.Interfaces;
+
+namespace SqlOS.AuthServer.Configuration;
+
+public sealed class SqlOSPasswordResetOptions
+{
+    public TimeSpan TokenLifetime { get; set; } = TimeSpan.FromHours(1);
+    public TimeSpan ResendCooldown { get; set; } = TimeSpan.FromSeconds(30);
+    public TimeSpan RateLimitWindow { get; set; } = TimeSpan.FromHours(1);
+    public int MaxRequestsPerEmailPerWindow { get; set; } = 5;
+    public int MaxRequestsPerIpPerWindow { get; set; } = 60;
+    public int MaxRequestsPerClientPerWindow { get; set; } = 300;
+    public string Subject { get; set; } = "Reset your {applicationName} password";
+    public Func<SqlOSPasswordResetUrlContext, string>? BuildResetUrl { get; set; }
+    public Func<SqlOSPasswordResetMessageContext, SqlOSAuthEmailMessage>? BuildMessage { get; set; }
+}
+
+public sealed record SqlOSPasswordResetUrlContext(
+    string Token,
+    string Email,
+    string MaskedEmail,
+    DateTime ExpiresAt,
+    TimeSpan TokenLifetime,
+    HttpContext? HttpContext);
+
+public sealed record SqlOSPasswordResetMessageContext(
+    string ApplicationName,
+    string Email,
+    string MaskedEmail,
+    string ResetUrl,
+    DateTime ExpiresAt,
+    TimeSpan TokenLifetime)
+{
+    public SqlOSAuthEmailBranding Branding { get; init; } = SqlOSAuthEmailBranding.Default;
+}

--- a/src/SqlOS/AuthServer/Contracts/SqlOSContracts.cs
+++ b/src/SqlOS/AuthServer/Contracts/SqlOSContracts.cs
@@ -82,13 +82,16 @@ public sealed record SqlOSExchangeCodeRequest(
     string Code,
     string ClientId);
 
-public sealed record SqlOSForgotPasswordRequest(string Email);
+public sealed record SqlOSForgotPasswordRequest(
+    string Email,
+    string? ClientId = null);
 
 public sealed record SqlOSResetPasswordRequest(string Token, string NewPassword);
 
 public sealed record SqlOSSendPasswordResetEmailRequest(
     string Email,
-    string? ResetUrlTemplate = null);
+    string? ResetUrlTemplate = null,
+    string? ClientId = null);
 
 public sealed record SqlOSSendUserPasswordResetEmailRequest(
     string? ResetUrlTemplate = null);
@@ -102,6 +105,13 @@ public sealed record SqlOSPasswordResetEmailResult(
     string? ProviderMessageId,
     string? SanitizedError,
     string Message);
+
+public sealed record SqlOSPasswordResetRequestResult(
+    string Email,
+    string MaskedEmail,
+    string Message,
+    DateTime ExpiresAt,
+    DateTime NextAllowedSendAt);
 
 public sealed record SqlOSCreateVerificationTokenRequest(string Email);
 

--- a/src/SqlOS/AuthServer/Contracts/SqlOSHeadlessAuthContracts.cs
+++ b/src/SqlOS/AuthServer/Contracts/SqlOSHeadlessAuthContracts.cs
@@ -72,6 +72,11 @@ public sealed record SqlOSHeadlessPasswordLoginRequest(
     string Password,
     string? InvitationToken = null);
 
+public sealed record SqlOSHeadlessPasswordResetEmailRequest(
+    string Email,
+    string? RequestId = null,
+    string? ResetUrlTemplate = null);
+
 public sealed record SqlOSHeadlessEmailOtpStartRequest(
     string RequestId,
     string Email,

--- a/src/SqlOS/AuthServer/Extensions/EndpointRouteBuilderExtensions.cs
+++ b/src/SqlOS/AuthServer/Extensions/EndpointRouteBuilderExtensions.cs
@@ -125,6 +125,7 @@ public static class EndpointRouteBuilderExtensions
                     "login" => "login",
                     "signup" => "signup",
                     "password" => "password",
+                    "forgot-password" => "forgot-password",
                     "email-otp" => "email-otp",
                     "phone-otp" => "phone-otp",
                     "phone-otp-signup" => "phone-otp-signup",
@@ -262,6 +263,83 @@ public static class EndpointRouteBuilderExtensions
                 invitation: invitation,
                 deviceUserCode: deviceUserCode);
             return Html(page);
+        });
+
+        auth.MapGet("/password/forgot", async (
+            HttpContext context,
+            SqlOSAuthorizationServerService authorizationServerService,
+            SqlOSHeadlessAuthService headlessAuthService,
+            CancellationToken cancellationToken) =>
+        {
+            if (headlessAuthService.IsBrowserUiEnabled)
+            {
+                return Results.Redirect(headlessAuthService.BuildStandaloneUiUrl(
+                    context,
+                    "forgot-password",
+                    context.Request.Query["request"].ToString(),
+                    context.Request.Query["email"].ToString(),
+                    uiContext: null));
+            }
+
+            var page = await BuildAuthPageViewModelAsync(
+                "forgot-password",
+                context.Request.Query["request"].ToString(),
+                context.Request.Query["email"].ToString(),
+                null,
+                null,
+                null,
+                authPrefix,
+                authorizationServerService,
+                cancellationToken);
+            return Html(page);
+        });
+
+        auth.MapPost("/password/forgot/submit", async (
+            HttpContext context,
+            SqlOSAuthorizationServerService authorizationServerService,
+            SqlOSAuthService authService,
+            CancellationToken cancellationToken) =>
+        {
+            var form = await context.Request.ReadFormAsync(cancellationToken);
+            var requestId = ReadRequestId(context, form);
+            var email = form["email"].ToString();
+            var authorizationRequest = await authorizationServerService.TryGetActiveAuthorizationRequestAsync(requestId, cancellationToken);
+
+            try
+            {
+                await authService.RequestPasswordResetEmailAsync(
+                    new SqlOSSendPasswordResetEmailRequest(
+                        email,
+                        ResetUrlTemplate: null,
+                        ClientId: authorizationRequest?.ClientApplication?.ClientId),
+                    context,
+                    cancellationToken);
+
+                return Html(await BuildAuthPageViewModelAsync(
+                    "forgot-password-sent",
+                    requestId,
+                    email,
+                    null,
+                    null,
+                    null,
+                    authPrefix,
+                    authorizationServerService,
+                    cancellationToken));
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Html(await BuildAuthPageViewModelAsync(
+                    "forgot-password",
+                    requestId,
+                    email,
+                    ex.Message,
+                    null,
+                    null,
+                    authPrefix,
+                    authorizationServerService,
+                    cancellationToken),
+                    StatusCodes.Status400BadRequest);
+            }
         });
 
         auth.MapGet("/invitations/accept", async (
@@ -2189,6 +2267,60 @@ public static class EndpointRouteBuilderExtensions
             }
         });
 
+        headless.MapPost("/password/forgot", async (
+            SqlOSHeadlessPasswordResetEmailRequest request,
+            HttpContext context,
+            SqlOSHeadlessAuthService headlessAuthService,
+            SqlOSAuthorizationServerService authorizationServerService,
+            SqlOSAuthService authService,
+            CancellationToken cancellationToken) =>
+        {
+            if (!headlessAuthService.IsApiEnabled)
+            {
+                return Results.NotFound();
+            }
+
+            try
+            {
+                var authorizationRequest = string.IsNullOrWhiteSpace(request.RequestId)
+                    ? null
+                    : await authorizationServerService.TryGetActiveAuthorizationRequestAsync(request.RequestId, cancellationToken);
+                return Results.Ok(await authService.RequestPasswordResetEmailAsync(
+                    new SqlOSSendPasswordResetEmailRequest(
+                        request.Email,
+                        request.ResetUrlTemplate,
+                        authorizationRequest?.ClientApplication?.ClientId),
+                    context,
+                    cancellationToken));
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.BadRequest(ex.Message);
+            }
+        });
+
+        headless.MapPost("/password/reset", async (
+            SqlOSResetPasswordRequest request,
+            SqlOSHeadlessAuthService headlessAuthService,
+            SqlOSAuthService authService,
+            CancellationToken cancellationToken) =>
+        {
+            if (!headlessAuthService.IsApiEnabled)
+            {
+                return Results.NotFound();
+            }
+
+            try
+            {
+                await authService.ResetPasswordAsync(request, cancellationToken);
+                return Results.NoContent();
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.BadRequest(ex.Message);
+            }
+        });
+
         headless.MapPost("/email-otp/start", async (
             SqlOSHeadlessEmailOtpStartRequest request,
             HttpContext context,
@@ -2618,11 +2750,11 @@ public static class EndpointRouteBuilderExtensions
             return Results.NoContent();
         });
 
-        auth.MapPost("/password/forgot", async (SqlOSForgotPasswordRequest request, SqlOSAuthService authService, CancellationToken cancellationToken) =>
-            Results.Ok(new { token = await authService.CreatePasswordResetTokenAsync(request, cancellationToken) }));
+        auth.MapPost("/password/forgot", async (SqlOSForgotPasswordRequest request, SqlOSAuthService authService, HttpContext httpContext, CancellationToken cancellationToken) =>
+            Results.Ok(await authService.RequestPasswordResetEmailAsync(request, httpContext, cancellationToken)));
 
         auth.MapPost("/password/reset-email", async (SqlOSSendPasswordResetEmailRequest request, SqlOSAuthService authService, HttpContext httpContext, CancellationToken cancellationToken) =>
-            Results.Ok(await authService.SendPasswordResetEmailAsync(request, httpContext, cancellationToken)));
+            Results.Ok(await authService.RequestPasswordResetEmailAsync(request, httpContext, cancellationToken)));
 
         auth.MapGet("/password/reset", (HttpContext context) =>
             Results.Content(
@@ -2634,9 +2766,15 @@ public static class EndpointRouteBuilderExtensions
             var form = await context.Request.ReadFormAsync(cancellationToken);
             var token = form["token"].ToString();
             var newPassword = form["newPassword"].ToString();
+            var confirmPassword = form["confirmPassword"].ToString();
 
             try
             {
+                if (!string.Equals(newPassword, confirmPassword, StringComparison.Ordinal))
+                {
+                    throw new InvalidOperationException("Passwords do not match.");
+                }
+
                 await authService.ResetPasswordAsync(new SqlOSResetPasswordRequest(token, newPassword), cancellationToken);
                 return Results.Content(BuildPasswordResetPage(token: null, error: null, success: true), contentType: "text/html");
             }
@@ -3655,6 +3793,10 @@ public static class EndpointRouteBuilderExtensions
                 <label>
                   <span>New password</span>
                   <input name="newPassword" type="password" autocomplete="new-password" required />
+                </label>
+                <label>
+                  <span>Confirm password</span>
+                  <input name="confirmPassword" type="password" autocomplete="new-password" required />
                 </label>
                 <button type="submit">Reset password</button>
               </form>

--- a/src/SqlOS/AuthServer/Services/SqlOSAuthEmailTemplateRenderer.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSAuthEmailTemplateRenderer.cs
@@ -50,6 +50,28 @@ internal static class SqlOSAuthEmailTemplateRenderer
         return $"You're invited to {context.OrganizationName} as {context.Role}. Accept the invitation for {context.MaskedEmail}: {context.AcceptUrl}. This link expires in {days} day{(days == 1 ? string.Empty : "s")}.";
     }
 
+    public static string BuildPasswordResetHtmlBody(SqlOSPasswordResetMessageContext context)
+    {
+        var minutes = Math.Max(1, (int)Math.Ceiling(context.TokenLifetime.TotalMinutes));
+        var resetUrl = WebUtility.HtmlEncode(context.ResetUrl);
+        var intro = $"Use this link to reset the password for {context.MaskedEmail}. It expires in {minutes} minute{(minutes == 1 ? string.Empty : "s")}.";
+        return BuildShell(
+            context.Branding,
+            "Reset your password",
+            WebUtility.HtmlEncode(intro),
+            $"""
+            <p style="margin:0 0 20px;"><a href="{resetUrl}" style="display:inline-block;background:{Css(context.Branding.PrimaryColor, "#2563eb")};color:{ButtonText(context.Branding.PrimaryColor)};text-decoration:none;border-radius:10px;padding:12px 18px;font-weight:600;">Reset password</a></p>
+            <p style="margin:0 0 12px;font-size:13px;line-height:1.6;color:#64748b;">If the button does not work, open this link: {resetUrl}</p>
+            <p style="margin:0;font-size:13px;line-height:1.6;color:#64748b;">If you did not request a password reset, you can ignore this email.</p>
+            """);
+    }
+
+    public static string BuildPasswordResetTextBody(SqlOSPasswordResetMessageContext context)
+    {
+        var minutes = Math.Max(1, (int)Math.Ceiling(context.TokenLifetime.TotalMinutes));
+        return $"Reset your {context.ApplicationName} password for {context.MaskedEmail}: {context.ResetUrl}. This link expires in {minutes} minute{(minutes == 1 ? string.Empty : "s")}.";
+    }
+
     private static string BuildShell(SqlOSAuthEmailBranding branding, string heading, string intro, string body)
     {
         var background = Css(branding.BackgroundColor, "#f8fafc");

--- a/src/SqlOS/AuthServer/Services/SqlOSAuthPageRenderer.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSAuthPageRenderer.cs
@@ -71,6 +71,9 @@ public static class SqlOSAuthPageRenderer
         var phoneOtpLink = supportsPhoneOtp
             ? $"<a class=\"secondary-link\" href=\"{Html(AuthPathWithQuery(model, "/login/phone-otp", model.AuthorizationRequestId, ("phoneNumber", model.PhoneNumber)))}\">Use a phone code instead</a>"
             : string.Empty;
+        var forgotPasswordLink = supportsPassword
+            ? $"<a class=\"secondary-link\" href=\"{Html(AuthPathWithQuery(model, "/password/forgot", model.AuthorizationRequestId, ("email", model.Email)))}\">Forgot password?</a>"
+            : string.Empty;
         var phoneOtpSignupLink = supportsPhoneOtpSignup
             ? $"<a class=\"secondary-link\" href=\"{Html(AuthPathWithQuery(model, "/signup/phone-otp", model.AuthorizationRequestId, ("phoneNumber", model.PhoneNumber)))}\">Create account with phone code</a>"
             : string.Empty;
@@ -301,10 +304,33 @@ public static class SqlOSAuthPageRenderer
                   </label>
                   {{RenderPrimaryAction("Continue", "Signing in")}}
                 </form>
-                {{(string.IsNullOrWhiteSpace(emailOtpLink) ? string.Empty : RenderFooterLinks(emailOtpLink))}}
-                {{(string.IsNullOrWhiteSpace(phoneOtpLink) ? string.Empty : RenderFooterLinks(phoneOtpLink))}}
+                {{RenderFooterLinks(string.Join(string.Empty, new[] { forgotPasswordLink, emailOtpLink, phoneOtpLink }.Where(link => !string.IsNullOrWhiteSpace(link))))}}
                 {{RenderProvidersSection(model)}}
                 {{RenderFooterPrompt("Don't have an account?", signupLink)}}
+                """,
+            "forgot-password" => $$"""
+                {{RenderPanelIntro("Reset Password", "Enter your email address and we'll send a reset link if the account can be reset.")}}
+                <form class="auth-form" method="post" action="{{Html(AuthPath(model, "/password/forgot/submit"))}}">
+                  {{requestIdInput}}
+                  {{invitationTokenInput}}
+                  {{deviceUserCodeInput}}
+                  <label class="field">
+                    <span>Email</span>
+                    <input name="email" type="email" value="{{emailValue}}" placeholder="Your email address" autocomplete="email" required{{emailReadonly}} />
+                  </label>
+                  {{RenderPrimaryAction("Send reset email", "Sending reset email")}}
+                </form>
+                {{RenderFooterLinks(loginLink)}}
+                """,
+            "forgot-password-sent" => $$"""
+                <div class="state-card">
+                  <span class="state-icon">OK</span>
+                  <div class="state-copy">
+                    <strong>Check your email.</strong>
+                    <p>If the account can be reset, a password reset link is on the way.</p>
+                  </div>
+                </div>
+                {{RenderFooterLinks(loginLink)}}
                 """,
             "email-otp" => $$"""
                 {{RenderPanelIntro("Email Code", "Get a one-time code sent to your email address.")}}

--- a/src/SqlOS/AuthServer/Services/SqlOSAuthService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSAuthService.cs
@@ -18,8 +18,13 @@ namespace SqlOS.AuthServer.Services;
 
 public sealed class SqlOSAuthService
 {
+    private const string PasswordResetPurpose = "password_reset";
+    private const string PasswordResetRequestPurpose = "password_reset_request";
+    private const string PasswordResetGenericMessage = "If an account can be reset, you'll receive a password reset email shortly.";
+
     private readonly ISqlOSAuthServerDbContext _context;
     private readonly SqlOSAuthServerOptions _options;
+    private readonly SqlOSPasswordResetOptions _passwordResetOptions;
     private readonly SqlOSAdminService _adminService;
     private readonly SqlOSCryptoService _cryptoService;
     private readonly SqlOSSettingsService _settingsService;
@@ -28,6 +33,7 @@ public sealed class SqlOSAuthService
     private readonly SqlOSInvitationService? _invitationService;
     private readonly SqlOSPasswordLoginAbuseService _passwordLoginAbuseService;
     private readonly ISqlOSTransactionalEmailService? _transactionalEmailService;
+    private readonly ISqlOSAuthEmailSender? _authEmailSender;
 
     public SqlOSAuthService(
         ISqlOSAuthServerDbContext context,
@@ -39,10 +45,12 @@ public sealed class SqlOSAuthService
         SqlOSInvitationService? invitationService = null,
         SqlOSPasswordLoginAbuseService? passwordLoginAbuseService = null,
         ISqlOSTransactionalEmailService? transactionalEmailService = null,
-        SqlOSPhoneOtpService? phoneOtpService = null)
+        SqlOSPhoneOtpService? phoneOtpService = null,
+        ISqlOSAuthEmailSender? authEmailSender = null)
     {
         _context = context;
         _options = options.Value;
+        _passwordResetOptions = _options.PasswordReset;
         _adminService = adminService;
         _cryptoService = cryptoService;
         _settingsService = settingsService;
@@ -52,6 +60,7 @@ public sealed class SqlOSAuthService
         _passwordLoginAbuseService = passwordLoginAbuseService
             ?? new SqlOSPasswordLoginAbuseService(context, adminService, cryptoService, options);
         _transactionalEmailService = transactionalEmailService;
+        _authEmailSender = authEmailSender;
     }
 
     public async Task<SqlOSLoginResult> SignUpAsync(SqlOSSignupRequest request, HttpContext httpContext, CancellationToken cancellationToken = default)
@@ -906,10 +915,117 @@ public sealed class SqlOSAuthService
     public async Task<string> CreatePasswordResetTokenAsync(SqlOSForgotPasswordRequest request, CancellationToken cancellationToken = default)
     {
         var normalizedEmail = SqlOSAdminService.NormalizeEmail(request.Email);
-        var email = await _context.Set<SqlOSUserEmail>().FirstOrDefaultAsync(x => x.NormalizedEmail == normalizedEmail, cancellationToken)
+        var email = await _context.Set<SqlOSUserEmail>()
+            .Include(x => x.User)
+            .FirstOrDefaultAsync(x => x.NormalizedEmail == normalizedEmail, cancellationToken)
             ?? throw new InvalidOperationException("Unknown email address.");
 
-        return await CreatePasswordResetTokenForEmailAsync(email, cancellationToken);
+        var credentialSettings = await _settingsService.GetResolvedCredentialSettingsAsync(cancellationToken);
+        if (!await IsPasswordResetEligibleAsync(email, credentialSettings, cancellationToken))
+        {
+            throw new InvalidOperationException("Password reset is unavailable for this account.");
+        }
+
+        var client = await TryResolveClientApplicationAsync(request.ClientId, cancellationToken);
+        var (token, _) = await CreatePasswordResetTokenForEmailAsync(email, client?.Id, cancellationToken);
+        return token;
+    }
+
+    public async Task<SqlOSPasswordResetRequestResult> RequestPasswordResetEmailAsync(
+        SqlOSForgotPasswordRequest request,
+        HttpContext? httpContext = null,
+        CancellationToken cancellationToken = default)
+        => await RequestPasswordResetEmailAsync(
+            new SqlOSSendPasswordResetEmailRequest(request.Email, ClientId: request.ClientId),
+            httpContext,
+            cancellationToken);
+
+    public async Task<SqlOSPasswordResetRequestResult> RequestPasswordResetEmailAsync(
+        SqlOSSendPasswordResetEmailRequest request,
+        HttpContext? httpContext = null,
+        CancellationToken cancellationToken = default)
+    {
+        var now = DateTime.UtcNow;
+        var trimmedEmail = NormalizeEmailInput(request.Email);
+        var normalizedEmail = SqlOSAdminService.NormalizeEmail(trimmedEmail);
+        var maskedEmail = MaskEmail(trimmedEmail);
+        var ipAddress = GetIp(httpContext);
+        var client = await TryResolveClientApplicationAsync(request.ClientId, cancellationToken);
+        var clientKey = NormalizeClientKey(request.ClientId);
+
+        var email = await _context.Set<SqlOSUserEmail>()
+            .Include(x => x.User)
+            .FirstOrDefaultAsync(x => x.NormalizedEmail == normalizedEmail, cancellationToken);
+
+        var rateLimit = await CheckPasswordResetRateLimitAsync(
+            normalizedEmail,
+            email?.UserId,
+            ipAddress,
+            clientKey,
+            now,
+            cancellationToken);
+
+        if (rateLimit.IsLimited)
+        {
+            await RecordPasswordResetAuditAsync(
+                "password_reset.rate_limit_rejected",
+                "system",
+                null,
+                email?.UserId,
+                maskedEmail,
+                ipAddress,
+                new
+                {
+                    scope = rateLimit.Scope,
+                    retryAfter = rateLimit.RetryAfter,
+                    clientKey
+                },
+                cancellationToken);
+            return BuildPasswordResetRequestResult(trimmedEmail, maskedEmail, now, rateLimit.RetryAfter);
+        }
+
+        await RecordPasswordResetRequestMarkerAsync(
+            normalizedEmail,
+            email?.UserId,
+            client?.Id,
+            ipAddress,
+            clientKey,
+            "public",
+            cancellationToken);
+
+        var credentialSettings = await _settingsService.GetResolvedCredentialSettingsAsync(cancellationToken);
+        var eligible = await IsPasswordResetEligibleAsync(email, credentialSettings, cancellationToken);
+
+        await RecordPasswordResetAuditAsync(
+            "password_reset.requested",
+            "system",
+            null,
+            email?.UserId,
+            maskedEmail,
+            ipAddress,
+            new { eligible, clientKey },
+            cancellationToken);
+
+        if (!eligible || email == null)
+        {
+            return BuildPasswordResetRequestResult(trimmedEmail, maskedEmail, now);
+        }
+
+        try
+        {
+            await SendPasswordResetEmailToEligibleUserAsync(
+                email,
+                request.ResetUrlTemplate,
+                client?.Id,
+                httpContext,
+                cancellationToken);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return BuildPasswordResetRequestResult(trimmedEmail, maskedEmail, now);
+        }
+
+        return BuildPasswordResetRequestResult(trimmedEmail, maskedEmail, now);
     }
 
     public async Task<SqlOSPasswordResetEmailResult> SendPasswordResetEmailAsync(
@@ -923,7 +1039,14 @@ public sealed class SqlOSAuthService
             .FirstOrDefaultAsync(x => x.NormalizedEmail == normalizedEmail, cancellationToken)
             ?? throw new InvalidOperationException("Unknown email address.");
 
-        return await SendPasswordResetEmailAsync(email, request.ResetUrlTemplate, httpContext, cancellationToken);
+        var credentialSettings = await _settingsService.GetResolvedCredentialSettingsAsync(cancellationToken);
+        if (!await IsPasswordResetEligibleAsync(email, credentialSettings, cancellationToken))
+        {
+            throw new InvalidOperationException("Password reset is unavailable for this account.");
+        }
+
+        var client = await TryResolveClientApplicationAsync(request.ClientId, cancellationToken);
+        return await SendPasswordResetEmailToEligibleUserAsync(email, request.ResetUrlTemplate, client?.Id, httpContext, cancellationToken);
     }
 
     public async Task<SqlOSPasswordResetEmailResult> SendPasswordResetEmailForUserAsync(
@@ -944,122 +1067,224 @@ public sealed class SqlOSAuthService
             ?? throw new InvalidOperationException("User not found.");
 
         var email = await _context.Set<SqlOSUserEmail>()
+            .Include(x => x.User)
             .FirstOrDefaultAsync(x => x.UserId == user.Id && x.Email == user.DefaultEmail, cancellationToken)
             ?? await _context.Set<SqlOSUserEmail>()
+                .Include(x => x.User)
                 .OrderByDescending(x => x.IsVerified)
                 .ThenBy(x => x.CreatedAt)
                 .FirstOrDefaultAsync(x => x.UserId == user.Id, cancellationToken)
             ?? throw new InvalidOperationException("User does not have an email address.");
 
-        return await SendPasswordResetEmailAsync(email, request.ResetUrlTemplate, httpContext, cancellationToken);
+        var credentialSettings = await _settingsService.GetResolvedCredentialSettingsAsync(cancellationToken);
+        if (!await IsPasswordResetEligibleAsync(email, credentialSettings, cancellationToken))
+        {
+            throw new InvalidOperationException("Password reset is unavailable for this account.");
+        }
+
+        var result = await SendPasswordResetEmailToEligibleUserAsync(email, request.ResetUrlTemplate, clientApplicationId: null, httpContext, cancellationToken);
+        await RecordPasswordResetAuditAsync(
+            "password_reset.admin_email_sent",
+            "admin",
+            null,
+            email.UserId,
+            result.MaskedEmail,
+            GetIp(httpContext),
+            new { result.DeliveryId, result.DeliveryStatus },
+            cancellationToken);
+        return result;
     }
 
-    private async Task<SqlOSPasswordResetEmailResult> SendPasswordResetEmailAsync(
+    private async Task<SqlOSPasswordResetEmailResult> SendPasswordResetEmailToEligibleUserAsync(
         SqlOSUserEmail email,
         string? resetUrlTemplate,
+        string? clientApplicationId,
         HttpContext? httpContext,
         CancellationToken cancellationToken)
     {
-        var transactionalEmailService = _transactionalEmailService
-            ?? throw new InvalidOperationException("Transactional email service is not registered.");
-
-        var token = await CreatePasswordResetTokenForEmailAsync(email, cancellationToken);
-        var resetUrl = BuildPasswordResetUrl(token, resetUrlTemplate, httpContext);
-        var branding = await _settingsService.GetResolvedAuthEmailBrandingAsync(cancellationToken);
-        var applicationName = string.IsNullOrWhiteSpace(branding.ApplicationName)
-            ? string.IsNullOrWhiteSpace(_options.EmailOtp.ApplicationName)
-                ? "SqlOS"
-                : _options.EmailOtp.ApplicationName.Trim()
-            : branding.ApplicationName;
-        var lifetime = TimeSpan.FromHours(1);
-        var maskedEmail = MaskEmail(email.Email);
-        var variables = new Dictionary<string, object?>(StringComparer.Ordinal)
-        {
-            ["applicationName"] = applicationName,
-            ["logoBase64"] = branding.LogoBase64 ?? string.Empty,
-            ["logoImageDisplay"] = string.IsNullOrWhiteSpace(branding.LogoBase64) ? "none" : "block",
-            ["logoTextDisplay"] = string.IsNullOrWhiteSpace(branding.LogoBase64) ? "block" : "none",
-            ["maskedEmail"] = maskedEmail,
-            ["resetUrl"] = resetUrl,
-            ["expiresInMinutes"] = Math.Max(1, (int)Math.Ceiling(lifetime.TotalMinutes)),
-            ["primaryColor"] = branding.PrimaryColor,
-            ["accentColor"] = branding.AccentColor,
-            ["backgroundColor"] = branding.BackgroundColor
-        };
-
-        var result = await transactionalEmailService.SendAsync(
-            new SqlOSSendEmailRequest(
-                SqlOSBuiltInEmailTemplates.AuthPasswordResetKey,
-                email.Email,
-                variables,
-                IdempotencyKey: $"auth-password-reset:{email.UserId}:{_cryptoService.HashToken(token)[..32]}"),
+        var (token, expiresAt) = await CreatePasswordResetTokenForEmailAsync(email, clientApplicationId, cancellationToken);
+        var context = await BuildPasswordResetMessageContextAsync(
+            email.Email,
+            MaskEmail(email.Email),
+            token,
+            expiresAt,
+            resetUrlTemplate,
+            httpContext,
             cancellationToken);
 
-        if (string.Equals(result.Status, SqlOSEmailDeliveryStatuses.Failed, StringComparison.Ordinal))
+        try
         {
-            throw new InvalidOperationException(result.SanitizedError ?? "Password reset email delivery failed.");
+            if (_passwordResetOptions.BuildMessage != null)
+            {
+                var authEmailSender = _authEmailSender
+                    ?? throw new InvalidOperationException("Auth email sender is not registered.");
+                if (!authEmailSender.IsConfigured)
+                {
+                    throw new InvalidOperationException("Auth email delivery is not configured.");
+                }
+
+                var message = BuildLegacyPasswordResetMessage(context);
+                await authEmailSender.SendAsync(message, cancellationToken);
+                var deliveryId = _cryptoService.GenerateId("edl");
+                await RecordPasswordResetAuditAsync(
+                    "password_reset.email_sent",
+                    "user",
+                    email.UserId,
+                    email.UserId,
+                    context.MaskedEmail,
+                    GetIp(httpContext),
+                    new { deliveryId, customMessage = true },
+                    cancellationToken);
+                return new SqlOSPasswordResetEmailResult(
+                    email.Email,
+                    context.MaskedEmail,
+                    expiresAt,
+                    deliveryId,
+                    SqlOSEmailDeliveryStatuses.Queued,
+                    ProviderMessageId: null,
+                    SanitizedError: null,
+                    $"Password reset email queued for {context.MaskedEmail}.");
+            }
+
+            var transactionalEmailService = _transactionalEmailService
+                ?? throw new InvalidOperationException("Transactional email service is not registered.");
+            var result = await transactionalEmailService.SendAsync(
+                new SqlOSSendEmailRequest(
+                    SqlOSBuiltInEmailTemplates.AuthPasswordResetKey,
+                    email.Email,
+                    BuildPasswordResetTemplateVariables(context),
+                    IdempotencyKey: $"auth-password-reset:{email.UserId}:{_cryptoService.HashToken(token)[..32]}"),
+                cancellationToken);
+
+            if (string.Equals(result.Status, SqlOSEmailDeliveryStatuses.Failed, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(result.SanitizedError ?? "Password reset email delivery failed.");
+            }
+
+            await RecordPasswordResetAuditAsync(
+                "password_reset.email_sent",
+                "user",
+                email.UserId,
+                email.UserId,
+                context.MaskedEmail,
+                GetIp(httpContext),
+                new { result.DeliveryId, DeliveryStatus = result.Status, result.ProviderMessageId },
+                cancellationToken);
+
+            return new SqlOSPasswordResetEmailResult(
+                email.Email,
+                context.MaskedEmail,
+                expiresAt,
+                result.DeliveryId,
+                result.Status,
+                result.ProviderMessageId,
+                result.SanitizedError,
+                $"Password reset email queued for {context.MaskedEmail}.");
         }
-
-        await _adminService.RecordAuditAsync(
-            "user.password-reset-email-sent",
-            "user",
-            email.UserId,
-            userId: email.UserId,
-            data: new { maskedEmail, deliveryId = result.DeliveryId },
-            cancellationToken: cancellationToken);
-
-        return new SqlOSPasswordResetEmailResult(
-            email.Email,
-            maskedEmail,
-            DateTime.UtcNow.Add(lifetime),
-            result.DeliveryId,
-            result.Status,
-            result.ProviderMessageId,
-            result.SanitizedError,
-            $"Password reset email queued for {maskedEmail}.");
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            await InvalidateActivePasswordResetTokensAsync(email.UserId, cancellationToken);
+            await RecordPasswordResetAuditAsync(
+                "password_reset.email_send_failed",
+                "system",
+                null,
+                email.UserId,
+                context.MaskedEmail,
+                GetIp(httpContext),
+                new { error = ex.Message },
+                cancellationToken);
+            throw;
+        }
     }
 
     public async Task ResetPasswordAsync(SqlOSResetPasswordRequest request, CancellationToken cancellationToken = default)
     {
-        var token = await _cryptoService.ConsumeTemporaryTokenAsync("password_reset", request.Token, cancellationToken)
-            ?? throw new InvalidOperationException("Password reset token is invalid or expired.");
+        var credentialSettings = await _settingsService.GetResolvedCredentialSettingsAsync(cancellationToken);
+        if (!credentialSettings.PasswordEnabled)
+        {
+            throw new InvalidOperationException("Local password authentication is disabled.");
+        }
+
+        var token = await _cryptoService.ConsumeTemporaryTokenAsync(PasswordResetPurpose, request.Token, cancellationToken);
+        if (token == null)
+        {
+            await RecordPasswordResetAuditAsync(
+                "password_reset.invalid_or_expired",
+                "system",
+                null,
+                null,
+                null,
+                null,
+                new { reason = "missing_or_consumed" },
+                cancellationToken);
+            throw new InvalidOperationException("Password reset token is invalid or expired.");
+        }
+
+        var user = await _context.Set<SqlOSUser>()
+            .FirstOrDefaultAsync(x => x.Id == token.UserId, cancellationToken);
+        if (user == null || !user.IsActive)
+        {
+            await RecordPasswordResetAuditAsync(
+                "password_reset.invalid_or_expired",
+                "system",
+                null,
+                token.UserId,
+                null,
+                null,
+                new { reason = user == null ? "missing_user" : "inactive_user" },
+                cancellationToken);
+            throw new InvalidOperationException("Password reset token is invalid or expired.");
+        }
 
         var credential = await _context.Set<SqlOSCredential>()
             .FirstOrDefaultAsync(x => x.UserId == token.UserId && x.Type == "password" && x.RevokedAt == null, cancellationToken);
 
         if (credential == null)
         {
-            credential = new SqlOSCredential
-            {
-                Id = _cryptoService.GenerateId("cred"),
-                UserId = token.UserId!,
-                Type = "password",
-                CreatedAt = DateTime.UtcNow
-            };
-            _context.Set<SqlOSCredential>().Add(credential);
+            await RecordPasswordResetAuditAsync(
+                "password_reset.invalid_or_expired",
+                "system",
+                null,
+                token.UserId,
+                null,
+                null,
+                new { reason = "missing_password_credential" },
+                cancellationToken);
+            throw new InvalidOperationException("Password reset token is invalid or expired.");
         }
 
         credential.SecretHash = _cryptoService.HashPassword(request.NewPassword);
         credential.LastUsedAt = null;
         await _context.SaveChangesAsync(cancellationToken);
-        await _adminService.RecordAuditAsync("user.password-reset", "user", token.UserId, userId: token.UserId, cancellationToken: cancellationToken);
+        await RecordPasswordResetAuditAsync(
+            "password_reset.completed",
+            "user",
+            token.UserId,
+            token.UserId,
+            null,
+            null,
+            null,
+            cancellationToken);
     }
 
-    private async Task<string> CreatePasswordResetTokenForEmailAsync(
+    private async Task<(string Token, DateTime ExpiresAt)> CreatePasswordResetTokenForEmailAsync(
         SqlOSUserEmail email,
+        string? clientApplicationId,
         CancellationToken cancellationToken)
     {
+        await InvalidateActivePasswordResetTokensAsync(email.UserId, cancellationToken);
+
+        var expiresAt = DateTime.UtcNow.Add(_passwordResetOptions.TokenLifetime);
         var token = await _cryptoService.CreateTemporaryTokenAsync(
-            "password_reset",
+            PasswordResetPurpose,
             email.UserId,
+            clientApplicationId,
             null,
-            null,
-            new PasswordResetPayload(email.Id),
-            TimeSpan.FromHours(1),
+            new PasswordResetPayload(email.Id, email.NormalizedEmail),
+            _passwordResetOptions.TokenLifetime,
             cancellationToken);
 
-        await _adminService.RecordAuditAsync("user.password-reset-token-created", "user", email.UserId, userId: email.UserId, cancellationToken: cancellationToken);
-        return token;
+        return (token, expiresAt);
     }
 
     public async Task<string> CreateEmailVerificationTokenAsync(SqlOSCreateVerificationTokenRequest request, CancellationToken cancellationToken = default)
@@ -1255,6 +1480,252 @@ public sealed class SqlOSAuthService
         return $"{GetPublicOrigin(httpContext)}{_options.BasePath.TrimEnd('/')}/password/reset?token={escapedToken}";
     }
 
+    private async Task<SqlOSPasswordResetMessageContext> BuildPasswordResetMessageContextAsync(
+        string email,
+        string maskedEmail,
+        string token,
+        DateTime expiresAt,
+        string? resetUrlTemplate,
+        HttpContext? httpContext,
+        CancellationToken cancellationToken)
+    {
+        var branding = await _settingsService.GetResolvedAuthEmailBrandingAsync(cancellationToken);
+        var applicationName = string.IsNullOrWhiteSpace(branding.ApplicationName)
+            ? string.IsNullOrWhiteSpace(_options.EmailOtp.ApplicationName)
+                ? "SqlOS"
+                : _options.EmailOtp.ApplicationName.Trim()
+            : branding.ApplicationName;
+        var resetUrl = _passwordResetOptions.BuildResetUrl?.Invoke(
+            new SqlOSPasswordResetUrlContext(
+                token,
+                email,
+                maskedEmail,
+                expiresAt,
+                _passwordResetOptions.TokenLifetime,
+                httpContext))
+            ?? BuildPasswordResetUrl(token, resetUrlTemplate, httpContext);
+
+        return new SqlOSPasswordResetMessageContext(
+            applicationName,
+            email,
+            maskedEmail,
+            resetUrl,
+            expiresAt,
+            _passwordResetOptions.TokenLifetime)
+        {
+            Branding = branding with { ApplicationName = applicationName }
+        };
+    }
+
+    private IReadOnlyDictionary<string, object?> BuildPasswordResetTemplateVariables(SqlOSPasswordResetMessageContext context)
+    {
+        var minutes = Math.Max(1, (int)Math.Ceiling(context.TokenLifetime.TotalMinutes));
+        return new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["applicationName"] = context.ApplicationName,
+            ["logoBase64"] = context.Branding.LogoBase64 ?? string.Empty,
+            ["logoImageDisplay"] = string.IsNullOrWhiteSpace(context.Branding.LogoBase64) ? "none" : "block",
+            ["logoTextDisplay"] = string.IsNullOrWhiteSpace(context.Branding.LogoBase64) ? "block" : "none",
+            ["maskedEmail"] = context.MaskedEmail,
+            ["resetUrl"] = context.ResetUrl,
+            ["expiresInMinutes"] = minutes,
+            ["primaryColor"] = context.Branding.PrimaryColor,
+            ["accentColor"] = context.Branding.AccentColor,
+            ["backgroundColor"] = context.Branding.BackgroundColor
+        };
+    }
+
+    private SqlOSAuthEmailMessage BuildLegacyPasswordResetMessage(SqlOSPasswordResetMessageContext context)
+    {
+        var subject = string.IsNullOrWhiteSpace(_passwordResetOptions.Subject)
+            ? "Reset your password"
+            : _passwordResetOptions.Subject
+                .Replace("{applicationName}", context.ApplicationName, StringComparison.Ordinal)
+                .Replace("{ApplicationName}", context.ApplicationName, StringComparison.Ordinal);
+
+        return _passwordResetOptions.BuildMessage?.Invoke(context)
+            ?? new SqlOSAuthEmailMessage(
+                context.Email,
+                subject,
+                SqlOSAuthEmailTemplateRenderer.BuildPasswordResetHtmlBody(context),
+                SqlOSAuthEmailTemplateRenderer.BuildPasswordResetTextBody(context));
+    }
+
+    private async Task<bool> IsPasswordResetEligibleAsync(
+        SqlOSUserEmail? email,
+        SqlOSResolvedCredentialSettings credentialSettings,
+        CancellationToken cancellationToken)
+    {
+        if (!credentialSettings.PasswordEnabled || email?.User == null || !email.User.IsActive)
+        {
+            return false;
+        }
+
+        return await _context.Set<SqlOSCredential>()
+            .AnyAsync(x => x.UserId == email.UserId && x.Type == "password" && x.RevokedAt == null, cancellationToken);
+    }
+
+    private async Task<SqlOSClientApplication?> TryResolveClientApplicationAsync(
+        string? clientId,
+        CancellationToken cancellationToken)
+    {
+        var normalized = NormalizeClientKey(clientId);
+        if (normalized == null)
+        {
+            return null;
+        }
+
+        return await _context.Set<SqlOSClientApplication>()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(x => x.ClientId == normalized && x.IsActive && x.DisabledAt == null, cancellationToken);
+    }
+
+    private async Task RecordPasswordResetRequestMarkerAsync(
+        string normalizedEmail,
+        string? userId,
+        string? clientApplicationId,
+        string? ipAddress,
+        string? clientKey,
+        string surface,
+        CancellationToken cancellationToken)
+    {
+        await _cryptoService.CreateTemporaryTokenAsync(
+            PasswordResetRequestPurpose,
+            userId,
+            clientApplicationId,
+            organizationId: null,
+            payload: new PasswordResetRequestPayload(normalizedEmail, ipAddress, clientKey, surface),
+            lifetime: _passwordResetOptions.RateLimitWindow,
+            cancellationToken: cancellationToken);
+    }
+
+    private async Task<PasswordResetRateLimitResult> CheckPasswordResetRateLimitAsync(
+        string normalizedEmail,
+        string? userId,
+        string? ipAddress,
+        string? clientKey,
+        DateTime now,
+        CancellationToken cancellationToken)
+    {
+        var windowStart = now.Subtract(_passwordResetOptions.RateLimitWindow);
+        var recentRequests = await _context.Set<SqlOSTemporaryToken>()
+            .AsNoTracking()
+            .Where(x => x.Purpose == PasswordResetRequestPurpose && x.CreatedAt >= windowStart)
+            .OrderBy(x => x.CreatedAt)
+            .ToListAsync(cancellationToken);
+
+        var requests = recentRequests
+            .Select(token => new
+            {
+                token.CreatedAt,
+                token.UserId,
+                token.ClientApplicationId,
+                Payload = _cryptoService.DeserializePayload<PasswordResetRequestPayload>(token)
+            })
+            .Where(x => x.Payload != null)
+            .ToList();
+
+        var emailMatches = requests
+            .Where(x => string.Equals(x.Payload!.NormalizedEmail, normalizedEmail, StringComparison.Ordinal))
+            .ToList();
+        if (emailMatches.Count >= _passwordResetOptions.MaxRequestsPerEmailPerWindow)
+        {
+            return PasswordResetRateLimitResult.Limited("email", emailMatches[0].CreatedAt.Add(_passwordResetOptions.RateLimitWindow));
+        }
+
+        if (!string.IsNullOrWhiteSpace(userId))
+        {
+            var userMatches = requests
+                .Where(x => string.Equals(x.UserId, userId, StringComparison.Ordinal))
+                .ToList();
+            if (userMatches.Count >= _passwordResetOptions.MaxRequestsPerEmailPerWindow)
+            {
+                return PasswordResetRateLimitResult.Limited("user", userMatches[0].CreatedAt.Add(_passwordResetOptions.RateLimitWindow));
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(ipAddress))
+        {
+            var ipMatches = requests
+                .Where(x => string.Equals(x.Payload!.IpAddress, ipAddress, StringComparison.Ordinal))
+                .ToList();
+            if (ipMatches.Count >= _passwordResetOptions.MaxRequestsPerIpPerWindow)
+            {
+                return PasswordResetRateLimitResult.Limited("ip", ipMatches[0].CreatedAt.Add(_passwordResetOptions.RateLimitWindow));
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(clientKey))
+        {
+            var clientMatches = requests
+                .Where(x => string.Equals(x.Payload!.ClientKey, clientKey, StringComparison.Ordinal))
+                .ToList();
+            if (clientMatches.Count >= _passwordResetOptions.MaxRequestsPerClientPerWindow)
+            {
+                return PasswordResetRateLimitResult.Limited("client", clientMatches[0].CreatedAt.Add(_passwordResetOptions.RateLimitWindow));
+            }
+        }
+
+        return PasswordResetRateLimitResult.Allowed();
+    }
+
+    private async Task InvalidateActivePasswordResetTokensAsync(string userId, CancellationToken cancellationToken)
+    {
+        var now = DateTime.UtcNow;
+        var activeTokens = await _context.Set<SqlOSTemporaryToken>()
+            .Where(x => x.Purpose == PasswordResetPurpose
+                && x.UserId == userId
+                && x.ConsumedAt == null
+                && x.ExpiresAt > now)
+            .ToListAsync(cancellationToken);
+
+        if (activeTokens.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var activeToken in activeTokens)
+        {
+            activeToken.ConsumedAt = now;
+        }
+
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+
+    private async Task RecordPasswordResetAuditAsync(
+        string eventType,
+        string actorType,
+        string? actorId,
+        string? userId,
+        string? maskedEmail,
+        string? ipAddress,
+        object? data,
+        CancellationToken cancellationToken)
+        => await _adminService.RecordAuditAsync(
+            eventType,
+            actorType,
+            actorId,
+            userId: userId,
+            ipAddress: ipAddress,
+            data: new
+            {
+                maskedEmail,
+                details = data
+            },
+            cancellationToken: cancellationToken);
+
+    private SqlOSPasswordResetRequestResult BuildPasswordResetRequestResult(
+        string email,
+        string maskedEmail,
+        DateTime now,
+        DateTime? nextAllowedSendAt = null)
+        => new(
+            email,
+            maskedEmail,
+            PasswordResetGenericMessage,
+            now.Add(_passwordResetOptions.TokenLifetime),
+            nextAllowedSendAt ?? now.Add(_passwordResetOptions.ResendCooldown));
+
     private string GetPublicOrigin(HttpContext? httpContext)
     {
         if (!string.IsNullOrWhiteSpace(_options.PublicOrigin))
@@ -1286,7 +1757,21 @@ public sealed class SqlOSAuthService
         return $"{local[..visibleCount]}***@{domain}";
     }
 
-    private static string? GetIp(HttpContext httpContext) => httpContext.Connection.RemoteIpAddress?.ToString();
+    private static string NormalizeEmailInput(string? email)
+    {
+        var trimmed = email?.Trim() ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(trimmed))
+        {
+            throw new InvalidOperationException("Email address is required.");
+        }
+
+        return trimmed;
+    }
+
+    private static string? NormalizeClientKey(string? clientKey)
+        => string.IsNullOrWhiteSpace(clientKey) ? null : clientKey.Trim();
+
+    private static string? GetIp(HttpContext? httpContext) => httpContext?.Connection.RemoteIpAddress?.ToString();
 
     private static string ResolveEffectiveAudience(SqlOSClientApplication client, string? resource)
         => string.IsNullOrWhiteSpace(resource)
@@ -1527,7 +2012,17 @@ public sealed class SqlOSAuthService
 
     private sealed record PendingAuthPayload(string ClientId, string AuthenticationMethod);
     private sealed record AuthCodePayload(string ClientId, string RedirectUri, string AuthenticationMethod);
-    private sealed record PasswordResetPayload(string EmailId);
+    private sealed record PasswordResetPayload(string EmailId, string NormalizedEmail);
+    private sealed record PasswordResetRequestPayload(
+        string NormalizedEmail,
+        string? IpAddress,
+        string? ClientKey,
+        string Surface);
+    private sealed record PasswordResetRateLimitResult(bool IsLimited, string? Scope, DateTime? RetryAfter)
+    {
+        public static PasswordResetRateLimitResult Allowed() => new(false, null, null);
+        public static PasswordResetRateLimitResult Limited(string scope, DateTime retryAfter) => new(true, scope, retryAfter);
+    }
     private sealed record EmailVerificationPayload(string EmailId);
 
     private SqlOSInvitationService RequireInvitationService()

--- a/src/SqlOS/AuthServer/Services/SqlOSCryptoService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSCryptoService.cs
@@ -149,7 +149,15 @@ public sealed class SqlOSCryptoService
         }
 
         token.ConsumedAt = DateTime.UtcNow;
-        await _context.SaveChangesAsync(cancellationToken);
+        try
+        {
+            await _context.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            return null;
+        }
+
         return token;
     }
 

--- a/src/SqlOS/AuthServer/Services/SqlOSHeadlessAuthService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSHeadlessAuthService.cs
@@ -1475,6 +1475,9 @@ public sealed class SqlOSHeadlessAuthService
         {
             "signup" => "signup",
             "password" => "password",
+            "forgot-password" => "forgot-password",
+            "forgot-password-sent" => "forgot-password-sent",
+            "password-reset" => "password-reset",
             "email-otp" => "email-otp",
             "email-otp-verify" => "email-otp-verify",
             "email-otp-signup-verify" => "email-otp-signup-verify",

--- a/src/SqlOS/Configuration/SqlOSOptionsValidator.cs
+++ b/src/SqlOS/Configuration/SqlOSOptionsValidator.cs
@@ -74,6 +74,7 @@ internal static class SqlOSOptionsValidator
         ValidateHeadlessOptions(options.AuthServer.Headless, errors);
         ValidateEmailOtpOptions(options.AuthServer.EmailOtp, errors);
         ValidatePhoneOtpOptions(options.AuthServer.PhoneOtp, errors);
+        ValidatePasswordResetOptions(options.AuthServer.PasswordReset, errors);
         ValidateEmailOptions(options.Email, errors);
         ValidatePasswordLoginAbuseOptions(options.AuthServer.PasswordLogin, errors);
         ValidateClientRegistrationOptions(options.AuthServer, errors);
@@ -165,6 +166,39 @@ internal static class SqlOSOptionsValidator
         if (options.LockoutDuration <= TimeSpan.Zero)
         {
             errors.Add("AuthServer.PasswordLogin.LockoutDuration must be greater than zero.");
+        }
+    }
+
+    private static void ValidatePasswordResetOptions(SqlOSPasswordResetOptions options, List<string> errors)
+    {
+        if (options.TokenLifetime <= TimeSpan.Zero)
+        {
+            errors.Add("AuthServer.PasswordReset.TokenLifetime must be greater than zero.");
+        }
+
+        if (options.ResendCooldown <= TimeSpan.Zero)
+        {
+            errors.Add("AuthServer.PasswordReset.ResendCooldown must be greater than zero.");
+        }
+
+        if (options.RateLimitWindow <= TimeSpan.Zero)
+        {
+            errors.Add("AuthServer.PasswordReset.RateLimitWindow must be greater than zero.");
+        }
+
+        if (options.MaxRequestsPerEmailPerWindow <= 0)
+        {
+            errors.Add("AuthServer.PasswordReset.MaxRequestsPerEmailPerWindow must be greater than zero.");
+        }
+
+        if (options.MaxRequestsPerIpPerWindow <= 0)
+        {
+            errors.Add("AuthServer.PasswordReset.MaxRequestsPerIpPerWindow must be greater than zero.");
+        }
+
+        if (options.MaxRequestsPerClientPerWindow <= 0)
+        {
+            errors.Add("AuthServer.PasswordReset.MaxRequestsPerClientPerWindow must be greater than zero.");
         }
     }
 

--- a/src/SqlOS/Email/Services/SqlOSBuiltInEmailTemplates.cs
+++ b/src/SqlOS/Email/Services/SqlOSBuiltInEmailTemplates.cs
@@ -66,6 +66,7 @@ public static class SqlOSBuiltInEmailTemplates
                 <h1 style="margin:0 0 12px;font-size:28px;line-height:1.1;color:{accentColor};">Reset your password</h1>
                 <p style="margin:0 0 20px;font-size:15px;line-height:1.6;color:#475569;">Use this link to reset the password for {maskedEmail}. It expires in {expiresInMinutes} minute(s).</p>
                 <p style="margin:0 0 20px;"><a href="{resetUrl}" style="display:inline-block;background:{primaryColor};color:#ffffff;text-decoration:none;border-radius:10px;padding:12px 18px;font-weight:600;">Reset password</a></p>
+                <p style="margin:0 0 12px;font-size:13px;line-height:1.6;color:#64748b;">If the button does not work, open this link: {resetUrl}</p>
                 <p style="margin:0;font-size:13px;line-height:1.6;color:#64748b;">If you did not request a password reset, you can ignore this email.</p>
               </div>
             </body>

--- a/src/SqlOS/SqlOS.csproj
+++ b/src/SqlOS/SqlOS.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>SqlOS</PackageId>
-    <Version>3.10.0</Version>
+    <Version>3.11.0</Version>
     <Authors>Ross Slaney</Authors>
     <Description>Embedded auth server and fine-grained authorization runtime for .NET + SQL Server + EF Core.</Description>
     <PackageTags>authentication;authorization;fga;saml;jwt;sessions;efcore;sqlserver</PackageTags>

--- a/tests/SqlOS.Tests/SqlOSAuthPageRendererTests.cs
+++ b/tests/SqlOS.Tests/SqlOSAuthPageRendererTests.cs
@@ -52,6 +52,8 @@ public sealed class SqlOSAuthPageRendererTests
         html.Should().Contain("action=\"/sqlos/auth/login/password\"");
         html.Should().Contain("href=\"/sqlos/auth/login/oidc/oidc_contoso?request=req_password&amp;email=alice%40example.com\"");
         html.Should().Contain("href=\"/sqlos/auth/signup?request=req_password\"");
+        html.Should().Contain("href=\"/sqlos/auth/password/forgot?request=req_password&amp;email=alice%40example.com\"");
+        html.Should().Contain("Forgot password?");
     }
 
     [TestMethod]
@@ -70,11 +72,19 @@ public sealed class SqlOSAuthPageRendererTests
                 new SqlOSOrganizationOption("org_1", "contoso", "Contoso", "admin")
             }));
         var loggedOutHtml = SqlOSAuthPageRenderer.RenderPage(CreateModel(mode: "logged-out"));
+        var forgotHtml = SqlOSAuthPageRenderer.RenderPage(CreateModel(
+            mode: "forgot-password",
+            requestId: "req_forgot",
+            email: "alice@example.com"));
+        var forgotSentHtml = SqlOSAuthPageRenderer.RenderPage(CreateModel(mode: "forgot-password-sent"));
 
         signupHtml.Should().Contain("action=\"/sqlos/auth/signup/submit\"");
         signupHtml.Should().Contain("href=\"/sqlos/auth/login?request=req_signup\"");
         organizationHtml.Should().Contain("action=\"/sqlos/auth/login/select-organization\"");
         loggedOutHtml.Should().Contain("href=\"/sqlos/auth/login\"");
+        forgotHtml.Should().Contain("action=\"/sqlos/auth/password/forgot/submit\"");
+        forgotHtml.Should().Contain("value=\"alice@example.com\"");
+        forgotSentHtml.Should().Contain("Check your email.");
     }
 
     [TestMethod]

--- a/tests/SqlOS.Tests/SqlOSAuthServiceTests.cs
+++ b/tests/SqlOS.Tests/SqlOSAuthServiceTests.cs
@@ -317,6 +317,247 @@ public sealed class SqlOSAuthServiceTests
     }
 
     [TestMethod]
+    public async Task PasswordResetEmail_Request_KnownUser_SendsBrandedEmail()
+    {
+        using var harness = await PasswordResetHarness.CreateAsync(options =>
+        {
+            options.SeedAuthEmails(email =>
+            {
+                email.ApplicationName = "Reset App";
+                email.PrimaryColor = "#0D9488";
+                email.AccentColor = "#1A1A1A";
+                email.BackgroundColor = "#FAFAF8";
+            });
+        });
+        var user = await harness.Admin.CreateUserAsync(new SqlOSCreateUserRequest(
+            "Reset User",
+            "reset-user@example.com",
+            "OldPassword123!"));
+
+        var result = await harness.Auth.RequestPasswordResetEmailAsync(
+            new SqlOSSendPasswordResetEmailRequest(user.DefaultEmail!, ClientId: "test-client"),
+            CreatePasswordHttpContext("203.0.113.90"));
+
+        result.Message.Should().Be("If an account can be reset, you'll receive a password reset email shortly.");
+        harness.EmailSender.Messages.Should().ContainSingle();
+        var message = harness.EmailSender.Messages.Single();
+        message.To.Should().Be(user.DefaultEmail);
+        message.Subject.Should().Be("Reset your Reset App password");
+        message.TextBody.Should().Contain("/sqlos/auth/password/reset?token=");
+        message.HtmlBody.Should().Contain("#0D9488");
+    }
+
+    [TestMethod]
+    public async Task PasswordResetEmail_Request_UnknownEmail_ReturnsGenericSuccessAndDoesNotSend()
+    {
+        using var harness = await PasswordResetHarness.CreateAsync();
+
+        var result = await harness.Auth.RequestPasswordResetEmailAsync(
+            new SqlOSSendPasswordResetEmailRequest("missing@example.com"),
+            CreatePasswordHttpContext("203.0.113.91"));
+
+        result.Message.Should().Be("If an account can be reset, you'll receive a password reset email shortly.");
+        result.MaskedEmail.Should().Be("mi***@example.com");
+        harness.EmailSender.Messages.Should().BeEmpty();
+        (await harness.Context.Set<SqlOSTemporaryToken>().CountAsync(x => x.Purpose == "password_reset")).Should().Be(0);
+    }
+
+    [TestMethod]
+    public async Task PasswordResetEmail_Request_InactiveUser_ReturnsGenericSuccessAndDoesNotSend()
+    {
+        using var harness = await PasswordResetHarness.CreateAsync();
+        var user = await harness.Admin.CreateUserAsync(new SqlOSCreateUserRequest(
+            "Inactive Reset",
+            "inactive-reset@example.com",
+            "OldPassword123!"));
+        user.IsActive = false;
+        await harness.Context.SaveChangesAsync();
+
+        await harness.Auth.RequestPasswordResetEmailAsync(
+            new SqlOSSendPasswordResetEmailRequest(user.DefaultEmail!),
+            CreatePasswordHttpContext("203.0.113.92"));
+
+        harness.EmailSender.Messages.Should().BeEmpty();
+        (await harness.Context.Set<SqlOSTemporaryToken>().CountAsync(x => x.Purpose == "password_reset")).Should().Be(0);
+    }
+
+    [TestMethod]
+    public async Task PasswordResetEmail_Request_LocalPasswordDisabled_DoesNotSendOrCreatePassword()
+    {
+        using var harness = await PasswordResetHarness.CreateAsync();
+        var user = await harness.Admin.CreateUserAsync(new SqlOSCreateUserRequest(
+            "Disabled Reset",
+            "disabled-reset@example.com",
+            "OldPassword123!"));
+        var token = await harness.Auth.CreatePasswordResetTokenAsync(new SqlOSForgotPasswordRequest(user.DefaultEmail!));
+
+        harness.Options.EnableLocalPasswordAuth = false;
+        await harness.Auth.RequestPasswordResetEmailAsync(
+            new SqlOSSendPasswordResetEmailRequest(user.DefaultEmail!),
+            CreatePasswordHttpContext("203.0.113.93"));
+        var resetAct = async () => await harness.Auth.ResetPasswordAsync(new SqlOSResetPasswordRequest(token, "NewPassword123!"));
+
+        harness.EmailSender.Messages.Should().BeEmpty();
+        await resetAct.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Local password authentication is disabled.");
+        var credential = await harness.Context.Set<SqlOSCredential>().SingleAsync(x => x.UserId == user.Id && x.Type == "password");
+        harness.Crypto.VerifyPassword(credential.SecretHash, "OldPassword123!").Should().BeTrue();
+    }
+
+    [TestMethod]
+    public async Task PasswordResetEmail_Request_RateLimitsByEmail()
+    {
+        using var harness = await PasswordResetHarness.CreateAsync(options =>
+        {
+            options.PasswordReset.MaxRequestsPerEmailPerWindow = 1;
+        });
+        var user = await harness.Admin.CreateUserAsync(new SqlOSCreateUserRequest(
+            "Limited Reset",
+            "limited-reset@example.com",
+            "OldPassword123!"));
+
+        await harness.Auth.RequestPasswordResetEmailAsync(
+            new SqlOSSendPasswordResetEmailRequest(user.DefaultEmail!),
+            CreatePasswordHttpContext("203.0.113.94"));
+        var second = await harness.Auth.RequestPasswordResetEmailAsync(
+            new SqlOSSendPasswordResetEmailRequest(user.DefaultEmail!),
+            CreatePasswordHttpContext("203.0.113.94"));
+
+        second.Message.Should().Be("If an account can be reset, you'll receive a password reset email shortly.");
+        harness.EmailSender.Messages.Should().ContainSingle();
+        (await harness.Context.Set<SqlOSAuditEvent>().CountAsync(x => x.EventType == "password_reset.rate_limit_rejected"))
+            .Should().Be(1);
+    }
+
+    [TestMethod]
+    public async Task PasswordResetEmail_Request_RateLimitsByIp()
+    {
+        using var harness = await PasswordResetHarness.CreateAsync(options =>
+        {
+            options.PasswordReset.MaxRequestsPerIpPerWindow = 1;
+        });
+        var first = await harness.Admin.CreateUserAsync(new SqlOSCreateUserRequest(
+            "IP Limited One",
+            "ip-limited-one@example.com",
+            "OldPassword123!"));
+        var second = await harness.Admin.CreateUserAsync(new SqlOSCreateUserRequest(
+            "IP Limited Two",
+            "ip-limited-two@example.com",
+            "OldPassword123!"));
+
+        await harness.Auth.RequestPasswordResetEmailAsync(
+            new SqlOSSendPasswordResetEmailRequest(first.DefaultEmail!),
+            CreatePasswordHttpContext("203.0.113.96"));
+        await harness.Auth.RequestPasswordResetEmailAsync(
+            new SqlOSSendPasswordResetEmailRequest(second.DefaultEmail!),
+            CreatePasswordHttpContext("203.0.113.96"));
+
+        harness.EmailSender.Messages.Should().ContainSingle();
+        harness.EmailSender.Messages.Single().To.Should().Be(first.DefaultEmail);
+        (await harness.Context.Set<SqlOSAuditEvent>().CountAsync(x => x.EventType == "password_reset.rate_limit_rejected"))
+            .Should().Be(1);
+    }
+
+    [TestMethod]
+    public async Task PasswordResetEmail_Request_RateLimitsByClient()
+    {
+        using var harness = await PasswordResetHarness.CreateAsync(options =>
+        {
+            options.PasswordReset.MaxRequestsPerClientPerWindow = 1;
+        });
+        var first = await harness.Admin.CreateUserAsync(new SqlOSCreateUserRequest(
+            "Client Limited One",
+            "client-limited-one@example.com",
+            "OldPassword123!"));
+        var second = await harness.Admin.CreateUserAsync(new SqlOSCreateUserRequest(
+            "Client Limited Two",
+            "client-limited-two@example.com",
+            "OldPassword123!"));
+
+        await harness.Auth.RequestPasswordResetEmailAsync(
+            new SqlOSSendPasswordResetEmailRequest(first.DefaultEmail!, ClientId: "test-client"),
+            CreatePasswordHttpContext("203.0.113.97"));
+        await harness.Auth.RequestPasswordResetEmailAsync(
+            new SqlOSSendPasswordResetEmailRequest(second.DefaultEmail!, ClientId: "test-client"),
+            CreatePasswordHttpContext("203.0.113.98"));
+
+        harness.EmailSender.Messages.Should().ContainSingle();
+        harness.EmailSender.Messages.Single().To.Should().Be(first.DefaultEmail);
+        (await harness.Context.Set<SqlOSAuditEvent>().CountAsync(x => x.EventType == "password_reset.rate_limit_rejected"))
+            .Should().Be(1);
+    }
+
+    [TestMethod]
+    public async Task PasswordResetEmail_DeliveryFailure_AuditsAndReturnsSafePublicResult()
+    {
+        using var harness = await PasswordResetHarness.CreateAsync();
+        var user = await harness.Admin.CreateUserAsync(new SqlOSCreateUserRequest(
+            "Failed Delivery Reset",
+            "failed-delivery-reset@example.com",
+            "OldPassword123!"));
+        harness.EmailSender.IsConfigured = false;
+
+        var result = await harness.Auth.RequestPasswordResetEmailAsync(
+            new SqlOSSendPasswordResetEmailRequest(user.DefaultEmail!),
+            CreatePasswordHttpContext("203.0.113.99"));
+
+        result.Message.Should().Be("If an account can be reset, you'll receive a password reset email shortly.");
+        harness.EmailSender.Messages.Should().BeEmpty();
+        (await harness.Context.Set<SqlOSTemporaryToken>().CountAsync(x => x.Purpose == "password_reset" && x.ConsumedAt == null))
+            .Should().Be(0);
+        (await harness.Context.Set<SqlOSAuditEvent>().CountAsync(x => x.EventType == "password_reset.email_send_failed"))
+            .Should().Be(1);
+    }
+
+    [TestMethod]
+    public async Task PasswordResetEmail_Request_SupersedesPriorActiveResetToken()
+    {
+        using var harness = await PasswordResetHarness.CreateAsync();
+        var user = await harness.Admin.CreateUserAsync(new SqlOSCreateUserRequest(
+            "Superseded Reset",
+            "superseded-reset@example.com",
+            "OldPassword123!"));
+
+        await harness.Auth.SendPasswordResetEmailAsync(new SqlOSSendPasswordResetEmailRequest(user.DefaultEmail!));
+        var firstToken = ExtractResetToken(harness.EmailSender.Messages.Last().TextBody);
+        await harness.Auth.SendPasswordResetEmailAsync(new SqlOSSendPasswordResetEmailRequest(user.DefaultEmail!));
+        var secondToken = ExtractResetToken(harness.EmailSender.Messages.Last().TextBody);
+
+        var firstAct = async () => await harness.Auth.ResetPasswordAsync(new SqlOSResetPasswordRequest(firstToken, "FirstNewPassword123!"));
+        await firstAct.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Password reset token is invalid or expired.");
+
+        await harness.Auth.ResetPasswordAsync(new SqlOSResetPasswordRequest(secondToken, "SecondNewPassword123!"));
+        var login = await harness.Auth.LoginWithPasswordAsync(
+            new SqlOSPasswordLoginRequest(user.DefaultEmail!, "SecondNewPassword123!", "test-client", null),
+            CreatePasswordHttpContext("203.0.113.95"));
+        login.Tokens.Should().NotBeNull();
+    }
+
+    [TestMethod]
+    public async Task PasswordResetEmail_CustomMessageBuilder_IsUsed()
+    {
+        using var harness = await PasswordResetHarness.CreateAsync(options =>
+        {
+            options.PasswordReset.BuildMessage = ctx => new SqlOS.AuthServer.Interfaces.SqlOSAuthEmailMessage(
+                ctx.Email,
+                "Custom reset",
+                $"<a href=\"{ctx.ResetUrl}\">Reset</a>",
+                $"Custom reset link: {ctx.ResetUrl}");
+        });
+        var user = await harness.Admin.CreateUserAsync(new SqlOSCreateUserRequest(
+            "Custom Reset",
+            "custom-reset@example.com",
+            "OldPassword123!"));
+
+        await harness.Auth.SendPasswordResetEmailAsync(new SqlOSSendPasswordResetEmailRequest(user.DefaultEmail!));
+
+        harness.EmailSender.Messages.Should().ContainSingle();
+        harness.EmailSender.Messages.Single().Subject.Should().Be("Custom reset");
+        harness.EmailSender.Messages.Single().TextBody.Should().Contain("/sqlos/auth/password/reset?token=");
+    }
+
+    [TestMethod]
     public async Task EmailOtpVerify_WhenAuthorizationChallengeIsUsedAsStandalone_DoesNotConsumeChallenge()
     {
         using var context = CreateContext();
@@ -929,6 +1170,13 @@ public sealed class SqlOSAuthServiceTests
         return Regex.Match(message.TextBody ?? string.Empty, @"\b\d{4,8}\b").Value;
     }
 
+    private static string ExtractResetToken(string? textBody)
+    {
+        var match = Regex.Match(textBody ?? string.Empty, @"token=([A-Za-z0-9_-]+)");
+        match.Success.Should().BeTrue();
+        return match.Groups[1].Value;
+    }
+
     private static SqlOSTransactionalEmailService CreateTransactionalEmailService(
         TestSqlOSInMemoryDbContext context,
         SqlOSCryptoService crypto,
@@ -944,6 +1192,69 @@ public sealed class SqlOSAuthServiceTests
         TestSqlOSInMemoryDbContext context,
         SqlOSCryptoService crypto)
         => new(context, crypto, new SqlOSEmailTemplateRenderer());
+
+    private sealed class PasswordResetHarness : IDisposable
+    {
+        public required TestSqlOSInMemoryDbContext Context { get; init; }
+        public required SqlOSAuthService Auth { get; init; }
+        public required SqlOSAdminService Admin { get; init; }
+        public required SqlOSCryptoService Crypto { get; init; }
+        public required SqlOSAuthServerOptions Options { get; init; }
+        public required TestAuthEmailSender EmailSender { get; init; }
+
+        public static async Task<PasswordResetHarness> CreateAsync(Action<SqlOSAuthServerOptions>? configure = null)
+        {
+            var context = new TestSqlOSInMemoryDbContext(
+                new DbContextOptionsBuilder<TestSqlOSInMemoryDbContext>()
+                    .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+                    .Options);
+
+            var authOptions = new SqlOSAuthServerOptions();
+            authOptions.SeedBrowserClient("test-client", "Test Client", "https://client.example.test/callback");
+            authOptions.SeedAuthPage(page =>
+            {
+                page.EnabledCredentialTypes = ["password"];
+                page.EnablePasswordSignup = true;
+            });
+            configure?.Invoke(authOptions);
+
+            var options = Microsoft.Extensions.Options.Options.Create(authOptions);
+            var emailSender = new TestAuthEmailSender { IsConfigured = true };
+            var crypto = new SqlOSCryptoService(context, options, new EphemeralDataProtectionProvider());
+            var admin = new SqlOSAdminService(context, options, crypto);
+            var settings = new SqlOSSettingsService(context, options, emailSender);
+            var transactionalEmailService = CreateTransactionalEmailService(context, crypto, emailSender);
+            var emailOtp = new SqlOSEmailOtpService(context, admin, crypto, settings, emailSender, options, transactionalEmailService);
+            var auth = new SqlOSAuthService(
+                context,
+                options,
+                admin,
+                crypto,
+                settings,
+                emailOtp,
+                transactionalEmailService: transactionalEmailService,
+                authEmailSender: emailSender);
+
+            await crypto.EnsureActiveSigningKeyAsync();
+            await admin.UpsertSeededClientsAsync();
+            await settings.UpsertSeededAuthPageSettingsAsync();
+            await settings.UpsertSeededAuthEmailSettingsAsync();
+            await CreateEmailAdmin(context, crypto).EnsureBuiltInTemplatesAsync();
+
+            return new PasswordResetHarness
+            {
+                Context = context,
+                Auth = auth,
+                Admin = admin,
+                Crypto = crypto,
+                Options = authOptions,
+                EmailSender = emailSender
+            };
+        }
+
+        public void Dispose()
+            => Context.Dispose();
+    }
 
     private sealed class EmailOtpHarness : IDisposable
     {

--- a/web/content/docs/authserver/password-login.mdx
+++ b/web/content/docs/authserver/password-login.mdx
@@ -90,6 +90,35 @@ if (login.requiresOrganizationSelection) {
 localStorage.setItem("access_token", login.accessToken);
 ```
 
+## Password reset
+
+Hosted AuthPage includes a **Forgot password?** action when local password auth is enabled. It sends a branded reset email and opens the built-in reset form at `/sqlos/auth/password/reset?token=...`.
+
+Headless and API-owned UIs can request the same email without exposing the token:
+
+```http
+POST /sqlos/auth/password/forgot
+POST /sqlos/auth/headless/password/forgot
+```
+
+Both routes return a generic success response for unknown, inactive, SSO-only, and otherwise ineligible accounts. Only active users with an existing local password credential receive email.
+
+```csharp
+await authService.RequestPasswordResetEmailAsync(
+    new SqlOSSendPasswordResetEmailRequest(
+        Email: email,
+        ResetUrlTemplate: null,
+        ClientId: clientId),
+    httpContext,
+    ct);
+```
+
+Support teams can send the same email from the dashboard user detail page or by calling:
+
+```http
+POST /sqlos/admin/auth/api/users/{userId}/password-reset-email
+```
+
 ## Configuration
 
 Disable password auth entirely:
@@ -129,3 +158,21 @@ builder.AddSqlOS<AppDbContext>(options =>
 SqlOS stores password-login throttle state in `SqlOSPasswordLoginBuckets`. Failed password attempts count against the normalized email, user ID when known, source IP, client, and user-agent fingerprint. Account buckets reset after a successful password login. IP, client, and device buckets expire through the configured failure window so one successful login cannot clear a password-spray pattern.
 
 Unknown-email, wrong-password, locked-account, and rate-limited password attempts return the same public failure message. Operators can distinguish them internally through `SqlOSAuditEvents` entries such as `password.login.failed`, `password.login.locked`, `password.login.rate_limit_rejected`, `password.login.suspicious_pattern`, and `password.login.succeeded`.
+
+Configure password-reset lifetime and request limits:
+
+```csharp
+builder.AddSqlOS<AppDbContext>(options =>
+{
+    options.AuthServer.ConfigurePasswordReset(reset =>
+    {
+        reset.TokenLifetime = TimeSpan.FromHours(1);
+        reset.ResendCooldown = TimeSpan.FromSeconds(30);
+        reset.MaxRequestsPerEmailPerWindow = 5;
+        reset.MaxRequestsPerIpPerWindow = 60;
+        reset.MaxRequestsPerClientPerWindow = 300;
+    });
+});
+```
+
+Password-reset requests are audited with events such as `password_reset.requested`, `password_reset.email_sent`, `password_reset.email_send_failed`, `password_reset.rate_limit_rejected`, `password_reset.completed`, and `password_reset.invalid_or_expired`.

--- a/web/content/docs/reference/authserver-api.mdx
+++ b/web/content/docs/reference/authserver-api.mdx
@@ -480,9 +480,38 @@ var tokens = await authService.ExchangeCodeAsync(
 
 ---
 
+### RequestPasswordResetEmailAsync
+
+Create a one-time password reset token and send the built-in password reset email. Public endpoints use this flow and return an enumeration-safe response; they do not return the raw reset token.
+
+```csharp
+var result = await authService.RequestPasswordResetEmailAsync(
+    new SqlOSSendPasswordResetEmailRequest(
+        Email: request.Email,
+        ResetUrlTemplate: "https://app.example.com/reset-password?token={token}",
+        ClientId: "web"),
+    httpContext,
+    ct);
+```
+
+Use `ResetUrlTemplate: null` to link to SqlOS' hosted reset form at `/sqlos/auth/password/reset?token=...`.
+
+Public routes:
+
+```text
+POST /sqlos/auth/password/forgot
+POST /sqlos/auth/password/reset-email
+POST /sqlos/auth/headless/password/forgot
+POST /sqlos/auth/headless/password/reset
+```
+
+`/password/forgot` and `/password/reset-email` return masked email, expiry, next send time, and a generic message whether or not the email maps to a resettable local-password account.
+
+---
+
 ### CreatePasswordResetTokenAsync
 
-Generate a one-time password reset token for custom reset flows. Most apps should use `SendPasswordResetEmailAsync`, which sends the built-in `auth.password-reset` template.
+Generate a one-time password reset token for custom server-side reset flows. Most apps should use `RequestPasswordResetEmailAsync`, which sends the built-in `auth.password-reset` template and keeps bearer tokens out of browser-facing responses.
 
 ```csharp
 var token = await authService.CreatePasswordResetTokenAsync(
@@ -504,7 +533,7 @@ var token = await authService.CreatePasswordResetTokenAsync(
 
 ### SendPasswordResetEmailAsync
 
-Generate a reset token and send a password reset email with the built-in transactional template.
+Generate a reset token and send a password reset email with delivery details. Use this for trusted server/admin workflows; use `RequestPasswordResetEmailAsync` for public browser or headless flows.
 
 ```csharp
 var result = await authService.SendPasswordResetEmailAsync(
@@ -514,14 +543,13 @@ var result = await authService.SendPasswordResetEmailAsync(
     httpContext);
 ```
 
-Use `ResetUrlTemplate: null` to link to SqlOS' hosted reset form at `/sqlos/auth/password/reset?token=...`.
-
 **Parameters**
 
 | Name | Type | Description |
 |------|------|-------------|
 | `request.Email` | `string` | The user's email address. |
 | `request.ResetUrlTemplate` | `string?` | Optional reset URL template. If it includes `{token}`, SqlOS replaces it with the escaped reset token. |
+| `request.ClientId` | `string?` | Optional client/application key used for rate limiting and audit context. |
 
 **Returns**
 
@@ -531,7 +559,7 @@ Use `ResetUrlTemplate: null` to link to SqlOS' hosted reset form at `/sqlos/auth
 
 ### ResetPasswordAsync
 
-Consume a password reset token and set the new password.
+Consume a password reset token and set the new password for an active user that already has a local password credential.
 
 ```csharp
 await authService.ResetPasswordAsync(
@@ -544,7 +572,7 @@ await authService.ResetPasswordAsync(
 
 | Name | Type | Description |
 |------|------|-------------|
-| `request.Token` | `string` | The reset token from `CreatePasswordResetTokenAsync`. |
+| `request.Token` | `string` | The reset token from the delivered password reset link. |
 | `request.NewPassword` | `string` | The new password. |
 
 **Returns**

--- a/web/content/docs/reference/sdk-reference.mdx
+++ b/web/content/docs/reference/sdk-reference.mdx
@@ -89,10 +89,14 @@ var tokens = await authService.CreateSessionTokensForUserAsync(
     user, client, organizationId, "password", userAgent, ipAddress, ct);
 
 // Password reset
-await authService.SendPasswordResetEmailAsync(
-    new SqlOSSendPasswordResetEmailRequest(email), httpContext, ct);
+await authService.RequestPasswordResetEmailAsync(
+    new SqlOSSendPasswordResetEmailRequest(email, ClientId: clientId), httpContext, ct);
 
-// Custom reset-token flows can still generate and deliver the token directly.
+// Trusted server/admin flows can still request delivery details.
+await authService.SendPasswordResetEmailAsync(
+    new SqlOSSendPasswordResetEmailRequest(email, ClientId: clientId), httpContext, ct);
+
+// Custom server-side reset-token flows can still generate and deliver the token directly.
 var token = await authService.CreatePasswordResetTokenAsync(
     new SqlOSForgotPasswordRequest(email), ct);
 await authService.ResetPasswordAsync(


### PR DESCRIPTION
## Summary
- Add first-class password reset email options, safe request result contracts, hosted forgot/reset views, and headless/API reset endpoints.
- Send branded built-in `auth.password-reset` email templates through the existing transactional/auth email delivery path, with custom URL/message hooks, audit events, public failure masking, and token superseding.
- Update example integration coverage and docs so public flows no longer expose raw reset tokens.

Closes #3

## Validation
- `./scripts/build.sh`
- `./scripts/unit-tests.sh` (203 tests)
- `./scripts/integration-tests.sh` (53 + 47 + 12 tests)
- `./scripts/docs-check.sh`
