### PR TITLE
Add MFA TOTP policy and enrollment flows

### DIFF
--- a/docs/MFA_TOTP.md
+++ b/docs/MFA_TOTP.md
@@ -1,0 +1,117 @@
+# MFA and TOTP
+
+SqlOS supports authenticator-app MFA as the first strong step-up factor. The
+runtime is policy-driven:
+
+- MFA is optional by default.
+- Admins can disable MFA entirely.
+- Users can self-enroll by default when MFA is enabled.
+- Admins can require MFA globally or per organization.
+- Organization policy can require MFA for all users, or for owner/admin roles.
+- Recovery codes are generated after TOTP enrollment and are single-use.
+
+## Configure Defaults
+
+Use startup options for code defaults:
+
+```csharp
+builder.AddSqlOS<AppDbContext>(options =>
+{
+    options.AuthServer.ConfigureMfa(mfa =>
+    {
+        mfa.Enabled = true;
+        mfa.AllowUserSelfEnrollmentByDefault = true;
+        mfa.RecoveryCodesEnabledByDefault = true;
+        mfa.Totp.Issuer = "Contoso";
+    });
+});
+```
+
+Startup defaults create the persisted MFA settings row on first boot. To
+reapply settings on each boot, use `SeedMfaPolicy`, matching the existing auth
+page and email settings pattern.
+
+```csharp
+options.AuthServer.SeedMfaPolicy(mfa =>
+{
+    mfa.Enabled = true;
+    mfa.UserSelfEnrollmentEnabled = true;
+    mfa.RequireForAllUsers = false;
+});
+```
+
+After the row exists, dashboard/API changes own the live values unless a startup
+seed reapplies them.
+
+## Admin API
+
+Dashboard/API settings endpoints:
+
+- `GET /sqlos/admin/auth/api/settings/mfa`
+- `PUT /sqlos/admin/auth/api/settings/mfa`
+- `GET /sqlos/admin/auth/api/organizations/{organizationId}/mfa-policy`
+- `PUT /sqlos/admin/auth/api/organizations/{organizationId}/mfa-policy`
+
+## Direct Auth API
+
+If a primary login requires MFA, the login result has:
+
+- `requiresMfa: true`
+- `mfaToken`
+- `requiresMfaEnrollment`
+- `mfaMethods`
+- `tokens: null`
+
+Verify an existing factor:
+
+```http
+POST /sqlos/auth/mfa/challenge/verify
+{
+  "mfaToken": "...",
+  "code": "123456"
+}
+```
+
+For forced enrollment:
+
+```http
+POST /sqlos/auth/mfa/challenge/totp/enroll/start
+{
+  "mfaToken": "...",
+  "displayName": "Authenticator app"
+}
+```
+
+Then verify:
+
+```http
+POST /sqlos/auth/mfa/challenge/totp/enroll/verify
+{
+  "mfaToken": "...",
+  "enrollmentToken": "...",
+  "code": "123456"
+}
+```
+
+## Hosted OAuth
+
+Hosted authorization-code login evaluates MFA after the user and organization
+are resolved and before the authorization code is issued. A required policy
+renders either:
+
+- a second-factor code form, when the user already has TOTP or recovery codes;
+- a forced authenticator-app enrollment form, when the user has no strong
+  factor yet.
+
+Successful MFA appends the second factor to `amr`, for example:
+
+```text
+amr: password
+amr: totp
+```
+
+## Secret Custody
+
+TOTP secrets are stored through `SqlOSCryptoService.ProtectSecret`, which uses
+ASP.NET Data Protection when available. Production deployments should configure
+a Data Protection key ring outside the application database.

--- a/examples/SqlOS.Example.Api/Endpoints/ExampleDemoEndpoints.cs
+++ b/examples/SqlOS.Example.Api/Endpoints/ExampleDemoEndpoints.cs
@@ -197,6 +197,17 @@ public static class ExampleDemoEndpoints
                     httpContext,
                     cancellationToken);
 
+                if (result.RequiresMfa && !string.IsNullOrWhiteSpace(result.MfaToken))
+                {
+                    return Results.Ok(new
+                    {
+                        requiresMfa = true,
+                        mfaToken = result.MfaToken,
+                        requiresMfaEnrollment = result.RequiresMfaEnrollment,
+                        mfaMethods = result.MfaMethods ?? Array.Empty<string>()
+                    });
+                }
+
                 if (result.Tokens == null)
                     return Results.BadRequest(new { error = "Login did not produce tokens." });
 

--- a/examples/SqlOS.Example.Api/Endpoints/ExampleEndpoints.cs
+++ b/examples/SqlOS.Example.Api/Endpoints/ExampleEndpoints.cs
@@ -1,6 +1,7 @@
 using System.IdentityModel.Tokens.Jwt;
 using Microsoft.EntityFrameworkCore;
 using SqlOS.AuthServer.Contracts;
+using SqlOS.AuthServer.Services;
 using SqlOS.Example.Api.Data;
 using SqlOS.Example.Api.Models;
 using SqlOS.Example.Api.Services;
@@ -76,6 +77,46 @@ public static class ExampleEndpoints
                         updatedAt = profile.UpdatedAt
                     }
             });
+        });
+
+        example.MapGet("/mfa/status", async (SqlOSAuthService authService, HttpContext httpContext, CancellationToken cancellationToken) =>
+        {
+            var subjectId = httpContext.User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value;
+            if (string.IsNullOrWhiteSpace(subjectId))
+            {
+                return Results.Unauthorized();
+            }
+
+            return Results.Ok(await authService.GetMfaStatusAsync(
+                subjectId,
+                httpContext.User.FindFirst("org_id")?.Value,
+                cancellationToken));
+        });
+
+        example.MapPost("/mfa/totp/enroll/start", async (SqlOSTotpEnrollmentStartRequest request, SqlOSAuthService authService, HttpContext httpContext, CancellationToken cancellationToken) =>
+        {
+            var subjectId = httpContext.User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value;
+            if (string.IsNullOrWhiteSpace(subjectId))
+            {
+                return Results.Unauthorized();
+            }
+
+            return Results.Ok(await authService.StartTotpEnrollmentAsync(
+                subjectId,
+                request,
+                httpContext.User.FindFirst("org_id")?.Value,
+                cancellationToken));
+        });
+
+        example.MapPost("/mfa/totp/enroll/verify", async (SqlOSTotpEnrollmentVerifyRequest request, SqlOSAuthService authService, HttpContext httpContext, CancellationToken cancellationToken) =>
+        {
+            var subjectId = httpContext.User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value;
+            if (string.IsNullOrWhiteSpace(subjectId))
+            {
+                return Results.Unauthorized();
+            }
+
+            return Results.Ok(await authService.VerifyTotpEnrollmentAsync(request, httpContext, cancellationToken));
         });
 
         example.MapGet("/workspaces", async (ExampleAppDbContext context, ExampleFgaService fgaService, ISqlOSFgaAuthService authService, HttpContext httpContext, CancellationToken cancellationToken) =>

--- a/examples/SqlOS.Example.Api/FgaRetail/Seeding/RetailSeedService.cs
+++ b/examples/SqlOS.Example.Api/FgaRetail/Seeding/RetailSeedService.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using SqlOS.AuthServer.Contracts;
+using SqlOS.AuthServer.Models;
 using SqlOS.AuthServer.Services;
 using SqlOS.Example.Api.Data;
 using SqlOS.Example.Api.FgaRetail.Models;
@@ -16,6 +17,7 @@ public class RetailSeedService
     private readonly SqlOSFgaSeedService _seedService;
     private readonly ISqlOSFgaSubjectService _subjectService;
     private readonly SqlOSAdminService _adminService;
+    private readonly SqlOSSettingsService _settingsService;
     private readonly ExampleFgaService _fgaService;
 
     public const string DemoPassword = "RetailDemo1!";
@@ -50,19 +52,24 @@ public class RetailSeedService
         SqlOSFgaSeedService seedService,
         ISqlOSFgaSubjectService subjectService,
         SqlOSAdminService adminService,
+        SqlOSSettingsService settingsService,
         ExampleFgaService fgaService)
     {
         _context = context;
         _seedService = seedService;
         _subjectService = subjectService;
         _adminService = adminService;
+        _settingsService = settingsService;
         _fgaService = fgaService;
     }
 
     public async Task SeedAsync(CancellationToken ct = default)
     {
         if (await _context.Chains.AnyAsync(ct))
+        {
+            await EnsureRetailMfaPolicyAsync(ct);
             return;
+        }
 
         await _seedService.SeedAuthorizationDataAsync(new SqlOSFgaSeedData
         {
@@ -100,6 +107,7 @@ public class RetailSeedService
         var org = await _adminService.CreateOrganizationAsync(
             new SqlOSCreateOrganizationRequest("Retail Demo", RetailOrgSlug), ct);
         var orgId = org.Id;
+        await EnsureRetailMfaPolicyAsync(ct);
 
         var companyAdminId = await CreateDemoUserAsync("Company Admin", CompanyAdminEmail, "owner", orgId, ct);
         var chainMgrWalmartId = await CreateDemoUserAsync("Walmart Chain Manager", ChainManagerWalmartEmail, "member", orgId, ct);
@@ -223,5 +231,27 @@ public class RetailSeedService
         await _adminService.CreateMembershipAsync(orgId, new SqlOSCreateMembershipRequest(user.Id, role), ct);
         await _fgaService.EnsureUserAccessAsync(user.Id, orgId, ct);
         return user.Id;
+    }
+
+    private async Task EnsureRetailMfaPolicyAsync(CancellationToken ct)
+    {
+        var org = await _context.Set<SqlOSOrganization>()
+            .FirstOrDefaultAsync(x => x.Slug == RetailOrgSlug, ct);
+        if (org == null)
+        {
+            return;
+        }
+
+        await _settingsService.UpdateOrganizationMfaPolicyAsync(
+            org.Id,
+            new SqlOSUpdateOrganizationMfaPolicyRequest(
+                IsEnabled: true,
+                RequireMfaForAllUsers: true,
+                RequireMfaForOwnersAndAdmins: true,
+                UserSelfEnrollmentEnabled: true,
+                RecoveryCodesEnabled: true,
+                RequiredRoles: ["owner", "admin"],
+                AvailableFactors: [SqlOSMfaFactorTypes.Totp, SqlOSMfaFactorTypes.RecoveryCode]),
+            ct);
     }
 }

--- a/examples/SqlOS.Example.Api/Program.cs
+++ b/examples/SqlOS.Example.Api/Program.cs
@@ -94,6 +94,13 @@ builder.AddSqlOS<ExampleAppDbContext>(options =>
             phone.DefaultRegion = phoneOtpDefaultRegion;
         }
     });
+    auth.ConfigureMfa(mfa =>
+    {
+        mfa.Enabled = true;
+        mfa.AllowUserSelfEnrollmentByDefault = true;
+        mfa.RecoveryCodesEnabledByDefault = true;
+        mfa.Totp.Issuer = "SqlOS Example";
+    });
 
     var headlessFrontendUrl = builder.Configuration["SqlOS:HeadlessFrontendUrl"]
         ?? builder.Configuration["ExampleFrontend:Origin"]

--- a/examples/SqlOS.Example.IntegrationTests/SqlOSExampleRetailFgaIntegrationTests.cs
+++ b/examples/SqlOS.Example.IntegrationTests/SqlOSExampleRetailFgaIntegrationTests.cs
@@ -1,6 +1,9 @@
+using System.Collections.Concurrent;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -11,6 +14,9 @@ namespace SqlOS.Example.IntegrationTests;
 [TestClass]
 public sealed class SqlOSExampleRetailFgaIntegrationTests
 {
+    private static readonly ConcurrentDictionary<string, string> TotpSecretByEmail = new(StringComparer.OrdinalIgnoreCase);
+    private static readonly ConcurrentDictionary<string, string> AccessTokenByEmail = new(StringComparer.OrdinalIgnoreCase);
+
     [TestMethod]
     public async Task CompanyAdmin_CanListAndCreateChains()
     {
@@ -253,10 +259,76 @@ public sealed class SqlOSExampleRetailFgaIntegrationTests
 
     private static async Task<string> GetAccessTokenAsync(string email)
     {
+        if (AccessTokenByEmail.TryGetValue(email, out var cachedAccessToken))
+        {
+            return cachedAccessToken;
+        }
+
         var response = await ExampleApiFixture.Client.PostAsJsonAsync("/api/v1/auth/demo/switch", new { email });
         response.EnsureSuccessStatusCode();
         var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
-        return json.RootElement.GetProperty("accessToken").GetString()!;
+        if (json.RootElement.TryGetProperty("accessToken", out var accessToken))
+        {
+            var token = accessToken.GetString()!;
+            AccessTokenByEmail[email] = token;
+            return token;
+        }
+
+        json.RootElement.GetProperty("requiresMfa").GetBoolean().Should().BeTrue();
+        var mfaToken = json.RootElement.GetProperty("mfaToken").GetString()
+            ?? throw new InvalidOperationException("Demo switch MFA response did not include an MFA token.");
+        var requiresEnrollment = json.RootElement.GetProperty("requiresMfaEnrollment").GetBoolean();
+        if (requiresEnrollment)
+        {
+            var startResponse = await ExampleApiFixture.Client.PostAsJsonAsync(
+                "/sqlos/auth/mfa/challenge/totp/enroll/start",
+                new { mfaToken, displayName = "Integration test authenticator" });
+            startResponse.EnsureSuccessStatusCode();
+            var startJson = JsonDocument.Parse(await startResponse.Content.ReadAsStringAsync());
+            var enrollmentToken = startJson.RootElement.GetProperty("enrollmentToken").GetString()
+                ?? throw new InvalidOperationException("TOTP enrollment did not include an enrollment token.");
+            var secret = startJson.RootElement.GetProperty("secret").GetString()
+                ?? throw new InvalidOperationException("TOTP enrollment did not include a secret.");
+            TotpSecretByEmail[email] = secret;
+
+            var verifyResponse = await ExampleApiFixture.Client.PostAsJsonAsync(
+                "/sqlos/auth/mfa/challenge/totp/enroll/verify",
+                new
+                {
+                    enrollmentToken,
+                    code = GenerateTotp(secret),
+                    mfaToken
+                });
+            verifyResponse.EnsureSuccessStatusCode();
+            var verifyJson = JsonDocument.Parse(await verifyResponse.Content.ReadAsStringAsync());
+            var token = verifyJson.RootElement
+                .GetProperty("tokens")
+                .GetProperty("accessToken")
+                .GetString()!;
+            AccessTokenByEmail[email] = token;
+            return token;
+        }
+
+        if (!TotpSecretByEmail.TryGetValue(email, out var existingSecret))
+        {
+            throw new InvalidOperationException($"MFA is required for {email}, but the test helper does not have that user's TOTP secret.");
+        }
+
+        var challengeResponse = await ExampleApiFixture.Client.PostAsJsonAsync(
+            "/sqlos/auth/mfa/challenge/verify",
+            new
+            {
+                mfaToken,
+                code = GenerateTotp(existingSecret)
+            });
+        challengeResponse.EnsureSuccessStatusCode();
+        var challengeJson = JsonDocument.Parse(await challengeResponse.Content.ReadAsStringAsync());
+        var challengeToken = challengeJson.RootElement
+            .GetProperty("tokens")
+            .GetProperty("accessToken")
+            .GetString()!;
+        AccessTokenByEmail[email] = challengeToken;
+        return challengeToken;
     }
 
     private static async Task<HttpResponseMessage> GetAsUserAsync(string path, string email)
@@ -309,4 +381,54 @@ public sealed class SqlOSExampleRetailFgaIntegrationTests
         string? Description,
         string Type,
         string? Credential);
+
+    private static string GenerateTotp(string secret)
+    {
+        var timeStep = DateTimeOffset.UtcNow.ToUnixTimeSeconds() / 30;
+        Span<byte> counter = stackalloc byte[8];
+        BitConverter.TryWriteBytes(counter, timeStep);
+        if (BitConverter.IsLittleEndian)
+        {
+            counter.Reverse();
+        }
+
+        var hash = HMACSHA1.HashData(DecodeBase32(secret), counter);
+        var offset = hash[^1] & 0x0f;
+        var binary =
+            ((hash[offset] & 0x7f) << 24)
+            | ((hash[offset + 1] & 0xff) << 16)
+            | ((hash[offset + 2] & 0xff) << 8)
+            | (hash[offset + 3] & 0xff);
+
+        return (binary % 1_000_000).ToString().PadLeft(6, '0');
+    }
+
+    private static byte[] DecodeBase32(string input)
+    {
+        const string alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+        var cleaned = new string((input ?? string.Empty)
+            .Where(char.IsLetterOrDigit)
+            .Select(char.ToUpperInvariant)
+            .ToArray());
+        var bytes = new List<byte>();
+        var buffer = 0;
+        var bitsLeft = 0;
+        foreach (var character in cleaned)
+        {
+            var value = alphabet.IndexOf(character, StringComparison.Ordinal);
+            if (value < 0)
+                throw new InvalidOperationException("TOTP secret contains an invalid Base32 character.");
+
+            buffer <<= 5;
+            buffer |= value & 0x1f;
+            bitsLeft += 5;
+            if (bitsLeft >= 8)
+            {
+                bytes.Add((byte)(buffer >> (bitsLeft - 8)));
+                bitsLeft -= 8;
+            }
+        }
+
+        return bytes.ToArray();
+    }
 }

--- a/examples/SqlOS.Example.Web/app/globals.css
+++ b/examples/SqlOS.Example.Web/app/globals.css
@@ -1173,6 +1173,13 @@ input::placeholder { color: var(--color-text-tertiary); }
   color: #737373;
 }
 
+.ha-helper-text {
+  margin: 0;
+  color: #737373;
+  font-size: 13px;
+  line-height: 1.6;
+}
+
 .ha-link-btn {
   background: none;
   border: none;
@@ -1182,6 +1189,66 @@ input::placeholder { color: var(--color-text-tertiary); }
   font-weight: 600;
   cursor: pointer;
   padding: 0;
+}
+
+.ha-mfa-setup {
+  display: grid;
+  grid-template-columns: 132px minmax(0, 1fr);
+  gap: 16px;
+  align-items: center;
+}
+
+.ha-mfa-setup strong {
+  display: block;
+  margin-bottom: 4px;
+  color: #0a0a0a;
+  font-size: 14px;
+}
+
+.ha-mfa-setup p {
+  margin: 0;
+  color: #737373;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.ha-mfa-qr-frame {
+  width: 132px;
+  aspect-ratio: 1;
+  border: 1px solid #e5e5e5;
+  border-radius: 10px;
+  background: #ffffff;
+  padding: 8px;
+}
+
+.ha-mfa-qr-frame img {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.ha-manual-setup {
+  display: grid;
+  gap: 8px;
+  font-size: 12px;
+}
+
+.ha-manual-setup summary {
+  color: var(--color-primary);
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.ha-manual-setup code {
+  display: block;
+  margin-top: 8px;
+  padding: 10px;
+  border: 1px solid #e5e5e5;
+  border-radius: 8px;
+  background: #fafafa;
+  color: #171717;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  overflow-wrap: anywhere;
 }
 
 .ha-link-btn:hover { text-decoration: underline; }
@@ -1955,3 +2022,88 @@ input::placeholder { color: var(--color-text-tertiary); }
 
 .lp-footer-sep { color: #d4d4d4; }
 .lp-footer-muted { color: #a3a3a3; }
+
+.code-block {
+  margin: 12px 0;
+  padding: 14px;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  background: #f8fafc;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 13px;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+}
+
+.code-block--small {
+  font-size: 11px;
+  color: var(--color-muted);
+}
+
+.totp-setup {
+  display: grid;
+  grid-template-columns: minmax(180px, 220px) minmax(0, 1fr);
+  gap: 18px;
+  align-items: start;
+  margin: 14px 0 16px;
+}
+
+.totp-qr-frame {
+  width: 100%;
+  aspect-ratio: 1;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  background: #ffffff;
+  padding: 12px;
+}
+
+.totp-qr-frame img {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.totp-setup-copy {
+  min-width: 0;
+}
+
+.totp-setup-copy > strong {
+  display: block;
+  margin-bottom: 4px;
+}
+
+.totp-setup-copy details {
+  margin-top: 14px;
+}
+
+.totp-setup-copy summary {
+  color: var(--color-primary);
+  cursor: pointer;
+  font-weight: 700;
+}
+
+@media (max-width: 720px) {
+  .totp-setup {
+    grid-template-columns: 1fr;
+  }
+
+  .totp-qr-frame {
+    max-width: 220px;
+  }
+}
+
+.recovery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.recovery-grid code {
+  padding: 10px 12px;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  background: #f8fafc;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 13px;
+}

--- a/examples/SqlOS.Example.Web/app/retail/account/page.tsx
+++ b/examples/SqlOS.Example.Web/app/retail/account/page.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useSession } from "next-auth/react";
+import { useEffect, useState } from "react";
+import { apiGet, apiPost } from "@/lib/api";
+
+type MfaStatus = {
+  mfaEnabled: boolean;
+  required: boolean;
+  enrollmentRequired: boolean;
+  userSelfEnrollmentEnabled: boolean;
+  hasTotp: boolean;
+  recoveryCodeCount: number;
+  availableFactors: string[];
+  policyReason?: string | null;
+};
+
+type TotpEnrollment = {
+  enrollmentToken: string;
+  authenticatorId: string;
+  secret: string;
+  provisioningUri: string;
+  qrCodeDataUrl: string;
+  expiresAt: string;
+};
+
+type TotpEnrollmentResult = {
+  authenticatorId: string;
+  recoveryCodes: string[];
+};
+
+export default function AccountPage() {
+  const { data: session } = useSession();
+  const [status, setStatus] = useState<MfaStatus | null>(null);
+  const [enrollment, setEnrollment] = useState<TotpEnrollment | null>(null);
+  const [code, setCode] = useState("");
+  const [recoveryCodes, setRecoveryCodes] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!session?.accessToken) return;
+    apiGet<MfaStatus>("/api/mfa/status", session.accessToken)
+      .then(setStatus)
+      .catch((e) => setError(e.message));
+  }, [session?.accessToken]);
+
+  async function startEnrollment() {
+    if (!session?.accessToken) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await apiPost<TotpEnrollment>("/api/mfa/totp/enroll/start", session.accessToken, {
+        displayName: "Authenticator app",
+      });
+      setEnrollment(result);
+      setRecoveryCodes([]);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Unable to start enrollment.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function verifyEnrollment() {
+    if (!session?.accessToken || !enrollment) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await apiPost<TotpEnrollmentResult>("/api/mfa/totp/enroll/verify", session.accessToken, {
+        enrollmentToken: enrollment.enrollmentToken,
+        code,
+      });
+      setRecoveryCodes(result.recoveryCodes ?? []);
+      setEnrollment(null);
+      setCode("");
+      const nextStatus = await apiGet<MfaStatus>("/api/mfa/status", session.accessToken);
+      setStatus(nextStatus);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Unable to verify enrollment.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="dashboard-page">
+      <div className="page-header-row">
+        <div>
+          <h1>Account Security</h1>
+          <p className="muted">Manage second-factor authentication for this account.</p>
+        </div>
+      </div>
+
+      {error && <div className="error-banner">{error}</div>}
+
+      <section className="data-card">
+        <div className="card-header">
+          <div>
+            <h2>Two-step Verification</h2>
+            <p className="muted">
+              {status?.mfaEnabled ? "Authenticator apps are available for this account." : "MFA is disabled by this application."}
+            </p>
+          </div>
+          <span className={`badge ${status?.hasTotp ? "badge-success" : status?.required ? "badge-warning" : ""}`}>
+            {status?.hasTotp ? "Enabled" : status?.required ? "Required" : "Optional"}
+          </span>
+        </div>
+
+        <div className="detail-grid">
+          <div>
+            <span className="detail-label">Policy</span>
+            <strong>{status?.required ? `Required${status.policyReason ? ` (${status.policyReason})` : ""}` : "Optional"}</strong>
+          </div>
+          <div>
+            <span className="detail-label">Recovery codes</span>
+            <strong>{status?.recoveryCodeCount ?? 0} available</strong>
+          </div>
+          <div>
+            <span className="detail-label">Enrollment</span>
+            <strong>{status?.userSelfEnrollmentEnabled ? "Allowed" : "Admin disabled"}</strong>
+          </div>
+        </div>
+
+        {!status?.hasTotp && status?.mfaEnabled && status?.userSelfEnrollmentEnabled && (
+          <button type="button" className="primary-button" onClick={startEnrollment} disabled={loading}>
+            {loading ? "Starting..." : "Add authenticator app"}
+          </button>
+        )}
+      </section>
+
+      {enrollment && (
+        <section className="data-card">
+          <div className="card-header">
+            <div>
+              <h2>Add Authenticator App</h2>
+              <p className="muted">Scan the QR code with your authenticator app, then verify the 6-digit code.</p>
+            </div>
+          </div>
+          <div className="totp-setup">
+            <div className="totp-qr-frame">
+              <img src={enrollment.qrCodeDataUrl} alt="Authenticator setup QR code" />
+            </div>
+            <div className="totp-setup-copy">
+              <strong>Scan with an authenticator app</strong>
+              <p className="muted">Use Google Authenticator, 1Password, Authy, or any app that supports TOTP codes.</p>
+              <details>
+                <summary>Use manual setup</summary>
+                <div className="code-block">{enrollment.secret}</div>
+                <div className="code-block code-block--small">{enrollment.provisioningUri}</div>
+              </details>
+            </div>
+          </div>
+          <div className="form-row">
+            <input
+              value={code}
+              onChange={(event) => setCode(event.target.value)}
+              inputMode="numeric"
+              autoComplete="one-time-code"
+              placeholder="123456"
+            />
+            <button type="button" className="primary-button" onClick={verifyEnrollment} disabled={loading || code.trim().length < 6}>
+              {loading ? "Verifying..." : "Verify"}
+            </button>
+          </div>
+        </section>
+      )}
+
+      {recoveryCodes.length > 0 && (
+        <section className="data-card">
+          <h2>Recovery Codes</h2>
+          <p className="muted">Store these one-time codes before leaving this page.</p>
+          <div className="recovery-grid">
+            {recoveryCodes.map((item) => (
+              <code key={item}>{item}</code>
+            ))}
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/examples/SqlOS.Example.Web/components/sidebar.tsx
+++ b/examples/SqlOS.Example.Web/components/sidebar.tsx
@@ -57,6 +57,7 @@ const links: ReadonlyArray<{
   { href: "/retail", label: "Dashboard", icon: IconDashboard, exact: true },
   { href: "/retail/chains", label: "Chains", icon: IconChain },
   { href: "/retail/stores", label: "Stores", icon: IconStore },
+  { href: "/retail/account", label: "Account", icon: IconShield },
 ];
 
 export function Sidebar() {

--- a/examples/SqlOS.Example.Web/components/sqlos-headless-auth-panel.tsx
+++ b/examples/SqlOS.Example.Web/components/sqlos-headless-auth-panel.tsx
@@ -9,13 +9,18 @@ import {
   getHeadlessRequest,
   headlessIdentify,
   headlessPasswordLogin,
+  headlessRequestPasswordResetEmail,
   headlessRequestEmailOtp,
   headlessRequestPhoneOtp,
   headlessRequestPhoneOtpSignup,
+  headlessResetPassword,
   headlessSelectOrganization,
   headlessSignup,
   headlessStartProvider,
+  headlessStartMfaTotpEnrollment,
   headlessVerifyEmailOtp,
+  headlessVerifyMfa,
+  headlessVerifyMfaTotpEnrollment,
   headlessVerifyPhoneOtp,
   headlessVerifyPhoneOtpSignup,
   type HeadlessViewModel,
@@ -84,11 +89,13 @@ export function SqlOSHeadlessAuthPanel() {
   const initialEmail = searchParams.get("email") || "";
   const pendingToken = searchParams.get("pendingToken");
   const initialDisplayName = searchParams.get("displayName") || "";
+  const initialResetToken = searchParams.get("token") || "";
   const nextPath = searchParams.get("next") || "/retail";
 
   const [view, setView] = useState(initialView);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(initialError);
+  const [notice, setNotice] = useState<string | null>(null);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
   const [viewModel, setViewModel] = useState<HeadlessViewModel | null>(null);
 
@@ -100,6 +107,13 @@ export function SqlOSHeadlessAuthPanel() {
   const [firstName, setFirstName] = useState("");
   const [lastName, setLastName] = useState("");
   const [referralSource, setReferralSource] = useState("");
+  const [mfaCode, setMfaCode] = useState("");
+  const [mfaEnrollmentCode, setMfaEnrollmentCode] = useState("");
+  const [startedMfaEnrollmentToken, setStartedMfaEnrollmentToken] = useState<string | null>(null);
+  const [resetEmail, setResetEmail] = useState(initialEmail);
+  const [resetToken, setResetToken] = useState(initialResetToken);
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmNewPassword, setConfirmNewPassword] = useState("");
 
   useEffect(() => {
     if (!requestId) return;
@@ -118,6 +132,7 @@ export function SqlOSHeadlessAuthPanel() {
         if (vm.view) setView(vm.view);
         if (vm.error) setError(vm.error);
         if (vm.email) setEmail(vm.email);
+        if (vm.email) setResetEmail(vm.email);
         if (vm.phoneNumber) setPhoneNumber(vm.phoneNumber);
         if (vm.displayName && !firstName && !lastName && initialDisplayName) {
           const [first = "", ...rest] = vm.displayName.split(" ");
@@ -133,7 +148,15 @@ export function SqlOSHeadlessAuthPanel() {
     void load();
   }, [requestId, initialView, initialError, pendingToken, initialEmail, initialDisplayName]);
 
+  useEffect(() => {
+    if (initialResetToken) {
+      setResetToken(initialResetToken);
+      setView("password-reset");
+    }
+  }, [initialResetToken]);
+
   const handleResult = useCallback(async (result: HeadlessActionResult) => {
+    setNotice(null);
     if (result.type === "redirect" && result.redirectUrl) {
       const url = new URL(result.redirectUrl);
       const code = url.searchParams.get("code");
@@ -192,15 +215,43 @@ export function SqlOSHeadlessAuthPanel() {
     }
 
     if (result.viewModel) {
-      setViewModel(result.viewModel);
-      if (result.viewModel.view) setView(result.viewModel.view);
-      if (result.viewModel.error) setError(result.viewModel.error);
-      if (result.viewModel.email) setEmail(result.viewModel.email);
-      if (result.viewModel.phoneNumber) setPhoneNumber(result.viewModel.phoneNumber);
-      if (result.viewModel.challengeToken) setOtpCode("");
-      setFieldErrors(result.viewModel.fieldErrors ?? {});
+      const nextViewModel =
+        result.viewModel.view === "mfa-enroll" && !result.viewModel.totpEnrollment && viewModel?.totpEnrollment
+          ? { ...result.viewModel, totpEnrollment: viewModel.totpEnrollment }
+          : result.viewModel;
+      setViewModel(nextViewModel);
+      if (nextViewModel.view) setView(nextViewModel.view);
+      if (nextViewModel.error) setError(nextViewModel.error);
+      if (nextViewModel.email) {
+        setEmail(nextViewModel.email);
+        setResetEmail(nextViewModel.email);
+      }
+      if (nextViewModel.phoneNumber) setPhoneNumber(nextViewModel.phoneNumber);
+      if (nextViewModel.challengeToken) setOtpCode("");
+      if (nextViewModel.mfaToken) setMfaCode("");
+      if (nextViewModel.totpEnrollment) setMfaEnrollmentCode("");
+      setFieldErrors(nextViewModel.fieldErrors ?? {});
     }
-  }, []);
+  }, [viewModel?.totpEnrollment]);
+
+  const onStartMfaEnrollment = useCallback(async () => {
+    if (!requestId || !viewModel?.mfaToken) return;
+    setLoading(true); setError(null); setFieldErrors({});
+    try {
+      await handleResult(await headlessStartMfaTotpEnrollment(requestId, viewModel.mfaToken, "Authenticator app"));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "We could not start authenticator enrollment.");
+    } finally {
+      setLoading(false);
+    }
+  }, [handleResult, requestId, viewModel?.mfaToken]);
+
+  useEffect(() => {
+    if (view !== "mfa-enroll" || !requestId || !viewModel?.mfaToken || viewModel.totpEnrollment) return;
+    if (startedMfaEnrollmentToken === viewModel.mfaToken) return;
+    setStartedMfaEnrollmentToken(viewModel.mfaToken);
+    void onStartMfaEnrollment();
+  }, [onStartMfaEnrollment, requestId, startedMfaEnrollmentToken, view, viewModel?.mfaToken, viewModel?.totpEnrollment]);
 
   const onIdentify = async (event: React.FormEvent) => {
     event.preventDefault();
@@ -218,6 +269,51 @@ export function SqlOSHeadlessAuthPanel() {
     try { await handleResult(await headlessPasswordLogin(requestId, email, password)); }
     catch (err) { setError(err instanceof Error ? err.message : "Login failed."); }
     finally { setLoading(false); }
+  };
+
+  const onRequestPasswordReset = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setLoading(true); setError(null); setNotice(null); setFieldErrors({});
+    try {
+      const targetEmail = (resetEmail || email).trim();
+      const resetUrl = new URL("/auth/authorize", window.location.origin);
+      resetUrl.searchParams.set("view", "password-reset");
+      if (requestId) resetUrl.searchParams.set("request", requestId);
+      if (targetEmail) resetUrl.searchParams.set("email", targetEmail);
+      const resetUrlBase = resetUrl.toString();
+      const resetUrlTemplate = `${resetUrlBase}${resetUrlBase.includes("?") ? "&" : "?"}token={token}`;
+      const result = await headlessRequestPasswordResetEmail(targetEmail, requestId, resetUrlTemplate);
+      setNotice(result.message || "If the account can be reset, a reset email is on the way.");
+      setView("forgot-password-sent");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "We could not request password recovery.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const onResetPassword = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setLoading(true); setError(null); setNotice(null); setFieldErrors({});
+    try {
+      if (!resetToken.trim()) {
+        throw new Error("Password reset token is missing.");
+      }
+      if (newPassword !== confirmNewPassword) {
+        setFieldErrors({ confirmNewPassword: "Passwords do not match." });
+        return;
+      }
+      await headlessResetPassword(resetToken, newPassword);
+      setPassword("");
+      setNewPassword("");
+      setConfirmNewPassword("");
+      setNotice("Your password has been reset. Sign in with your new password.");
+      setView("login");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "We could not reset your password.");
+    } finally {
+      setLoading(false);
+    }
   };
 
   const onRequestEmailOtp = async (event: React.FormEvent) => {
@@ -327,7 +423,40 @@ export function SqlOSHeadlessAuthPanel() {
     finally { setLoading(false); }
   };
 
+  const onVerifyMfa = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!requestId || !viewModel?.mfaToken) return;
+    setLoading(true); setError(null); setFieldErrors({});
+    try {
+      await handleResult(await headlessVerifyMfa(requestId, viewModel.mfaToken, mfaCode));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "The second-factor code was rejected.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const onVerifyMfaEnrollment = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!requestId || !viewModel?.mfaToken || !viewModel.totpEnrollment) return;
+    setLoading(true); setError(null); setFieldErrors({});
+    try {
+      await handleResult(await headlessVerifyMfaTotpEnrollment(
+        requestId,
+        viewModel.mfaToken,
+        viewModel.totpEnrollment.enrollmentToken,
+        mfaEnrollmentCode,
+      ));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Authenticator enrollment failed.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
   const isSignup = view === "signup" || view === "phone-otp-signup" || view === "phone-otp-signup-verify";
+  const isMfa = view === "mfa" || view === "mfa-enroll";
+  const isRecovery = view === "forgot-password" || view === "forgot-password-sent" || view === "password-reset";
   const showProviderButtons = (view === "login" || view === "identify" || view === "signup") && (viewModel?.providers?.length ?? 0) > 0;
   const supportsPassword = !!viewModel?.settings?.localPasswordRuntimeEnabled
     && (viewModel?.settings?.enabledCredentialTypes ?? []).includes("password");
@@ -336,17 +465,43 @@ export function SqlOSHeadlessAuthPanel() {
   const supportsPhoneOtp = !!viewModel?.settings?.phoneOtpRuntimeConfigured
     && (viewModel?.settings?.enabledCredentialTypes ?? []).includes("phone_otp");
 
-  const headline = isSignup ? "Start your free trial" : view === "organization" ? "Choose workspace" : "Welcome back";
+  const headline = isSignup
+    ? "Start your free trial"
+    : view === "organization"
+      ? "Choose workspace"
+      : view === "mfa"
+        ? "Two-step verification"
+        : view === "mfa-enroll"
+          ? "Add authenticator app"
+          : view === "forgot-password"
+            ? "Recover account"
+            : view === "forgot-password-sent"
+              ? "Check your email"
+              : view === "password-reset"
+                ? "Reset password"
+                : "Welcome back";
   const subtitle = isSignup
     ? "Create your account and start managing retail operations in minutes."
     : view === "organization"
       ? "Select the organization you'd like to sign in to."
-      : "Sign in to your Northwind Retail account.";
+      : view === "mfa"
+        ? "Enter an authenticator code or one of your recovery codes."
+        : view === "mfa-enroll"
+          ? "Set up an authenticator app before continuing."
+          : view === "forgot-password"
+            ? "Enter your email and we'll send recovery instructions if the account can be reset."
+            : view === "forgot-password-sent"
+              ? "Use the link in your email to choose a new password."
+              : view === "password-reset"
+                ? "Choose a new password for your account."
+                : "Sign in to your Northwind Retail account.";
   const testimonialQuote = isSignup
     ? "Setting up took less than five minutes. We had our entire team onboarded before lunch."
+    : isMfa || isRecovery
+      ? "I can keep access secure without slowing down the team."
     : "I love that I can see exactly my stores. No noise, no clutter — just the data I need.";
-  const testimonialName = isSignup ? "Marcus Rivera" : "Priya Sharma";
-  const testimonialRole = isSignup ? "Head of Retail Ops, FreshMart" : "Store Manager, Target #100";
+  const testimonialName = isSignup ? "Marcus Rivera" : isMfa || isRecovery ? "Avery Chen" : "Priya Sharma";
+  const testimonialRole = isSignup ? "Head of Retail Ops, FreshMart" : isMfa || isRecovery ? "IT Manager, Northwind Retail" : "Store Manager, Target #100";
 
   return (
     <div className="ha">
@@ -386,9 +541,38 @@ export function SqlOSHeadlessAuthPanel() {
           </div>
 
           {error && <div className="ha-error">{error}</div>}
-          {viewModel?.info && <div className="ha-success">{viewModel.info}</div>}
+          {(notice || viewModel?.info) && <div className="ha-success">{notice || viewModel?.info}</div>}
 
-          {!requestId ? (
+          {!requestId && view === "password-reset" ? (
+            <form className="ha-form" onSubmit={onResetPassword}>
+              <div className="ha-field">
+                <label htmlFor="ha-reset-token">Reset token</label>
+                <input id="ha-reset-token" type="text" value={resetToken} onChange={(e) => setResetToken(e.target.value)} required />
+              </div>
+              <div className="ha-field">
+                <label htmlFor="ha-new-password">New password</label>
+                <input id="ha-new-password" type="password" value={newPassword} onChange={(e) => setNewPassword(e.target.value)} autoComplete="new-password" required autoFocus />
+              </div>
+              <div className="ha-field">
+                <label htmlFor="ha-confirm-password">Confirm password</label>
+                <input id="ha-confirm-password" type="password" value={confirmNewPassword} onChange={(e) => setConfirmNewPassword(e.target.value)} autoComplete="new-password" required />
+                {fieldErrors.confirmNewPassword && <p className="ha-field-error">{fieldErrors.confirmNewPassword}</p>}
+              </div>
+              <button type="submit" className="ha-submit" disabled={loading}>
+                {loading ? "Resetting..." : "Reset password"}
+              </button>
+            </form>
+          ) : !requestId && view === "forgot-password" ? (
+            <form className="ha-form" onSubmit={onRequestPasswordReset}>
+              <div className="ha-field">
+                <label htmlFor="ha-forgot-email-standalone">Email address</label>
+                <input id="ha-forgot-email-standalone" type="email" value={resetEmail} onChange={(e) => setResetEmail(e.target.value)} placeholder="you@company.com" required autoFocus />
+              </div>
+              <button type="submit" className="ha-submit" disabled={loading}>
+                {loading ? "Sending..." : "Send recovery email"}
+              </button>
+            </form>
+          ) : !requestId ? (
             <HeadlessFlowStarter initialView={isSignup ? "signup" : "login"} nextPath={nextPath} />
           ) : (
             <>
@@ -426,9 +610,54 @@ export function SqlOSHeadlessAuthPanel() {
                   </button>
                   <div className="ha-alt">
                     <button type="button" className="ha-link-btn" onClick={() => setView("login")}>Use a different email</button>
+                    <button type="button" className="ha-link-btn" onClick={() => { setResetEmail(email); setView("forgot-password"); }}>Forgot password?</button>
                     {supportsEmailOtp && <button type="button" className="ha-link-btn" onClick={() => setView("email-otp")}>Email me a code instead</button>}
                     {supportsPhoneOtp && <button type="button" className="ha-link-btn" onClick={() => setView("phone-otp")}>Text me a code instead</button>}
                   </div>
+                </form>
+              )}
+
+              {view === "forgot-password" && (
+                <form className="ha-form" onSubmit={onRequestPasswordReset}>
+                  <div className="ha-field">
+                    <label htmlFor="ha-forgot-email">Email address</label>
+                    <input id="ha-forgot-email" type="email" value={resetEmail || email} onChange={(e) => setResetEmail(e.target.value)} placeholder="you@company.com" required autoFocus />
+                  </div>
+                  <button type="submit" className="ha-submit" disabled={loading}>
+                    {loading ? "Sending..." : "Send recovery email"}
+                  </button>
+                  <div className="ha-alt">
+                    <button type="button" className="ha-link-btn" onClick={() => setView(email ? "password" : "login")}>Back to sign in</button>
+                  </div>
+                </form>
+              )}
+
+              {view === "forgot-password-sent" && (
+                <div className="ha-form">
+                  <button type="button" className="ha-submit" onClick={() => setView("login")}>
+                    Back to sign in
+                  </button>
+                </div>
+              )}
+
+              {view === "password-reset" && (
+                <form className="ha-form" onSubmit={onResetPassword}>
+                  <div className="ha-field">
+                    <label htmlFor="ha-reset-token-flow">Reset token</label>
+                    <input id="ha-reset-token-flow" type="text" value={resetToken} onChange={(e) => setResetToken(e.target.value)} required />
+                  </div>
+                  <div className="ha-field">
+                    <label htmlFor="ha-new-password-flow">New password</label>
+                    <input id="ha-new-password-flow" type="password" value={newPassword} onChange={(e) => setNewPassword(e.target.value)} autoComplete="new-password" required autoFocus />
+                  </div>
+                  <div className="ha-field">
+                    <label htmlFor="ha-confirm-password-flow">Confirm password</label>
+                    <input id="ha-confirm-password-flow" type="password" value={confirmNewPassword} onChange={(e) => setConfirmNewPassword(e.target.value)} autoComplete="new-password" required />
+                    {fieldErrors.confirmNewPassword && <p className="ha-field-error">{fieldErrors.confirmNewPassword}</p>}
+                  </div>
+                  <button type="submit" className="ha-submit" disabled={loading}>
+                    {loading ? "Resetting..." : "Reset password"}
+                  </button>
                 </form>
               )}
 
@@ -617,6 +846,78 @@ export function SqlOSHeadlessAuthPanel() {
                       </button>
                     ))}
                   </div>
+                </div>
+              )}
+
+              {view === "mfa" && (
+                <form className="ha-form" onSubmit={onVerifyMfa}>
+                  <div className="ha-field">
+                    <label htmlFor="ha-mfa-code">Authenticator or recovery code</label>
+                    <input
+                      id="ha-mfa-code"
+                      type="text"
+                      value={mfaCode}
+                      onChange={(e) => setMfaCode(e.target.value)}
+                      inputMode="numeric"
+                      autoComplete="one-time-code"
+                      placeholder="123456"
+                      required
+                      autoFocus
+                    />
+                  </div>
+                  <button type="submit" className="ha-submit" disabled={loading || !viewModel?.mfaToken}>
+                    {loading ? "Verifying..." : "Verify and continue"}
+                  </button>
+                  <div className="ha-alt">
+                    Use a 6-digit authenticator code, or paste one of your saved recovery codes.
+                  </div>
+                </form>
+              )}
+
+              {view === "mfa-enroll" && (
+                <div className="ha-form">
+                  {viewModel?.totpEnrollment ? (
+                    <form className="ha-form" onSubmit={onVerifyMfaEnrollment}>
+                      <div className="ha-mfa-setup">
+                        <div className="ha-mfa-qr-frame">
+                          <img src={viewModel.totpEnrollment.qrCodeDataUrl} alt="Authenticator setup QR code" />
+                        </div>
+                        <div>
+                          <strong>Scan with an authenticator app</strong>
+                          <p>Use Google Authenticator, 1Password, Authy, or any TOTP-compatible app.</p>
+                        </div>
+                      </div>
+                      <details className="ha-manual-setup">
+                        <summary>Use manual setup</summary>
+                        <code>{viewModel.totpEnrollment.secret}</code>
+                        <code>{viewModel.totpEnrollment.provisioningUri}</code>
+                      </details>
+                      <div className="ha-field">
+                        <label htmlFor="ha-mfa-enroll-code">Verification code</label>
+                        <input
+                          id="ha-mfa-enroll-code"
+                          type="text"
+                          value={mfaEnrollmentCode}
+                          onChange={(e) => setMfaEnrollmentCode(e.target.value)}
+                          inputMode="numeric"
+                          autoComplete="one-time-code"
+                          placeholder="123456"
+                          required
+                          autoFocus
+                        />
+                      </div>
+                      <button type="submit" className="ha-submit" disabled={loading || mfaEnrollmentCode.trim().length < 6}>
+                        {loading ? "Verifying..." : "Verify and continue"}
+                      </button>
+                    </form>
+                  ) : (
+                    <>
+                      <p className="ha-helper-text">This organization requires an authenticator app before you can continue.</p>
+                      <button type="button" className="ha-submit" onClick={() => void onStartMfaEnrollment()} disabled={loading || !viewModel?.mfaToken}>
+                        {loading ? "Starting..." : "Add authenticator app"}
+                      </button>
+                    </>
+                  )}
                 </div>
               )}
 

--- a/examples/SqlOS.Example.Web/lib/sqlos-headless.ts
+++ b/examples/SqlOS.Example.Web/lib/sqlos-headless.ts
@@ -22,6 +22,27 @@ export type HeadlessViewModel = {
   organizationSelection?: HeadlessOrganizationOption[];
   settings?: HeadlessSettings | null;
   fieldErrors?: Record<string, string>;
+  mfaToken?: string | null;
+  requiresMfaEnrollment?: boolean;
+  mfaMethods?: string[] | null;
+  totpEnrollment?: HeadlessTotpEnrollment | null;
+};
+
+export type HeadlessTotpEnrollment = {
+  enrollmentToken: string;
+  authenticatorId: string;
+  secret: string;
+  provisioningUri: string;
+  qrCodeDataUrl: string;
+  expiresAt: string;
+};
+
+export type HeadlessPasswordResetRequestResult = {
+  email: string;
+  maskedEmail: string;
+  message: string;
+  expiresAt: string;
+  nextAllowedSendAt: string;
 };
 
 export type HeadlessProvider = {
@@ -57,7 +78,7 @@ export type HeadlessActionResult = {
   viewModel?: HeadlessViewModel;
 };
 
-async function headlessPost(path: string, body: unknown): Promise<HeadlessActionResult> {
+async function headlessPostJson<T>(path: string, body: unknown): Promise<T> {
   const res = await fetch(`${headlessBase()}${path}`, {
     method: "POST",
     credentials: "include",
@@ -70,7 +91,15 @@ async function headlessPost(path: string, body: unknown): Promise<HeadlessAction
     throw new Error(text || `Headless API error: ${res.status}`);
   }
 
-  return res.json();
+  if (res.status === 204) {
+    return undefined as T;
+  }
+
+  return res.json() as Promise<T>;
+}
+
+async function headlessPost(path: string, body: unknown): Promise<HeadlessActionResult> {
+  return headlessPostJson<HeadlessActionResult>(path, body);
 }
 
 export async function getHeadlessRequest(
@@ -105,6 +134,18 @@ export async function headlessIdentify(requestId: string, email: string): Promis
 
 export async function headlessPasswordLogin(requestId: string, email: string, password: string): Promise<HeadlessActionResult> {
   return headlessPost("/password/login", { requestId, email, password });
+}
+
+export async function headlessRequestPasswordResetEmail(
+  email: string,
+  requestId?: string | null,
+  resetUrlTemplate?: string | null,
+): Promise<HeadlessPasswordResetRequestResult> {
+  return headlessPostJson<HeadlessPasswordResetRequestResult>("/password/forgot", { email, requestId, resetUrlTemplate });
+}
+
+export async function headlessResetPassword(token: string, newPassword: string): Promise<void> {
+  await headlessPostJson<void>("/password/reset", { token, newPassword });
 }
 
 export async function headlessRequestEmailOtp(requestId: string, email: string): Promise<HeadlessActionResult> {
@@ -172,4 +213,25 @@ export async function headlessSelectOrganization(pendingToken: string, organizat
 
 export async function headlessStartProvider(requestId: string, connectionId: string, email?: string): Promise<HeadlessActionResult> {
   return headlessPost("/provider/start", { requestId, connectionId, email });
+}
+
+export async function headlessVerifyMfa(requestId: string, mfaToken: string, code: string): Promise<HeadlessActionResult> {
+  return headlessPost("/mfa/verify", { requestId, mfaToken, code });
+}
+
+export async function headlessStartMfaTotpEnrollment(
+  requestId: string,
+  mfaToken: string,
+  displayName?: string,
+): Promise<HeadlessActionResult> {
+  return headlessPost("/mfa/totp/enroll/start", { requestId, mfaToken, displayName });
+}
+
+export async function headlessVerifyMfaTotpEnrollment(
+  requestId: string,
+  mfaToken: string,
+  enrollmentToken: string,
+  code: string,
+): Promise<HeadlessActionResult> {
+  return headlessPost("/mfa/totp/enroll/verify", { requestId, mfaToken, enrollmentToken, code });
 }

--- a/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerModelConfiguration.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerModelConfiguration.cs
@@ -373,6 +373,75 @@ public static class SqlOSAuthServerModelConfiguration
             entity.HasKey(x => x.Id);
         });
 
+        modelBuilder.Entity<SqlOSMfaSettings>(entity =>
+        {
+            entity.ToTable("SqlOSMfaSettings", schema, t => t.ExcludeFromMigrations());
+            entity.HasKey(x => x.Id);
+            entity.Property(x => x.Id).HasMaxLength(64);
+            entity.Property(x => x.RequiredRolesJson).HasColumnType("nvarchar(max)");
+            entity.Property(x => x.AvailableFactorsJson).HasColumnType("nvarchar(max)");
+        });
+
+        modelBuilder.Entity<SqlOSOrganizationMfaPolicy>(entity =>
+        {
+            entity.ToTable("SqlOSOrganizationMfaPolicies", schema, t => t.ExcludeFromMigrations());
+            entity.HasKey(x => x.OrganizationId);
+            entity.Property(x => x.OrganizationId).HasMaxLength(64);
+            entity.Property(x => x.RequiredRolesJson).HasColumnType("nvarchar(max)");
+            entity.Property(x => x.AvailableFactorsJson).HasColumnType("nvarchar(max)");
+            entity.HasOne(x => x.Organization)
+                .WithOne(x => x.MfaPolicy)
+                .HasForeignKey<SqlOSOrganizationMfaPolicy>(x => x.OrganizationId)
+                .OnDelete(DeleteBehavior.Restrict);
+        });
+
+        modelBuilder.Entity<SqlOSUserMfaPolicyOverride>(entity =>
+        {
+            entity.ToTable("SqlOSUserMfaPolicyOverrides", schema, t => t.ExcludeFromMigrations());
+            entity.HasKey(x => x.UserId);
+            entity.Property(x => x.UserId).HasMaxLength(64);
+            entity.HasOne(x => x.User)
+                .WithOne(x => x.MfaPolicyOverride)
+                .HasForeignKey<SqlOSUserMfaPolicyOverride>(x => x.UserId)
+                .OnDelete(DeleteBehavior.Restrict);
+        });
+
+        modelBuilder.Entity<SqlOSUserAuthenticator>(entity =>
+        {
+            entity.ToTable("SqlOSUserAuthenticators", schema, t => t.ExcludeFromMigrations());
+            entity.HasKey(x => x.Id);
+            entity.HasIndex(x => new { x.UserId, x.Type, x.RevokedAt });
+            entity.HasIndex(x => new { x.UserId, x.IsConfirmed, x.RevokedAt });
+            entity.Property(x => x.Id).HasMaxLength(64);
+            entity.Property(x => x.UserId).HasMaxLength(64);
+            entity.Property(x => x.Type).HasMaxLength(40);
+            entity.Property(x => x.DisplayName).HasMaxLength(120);
+            entity.Property(x => x.SecretProtected).HasMaxLength(2048);
+            entity.Property(x => x.Algorithm).HasMaxLength(20);
+            entity.Property(x => x.RevocationReason).HasMaxLength(120);
+            entity.Property(x => x.LastAcceptedTimeStep).IsConcurrencyToken();
+            entity.HasOne(x => x.User)
+                .WithMany(x => x.Authenticators)
+                .HasForeignKey(x => x.UserId)
+                .OnDelete(DeleteBehavior.Restrict);
+        });
+
+        modelBuilder.Entity<SqlOSRecoveryCode>(entity =>
+        {
+            entity.ToTable("SqlOSRecoveryCodes", schema, t => t.ExcludeFromMigrations());
+            entity.HasKey(x => x.Id);
+            entity.HasIndex(x => x.CodeHash).IsUnique();
+            entity.HasIndex(x => new { x.UserId, x.ConsumedAt, x.RevokedAt });
+            entity.Property(x => x.Id).HasMaxLength(64);
+            entity.Property(x => x.UserId).HasMaxLength(64);
+            entity.Property(x => x.CodeHash).HasMaxLength(128);
+            entity.Property(x => x.ConsumedAt).IsConcurrencyToken();
+            entity.HasOne(x => x.User)
+                .WithMany(x => x.RecoveryCodes)
+                .HasForeignKey(x => x.UserId)
+                .OnDelete(DeleteBehavior.Restrict);
+        });
+
         modelBuilder.Entity<SqlOSAuthPageSettings>(entity =>
         {
             entity.ToTable("SqlOSAuthPageSettings", schema, t => t.ExcludeFromMigrations());

--- a/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerOptions.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerOptions.cs
@@ -37,6 +37,7 @@ public class SqlOSAuthServerOptions
     public int DefaultSigningKeyRetiredCleanupDays { get; set; } = 30;
     public SqlOSEmailOtpOptions EmailOtp { get; } = new();
     public SqlOSPhoneOtpOptions PhoneOtp { get; } = new();
+    public SqlOSMfaOptions Mfa { get; } = new();
     public SqlOSPasswordResetOptions PasswordReset { get; } = new();
     public SqlOSPasswordLoginAbuseOptions PasswordLogin { get; } = new();
     public SqlOSInvitationOptions Invitations { get; } = new();
@@ -47,6 +48,7 @@ public class SqlOSAuthServerOptions
     public SqlOSHeadlessAuthOptions Headless { get; } = new();
     public SqlOSAuthPageSeedOptions? AuthPageSeed { get; private set; }
     public SqlOSAuthEmailSeedOptions? AuthEmailSeed { get; private set; }
+    public SqlOSMfaSeedOptions? MfaSeed { get; private set; }
     public SqlOSSingleApplicationOptions? SingleApplication { get; private set; }
     public List<SqlOSClientSeedOptions> ClientSeeds { get; } = [];
 
@@ -69,6 +71,14 @@ public class SqlOSAuthServerOptions
         var seed = AuthEmailSeed ?? new SqlOSAuthEmailSeedOptions();
         configure(seed);
         AuthEmailSeed = seed;
+        return this;
+    }
+
+    public SqlOSAuthServerOptions SeedMfaPolicy(Action<SqlOSMfaSeedOptions> configure)
+    {
+        var seed = MfaSeed ?? new SqlOSMfaSeedOptions();
+        configure(seed);
+        MfaSeed = seed;
         return this;
     }
 
@@ -172,6 +182,12 @@ public class SqlOSAuthServerOptions
     public SqlOSAuthServerOptions ConfigurePhoneOtp(Action<SqlOSPhoneOtpOptions> configure)
     {
         configure(PhoneOtp);
+        return this;
+    }
+
+    public SqlOSAuthServerOptions ConfigureMfa(Action<SqlOSMfaOptions> configure)
+    {
+        configure(Mfa);
         return this;
     }
 

--- a/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerSeedOptions.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerSeedOptions.cs
@@ -37,6 +37,32 @@ public sealed class SqlOSAuthEmailSeedOptions
     public string BackgroundColor { get; set; } = "#f8fafc";
 }
 
+public sealed class SqlOSMfaSeedOptions
+{
+    public bool Enabled { get; set; } = true;
+    public bool TotpEnabled { get; set; } = true;
+    public bool UserSelfEnrollmentEnabled { get; set; } = true;
+    public bool RecoveryCodesEnabled { get; set; } = true;
+    public bool RequireForAllUsers { get; set; }
+    public bool RequireForOwnersAndAdmins { get; set; }
+    public List<string> RequiredRoles { get; set; } = ["owner", "admin"];
+    public List<string> AvailableFactors { get; set; } = ["totp", "recovery_code"];
+    public List<SqlOSOrganizationMfaPolicySeedOptions> Organizations { get; } = [];
+}
+
+public sealed class SqlOSOrganizationMfaPolicySeedOptions
+{
+    public string OrganizationId { get; set; } = string.Empty;
+    public string? OrganizationSlug { get; set; }
+    public bool IsEnabled { get; set; } = true;
+    public bool RequireMfaForAllUsers { get; set; }
+    public bool RequireMfaForOwnersAndAdmins { get; set; }
+    public bool UserSelfEnrollmentEnabled { get; set; } = true;
+    public bool RecoveryCodesEnabled { get; set; } = true;
+    public List<string> RequiredRoles { get; set; } = ["owner", "admin"];
+    public List<string> AvailableFactors { get; set; } = ["totp", "recovery_code"];
+}
+
 public sealed class SqlOSClientSeedOptions
 {
     public string ClientId { get; set; } = string.Empty;

--- a/src/SqlOS/AuthServer/Configuration/SqlOSMfaOptions.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSMfaOptions.cs
@@ -1,0 +1,33 @@
+namespace SqlOS.AuthServer.Configuration;
+
+public sealed class SqlOSMfaOptions
+{
+    public bool Enabled { get; set; } = true;
+    public bool AllowUserSelfEnrollmentByDefault { get; set; } = true;
+    public bool RecoveryCodesEnabledByDefault { get; set; } = true;
+    public bool RequireForAllUsersByDefault { get; set; }
+    public bool RequireForOwnersAndAdminsByDefault { get; set; }
+    public List<string> RequiredRolesByDefault { get; set; } = ["owner", "admin"];
+    public List<string> AvailableFactorsByDefault { get; set; } = ["totp", "recovery_code"];
+    public SqlOSTotpMfaOptions Totp { get; } = new();
+
+    public SqlOSMfaOptions Disable()
+    {
+        Enabled = false;
+        return this;
+    }
+}
+
+public sealed class SqlOSTotpMfaOptions
+{
+    public bool Enabled { get; set; } = true;
+    public string Issuer { get; set; } = "SqlOS";
+    public string Algorithm { get; set; } = "SHA1";
+    public int Digits { get; set; } = 6;
+    public int PeriodSeconds { get; set; } = 30;
+    public int AllowedClockSkewSteps { get; set; } = 1;
+    public int SecretBytes { get; set; } = 20;
+    public int RecoveryCodeCount { get; set; } = 10;
+    public TimeSpan EnrollmentTokenLifetime { get; set; } = TimeSpan.FromMinutes(10);
+    public TimeSpan ChallengeTokenLifetime { get; set; } = TimeSpan.FromMinutes(10);
+}

--- a/src/SqlOS/AuthServer/Contracts/SqlOSContracts.cs
+++ b/src/SqlOS/AuthServer/Contracts/SqlOSContracts.cs
@@ -45,7 +45,11 @@ public sealed record SqlOSLoginResult(
     bool RequiresOrganizationSelection,
     string? PendingAuthToken,
     IReadOnlyList<SqlOSOrganizationOption> Organizations,
-    SqlOSTokenResponse? Tokens);
+    SqlOSTokenResponse? Tokens,
+    bool RequiresMfa = false,
+    string? MfaToken = null,
+    bool RequiresMfaEnrollment = false,
+    IReadOnlyList<string>? MfaMethods = null);
 
 public sealed record SqlOSValidatedToken(
     ClaimsPrincipal Principal,

--- a/src/SqlOS/AuthServer/Contracts/SqlOSHeadlessAuthContracts.cs
+++ b/src/SqlOS/AuthServer/Contracts/SqlOSHeadlessAuthContracts.cs
@@ -38,7 +38,11 @@ public sealed record SqlOSHeadlessViewModel(
     SqlOSEmailInvitationResult? Invitation,
     JsonObject? UiContext,
     SqlOSHeadlessDeviceAuthorizationDto? DeviceAuthorization = null,
-    string? PhoneNumber = null);
+    string? PhoneNumber = null,
+    string? MfaToken = null,
+    bool RequiresMfaEnrollment = false,
+    IReadOnlyList<string>? MfaMethods = null,
+    SqlOSTotpEnrollmentStartResult? TotpEnrollment = null);
 
 public sealed record SqlOSHeadlessActionResult(
     string Type,
@@ -141,6 +145,22 @@ public sealed record SqlOSHeadlessSignupRequest(
 public sealed record SqlOSHeadlessOrganizationSelectionRequest(
     string PendingToken,
     string OrganizationId);
+
+public sealed record SqlOSHeadlessMfaVerifyRequest(
+    string RequestId,
+    string MfaToken,
+    string Code);
+
+public sealed record SqlOSHeadlessMfaTotpEnrollmentStartRequest(
+    string RequestId,
+    string MfaToken,
+    string? DisplayName = null);
+
+public sealed record SqlOSHeadlessMfaTotpEnrollmentVerifyRequest(
+    string RequestId,
+    string MfaToken,
+    string EnrollmentToken,
+    string Code);
 
 public sealed record SqlOSHeadlessDeviceAuthorizationResolveRequest(
     string? UserCode,

--- a/src/SqlOS/AuthServer/Contracts/SqlOSMfaContracts.cs
+++ b/src/SqlOS/AuthServer/Contracts/SqlOSMfaContracts.cs
@@ -1,0 +1,110 @@
+namespace SqlOS.AuthServer.Contracts;
+
+public static class SqlOSMfaFactorTypes
+{
+    public const string Totp = "totp";
+    public const string RecoveryCode = "recovery_code";
+}
+
+public sealed record SqlOSMfaSettingsDto(
+    bool Enabled,
+    bool TotpEnabled,
+    bool UserSelfEnrollmentEnabled,
+    bool RecoveryCodesEnabled,
+    bool RequireForAllUsers,
+    bool RequireForOwnersAndAdmins,
+    IReadOnlyList<string> RequiredRoles,
+    IReadOnlyList<string> AvailableFactors,
+    DateTime UpdatedAt,
+    bool ManagedByStartupSeed);
+
+public sealed record SqlOSUpdateMfaSettingsRequest(
+    bool Enabled,
+    bool TotpEnabled,
+    bool UserSelfEnrollmentEnabled,
+    bool RecoveryCodesEnabled,
+    bool RequireForAllUsers,
+    bool RequireForOwnersAndAdmins,
+    IReadOnlyList<string>? RequiredRoles,
+    IReadOnlyList<string>? AvailableFactors);
+
+public sealed record SqlOSOrganizationMfaPolicyDto(
+    string OrganizationId,
+    string? OrganizationSlug,
+    string? OrganizationName,
+    bool IsEnabled,
+    bool RequireMfaForAllUsers,
+    bool RequireMfaForOwnersAndAdmins,
+    bool UserSelfEnrollmentEnabled,
+    bool RecoveryCodesEnabled,
+    IReadOnlyList<string> RequiredRoles,
+    IReadOnlyList<string> AvailableFactors,
+    DateTime UpdatedAt);
+
+public sealed record SqlOSUpdateOrganizationMfaPolicyRequest(
+    bool IsEnabled,
+    bool RequireMfaForAllUsers,
+    bool RequireMfaForOwnersAndAdmins,
+    bool UserSelfEnrollmentEnabled,
+    bool RecoveryCodesEnabled,
+    IReadOnlyList<string>? RequiredRoles,
+    IReadOnlyList<string>? AvailableFactors);
+
+public sealed record SqlOSMfaStatusResult(
+    bool MfaEnabled,
+    bool Required,
+    bool EnrollmentRequired,
+    bool UserSelfEnrollmentEnabled,
+    bool HasTotp,
+    int RecoveryCodeCount,
+    IReadOnlyList<string> AvailableFactors,
+    string? PolicyReason);
+
+public sealed record SqlOSMfaAuthenticatorDto(
+    string Id,
+    string Type,
+    string DisplayName,
+    bool IsConfirmed,
+    DateTime CreatedAt,
+    DateTime? ConfirmedAt,
+    DateTime? LastUsedAt);
+
+public sealed record SqlOSTotpEnrollmentStartRequest(string? DisplayName = null);
+
+public sealed record SqlOSTotpChallengeEnrollmentStartRequest(
+    string MfaToken,
+    string? DisplayName = null);
+
+public sealed record SqlOSTotpEnrollmentStartResult(
+    string EnrollmentToken,
+    string AuthenticatorId,
+    string Secret,
+    string ProvisioningUri,
+    string QrCodeDataUrl,
+    DateTime ExpiresAt);
+
+public sealed record SqlOSTotpEnrollmentVerifyRequest(
+    string EnrollmentToken,
+    string Code,
+    string? MfaToken = null);
+
+public sealed record SqlOSTotpEnrollmentVerifyResult(
+    string AuthenticatorId,
+    IReadOnlyList<string> RecoveryCodes,
+    SqlOSTokenResponse? Tokens = null,
+    string? RedirectUrl = null);
+
+public sealed record SqlOSMfaChallengeVerifyRequest(
+    string MfaToken,
+    string Code);
+
+public sealed record SqlOSMfaChallengeVerifyResult(
+    SqlOSTokenResponse? Tokens,
+    string? RedirectUrl);
+
+public sealed record SqlOSMfaChallengePayload(
+    string Flow,
+    string ClientId,
+    string AuthenticationMethod,
+    string? AuthorizationRequestId = null,
+    string? Resource = null);

--- a/src/SqlOS/AuthServer/Extensions/EndpointRouteBuilderExtensions.cs
+++ b/src/SqlOS/AuthServer/Extensions/EndpointRouteBuilderExtensions.cs
@@ -775,6 +775,7 @@ public static class EndpointRouteBuilderExtensions
         auth.MapPost("/login/password", async (
             HttpContext context,
             SqlOSAuthorizationServerService authorizationServerService,
+            SqlOSAuthService authService,
             SqlOSAuthPageSessionService authPageSessionService,
             SqlOSInvitationService invitationService,
             SqlOSHomeRealmDiscoveryService discoveryService,
@@ -855,6 +856,20 @@ public static class EndpointRouteBuilderExtensions
                         invitation: invitation,
                         invitationService: invitationService);
                     return Html(organizationPage);
+                }
+
+                if (completion.RequiresMfa)
+                {
+                    return await RenderMfaChallengeAsync(
+                        completion,
+                        requestId,
+                        email,
+                        authPrefix,
+                        authorizationServerService,
+                        authService,
+                        cancellationToken,
+                        invitationToken: invitationToken,
+                        invitationService: invitationService);
                 }
 
                 return Results.Redirect(completion.RedirectUrl!);
@@ -1007,6 +1022,7 @@ public static class EndpointRouteBuilderExtensions
             HttpContext context,
             SqlOSAuthorizationServerService authorizationServerService,
             SqlOSEmailOtpService emailOtpService,
+            SqlOSAuthService authService,
             SqlOSAuthPageSessionService authPageSessionService,
             SqlOSInvitationService invitationService,
             CancellationToken cancellationToken) =>
@@ -1081,6 +1097,20 @@ public static class EndpointRouteBuilderExtensions
                         invitation: invitation,
                         invitationService: invitationService);
                     return Html(organizationPage);
+                }
+
+                if (completion.RequiresMfa)
+                {
+                    return await RenderMfaChallengeAsync(
+                        completion,
+                        requestId,
+                        verification.Challenge.Email,
+                        authPrefix,
+                        authorizationServerService,
+                        authService,
+                        cancellationToken,
+                        invitationToken: invitationToken,
+                        invitationService: invitationService);
                 }
 
                 return Results.Redirect(completion.RedirectUrl!);
@@ -1202,6 +1232,7 @@ public static class EndpointRouteBuilderExtensions
             HttpContext context,
             SqlOSAuthorizationServerService authorizationServerService,
             SqlOSPhoneOtpService phoneOtpService,
+            SqlOSAuthService authService,
             SqlOSAuthPageSessionService authPageSessionService,
             CancellationToken cancellationToken) =>
         {
@@ -1257,6 +1288,19 @@ public static class EndpointRouteBuilderExtensions
                     return Html(organizationPage);
                 }
 
+                if (completion.RequiresMfa)
+                {
+                    return await RenderMfaChallengeAsync(
+                        completion,
+                        requestId,
+                        email: null,
+                        authPrefix,
+                        authorizationServerService,
+                        authService,
+                        cancellationToken,
+                        phoneNumber: phoneNumber);
+                }
+
                 return Results.Redirect(completion.RedirectUrl!);
             }
             catch (InvalidOperationException ex)
@@ -1281,17 +1325,116 @@ public static class EndpointRouteBuilderExtensions
         auth.MapPost("/login/select-organization", async (
             HttpContext context,
             SqlOSAuthorizationServerService authorizationServerService,
+            SqlOSAuthService authService,
             CancellationToken cancellationToken) =>
         {
             var form = await context.Request.ReadFormAsync(cancellationToken);
+            var requestId = form["requestId"].ToString();
             var pendingToken = form["pendingToken"].ToString();
             var organizationId = form["organizationId"].ToString();
-            var redirectUrl = await authorizationServerService.CompletePendingOrganizationSelectionAsync(
+            var completion = await authorizationServerService.CompletePendingOrganizationSelectionForLoginAsync(
                 pendingToken,
                 organizationId,
                 context,
                 cancellationToken);
-            return Results.Redirect(redirectUrl);
+            if (completion.RequiresMfa)
+            {
+                return await RenderMfaChallengeAsync(
+                    completion,
+                    requestId,
+                    email: null,
+                    authPrefix,
+                    authorizationServerService,
+                    authService,
+                    cancellationToken);
+            }
+
+            return Results.Redirect(completion.RedirectUrl!);
+        });
+
+        auth.MapPost("/mfa/verify", async (
+            HttpContext context,
+            SqlOSAuthorizationServerService authorizationServerService,
+            SqlOSAuthService authService,
+            CancellationToken cancellationToken) =>
+        {
+            var form = await context.Request.ReadFormAsync(cancellationToken);
+            var requestId = form["requestId"].ToString();
+            var mfaToken = form["mfaToken"].ToString();
+            var code = form["code"].ToString();
+
+            try
+            {
+                var redirectUrl = await authorizationServerService.CompleteMfaChallengeAsync(
+                    mfaToken,
+                    code,
+                    context,
+                    cancellationToken);
+                return Results.Redirect(redirectUrl);
+            }
+            catch (InvalidOperationException ex)
+            {
+                var page = await BuildAuthPageViewModelAsync(
+                    "mfa",
+                    requestId,
+                    email: null,
+                    error: ex.Message,
+                    displayName: null,
+                    pendingToken: null,
+                    authPrefix,
+                    authorizationServerService,
+                    cancellationToken,
+                    mfaToken: mfaToken);
+                return Html(page, StatusCodes.Status400BadRequest);
+            }
+        });
+
+        auth.MapPost("/mfa/totp/enroll/verify", async (
+            HttpContext context,
+            SqlOSAuthorizationServerService authorizationServerService,
+            SqlOSAuthService authService,
+            CancellationToken cancellationToken) =>
+        {
+            var form = await context.Request.ReadFormAsync(cancellationToken);
+            var requestId = form["requestId"].ToString();
+            var mfaToken = form["mfaToken"].ToString();
+            var enrollmentToken = form["enrollmentToken"].ToString();
+            var code = form["code"].ToString();
+
+            try
+            {
+                await authService.VerifyTotpEnrollmentAsync(
+                    new SqlOSTotpEnrollmentVerifyRequest(enrollmentToken, code),
+                    context,
+                    cancellationToken);
+                var redirectUrl = await authorizationServerService.CompleteMfaChallengeWithoutCodeAsync(
+                    mfaToken,
+                    SqlOSMfaFactorTypes.Totp,
+                    context,
+                    cancellationToken);
+                return Results.Redirect(redirectUrl);
+            }
+            catch (InvalidOperationException ex)
+            {
+                var completion = new SqlOSAuthorizationRequestLoginResult(
+                    null,
+                    false,
+                    null,
+                    Array.Empty<SqlOSOrganizationOption>(),
+                    RequiresMfa: true,
+                    MfaToken: mfaToken,
+                    RequiresMfaEnrollment: true,
+                    MfaMethods: [SqlOSMfaFactorTypes.Totp]);
+                return await RenderMfaChallengeAsync(
+                    completion,
+                    requestId,
+                    email: null,
+                    authPrefix,
+                    authorizationServerService,
+                    authService,
+                    cancellationToken,
+                    error: ex.Message);
+            }
         });
 
         auth.MapGet("/login/oidc/{connectionId}", async (
@@ -2552,6 +2695,68 @@ public static class EndpointRouteBuilderExtensions
             }
         });
 
+        headless.MapPost("/mfa/verify", async (
+            SqlOSHeadlessMfaVerifyRequest request,
+            HttpContext context,
+            SqlOSHeadlessAuthService headlessAuthService,
+            CancellationToken cancellationToken) =>
+        {
+            if (!headlessAuthService.IsApiEnabled)
+            {
+                return Results.NotFound();
+            }
+
+            try
+            {
+                return Results.Ok(await headlessAuthService.VerifyMfaAsync(context, request, cancellationToken));
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.BadRequest(ex.Message);
+            }
+        });
+
+        headless.MapPost("/mfa/totp/enroll/start", async (
+            SqlOSHeadlessMfaTotpEnrollmentStartRequest request,
+            SqlOSHeadlessAuthService headlessAuthService,
+            CancellationToken cancellationToken) =>
+        {
+            if (!headlessAuthService.IsApiEnabled)
+            {
+                return Results.NotFound();
+            }
+
+            try
+            {
+                return Results.Ok(await headlessAuthService.StartMfaTotpEnrollmentAsync(request, cancellationToken));
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.BadRequest(ex.Message);
+            }
+        });
+
+        headless.MapPost("/mfa/totp/enroll/verify", async (
+            SqlOSHeadlessMfaTotpEnrollmentVerifyRequest request,
+            HttpContext context,
+            SqlOSHeadlessAuthService headlessAuthService,
+            CancellationToken cancellationToken) =>
+        {
+            if (!headlessAuthService.IsApiEnabled)
+            {
+                return Results.NotFound();
+            }
+
+            try
+            {
+                return Results.Ok(await headlessAuthService.VerifyMfaTotpEnrollmentAsync(context, request, cancellationToken));
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.BadRequest(ex.Message);
+            }
+        });
+
         headless.MapPost("/provider/start", async (
             SqlOSHeadlessProviderStartRequest request,
             HttpContext context,
@@ -2729,7 +2934,19 @@ public static class EndpointRouteBuilderExtensions
             Results.Ok(await authService.VerifyEmailOtpAsync(request, httpContext, cancellationToken)));
 
         auth.MapPost("/select-organization", async (SqlOSSelectOrganizationRequest request, SqlOSAuthService authService, HttpContext httpContext, CancellationToken cancellationToken) =>
-            Results.Ok(await authService.SelectOrganizationAsync(request, httpContext, cancellationToken)));
+            Results.Ok(await authService.SelectOrganizationForLoginAsync(request, httpContext, cancellationToken)));
+
+        auth.MapPost("/mfa/challenge/verify", async (SqlOSMfaChallengeVerifyRequest request, SqlOSAuthService authService, HttpContext httpContext, CancellationToken cancellationToken) =>
+            Results.Ok(await authService.VerifyMfaChallengeAsync(request, httpContext, cancellationToken)));
+
+        auth.MapPost("/mfa/challenge/totp/enroll/start", async (SqlOSTotpChallengeEnrollmentStartRequest request, SqlOSAuthService authService, CancellationToken cancellationToken) =>
+            Results.Ok(await authService.StartTotpEnrollmentForChallengeAsync(
+                request.MfaToken,
+                new SqlOSTotpEnrollmentStartRequest(request.DisplayName),
+                cancellationToken)));
+
+        auth.MapPost("/mfa/challenge/totp/enroll/verify", async (SqlOSTotpEnrollmentVerifyRequest request, SqlOSAuthService authService, HttpContext httpContext, CancellationToken cancellationToken) =>
+            Results.Ok(await authService.VerifyTotpEnrollmentAsync(request, httpContext, cancellationToken)));
 
         auth.MapPost("/token/exchange", async (SqlOSExchangeCodeRequest request, SqlOSAuthService authService, HttpContext httpContext, CancellationToken cancellationToken) =>
             Results.Ok(await authService.ExchangeCodeAsync(request, httpContext, cancellationToken)));
@@ -3628,6 +3845,46 @@ public static class EndpointRouteBuilderExtensions
             return Results.Ok(await settingsService.UpdateSecuritySettingsAsync(request, cancellationToken));
         });
 
+        api.MapGet("/settings/mfa", async (HttpContext context, SqlOSSettingsService settingsService, IOptions<SqlOSAuthServerOptions> options, IHostEnvironment environment, CancellationToken cancellationToken) =>
+        {
+            if (!await IsAdminAuthorizedAsync(context, options.Value, environment))
+            {
+                return Results.NotFound();
+            }
+
+            return Results.Ok(await settingsService.GetMfaSettingsAsync(cancellationToken));
+        });
+
+        api.MapPut("/settings/mfa", async (HttpContext context, SqlOSUpdateMfaSettingsRequest request, SqlOSSettingsService settingsService, IOptions<SqlOSAuthServerOptions> options, IHostEnvironment environment, CancellationToken cancellationToken) =>
+        {
+            if (!await IsAdminAuthorizedAsync(context, options.Value, environment))
+            {
+                return Results.NotFound();
+            }
+
+            return Results.Ok(await settingsService.UpdateMfaSettingsAsync(request, cancellationToken));
+        });
+
+        api.MapGet("/organizations/{organizationId}/mfa-policy", async (HttpContext context, string organizationId, SqlOSSettingsService settingsService, IOptions<SqlOSAuthServerOptions> options, IHostEnvironment environment, CancellationToken cancellationToken) =>
+        {
+            if (!await IsAdminAuthorizedAsync(context, options.Value, environment))
+            {
+                return Results.NotFound();
+            }
+
+            return Results.Ok(await settingsService.GetOrganizationMfaPolicyAsync(organizationId, cancellationToken));
+        });
+
+        api.MapPut("/organizations/{organizationId}/mfa-policy", async (HttpContext context, string organizationId, SqlOSUpdateOrganizationMfaPolicyRequest request, SqlOSSettingsService settingsService, IOptions<SqlOSAuthServerOptions> options, IHostEnvironment environment, CancellationToken cancellationToken) =>
+        {
+            if (!await IsAdminAuthorizedAsync(context, options.Value, environment))
+            {
+                return Results.NotFound();
+            }
+
+            return Results.Ok(await settingsService.UpdateOrganizationMfaPolicyAsync(organizationId, request, cancellationToken));
+        });
+
         api.MapGet("/signing-keys", async (HttpContext context, SqlOSCryptoService cryptoService, SqlOSSettingsService settingsService, IOptions<SqlOSAuthServerOptions> options, IHostEnvironment environment, CancellationToken cancellationToken) =>
         {
             if (!await IsAdminAuthorizedAsync(context, options.Value, environment))
@@ -3835,6 +4092,70 @@ public static class EndpointRouteBuilderExtensions
         """;
     }
 
+    private static async Task<IResult> RenderMfaChallengeAsync(
+        SqlOSAuthorizationRequestLoginResult completion,
+        string? authorizationRequestId,
+        string? email,
+        string authPrefix,
+        SqlOSAuthorizationServerService authorizationServerService,
+        SqlOSAuthService authService,
+        CancellationToken cancellationToken,
+        string? error = null,
+        string? invitationToken = null,
+        SqlOSInvitationService? invitationService = null,
+        string? phoneNumber = null)
+    {
+        if (string.IsNullOrWhiteSpace(completion.MfaToken))
+        {
+            throw new InvalidOperationException("MFA challenge is invalid.");
+        }
+
+        if (completion.RequiresMfaEnrollment)
+        {
+            var enrollment = await authService.StartTotpEnrollmentForChallengeAsync(
+                completion.MfaToken,
+                new SqlOSTotpEnrollmentStartRequest(),
+                cancellationToken);
+            var enrollmentPage = await BuildAuthPageViewModelAsync(
+                "mfa-enroll",
+                authorizationRequestId,
+                email,
+                error,
+                null,
+                null,
+                authPrefix,
+                authorizationServerService,
+                cancellationToken,
+                invitationToken: invitationToken,
+                invitationService: invitationService,
+                phoneNumber: phoneNumber,
+                mfaToken: completion.MfaToken,
+                mfaMethods: completion.MfaMethods,
+                enrollmentToken: enrollment.EnrollmentToken,
+                totpSecret: enrollment.Secret,
+                totpProvisioningUri: enrollment.ProvisioningUri,
+                totpQrCodeDataUrl: enrollment.QrCodeDataUrl);
+            return Html(enrollmentPage, string.IsNullOrWhiteSpace(error) ? StatusCodes.Status200OK : StatusCodes.Status400BadRequest);
+        }
+
+        var page = await BuildAuthPageViewModelAsync(
+            "mfa",
+            authorizationRequestId,
+            email,
+            error,
+            null,
+            null,
+            authPrefix,
+            authorizationServerService,
+            cancellationToken,
+            invitationToken: invitationToken,
+            invitationService: invitationService,
+            phoneNumber: phoneNumber,
+            mfaToken: completion.MfaToken,
+            mfaMethods: completion.MfaMethods);
+        return Html(page, string.IsNullOrWhiteSpace(error) ? StatusCodes.Status200OK : StatusCodes.Status400BadRequest);
+    }
+
     private static async Task<SqlOSAuthPageViewModel> BuildAuthPageViewModelAsync(
         string mode,
         string? authorizationRequestId,
@@ -3854,7 +4175,13 @@ public static class EndpointRouteBuilderExtensions
         SqlOSInvitationService? invitationService = null,
         string? deviceUserCode = null,
         SqlOSDeviceAuthorizationResolveResult? deviceAuthorization = null,
-        string? phoneNumber = null)
+        string? phoneNumber = null,
+        string? mfaToken = null,
+        IReadOnlyList<string>? mfaMethods = null,
+        string? enrollmentToken = null,
+        string? totpSecret = null,
+        string? totpProvisioningUri = null,
+        string? totpQrCodeDataUrl = null)
     {
         var settings = await authorizationServerService.GetAuthPageSettingsAsync(cancellationToken);
         var isDeviceView = string.Equals(mode, "device", StringComparison.OrdinalIgnoreCase)
@@ -3916,7 +4243,13 @@ public static class EndpointRouteBuilderExtensions
             invitation,
             effectiveDeviceUserCode,
             deviceAuthorization,
-            phoneNumber);
+            phoneNumber,
+            mfaToken,
+            mfaMethods,
+            enrollmentToken,
+            totpSecret,
+            totpProvisioningUri,
+            totpQrCodeDataUrl);
     }
 
     private static string ResolvePreferredLocalView(SqlOSResolvedCredentialSettings credentialSettings)

--- a/src/SqlOS/AuthServer/Models/SqlOSEntities.cs
+++ b/src/SqlOS/AuthServer/Models/SqlOSEntities.cs
@@ -14,6 +14,7 @@ public sealed class SqlOSOrganization
     public ICollection<SqlOSMembership> Memberships { get; set; } = new List<SqlOSMembership>();
     public ICollection<SqlOSSsoConnection> SsoConnections { get; set; } = new List<SqlOSSsoConnection>();
     public ICollection<SqlOSApplicationAssignment> ApplicationAssignments { get; set; } = new List<SqlOSApplicationAssignment>();
+    public SqlOSOrganizationMfaPolicy? MfaPolicy { get; set; }
 }
 
 public sealed class SqlOSUser
@@ -31,6 +32,9 @@ public sealed class SqlOSUser
     public ICollection<SqlOSMembership> Memberships { get; set; } = new List<SqlOSMembership>();
     public ICollection<SqlOSExternalIdentity> ExternalIdentities { get; set; } = new List<SqlOSExternalIdentity>();
     public ICollection<SqlOSSession> Sessions { get; set; } = new List<SqlOSSession>();
+    public ICollection<SqlOSUserAuthenticator> Authenticators { get; set; } = new List<SqlOSUserAuthenticator>();
+    public ICollection<SqlOSRecoveryCode> RecoveryCodes { get; set; } = new List<SqlOSRecoveryCode>();
+    public SqlOSUserMfaPolicyOverride? MfaPolicyOverride { get; set; }
 }
 
 public sealed class SqlOSUserEmail
@@ -425,6 +429,79 @@ public sealed class SqlOSSettings
     /// </summary>
     public int RefreshTokenGraceWindowSeconds { get; set; } = 30;
     public DateTime UpdatedAt { get; set; }
+}
+
+public sealed class SqlOSMfaSettings
+{
+    public string Id { get; set; } = "default";
+    public bool Enabled { get; set; } = true;
+    public bool TotpEnabled { get; set; } = true;
+    public bool UserSelfEnrollmentEnabled { get; set; } = true;
+    public bool RecoveryCodesEnabled { get; set; } = true;
+    public bool RequireForAllUsers { get; set; }
+    public bool RequireForOwnersAndAdmins { get; set; }
+    public string RequiredRolesJson { get; set; } = "[\"owner\",\"admin\"]";
+    public string AvailableFactorsJson { get; set; } = "[\"totp\",\"recovery_code\"]";
+    public DateTime UpdatedAt { get; set; }
+}
+
+public sealed class SqlOSOrganizationMfaPolicy
+{
+    public string OrganizationId { get; set; } = string.Empty;
+    public bool IsEnabled { get; set; } = true;
+    public bool RequireMfaForAllUsers { get; set; }
+    public bool RequireMfaForOwnersAndAdmins { get; set; }
+    public bool UserSelfEnrollmentEnabled { get; set; } = true;
+    public bool RecoveryCodesEnabled { get; set; } = true;
+    public string RequiredRolesJson { get; set; } = "[\"owner\",\"admin\"]";
+    public string AvailableFactorsJson { get; set; } = "[\"totp\",\"recovery_code\"]";
+    public DateTime UpdatedAt { get; set; }
+
+    public SqlOSOrganization? Organization { get; set; }
+}
+
+public sealed class SqlOSUserMfaPolicyOverride
+{
+    public string UserId { get; set; } = string.Empty;
+    public bool? RequireMfa { get; set; }
+    public bool? UserSelfEnrollmentEnabled { get; set; }
+    public DateTime UpdatedAt { get; set; }
+
+    public SqlOSUser? User { get; set; }
+}
+
+public sealed class SqlOSUserAuthenticator
+{
+    public string Id { get; set; } = string.Empty;
+    public string UserId { get; set; } = string.Empty;
+    public string Type { get; set; } = "totp";
+    public string DisplayName { get; set; } = "Authenticator app";
+    public string SecretProtected { get; set; } = string.Empty;
+    public int SecretVersion { get; set; } = 1;
+    public string Algorithm { get; set; } = "SHA1";
+    public int Digits { get; set; } = 6;
+    public int PeriodSeconds { get; set; } = 30;
+    public bool IsConfirmed { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime? ConfirmedAt { get; set; }
+    public DateTime? LastUsedAt { get; set; }
+    public DateTime? RevokedAt { get; set; }
+    public string? RevocationReason { get; set; }
+    public long? LastAcceptedTimeStep { get; set; }
+
+    public SqlOSUser? User { get; set; }
+}
+
+public sealed class SqlOSRecoveryCode
+{
+    public string Id { get; set; } = string.Empty;
+    public string UserId { get; set; } = string.Empty;
+    public string CodeHash { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; }
+    public DateTime? ConsumedAt { get; set; }
+    public DateTime? RevokedAt { get; set; }
+
+    public SqlOSUser? User { get; set; }
 }
 
 public sealed class SqlOSAuthPageSettings

--- a/src/SqlOS/AuthServer/Schema/019_MfaTotp.sql
+++ b/src/SqlOS/AuthServer/Schema/019_MfaTotp.sql
@@ -1,0 +1,115 @@
+IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'SqlOSMfaSettings' AND schema_id = SCHEMA_ID('{Schema}'))
+BEGIN
+    CREATE TABLE [{Schema}].[SqlOSMfaSettings] (
+        [Id] NVARCHAR(64) NOT NULL CONSTRAINT [PK_SqlOSMfaSettings] PRIMARY KEY,
+        [Enabled] BIT NOT NULL,
+        [TotpEnabled] BIT NOT NULL,
+        [UserSelfEnrollmentEnabled] BIT NOT NULL,
+        [RecoveryCodesEnabled] BIT NOT NULL,
+        [RequireForAllUsers] BIT NOT NULL,
+        [RequireForOwnersAndAdmins] BIT NOT NULL,
+        [RequiredRolesJson] NVARCHAR(MAX) NOT NULL,
+        [AvailableFactorsJson] NVARCHAR(MAX) NOT NULL,
+        [UpdatedAt] DATETIME2 NOT NULL
+    );
+END
+
+GO
+
+IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'SqlOSOrganizationMfaPolicies' AND schema_id = SCHEMA_ID('{Schema}'))
+BEGIN
+    CREATE TABLE [{Schema}].[SqlOSOrganizationMfaPolicies] (
+        [OrganizationId] NVARCHAR(64) NOT NULL CONSTRAINT [PK_SqlOSOrganizationMfaPolicies] PRIMARY KEY,
+        [IsEnabled] BIT NOT NULL,
+        [RequireMfaForAllUsers] BIT NOT NULL,
+        [RequireMfaForOwnersAndAdmins] BIT NOT NULL,
+        [UserSelfEnrollmentEnabled] BIT NOT NULL,
+        [RecoveryCodesEnabled] BIT NOT NULL,
+        [RequiredRolesJson] NVARCHAR(MAX) NOT NULL,
+        [AvailableFactorsJson] NVARCHAR(MAX) NOT NULL,
+        [UpdatedAt] DATETIME2 NOT NULL
+    );
+
+    ALTER TABLE [{Schema}].[SqlOSOrganizationMfaPolicies]
+        ADD CONSTRAINT [FK_SqlOSOrganizationMfaPolicies_Organizations_OrganizationId]
+            FOREIGN KEY ([OrganizationId]) REFERENCES [{Schema}].[SqlOSOrganizations]([Id]);
+END
+
+GO
+
+IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'SqlOSUserMfaPolicyOverrides' AND schema_id = SCHEMA_ID('{Schema}'))
+BEGIN
+    CREATE TABLE [{Schema}].[SqlOSUserMfaPolicyOverrides] (
+        [UserId] NVARCHAR(64) NOT NULL CONSTRAINT [PK_SqlOSUserMfaPolicyOverrides] PRIMARY KEY,
+        [RequireMfa] BIT NULL,
+        [UserSelfEnrollmentEnabled] BIT NULL,
+        [UpdatedAt] DATETIME2 NOT NULL
+    );
+
+    ALTER TABLE [{Schema}].[SqlOSUserMfaPolicyOverrides]
+        ADD CONSTRAINT [FK_SqlOSUserMfaPolicyOverrides_Users_UserId]
+            FOREIGN KEY ([UserId]) REFERENCES [{Schema}].[SqlOSUsers]([Id]);
+END
+
+GO
+
+IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'SqlOSUserAuthenticators' AND schema_id = SCHEMA_ID('{Schema}'))
+BEGIN
+    CREATE TABLE [{Schema}].[SqlOSUserAuthenticators] (
+        [Id] NVARCHAR(64) NOT NULL CONSTRAINT [PK_SqlOSUserAuthenticators] PRIMARY KEY,
+        [UserId] NVARCHAR(64) NOT NULL,
+        [Type] NVARCHAR(40) NOT NULL,
+        [DisplayName] NVARCHAR(120) NOT NULL,
+        [SecretProtected] NVARCHAR(2048) NOT NULL,
+        [SecretVersion] INT NOT NULL,
+        [Algorithm] NVARCHAR(20) NOT NULL,
+        [Digits] INT NOT NULL,
+        [PeriodSeconds] INT NOT NULL,
+        [IsConfirmed] BIT NOT NULL,
+        [CreatedAt] DATETIME2 NOT NULL,
+        [ConfirmedAt] DATETIME2 NULL,
+        [LastUsedAt] DATETIME2 NULL,
+        [RevokedAt] DATETIME2 NULL,
+        [RevocationReason] NVARCHAR(120) NULL,
+        [LastAcceptedTimeStep] BIGINT NULL
+    );
+
+    CREATE INDEX [IX_SqlOSUserAuthenticators_User_Type_Revoked]
+        ON [{Schema}].[SqlOSUserAuthenticators]([UserId], [Type], [RevokedAt]);
+
+    CREATE INDEX [IX_SqlOSUserAuthenticators_User_Confirmed_Revoked]
+        ON [{Schema}].[SqlOSUserAuthenticators]([UserId], [IsConfirmed], [RevokedAt]);
+
+    ALTER TABLE [{Schema}].[SqlOSUserAuthenticators]
+        ADD CONSTRAINT [FK_SqlOSUserAuthenticators_Users_UserId]
+            FOREIGN KEY ([UserId]) REFERENCES [{Schema}].[SqlOSUsers]([Id]);
+END
+
+GO
+
+IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'SqlOSRecoveryCodes' AND schema_id = SCHEMA_ID('{Schema}'))
+BEGIN
+    CREATE TABLE [{Schema}].[SqlOSRecoveryCodes] (
+        [Id] NVARCHAR(64) NOT NULL CONSTRAINT [PK_SqlOSRecoveryCodes] PRIMARY KEY,
+        [UserId] NVARCHAR(64) NOT NULL,
+        [CodeHash] NVARCHAR(128) NOT NULL,
+        [CreatedAt] DATETIME2 NOT NULL,
+        [ConsumedAt] DATETIME2 NULL,
+        [RevokedAt] DATETIME2 NULL
+    );
+
+    CREATE UNIQUE INDEX [IX_SqlOSRecoveryCodes_CodeHash]
+        ON [{Schema}].[SqlOSRecoveryCodes]([CodeHash]);
+
+    CREATE INDEX [IX_SqlOSRecoveryCodes_User_Consumed_Revoked]
+        ON [{Schema}].[SqlOSRecoveryCodes]([UserId], [ConsumedAt], [RevokedAt]);
+
+    ALTER TABLE [{Schema}].[SqlOSRecoveryCodes]
+        ADD CONSTRAINT [FK_SqlOSRecoveryCodes_Users_UserId]
+            FOREIGN KEY ([UserId]) REFERENCES [{Schema}].[SqlOSUsers]([Id]);
+END
+
+GO
+
+DELETE FROM [{Schema}].[SqlOSSchema];
+INSERT INTO [{Schema}].[SqlOSSchema] ([Version]) VALUES (19);

--- a/src/SqlOS/AuthServer/Services/SqlOSAuthPageRenderer.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSAuthPageRenderer.cs
@@ -44,6 +44,15 @@ public static class SqlOSAuthPageRenderer
         var deviceUserCodeInput = string.IsNullOrWhiteSpace(model.DeviceUserCode)
             ? string.Empty
             : $"<input type=\"hidden\" name=\"deviceUserCode\" value=\"{Html(model.DeviceUserCode)}\" />";
+        var mfaTokenInput = string.IsNullOrWhiteSpace(model.MfaToken)
+            ? string.Empty
+            : $"<input type=\"hidden\" name=\"mfaToken\" value=\"{Html(model.MfaToken)}\" />";
+        var mfaMethodValues = model.MfaMethods ?? Array.Empty<string>();
+        var mfaMethods = mfaMethodValues.Count == 0
+            ? "an authenticator app or recovery code"
+            : string.Join(" or ", mfaMethodValues.Select(static method => string.Equals(method, SqlOSMfaFactorTypes.Totp, StringComparison.OrdinalIgnoreCase)
+                ? "an authenticator app"
+                : "a recovery code"));
         var emailValue = Html(model.Email ?? string.Empty);
         var emailReadonly = model.Invitation == null ? string.Empty : " readonly";
         var encodedMode = Html(normalizedMode);
@@ -459,10 +468,52 @@ public static class SqlOSAuthPageRenderer
             "organization" => $$"""
                 {{RenderPanelIntro("Organization", "Choose the workspace you want to continue into.")}}
                 <form class="auth-form organization-form" method="post" action="{{Html(AuthPath(model, "/login/select-organization"))}}">
+                  {{requestIdInput}}
                   <input type="hidden" name="pendingToken" value="{{Html(model.PendingToken ?? string.Empty)}}" />
                   <div class="organization-list">{{RenderOrganizationOptions(model.OrganizationSelection)}}</div>
                 </form>
                 {{RenderFooterLinks(loginLink)}}
+                """,
+            "mfa" => $$"""
+                {{RenderPanelIntro("Two-step verification", $"Enter a code from {mfaMethods}.")}}
+                <form class="auth-form" method="post" action="{{Html(AuthPath(model, "/mfa/verify"))}}">
+                  {{requestIdInput}}
+                  {{mfaTokenInput}}
+                  <label class="field">
+                    <span>Code</span>
+                    <input name="code" inputmode="numeric" autocomplete="one-time-code" placeholder="123456" required autofocus />
+                  </label>
+                  {{RenderPrimaryAction("Verify", "Verifying")}}
+                </form>
+                {{RenderFooterLinks(loginLink)}}
+                """,
+            "mfa-enroll" => $$"""
+                {{RenderPanelIntro("Add authenticator app", "Use an authenticator app to add a second step before continuing.")}}
+                <div class="qr-panel">
+                  <img class="qr-code" src="{{Html(model.TotpQrCodeDataUrl ?? string.Empty)}}" alt="Authenticator setup QR code" />
+                  <p>Scan this QR code with your authenticator app.</p>
+                </div>
+                <details class="manual-setup">
+                  <summary>Use manual setup</summary>
+                  <div class="secret-panel">
+                    <span>Setup key</span>
+                    <code>{{Html(model.TotpSecret ?? string.Empty)}}</code>
+                  </div>
+                  <div class="secret-panel">
+                    <span>Provisioning URI</span>
+                    <code>{{Html(model.TotpProvisioningUri ?? string.Empty)}}</code>
+                  </div>
+                </details>
+                <form class="auth-form" method="post" action="{{Html(AuthPath(model, "/mfa/totp/enroll/verify"))}}">
+                  {{requestIdInput}}
+                  {{mfaTokenInput}}
+                  <input type="hidden" name="enrollmentToken" value="{{Html(model.EnrollmentToken ?? string.Empty)}}" />
+                  <label class="field">
+                    <span>Code</span>
+                    <input name="code" inputmode="numeric" autocomplete="one-time-code" placeholder="123456" required autofocus />
+                  </label>
+                  {{RenderPrimaryAction("Verify and continue", "Verifying")}}
+                </form>
                 """,
             "logged-out" => $$"""
                 <div class="state-card">
@@ -684,6 +735,58 @@ public static class SqlOSAuthPageRenderer
               background: color-mix(in srgb, var(--primary) 6%, var(--panel));
               font-size: 14px;
               line-height: 1.45;
+            }
+            .secret-panel {
+              display: grid;
+              gap: 6px;
+              padding: 12px;
+              border: 1px solid var(--border);
+              border-radius: 10px;
+              background: color-mix(in srgb, var(--primary) 5%, var(--panel));
+            }
+            .secret-panel span {
+              color: var(--muted);
+              font-size: 12px;
+              font-weight: 700;
+              text-transform: uppercase;
+            }
+            .secret-panel code {
+              overflow-wrap: anywhere;
+              font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+              font-size: 12px;
+              line-height: 1.45;
+            }
+            .qr-panel {
+              display: grid;
+              justify-items: center;
+              gap: 10px;
+              margin-bottom: 14px;
+              color: var(--muted);
+              font-size: 13px;
+              line-height: 1.5;
+              text-align: center;
+            }
+            .qr-code {
+              width: min(220px, 100%);
+              aspect-ratio: 1;
+              border: 1px solid var(--border);
+              border-radius: 12px;
+              background: #ffffff;
+              padding: 10px;
+            }
+            .manual-setup {
+              display: grid;
+              gap: 10px;
+              margin-bottom: 14px;
+            }
+            .manual-setup summary {
+              color: color-mix(in srgb, var(--primary) 80%, var(--text));
+              cursor: pointer;
+              font-size: 13px;
+              font-weight: 600;
+            }
+            .manual-setup[open] {
+              gap: 10px;
             }
             .invite-summary strong {
               font-size: 15px;
@@ -1458,6 +1561,12 @@ public sealed record SqlOSAuthPageViewModel(
     SqlOSEmailInvitationResult? Invitation = null,
     string? DeviceUserCode = null,
     SqlOSDeviceAuthorizationResolveResult? DeviceAuthorization = null,
-    string? PhoneNumber = null);
+    string? PhoneNumber = null,
+    string? MfaToken = null,
+    IReadOnlyList<string>? MfaMethods = null,
+    string? EnrollmentToken = null,
+    string? TotpSecret = null,
+    string? TotpProvisioningUri = null,
+    string? TotpQrCodeDataUrl = null);
 
 public sealed record SqlOSAuthPageProviderLink(string ConnectionId, string DisplayName, string Url, string? LogoDataUrl = null);

--- a/src/SqlOS/AuthServer/Services/SqlOSAuthService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSAuthService.cs
@@ -18,6 +18,7 @@ namespace SqlOS.AuthServer.Services;
 
 public sealed class SqlOSAuthService
 {
+    public const string MfaChallengePurpose = "mfa_challenge";
     private const string PasswordResetPurpose = "password_reset";
     private const string PasswordResetRequestPurpose = "password_reset_request";
     private const string PasswordResetGenericMessage = "If an account can be reset, you'll receive a password reset email shortly.";
@@ -30,6 +31,8 @@ public sealed class SqlOSAuthService
     private readonly SqlOSSettingsService _settingsService;
     private readonly SqlOSEmailOtpService _emailOtpService;
     private readonly SqlOSPhoneOtpService? _phoneOtpService;
+    private readonly SqlOSMfaPolicyService? _mfaPolicyService;
+    private readonly SqlOSTotpMfaService? _totpMfaService;
     private readonly SqlOSInvitationService? _invitationService;
     private readonly SqlOSPasswordLoginAbuseService _passwordLoginAbuseService;
     private readonly ISqlOSTransactionalEmailService? _transactionalEmailService;
@@ -46,7 +49,9 @@ public sealed class SqlOSAuthService
         SqlOSPasswordLoginAbuseService? passwordLoginAbuseService = null,
         ISqlOSTransactionalEmailService? transactionalEmailService = null,
         SqlOSPhoneOtpService? phoneOtpService = null,
-        ISqlOSAuthEmailSender? authEmailSender = null)
+        ISqlOSAuthEmailSender? authEmailSender = null,
+        SqlOSMfaPolicyService? mfaPolicyService = null,
+        SqlOSTotpMfaService? totpMfaService = null)
     {
         _context = context;
         _options = options.Value;
@@ -61,6 +66,8 @@ public sealed class SqlOSAuthService
             ?? new SqlOSPasswordLoginAbuseService(context, adminService, cryptoService, options);
         _transactionalEmailService = transactionalEmailService;
         _authEmailSender = authEmailSender;
+        _mfaPolicyService = mfaPolicyService;
+        _totpMfaService = totpMfaService;
     }
 
     public async Task<SqlOSLoginResult> SignUpAsync(SqlOSSignupRequest request, HttpContext httpContext, CancellationToken cancellationToken = default)
@@ -86,8 +93,7 @@ public sealed class SqlOSAuthService
         await _adminService.RecordAuditAsync("user.signup", "user", user.Id, userId: user.Id, organizationId: organizationId, ipAddress: GetIp(httpContext), cancellationToken: cancellationToken);
 
         var client = await _adminService.RequireClientAsync(request.ClientId, null, cancellationToken);
-        var tokens = await CreateSessionAndTokensAsync(user, client, organizationId, "password", httpContext, cancellationToken);
-        return new SqlOSLoginResult(false, null, Array.Empty<SqlOSOrganizationOption>(), tokens);
+        return await FinalizeClientLoginAsync(user, client, organizationId, "password", httpContext, cancellationToken);
     }
 
     public async Task<SqlOSLoginResult> LoginWithPasswordAsync(SqlOSPasswordLoginRequest request, HttpContext httpContext, CancellationToken cancellationToken = default)
@@ -280,7 +286,7 @@ public sealed class SqlOSAuthService
                 ipAddress: GetIp(httpContext),
                 cancellationToken: cancellationToken);
 
-            var tokens = await CreateSessionAndTokensAsync(
+            var result = await FinalizeClientLoginAsync(
                 signup.User,
                 client,
                 acceptance.OrganizationId,
@@ -294,7 +300,7 @@ public sealed class SqlOSAuthService
                 await transaction.CommitAsync(cancellationToken);
             }
 
-            return new SqlOSLoginResult(false, null, organizations, tokens);
+            return result with { Organizations = organizations };
         }
         catch
         {
@@ -567,11 +573,21 @@ public sealed class SqlOSAuthService
         }
 
         var organizationId = organizations.Count == 1 ? organizations[0].Id : null;
-        var tokens = await CreateSessionAndTokensAsync(user, client, organizationId, authenticationMethod, httpContext, cancellationToken);
-        return new SqlOSLoginResult(false, null, organizations, tokens);
+        return await FinalizeClientLoginAsync(user, client, organizationId, authenticationMethod, httpContext, cancellationToken);
     }
 
     public async Task<SqlOSTokenResponse> SelectOrganizationAsync(SqlOSSelectOrganizationRequest request, HttpContext httpContext, CancellationToken cancellationToken = default)
+    {
+        var result = await SelectOrganizationForLoginAsync(request, httpContext, cancellationToken);
+        if (result.Tokens == null)
+        {
+            throw new InvalidOperationException("The selected organization requires MFA.");
+        }
+
+        return result.Tokens;
+    }
+
+    public async Task<SqlOSLoginResult> SelectOrganizationForLoginAsync(SqlOSSelectOrganizationRequest request, HttpContext httpContext, CancellationToken cancellationToken = default)
     {
         var token = await _cryptoService.ConsumeTemporaryTokenAsync("pending_auth", request.PendingAuthToken, cancellationToken)
             ?? throw new InvalidOperationException("Pending auth token is invalid or expired.");
@@ -589,9 +605,17 @@ public sealed class SqlOSAuthService
         var client = await _context.Set<SqlOSClientApplication>().FirstAsync(x => x.Id == token.ClientApplicationId, cancellationToken);
         var payload = _cryptoService.DeserializePayload<PendingAuthPayload>(token);
         var authMethod = payload?.AuthenticationMethod ?? "password";
-        var tokens = await CreateSessionAndTokensAsync(user, client, request.OrganizationId, authMethod, httpContext, cancellationToken);
-        await _adminService.RecordAuditAsync("user.login.organization-selected", "user", user.Id, userId: user.Id, organizationId: request.OrganizationId, ipAddress: GetIp(httpContext), cancellationToken: cancellationToken);
-        return tokens;
+        var organizations = await _adminService.GetUserOrganizationsAsync(user.Id, cancellationToken);
+        var result = await FinalizeClientLoginAsync(user, client, request.OrganizationId, authMethod, httpContext, cancellationToken);
+        await _adminService.RecordAuditAsync(
+            "user.login.organization-selected",
+            "user",
+            user.Id,
+            userId: user.Id,
+            organizationId: request.OrganizationId,
+            ipAddress: GetIp(httpContext),
+            cancellationToken: cancellationToken);
+        return result with { Organizations = organizations };
     }
 
     public async Task<SqlOSTokenResponse> ExchangeCodeAsync(SqlOSExchangeCodeRequest request, HttpContext httpContext, CancellationToken cancellationToken = default)
@@ -1335,6 +1359,162 @@ public sealed class SqlOSAuthService
         CancellationToken cancellationToken = default)
         => _cryptoService.ValidateAccessTokenWithoutAudienceForIntrospectionOnlyAsync(rawToken, cancellationToken);
 
+    public async Task<SqlOSMfaStatusResult> GetMfaStatusAsync(
+        string userId,
+        string? organizationId = null,
+        CancellationToken cancellationToken = default)
+        => await RequireTotpMfaService().GetStatusAsync(userId, organizationId, cancellationToken);
+
+    public async Task<IReadOnlyList<SqlOSMfaAuthenticatorDto>> ListMfaAuthenticatorsAsync(
+        string userId,
+        CancellationToken cancellationToken = default)
+        => await RequireTotpMfaService().ListAuthenticatorsAsync(userId, cancellationToken);
+
+    public async Task<SqlOSTotpEnrollmentStartResult> StartTotpEnrollmentAsync(
+        string userId,
+        SqlOSTotpEnrollmentStartRequest request,
+        string? organizationId = null,
+        CancellationToken cancellationToken = default)
+        => await RequireTotpMfaService().StartEnrollmentAsync(
+            userId,
+            organizationId,
+            request.DisplayName,
+            cancellationToken: cancellationToken);
+
+    public async Task<SqlOSTotpEnrollmentStartResult> StartTotpEnrollmentForChallengeAsync(
+        string mfaToken,
+        SqlOSTotpEnrollmentStartRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var token = await RequireTotpMfaService().GetPendingMfaTokenAsync(mfaToken, cancellationToken);
+        if (token.UserId == null)
+        {
+            throw new InvalidOperationException("MFA challenge is invalid.");
+        }
+
+        return await RequireTotpMfaService().StartEnrollmentAsync(
+            token.UserId,
+            token.OrganizationId,
+            request.DisplayName,
+            requireEnrollmentAllowed: false,
+            cancellationToken);
+    }
+
+    public async Task<SqlOSTotpEnrollmentVerifyResult> VerifyTotpEnrollmentAsync(
+        SqlOSTotpEnrollmentVerifyRequest request,
+        HttpContext? httpContext = null,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await RequireTotpMfaService().VerifyEnrollmentAsync(request, cancellationToken);
+        if (string.IsNullOrWhiteSpace(request.MfaToken))
+        {
+            return result;
+        }
+
+        var challengeResult = await CompleteMfaChallengeWithoutCodeAsync(
+            request.MfaToken,
+            SqlOSMfaFactorTypes.Totp,
+            httpContext,
+            cancellationToken);
+        return result with { Tokens = challengeResult.Tokens, RedirectUrl = challengeResult.RedirectUrl };
+    }
+
+    public async Task<SqlOSMfaChallengeVerifyResult> VerifyMfaChallengeAsync(
+        SqlOSMfaChallengeVerifyRequest request,
+        HttpContext? httpContext = null,
+        CancellationToken cancellationToken = default)
+    {
+        var token = await _cryptoService.FindTemporaryTokenAsync(MfaChallengePurpose, request.MfaToken, cancellationToken)
+            ?? throw new InvalidOperationException("MFA challenge is invalid or expired.");
+        if (token.UserId == null || token.ClientApplicationId == null)
+        {
+            throw new InvalidOperationException("MFA challenge payload is invalid.");
+        }
+
+        var factorMethod = await RequireTotpMfaService().VerifySecondFactorCodeAsync(token.UserId, request.Code, cancellationToken);
+        token.ConsumedAt = DateTime.UtcNow;
+        return await CompleteConsumedMfaChallengeAsync(token, factorMethod, httpContext, cancellationToken);
+    }
+
+    public async Task<string> CreateMfaChallengeAsync(
+        SqlOSUser user,
+        SqlOSClientApplication client,
+        string? organizationId,
+        string authenticationMethod,
+        string flow,
+        string? authorizationRequestId = null,
+        string? resource = null,
+        CancellationToken cancellationToken = default)
+        => await _cryptoService.CreateTemporaryTokenAsync(
+            MfaChallengePurpose,
+            user.Id,
+            client.Id,
+            organizationId,
+            new SqlOSMfaChallengePayload(
+                flow,
+                client.ClientId,
+                authenticationMethod,
+                authorizationRequestId,
+                resource),
+            _options.Mfa.Totp.ChallengeTokenLifetime,
+            cancellationToken);
+
+    public async Task<SqlOSMfaChallengeVerifyResult> CompleteMfaChallengeWithoutCodeAsync(
+        string mfaToken,
+        string factorMethod,
+        HttpContext? httpContext = null,
+        CancellationToken cancellationToken = default)
+    {
+        var token = await _cryptoService.FindTemporaryTokenAsync(MfaChallengePurpose, mfaToken, cancellationToken)
+            ?? throw new InvalidOperationException("MFA challenge is invalid or expired.");
+        token.ConsumedAt = DateTime.UtcNow;
+        return await CompleteConsumedMfaChallengeAsync(token, factorMethod, httpContext, cancellationToken);
+    }
+
+    private async Task<SqlOSMfaChallengeVerifyResult> CompleteConsumedMfaChallengeAsync(
+        SqlOSTemporaryToken token,
+        string factorMethod,
+        HttpContext? httpContext,
+        CancellationToken cancellationToken)
+    {
+        if (token.UserId == null || token.ClientApplicationId == null)
+        {
+            throw new InvalidOperationException("MFA challenge payload is invalid.");
+        }
+
+        var payload = _cryptoService.DeserializePayload<SqlOSMfaChallengePayload>(token)
+            ?? throw new InvalidOperationException("MFA challenge payload is invalid.");
+        if (!string.Equals(payload.Flow, "client", StringComparison.Ordinal))
+        {
+            return new SqlOSMfaChallengeVerifyResult(null, null);
+        }
+
+        var user = await _context.Set<SqlOSUser>().FirstAsync(x => x.Id == token.UserId, cancellationToken);
+        var client = await _context.Set<SqlOSClientApplication>().FirstAsync(x => x.Id == token.ClientApplicationId, cancellationToken);
+        var authenticationMethod = SqlOSMfaPolicyService.AddAuthenticationMethod(payload.AuthenticationMethod, factorMethod);
+        var tokens = await CreateSessionAndTokensAsync(
+            user,
+            client,
+            token.OrganizationId,
+            authenticationMethod,
+            httpContext?.Request.Headers.UserAgent.ToString(),
+            GetIp(httpContext),
+            payload.Resource,
+            await _settingsService.GetResolvedSecuritySettingsAsync(cancellationToken),
+            cancellationToken);
+
+        await _adminService.RecordAuditAsync(
+            "user.login.mfa",
+            "user",
+            user.Id,
+            userId: user.Id,
+            organizationId: token.OrganizationId,
+            ipAddress: GetIp(httpContext),
+            cancellationToken: cancellationToken);
+
+        return new SqlOSMfaChallengeVerifyResult(tokens, null);
+    }
+
     public async Task<SqlOSTokenResponse> CreateSessionTokensForUserAsync(
         SqlOSUser user,
         SqlOSClientApplication client,
@@ -1934,6 +2114,47 @@ public sealed class SqlOSAuthService
     private SqlOSPhoneOtpService RequirePhoneOtpService()
         => _phoneOtpService ?? throw new InvalidOperationException("Phone OTP service is not registered.");
 
+    private SqlOSTotpMfaService RequireTotpMfaService()
+        => _totpMfaService ?? throw new InvalidOperationException("TOTP MFA service is not registered.");
+
+    private async Task<SqlOSLoginResult?> TryCreateMfaLoginResultAsync(
+        SqlOSUser user,
+        SqlOSClientApplication client,
+        string? organizationId,
+        string authenticationMethod,
+        IReadOnlyList<SqlOSOrganizationOption> organizations,
+        CancellationToken cancellationToken)
+    {
+        if (_mfaPolicyService == null)
+        {
+            return null;
+        }
+
+        var evaluation = await _mfaPolicyService.EvaluateAsync(user.Id, organizationId, authenticationMethod, cancellationToken);
+        if (!evaluation.RequiresMfa)
+        {
+            return null;
+        }
+
+        var mfaToken = await CreateMfaChallengeAsync(
+            user,
+            client,
+            organizationId,
+            authenticationMethod,
+            "client",
+            cancellationToken: cancellationToken);
+
+        return new SqlOSLoginResult(
+            false,
+            null,
+            organizations,
+            null,
+            RequiresMfa: true,
+            MfaToken: mfaToken,
+            RequiresMfaEnrollment: evaluation.EnrollmentRequired,
+            MfaMethods: evaluation.AvailableFactors);
+    }
+
     private async Task<SqlOSLoginResult> FinalizeClientLoginAsync(
         SqlOSUser user,
         SqlOSClientApplication client,
@@ -1949,6 +2170,18 @@ public sealed class SqlOSAuthService
             if (!await _adminService.UserHasMembershipAsync(user.Id, requestedOrganizationId, cancellationToken))
             {
                 throw new InvalidOperationException("User is not a member of the selected organization.");
+            }
+
+            var mfaResult = await TryCreateMfaLoginResultAsync(
+                user,
+                client,
+                requestedOrganizationId,
+                authenticationMethod,
+                organizations,
+                cancellationToken);
+            if (mfaResult != null)
+            {
+                return mfaResult;
             }
 
             var tokens = await CreateSessionAndTokensAsync(user, client, requestedOrganizationId, authenticationMethod, httpContext, cancellationToken);
@@ -1977,6 +2210,18 @@ public sealed class SqlOSAuthService
         }
 
         var organizationId = organizations.Count == 1 ? organizations[0].Id : null;
+        var directMfaResult = await TryCreateMfaLoginResultAsync(
+            user,
+            client,
+            organizationId,
+            authenticationMethod,
+            organizations,
+            cancellationToken);
+        if (directMfaResult != null)
+        {
+            return directMfaResult;
+        }
+
         var directTokens = await CreateSessionAndTokensAsync(user, client, organizationId, authenticationMethod, httpContext, cancellationToken);
         await _adminService.RecordAuditAsync(
             $"user.login.{authenticationMethod}",

--- a/src/SqlOS/AuthServer/Services/SqlOSAuthorizationServerService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSAuthorizationServerService.cs
@@ -22,6 +22,8 @@ public sealed class SqlOSAuthorizationServerService
     private readonly SqlOSAuthServerOptions _options;
     private readonly SqlOSInvitationService? _invitationService;
     private readonly SqlOSPasswordLoginAbuseService _passwordLoginAbuseService;
+    private readonly SqlOSMfaPolicyService? _mfaPolicyService;
+    private readonly SqlOSTotpMfaService? _totpMfaService;
 
     public SqlOSAuthorizationServerService(
         ISqlOSAuthServerDbContext context,
@@ -32,7 +34,9 @@ public sealed class SqlOSAuthorizationServerService
         SqlOSAuthPageSessionService authPageSessionService,
         IOptions<SqlOSAuthServerOptions> options,
         SqlOSInvitationService? invitationService = null,
-        SqlOSPasswordLoginAbuseService? passwordLoginAbuseService = null)
+        SqlOSPasswordLoginAbuseService? passwordLoginAbuseService = null,
+        SqlOSMfaPolicyService? mfaPolicyService = null,
+        SqlOSTotpMfaService? totpMfaService = null)
     {
         _context = context;
         _adminService = adminService;
@@ -44,6 +48,8 @@ public sealed class SqlOSAuthorizationServerService
         _invitationService = invitationService;
         _passwordLoginAbuseService = passwordLoginAbuseService
             ?? new SqlOSPasswordLoginAbuseService(context, adminService, cryptoService, options);
+        _mfaPolicyService = mfaPolicyService;
+        _totpMfaService = totpMfaService;
     }
 
     public async Task<SqlOSAuthorizationServerMetadataDto> GetMetadataAsync(HttpContext httpContext, CancellationToken cancellationToken = default)
@@ -452,6 +458,25 @@ public sealed class SqlOSAuthorizationServerService
         HttpContext httpContext,
         CancellationToken cancellationToken = default)
     {
+        var result = await CompletePendingOrganizationSelectionForLoginAsync(
+            pendingToken,
+            organizationId,
+            httpContext,
+            cancellationToken);
+        if (result.RequiresMfa)
+        {
+            throw new InvalidOperationException("The selected organization requires MFA.");
+        }
+
+        return result.RedirectUrl ?? throw new InvalidOperationException("The organization selection could not be completed.");
+    }
+
+    public async Task<SqlOSAuthorizationRequestLoginResult> CompletePendingOrganizationSelectionForLoginAsync(
+        string pendingToken,
+        string organizationId,
+        HttpContext httpContext,
+        CancellationToken cancellationToken = default)
+    {
         var temporaryToken = await _cryptoService.ConsumeTemporaryTokenAsync("auth_page_pending", pendingToken, cancellationToken)
             ?? throw new InvalidOperationException("The organization selection session is invalid or expired.");
         if (temporaryToken.UserId == null)
@@ -468,7 +493,25 @@ public sealed class SqlOSAuthorizationServerService
         }
 
         var user = await _context.Set<SqlOSUser>().FirstAsync(x => x.Id == temporaryToken.UserId, cancellationToken);
-        return await IssueAuthorizationRedirectAsync(authorizationRequest, user, organizationId, payload.AuthenticationMethod, httpContext, cancellationToken);
+        var organizations = await _adminService.GetUserOrganizationsAsync(user.Id, cancellationToken);
+        var mfaResult = await TryCreateMfaAuthorizationResultAsync(
+            authorizationRequest,
+            user,
+            organizationId,
+            payload.AuthenticationMethod,
+            organizations,
+            cancellationToken);
+        if (mfaResult != null)
+        {
+            return mfaResult;
+        }
+
+        return new SqlOSAuthorizationRequestLoginResult(
+            await IssueAuthorizationRedirectAsync(authorizationRequest, user, organizationId, payload.AuthenticationMethod, httpContext, cancellationToken),
+            false,
+            null,
+            organizations,
+            AuthorizationRequestId: authorizationRequest.Id);
     }
 
     public async Task<SqlOSAuthorizationRequestLoginResult> CompleteAuthorizationRequestLoginAsync(
@@ -480,6 +523,19 @@ public sealed class SqlOSAuthorizationServerService
     {
         if (!string.IsNullOrWhiteSpace(authorizationRequest.InvitationId))
         {
+            var invitationOrganizations = await _adminService.GetUserOrganizationsAsync(user.Id, cancellationToken);
+            var mfaResult = await TryCreateMfaAuthorizationResultAsync(
+                authorizationRequest,
+                user,
+                organizationId: null,
+                authenticationMethod,
+                invitationOrganizations,
+                cancellationToken);
+            if (mfaResult != null)
+            {
+                return mfaResult;
+            }
+
             return new SqlOSAuthorizationRequestLoginResult(
                 await IssueAuthorizationRedirectAsync(
                     authorizationRequest,
@@ -500,6 +556,18 @@ public sealed class SqlOSAuthorizationServerService
             if (organizations.All(x => x.Id != authorizationRequest.OrganizationId))
             {
                 throw new InvalidOperationException("The selected organization is not available to this user.");
+            }
+
+            var mfaResult = await TryCreateMfaAuthorizationResultAsync(
+                authorizationRequest,
+                user,
+                authorizationRequest.OrganizationId,
+                authenticationMethod,
+                organizations,
+                cancellationToken);
+            if (mfaResult != null)
+            {
+                return mfaResult;
             }
 
             return new SqlOSAuthorizationRequestLoginResult(
@@ -528,17 +596,145 @@ public sealed class SqlOSAuthorizationServerService
                 organizations);
         }
 
+        var selectedOrganizationId = organizations.FirstOrDefault()?.Id;
+        var directMfaResult = await TryCreateMfaAuthorizationResultAsync(
+            authorizationRequest,
+            user,
+            selectedOrganizationId,
+            authenticationMethod,
+            organizations,
+            cancellationToken);
+        if (directMfaResult != null)
+        {
+            return directMfaResult;
+        }
+
         return new SqlOSAuthorizationRequestLoginResult(
             await IssueAuthorizationRedirectAsync(
                 authorizationRequest,
                 user,
-                organizations.FirstOrDefault()?.Id,
+                selectedOrganizationId,
                 authenticationMethod,
                 httpContext,
                 cancellationToken),
             false,
             null,
             organizations);
+    }
+
+    public async Task<string> CompleteMfaChallengeAsync(
+        string mfaToken,
+        string code,
+        HttpContext httpContext,
+        CancellationToken cancellationToken = default)
+    {
+        var token = await _cryptoService.FindTemporaryTokenAsync(SqlOSAuthService.MfaChallengePurpose, mfaToken, cancellationToken)
+            ?? throw new InvalidOperationException("MFA challenge is invalid or expired.");
+        if (token.UserId == null || token.ClientApplicationId == null)
+        {
+            throw new InvalidOperationException("MFA challenge payload is invalid.");
+        }
+
+        var factorMethod = await RequireTotpMfaService().VerifySecondFactorCodeAsync(token.UserId, code, cancellationToken);
+        token.ConsumedAt = DateTime.UtcNow;
+        return await CompleteConsumedMfaChallengeAsync(token, factorMethod, httpContext, cancellationToken);
+    }
+
+    public async Task<string> CompleteMfaChallengeWithoutCodeAsync(
+        string mfaToken,
+        string factorMethod,
+        HttpContext httpContext,
+        CancellationToken cancellationToken = default)
+    {
+        var token = await _cryptoService.FindTemporaryTokenAsync(SqlOSAuthService.MfaChallengePurpose, mfaToken, cancellationToken)
+            ?? throw new InvalidOperationException("MFA challenge is invalid or expired.");
+        token.ConsumedAt = DateTime.UtcNow;
+        return await CompleteConsumedMfaChallengeAsync(token, factorMethod, httpContext, cancellationToken);
+    }
+
+    private async Task<string> CompleteConsumedMfaChallengeAsync(
+        SqlOSTemporaryToken token,
+        string factorMethod,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        var payload = _cryptoService.DeserializePayload<SqlOSMfaChallengePayload>(token)
+            ?? throw new InvalidOperationException("MFA challenge payload is invalid.");
+        if (!string.Equals(payload.Flow, "authorization", StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("MFA challenge is not valid for hosted authorization.");
+        }
+
+        if (string.IsNullOrWhiteSpace(payload.AuthorizationRequestId) || token.UserId == null)
+        {
+            throw new InvalidOperationException("MFA challenge payload is invalid.");
+        }
+
+        var authorizationRequest = await GetRequiredAuthorizationRequestAsync(payload.AuthorizationRequestId, cancellationToken);
+        var user = await _context.Set<SqlOSUser>().FirstAsync(x => x.Id == token.UserId, cancellationToken);
+        var authenticationMethod = SqlOSMfaPolicyService.AddAuthenticationMethod(payload.AuthenticationMethod, factorMethod);
+        var redirectUrl = await IssueAuthorizationRedirectAsync(
+            authorizationRequest,
+            user,
+            token.OrganizationId,
+            authenticationMethod,
+            httpContext,
+            cancellationToken);
+
+        await _adminService.RecordAuditAsync(
+            "user.login.mfa",
+            "user",
+            user.Id,
+            userId: user.Id,
+            organizationId: token.OrganizationId,
+            ipAddress: httpContext.Connection.RemoteIpAddress?.ToString(),
+            cancellationToken: cancellationToken);
+
+        return redirectUrl;
+    }
+
+    private async Task<SqlOSAuthorizationRequestLoginResult?> TryCreateMfaAuthorizationResultAsync(
+        SqlOSAuthorizationRequest authorizationRequest,
+        SqlOSUser user,
+        string? organizationId,
+        string authenticationMethod,
+        IReadOnlyList<SqlOSOrganizationOption> organizations,
+        CancellationToken cancellationToken)
+    {
+        if (_mfaPolicyService == null)
+        {
+            return null;
+        }
+
+        var evaluation = await _mfaPolicyService.EvaluateAsync(user.Id, organizationId, authenticationMethod, cancellationToken);
+        if (!evaluation.RequiresMfa)
+        {
+            return null;
+        }
+
+        var client = authorizationRequest.ClientApplication
+            ?? await _context.Set<SqlOSClientApplication>()
+                .FirstAsync(x => x.Id == authorizationRequest.ClientApplicationId, cancellationToken);
+        var mfaToken = await _authService.CreateMfaChallengeAsync(
+            user,
+            client,
+            organizationId,
+            authenticationMethod,
+            "authorization",
+            authorizationRequest.Id,
+            authorizationRequest.Resource,
+            cancellationToken);
+
+        return new SqlOSAuthorizationRequestLoginResult(
+            null,
+            false,
+            null,
+            organizations,
+            RequiresMfa: true,
+            MfaToken: mfaToken,
+            RequiresMfaEnrollment: evaluation.EnrollmentRequired,
+            MfaMethods: evaluation.AvailableFactors,
+            AuthorizationRequestId: authorizationRequest.Id);
     }
 
     public async Task<string> IssueAuthorizationRedirectAsync(
@@ -808,6 +1004,9 @@ public sealed class SqlOSAuthorizationServerService
 
     private SqlOSInvitationService RequireInvitationService()
         => _invitationService ?? throw new InvalidOperationException("SqlOS invitations are not configured.");
+
+    private SqlOSTotpMfaService RequireTotpMfaService()
+        => _totpMfaService ?? throw new InvalidOperationException("TOTP MFA service is not registered.");
 }
 
 public sealed record SqlOSAuthorizeRequestInput(
@@ -834,7 +1033,12 @@ public sealed record SqlOSAuthorizationRequestLoginResult(
     string? RedirectUrl,
     bool RequiresOrganizationSelection,
     string? PendingToken,
-    IReadOnlyList<SqlOSOrganizationOption> Organizations);
+    IReadOnlyList<SqlOSOrganizationOption> Organizations,
+    bool RequiresMfa = false,
+    string? MfaToken = null,
+    bool RequiresMfaEnrollment = false,
+    IReadOnlyList<string>? MfaMethods = null,
+    string? AuthorizationRequestId = null);
 
 public sealed record SqlOSTokenRequest(
     string GrantType,

--- a/src/SqlOS/AuthServer/Services/SqlOSCryptoService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSCryptoService.cs
@@ -267,9 +267,13 @@ public sealed class SqlOSCryptoService
         {
             new(JwtRegisteredClaimNames.Sub, user.Id),
             new("sid", session.Id),
-            new("client_id", client.ClientId),
-            new("amr", session.AuthenticationMethod ?? "password")
+            new("client_id", client.ClientId)
         };
+
+        foreach (var method in SqlOSMfaPolicyService.SplitAuthenticationMethods(session.AuthenticationMethod ?? "password"))
+        {
+            claims.Add(new Claim("amr", method));
+        }
 
         if (!string.IsNullOrWhiteSpace(user.DefaultEmail))
         {

--- a/src/SqlOS/AuthServer/Services/SqlOSHeadlessAuthService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSHeadlessAuthService.cs
@@ -14,6 +14,7 @@ public sealed class SqlOSHeadlessAuthService
 {
     private readonly ISqlOSAuthServerDbContext _context;
     private readonly SqlOSAdminService _adminService;
+    private readonly SqlOSAuthService? _authService;
     private readonly SqlOSAuthorizationServerService _authorizationServerService;
     private readonly SqlOSHomeRealmDiscoveryService _discoveryService;
     private readonly SqlOSOidcBrowserAuthService _oidcBrowserAuthService;
@@ -39,10 +40,12 @@ public sealed class SqlOSHeadlessAuthService
         SqlOSInvitationService? invitationService = null,
         SqlOSDeviceAuthorizationService? deviceAuthorizationService = null,
         SqlOSAuthPageSessionService? authPageSessionService = null,
-        SqlOSPhoneOtpService? phoneOtpService = null)
+        SqlOSPhoneOtpService? phoneOtpService = null,
+        SqlOSAuthService? authService = null)
     {
         _context = context;
         _adminService = adminService;
+        _authService = authService;
         _authorizationServerService = authorizationServerService;
         _discoveryService = discoveryService;
         _oidcBrowserAuthService = oidcBrowserAuthService;
@@ -425,23 +428,11 @@ public sealed class SqlOSHeadlessAuthService
                 httpContext,
                 cancellationToken);
 
-            if (completion.RequiresOrganizationSelection)
-            {
-                return View(await BuildViewModelAsync(
-                    authorizationRequest,
-                    "organization",
-                    error: null,
-                    pendingToken: completion.PendingToken,
-                    email: email,
-                    displayName: null,
-                    fieldErrors: null,
-                    organizationSelection: completion.Organizations,
-                    info: null,
-                    challengeToken: null,
-                    cancellationToken: cancellationToken));
-            }
-
-            return Redirect(completion.RedirectUrl!);
+            return await BuildCompletionActionResultAsync(
+                authorizationRequest,
+                completion,
+                email,
+                cancellationToken);
         }
         catch (InvalidOperationException ex)
         {
@@ -632,23 +623,11 @@ public sealed class SqlOSHeadlessAuthService
                 httpContext,
                 cancellationToken);
 
-            if (completion.RequiresOrganizationSelection)
-            {
-                return View(await BuildViewModelAsync(
-                    authorizationRequest,
-                    "organization",
-                    error: null,
-                    pendingToken: completion.PendingToken,
-                    email: verification.Challenge.Email,
-                    displayName: null,
-                    fieldErrors: null,
-                    organizationSelection: completion.Organizations,
-                    info: null,
-                    challengeToken: null,
-                    cancellationToken: cancellationToken));
-            }
-
-            return Redirect(completion.RedirectUrl!);
+            return await BuildCompletionActionResultAsync(
+                authorizationRequest,
+                completion,
+                verification.Challenge.Email,
+                cancellationToken);
         }
         catch (InvalidOperationException ex)
         {
@@ -870,23 +849,11 @@ public sealed class SqlOSHeadlessAuthService
                 httpContext,
                 cancellationToken);
 
-            if (completion.RequiresOrganizationSelection)
-            {
-                return View(await BuildViewModelAsync(
-                    authorizationRequest,
-                    "organization",
-                    error: null,
-                    pendingToken: completion.PendingToken,
-                    email: null,
-                    displayName: null,
-                    fieldErrors: null,
-                    organizationSelection: completion.Organizations,
-                    info: null,
-                    challengeToken: null,
-                    cancellationToken: cancellationToken));
-            }
-
-            return Redirect(completion.RedirectUrl!);
+            return await BuildCompletionActionResultAsync(
+                authorizationRequest,
+                completion,
+                email: null,
+                cancellationToken);
         }
         catch (InvalidOperationException ex)
         {
@@ -1329,11 +1296,137 @@ public sealed class SqlOSHeadlessAuthService
         HttpContext httpContext,
         SqlOSHeadlessOrganizationSelectionRequest request,
         CancellationToken cancellationToken = default)
-        => Redirect(await _authorizationServerService.CompletePendingOrganizationSelectionAsync(
+    {
+        var completion = await _authorizationServerService.CompletePendingOrganizationSelectionForLoginAsync(
             request.PendingToken,
             request.OrganizationId,
             httpContext,
-            cancellationToken));
+            cancellationToken);
+        if (string.IsNullOrWhiteSpace(completion.AuthorizationRequestId))
+        {
+            return Redirect(completion.RedirectUrl!);
+        }
+
+        var authorizationRequest = await _authorizationServerService.GetRequiredAuthorizationRequestAsync(
+            completion.AuthorizationRequestId,
+            cancellationToken);
+        return await BuildCompletionActionResultAsync(
+            authorizationRequest,
+            completion,
+            email: null,
+            cancellationToken);
+    }
+
+    public async Task<SqlOSHeadlessActionResult> VerifyMfaAsync(
+        HttpContext httpContext,
+        SqlOSHeadlessMfaVerifyRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var authorizationRequest = await _authorizationServerService.GetRequiredAuthorizationRequestAsync(request.RequestId, cancellationToken);
+        try
+        {
+            return Redirect(await _authorizationServerService.CompleteMfaChallengeAsync(
+                request.MfaToken,
+                request.Code,
+                httpContext,
+                cancellationToken));
+        }
+        catch (InvalidOperationException ex)
+        {
+            return View(await BuildViewModelAsync(
+                authorizationRequest,
+                "mfa",
+                ex.Message,
+                pendingToken: null,
+                email: authorizationRequest.LoginHintEmail,
+                displayName: null,
+                fieldErrors: null,
+                organizationSelection: null,
+                mfaToken: request.MfaToken,
+                mfaMethods: [SqlOSMfaFactorTypes.Totp, SqlOSMfaFactorTypes.RecoveryCode],
+                cancellationToken: cancellationToken));
+        }
+    }
+
+    public async Task<SqlOSHeadlessActionResult> StartMfaTotpEnrollmentAsync(
+        SqlOSHeadlessMfaTotpEnrollmentStartRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var authorizationRequest = await _authorizationServerService.GetRequiredAuthorizationRequestAsync(request.RequestId, cancellationToken);
+        try
+        {
+            var enrollment = await RequireAuthService().StartTotpEnrollmentForChallengeAsync(
+                request.MfaToken,
+                new SqlOSTotpEnrollmentStartRequest(request.DisplayName),
+                cancellationToken);
+            return View(await BuildViewModelAsync(
+                authorizationRequest,
+                "mfa-enroll",
+                error: null,
+                pendingToken: null,
+                email: authorizationRequest.LoginHintEmail,
+                displayName: null,
+                fieldErrors: null,
+                organizationSelection: null,
+                mfaToken: request.MfaToken,
+                requiresMfaEnrollment: true,
+                mfaMethods: [SqlOSMfaFactorTypes.Totp],
+                totpEnrollment: enrollment,
+                cancellationToken: cancellationToken));
+        }
+        catch (InvalidOperationException ex)
+        {
+            return View(await BuildViewModelAsync(
+                authorizationRequest,
+                "mfa-enroll",
+                ex.Message,
+                pendingToken: null,
+                email: authorizationRequest.LoginHintEmail,
+                displayName: null,
+                fieldErrors: null,
+                organizationSelection: null,
+                mfaToken: request.MfaToken,
+                requiresMfaEnrollment: true,
+                mfaMethods: [SqlOSMfaFactorTypes.Totp],
+                cancellationToken: cancellationToken));
+        }
+    }
+
+    public async Task<SqlOSHeadlessActionResult> VerifyMfaTotpEnrollmentAsync(
+        HttpContext httpContext,
+        SqlOSHeadlessMfaTotpEnrollmentVerifyRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var authorizationRequest = await _authorizationServerService.GetRequiredAuthorizationRequestAsync(request.RequestId, cancellationToken);
+        try
+        {
+            await RequireAuthService().VerifyTotpEnrollmentAsync(
+                new SqlOSTotpEnrollmentVerifyRequest(request.EnrollmentToken, request.Code),
+                httpContext,
+                cancellationToken);
+            return Redirect(await _authorizationServerService.CompleteMfaChallengeWithoutCodeAsync(
+                request.MfaToken,
+                SqlOSMfaFactorTypes.Totp,
+                httpContext,
+                cancellationToken));
+        }
+        catch (InvalidOperationException ex)
+        {
+            return View(await BuildViewModelAsync(
+                authorizationRequest,
+                "mfa-enroll",
+                ex.Message,
+                pendingToken: null,
+                email: authorizationRequest.LoginHintEmail,
+                displayName: null,
+                fieldErrors: null,
+                organizationSelection: null,
+                mfaToken: request.MfaToken,
+                requiresMfaEnrollment: true,
+                mfaMethods: [SqlOSMfaFactorTypes.Totp],
+                cancellationToken: cancellationToken));
+        }
+    }
 
     public async Task<SqlOSHeadlessActionResult> StartProviderAsync(
         HttpContext httpContext,
@@ -1369,6 +1462,10 @@ public sealed class SqlOSHeadlessAuthService
         string? challengeToken = null,
         string? signupToken = null,
         string? phoneNumber = null,
+        string? mfaToken = null,
+        bool requiresMfaEnrollment = false,
+        IReadOnlyList<string>? mfaMethods = null,
+        SqlOSTotpEnrollmentStartResult? totpEnrollment = null,
         CancellationToken cancellationToken = default)
     {
         var settings = await _settingsService.GetAuthPageSettingsAsync(cancellationToken);
@@ -1404,7 +1501,11 @@ public sealed class SqlOSHeadlessAuthService
             await GetBoundInvitationOrNullAsync(authorizationRequest, cancellationToken),
             ParseUiContext(authorizationRequest.UiContextJson),
             DeviceAuthorization: deviceAuthorization,
-            PhoneNumber: phoneNumber);
+            PhoneNumber: phoneNumber,
+            MfaToken: mfaToken,
+            RequiresMfaEnrollment: requiresMfaEnrollment,
+            MfaMethods: mfaMethods ?? Array.Empty<string>(),
+            TotpEnrollment: totpEnrollment);
     }
 
     public static bool IsHeadlessRequest(SqlOSAuthorizationRequest authorizationRequest)
@@ -1493,10 +1594,64 @@ public sealed class SqlOSHeadlessAuthService
             "device-approve" => "device-approve",
             "device-approved" => "device-approved",
             "device-denied" => "device-denied",
+            "mfa" => "mfa",
+            "mfa-enroll" => "mfa-enroll",
             "organization" => "organization",
             "logged-out" => "logged-out",
             _ => "login"
         };
+    }
+
+    private async Task<SqlOSHeadlessActionResult> BuildCompletionActionResultAsync(
+        SqlOSAuthorizationRequest authorizationRequest,
+        SqlOSAuthorizationRequestLoginResult completion,
+        string? email,
+        CancellationToken cancellationToken)
+    {
+        if (completion.RequiresOrganizationSelection)
+        {
+            return View(await BuildViewModelAsync(
+                authorizationRequest,
+                "organization",
+                error: null,
+                pendingToken: completion.PendingToken,
+                email: email,
+                displayName: null,
+                fieldErrors: null,
+                organizationSelection: completion.Organizations,
+                info: null,
+                challengeToken: null,
+                cancellationToken: cancellationToken));
+        }
+
+        if (completion.RequiresMfa)
+        {
+            SqlOSTotpEnrollmentStartResult? totpEnrollment = null;
+            if (completion.RequiresMfaEnrollment && !string.IsNullOrWhiteSpace(completion.MfaToken))
+            {
+                totpEnrollment = await RequireAuthService().StartTotpEnrollmentForChallengeAsync(
+                    completion.MfaToken,
+                    new SqlOSTotpEnrollmentStartRequest(),
+                    cancellationToken);
+            }
+
+            return View(await BuildViewModelAsync(
+                authorizationRequest,
+                completion.RequiresMfaEnrollment ? "mfa-enroll" : "mfa",
+                error: null,
+                pendingToken: null,
+                email: email,
+                displayName: null,
+                fieldErrors: null,
+                organizationSelection: completion.Organizations,
+                mfaToken: completion.MfaToken,
+                requiresMfaEnrollment: completion.RequiresMfaEnrollment,
+                mfaMethods: completion.MfaMethods ?? Array.Empty<string>(),
+                totpEnrollment: totpEnrollment,
+                cancellationToken: cancellationToken));
+        }
+
+        return Redirect(completion.RedirectUrl!);
     }
 
     private static SqlOSHeadlessActionResult Redirect(string url)
@@ -1530,6 +1685,9 @@ public sealed class SqlOSHeadlessAuthService
 
     private SqlOSPhoneOtpService RequirePhoneOtpService()
         => _phoneOtpService ?? throw new InvalidOperationException("Phone OTP service is not registered.");
+
+    private SqlOSAuthService RequireAuthService()
+        => _authService ?? throw new InvalidOperationException("Auth service is not registered.");
 
     private async Task BindInvitationIfPresentAsync(
         SqlOSAuthorizationRequest authorizationRequest,

--- a/src/SqlOS/AuthServer/Services/SqlOSMfaPolicyService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSMfaPolicyService.cs
@@ -1,15 +1,140 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using SqlOS.AuthServer.Configuration;
+using SqlOS.AuthServer.Contracts;
+using SqlOS.AuthServer.Interfaces;
+using SqlOS.AuthServer.Models;
 
 namespace SqlOS.AuthServer.Services;
 
 public sealed class SqlOSMfaPolicyService
 {
+    private readonly ISqlOSAuthServerDbContext? _context;
+    private readonly SqlOSSettingsService? _settingsService;
     private readonly SqlOSAuthServerOptions _options;
 
     public SqlOSMfaPolicyService(IOptions<SqlOSAuthServerOptions> options)
     {
         _options = options.Value;
+    }
+
+    public SqlOSMfaPolicyService(
+        ISqlOSAuthServerDbContext context,
+        SqlOSSettingsService settingsService,
+        IOptions<SqlOSAuthServerOptions> options)
+        : this(options)
+    {
+        _context = context;
+        _settingsService = settingsService;
+    }
+
+    public async Task<SqlOSMfaPolicyEvaluation> EvaluateAsync(
+        string userId,
+        string? organizationId,
+        string? authenticationMethod,
+        CancellationToken cancellationToken = default)
+    {
+        var context = _context ?? throw new InvalidOperationException("MFA policy evaluation requires a database context.");
+        var settingsService = _settingsService ?? throw new InvalidOperationException("MFA policy evaluation requires settings service.");
+
+        await settingsService.EnsureDefaultMfaSettingsAsync(cancellationToken);
+        var settings = await context.Set<SqlOSMfaSettings>()
+            .AsNoTracking()
+            .FirstAsync(x => x.Id == "default", cancellationToken);
+
+        if (!_options.Mfa.Enabled || !settings.Enabled || !_options.Mfa.Totp.Enabled || !settings.TotpEnabled)
+        {
+            return SqlOSMfaPolicyEvaluation.Disabled();
+        }
+
+        var orgPolicy = string.IsNullOrWhiteSpace(organizationId)
+            ? null
+            : await context.Set<SqlOSOrganizationMfaPolicy>()
+                .AsNoTracking()
+                .FirstOrDefaultAsync(x => x.OrganizationId == organizationId, cancellationToken);
+        var userOverride = await context.Set<SqlOSUserMfaPolicyOverride>()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(x => x.UserId == userId, cancellationToken);
+        var membership = string.IsNullOrWhiteSpace(organizationId)
+            ? null
+            : await context.Set<SqlOSMembership>()
+                .AsNoTracking()
+                .FirstOrDefaultAsync(x =>
+                    x.OrganizationId == organizationId
+                    && x.UserId == userId
+                    && x.IsActive,
+                    cancellationToken);
+
+        var policyEnabled = orgPolicy?.IsEnabled ?? false;
+        var requiredRoles = DeserializeList(policyEnabled ? orgPolicy!.RequiredRolesJson : settings.RequiredRolesJson, ["owner", "admin"]);
+        var availableFactors = DeserializeList(policyEnabled ? orgPolicy!.AvailableFactorsJson : settings.AvailableFactorsJson, [SqlOSMfaFactorTypes.Totp, SqlOSMfaFactorTypes.RecoveryCode])
+            .Where(static value =>
+                string.Equals(value, SqlOSMfaFactorTypes.Totp, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(value, SqlOSMfaFactorTypes.RecoveryCode, StringComparison.OrdinalIgnoreCase))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        if (availableFactors.Length == 0)
+        {
+            availableFactors = [SqlOSMfaFactorTypes.Totp];
+        }
+
+        var requireAll = policyEnabled ? orgPolicy!.RequireMfaForAllUsers : settings.RequireForAllUsers;
+        var requirePrivileged = policyEnabled ? orgPolicy!.RequireMfaForOwnersAndAdmins : settings.RequireForOwnersAndAdmins;
+        var selfEnrollment = policyEnabled ? orgPolicy!.UserSelfEnrollmentEnabled : settings.UserSelfEnrollmentEnabled;
+        var recoveryCodesEnabled = policyEnabled ? orgPolicy!.RecoveryCodesEnabled : settings.RecoveryCodesEnabled;
+
+        if (userOverride?.RequireMfa is bool userRequires)
+        {
+            requireAll = userRequires;
+        }
+
+        if (userOverride?.UserSelfEnrollmentEnabled is bool userSelfEnrollment)
+        {
+            selfEnrollment = userSelfEnrollment;
+        }
+
+        var roleRequires = requirePrivileged
+            && membership != null
+            && requiredRoles.Contains(membership.Role, StringComparer.OrdinalIgnoreCase);
+        var requiresMfa = requireAll || roleRequires;
+        var reason = requireAll
+            ? "all_users"
+            : roleRequires
+                ? "role"
+                : null;
+
+        var hasTotp = await context.Set<SqlOSUserAuthenticator>()
+            .AsNoTracking()
+            .AnyAsync(x =>
+                x.UserId == userId
+                && x.Type == SqlOSMfaFactorTypes.Totp
+                && x.IsConfirmed
+                && x.RevokedAt == null,
+                cancellationToken);
+        var recoveryCodeCount = await context.Set<SqlOSRecoveryCode>()
+            .AsNoTracking()
+            .CountAsync(x =>
+                x.UserId == userId
+                && x.ConsumedAt == null
+                && x.RevokedAt == null,
+                cancellationToken);
+
+        var hasRecoveryCodes = recoveryCodeCount > 0;
+        var canSelfEnroll = selfEnrollment && availableFactors.Contains(SqlOSMfaFactorTypes.Totp, StringComparer.OrdinalIgnoreCase);
+        var enrollmentRequired = requiresMfa && !SatisfiesStrongMfa(authenticationMethod) && !hasTotp;
+
+        return new SqlOSMfaPolicyEvaluation(
+            true,
+            requiresMfa && !SatisfiesStrongMfa(authenticationMethod),
+            canSelfEnroll,
+            enrollmentRequired,
+            hasTotp,
+            hasRecoveryCodes,
+            recoveryCodeCount,
+            recoveryCodesEnabled,
+            availableFactors,
+            reason);
     }
 
     public bool SatisfiesStrongMfa(string? authenticationMethod)
@@ -19,17 +144,82 @@ public sealed class SqlOSMfaPolicyService
             return false;
         }
 
-        if (string.Equals(authenticationMethod, "phone_otp", StringComparison.OrdinalIgnoreCase))
+        foreach (var method in SplitAuthenticationMethods(authenticationMethod))
         {
-            return _options.PhoneOtp.SatisfiesMfa;
+            if (string.Equals(method, "phone_otp", StringComparison.OrdinalIgnoreCase))
+            {
+                if (_options.PhoneOtp.SatisfiesMfa)
+                {
+                    return true;
+                }
+
+                continue;
+            }
+
+            if (string.Equals(method, SqlOSMfaFactorTypes.Totp, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(method, SqlOSMfaFactorTypes.RecoveryCode, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(method, "passkey", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(method, "webauthn", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
         }
 
-        return string.Equals(authenticationMethod, "totp", StringComparison.OrdinalIgnoreCase)
-            || string.Equals(authenticationMethod, "passkey", StringComparison.OrdinalIgnoreCase)
-            || string.Equals(authenticationMethod, "webauthn", StringComparison.OrdinalIgnoreCase);
+        return false;
     }
 
     public bool SatisfiesAdminOwnerStrongMfa(string? authenticationMethod)
-        => !string.Equals(authenticationMethod, "phone_otp", StringComparison.OrdinalIgnoreCase)
-            && SatisfiesStrongMfa(authenticationMethod);
+        => SplitAuthenticationMethods(authenticationMethod)
+            .Any(method =>
+                !string.Equals(method, "phone_otp", StringComparison.OrdinalIgnoreCase)
+                && SatisfiesStrongMfa(method));
+
+    public static string AddAuthenticationMethod(string authenticationMethod, string secondFactorMethod)
+    {
+        var existing = SplitAuthenticationMethods(authenticationMethod).ToList();
+        if (!existing.Contains(secondFactorMethod, StringComparer.OrdinalIgnoreCase))
+        {
+            existing.Add(secondFactorMethod);
+        }
+
+        return string.Join("+", existing);
+    }
+
+    internal static IEnumerable<string> SplitAuthenticationMethods(string? authenticationMethod)
+        => (authenticationMethod ?? string.Empty)
+            .Split(['+', ',', ' '], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+    private static string[] DeserializeList(string json, string[] fallback)
+    {
+        try
+        {
+            var values = JsonSerializer.Deserialize<string[]>(json) ?? fallback;
+            var normalized = values
+                .Where(static value => !string.IsNullOrWhiteSpace(value))
+                .Select(static value => value.Trim().ToLowerInvariant())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            return normalized.Length == 0 ? fallback : normalized;
+        }
+        catch
+        {
+            return fallback;
+        }
+    }
+}
+
+public sealed record SqlOSMfaPolicyEvaluation(
+    bool Enabled,
+    bool RequiresMfa,
+    bool CanSelfEnroll,
+    bool EnrollmentRequired,
+    bool HasTotp,
+    bool HasRecoveryCodes,
+    int RecoveryCodeCount,
+    bool RecoveryCodesEnabled,
+    IReadOnlyList<string> AvailableFactors,
+    string? Reason)
+{
+    public static SqlOSMfaPolicyEvaluation Disabled()
+        => new(false, false, false, false, false, false, 0, false, Array.Empty<string>(), null);
 }

--- a/src/SqlOS/AuthServer/Services/SqlOSSettingsService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSSettingsService.cs
@@ -127,6 +127,156 @@ public sealed class SqlOSSettingsService
         await _context.SaveChangesAsync(cancellationToken);
     }
 
+    public async Task EnsureDefaultMfaSettingsAsync(CancellationToken cancellationToken = default)
+    {
+        var existing = await _context.Set<SqlOSMfaSettings>().FirstOrDefaultAsync(x => x.Id == "default", cancellationToken);
+        if (existing != null)
+        {
+            return;
+        }
+
+        _context.Set<SqlOSMfaSettings>().Add(new SqlOSMfaSettings
+        {
+            Id = "default",
+            Enabled = _options.Mfa.Enabled,
+            TotpEnabled = _options.Mfa.Totp.Enabled,
+            UserSelfEnrollmentEnabled = _options.Mfa.AllowUserSelfEnrollmentByDefault,
+            RecoveryCodesEnabled = _options.Mfa.RecoveryCodesEnabledByDefault,
+            RequireForAllUsers = _options.Mfa.RequireForAllUsersByDefault,
+            RequireForOwnersAndAdmins = _options.Mfa.RequireForOwnersAndAdminsByDefault,
+            RequiredRolesJson = JsonSerializer.Serialize(NormalizeList(_options.Mfa.RequiredRolesByDefault, ["owner", "admin"])),
+            AvailableFactorsJson = JsonSerializer.Serialize(NormalizeAvailableFactors(_options.Mfa.AvailableFactorsByDefault)),
+            UpdatedAt = DateTime.UtcNow
+        });
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task UpsertSeededMfaSettingsAsync(CancellationToken cancellationToken = default)
+    {
+        if (_options.MfaSeed == null)
+        {
+            return;
+        }
+
+        await EnsureDefaultMfaSettingsAsync(cancellationToken);
+        var settings = await _context.Set<SqlOSMfaSettings>().FirstAsync(x => x.Id == "default", cancellationToken);
+
+        settings.Enabled = _options.MfaSeed.Enabled;
+        settings.TotpEnabled = _options.MfaSeed.TotpEnabled;
+        settings.UserSelfEnrollmentEnabled = _options.MfaSeed.UserSelfEnrollmentEnabled;
+        settings.RecoveryCodesEnabled = _options.MfaSeed.RecoveryCodesEnabled;
+        settings.RequireForAllUsers = _options.MfaSeed.RequireForAllUsers;
+        settings.RequireForOwnersAndAdmins = _options.MfaSeed.RequireForOwnersAndAdmins;
+        settings.RequiredRolesJson = JsonSerializer.Serialize(NormalizeList(_options.MfaSeed.RequiredRoles, ["owner", "admin"]));
+        settings.AvailableFactorsJson = JsonSerializer.Serialize(NormalizeAvailableFactors(_options.MfaSeed.AvailableFactors));
+        settings.UpdatedAt = DateTime.UtcNow;
+
+        foreach (var organizationSeed in _options.MfaSeed.Organizations)
+        {
+            var organizationId = organizationSeed.OrganizationId;
+            if (string.IsNullOrWhiteSpace(organizationId) && !string.IsNullOrWhiteSpace(organizationSeed.OrganizationSlug))
+            {
+                organizationId = await _context.Set<SqlOSOrganization>()
+                    .Where(x => x.Slug == organizationSeed.OrganizationSlug.Trim())
+                    .Select(x => x.Id)
+                    .FirstOrDefaultAsync(cancellationToken);
+            }
+
+            if (string.IsNullOrWhiteSpace(organizationId))
+            {
+                continue;
+            }
+
+            var policy = await _context.Set<SqlOSOrganizationMfaPolicy>()
+                .FirstOrDefaultAsync(x => x.OrganizationId == organizationId, cancellationToken);
+            if (policy == null)
+            {
+                policy = new SqlOSOrganizationMfaPolicy { OrganizationId = organizationId };
+                _context.Set<SqlOSOrganizationMfaPolicy>().Add(policy);
+            }
+
+            policy.IsEnabled = organizationSeed.IsEnabled;
+            policy.RequireMfaForAllUsers = organizationSeed.RequireMfaForAllUsers;
+            policy.RequireMfaForOwnersAndAdmins = organizationSeed.RequireMfaForOwnersAndAdmins;
+            policy.UserSelfEnrollmentEnabled = organizationSeed.UserSelfEnrollmentEnabled;
+            policy.RecoveryCodesEnabled = organizationSeed.RecoveryCodesEnabled;
+            policy.RequiredRolesJson = JsonSerializer.Serialize(NormalizeList(organizationSeed.RequiredRoles, ["owner", "admin"]));
+            policy.AvailableFactorsJson = JsonSerializer.Serialize(NormalizeAvailableFactors(organizationSeed.AvailableFactors));
+            policy.UpdatedAt = DateTime.UtcNow;
+        }
+
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task<SqlOSMfaSettingsDto> GetMfaSettingsAsync(CancellationToken cancellationToken = default)
+    {
+        await EnsureDefaultMfaSettingsAsync(cancellationToken);
+        var settings = await _context.Set<SqlOSMfaSettings>().FirstAsync(x => x.Id == "default", cancellationToken);
+        return ToMfaSettingsDto(settings, _options.MfaSeed != null);
+    }
+
+    public async Task<SqlOSMfaSettingsDto> UpdateMfaSettingsAsync(SqlOSUpdateMfaSettingsRequest request, CancellationToken cancellationToken = default)
+    {
+        await EnsureDefaultMfaSettingsAsync(cancellationToken);
+        var settings = await _context.Set<SqlOSMfaSettings>().FirstAsync(x => x.Id == "default", cancellationToken);
+
+        settings.Enabled = request.Enabled;
+        settings.TotpEnabled = request.TotpEnabled;
+        settings.UserSelfEnrollmentEnabled = request.UserSelfEnrollmentEnabled;
+        settings.RecoveryCodesEnabled = request.RecoveryCodesEnabled;
+        settings.RequireForAllUsers = request.RequireForAllUsers;
+        settings.RequireForOwnersAndAdmins = request.RequireForOwnersAndAdmins;
+        settings.RequiredRolesJson = JsonSerializer.Serialize(NormalizeList(request.RequiredRoles, ["owner", "admin"]));
+        settings.AvailableFactorsJson = JsonSerializer.Serialize(NormalizeAvailableFactors(request.AvailableFactors));
+        settings.UpdatedAt = DateTime.UtcNow;
+        await _context.SaveChangesAsync(cancellationToken);
+        return ToMfaSettingsDto(settings, _options.MfaSeed != null);
+    }
+
+    public async Task<SqlOSOrganizationMfaPolicyDto> GetOrganizationMfaPolicyAsync(string organizationId, CancellationToken cancellationToken = default)
+    {
+        var organization = await _context.Set<SqlOSOrganization>()
+            .FirstOrDefaultAsync(x => x.Id == organizationId || x.Slug == organizationId, cancellationToken)
+            ?? throw new InvalidOperationException("Organization not found.");
+
+        await EnsureDefaultMfaSettingsAsync(cancellationToken);
+        var global = await _context.Set<SqlOSMfaSettings>().FirstAsync(x => x.Id == "default", cancellationToken);
+        var policy = await _context.Set<SqlOSOrganizationMfaPolicy>()
+            .FirstOrDefaultAsync(x => x.OrganizationId == organization.Id, cancellationToken);
+
+        return ToOrganizationMfaPolicyDto(organization, policy, global);
+    }
+
+    public async Task<SqlOSOrganizationMfaPolicyDto> UpdateOrganizationMfaPolicyAsync(
+        string organizationId,
+        SqlOSUpdateOrganizationMfaPolicyRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var organization = await _context.Set<SqlOSOrganization>()
+            .FirstOrDefaultAsync(x => x.Id == organizationId || x.Slug == organizationId, cancellationToken)
+            ?? throw new InvalidOperationException("Organization not found.");
+
+        var policy = await _context.Set<SqlOSOrganizationMfaPolicy>()
+            .FirstOrDefaultAsync(x => x.OrganizationId == organization.Id, cancellationToken);
+        if (policy == null)
+        {
+            policy = new SqlOSOrganizationMfaPolicy { OrganizationId = organization.Id };
+            _context.Set<SqlOSOrganizationMfaPolicy>().Add(policy);
+        }
+
+        policy.IsEnabled = request.IsEnabled;
+        policy.RequireMfaForAllUsers = request.RequireMfaForAllUsers;
+        policy.RequireMfaForOwnersAndAdmins = request.RequireMfaForOwnersAndAdmins;
+        policy.UserSelfEnrollmentEnabled = request.UserSelfEnrollmentEnabled;
+        policy.RecoveryCodesEnabled = request.RecoveryCodesEnabled;
+        policy.RequiredRolesJson = JsonSerializer.Serialize(NormalizeList(request.RequiredRoles, ["owner", "admin"]));
+        policy.AvailableFactorsJson = JsonSerializer.Serialize(NormalizeAvailableFactors(request.AvailableFactors));
+        policy.UpdatedAt = DateTime.UtcNow;
+        await _context.SaveChangesAsync(cancellationToken);
+
+        return await GetOrganizationMfaPolicyAsync(organization.Id, cancellationToken);
+    }
+
     public async Task<SqlOSSecuritySettingsDto> GetSecuritySettingsAsync(CancellationToken cancellationToken = default)
     {
         await EnsureDefaultSettingsAsync(cancellationToken);
@@ -356,6 +506,71 @@ public sealed class SqlOSSettingsService
             return ["password"];
         }
     }
+
+    private static string[] DeserializeStringArray(string json, string[] fallback)
+    {
+        try
+        {
+            return NormalizeList(JsonSerializer.Deserialize<string[]>(json), fallback);
+        }
+        catch
+        {
+            return fallback;
+        }
+    }
+
+    private static string[] NormalizeList(IEnumerable<string>? values, string[] fallback)
+    {
+        var normalized = (values ?? Array.Empty<string>())
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .Select(static value => value.Trim().ToLowerInvariant())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        return normalized.Length == 0 ? fallback : normalized;
+    }
+
+    private static string[] NormalizeAvailableFactors(IEnumerable<string>? values)
+    {
+        var normalized = NormalizeList(values, [SqlOSMfaFactorTypes.Totp, SqlOSMfaFactorTypes.RecoveryCode])
+            .Where(static value =>
+                string.Equals(value, SqlOSMfaFactorTypes.Totp, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(value, SqlOSMfaFactorTypes.RecoveryCode, StringComparison.OrdinalIgnoreCase))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        return normalized.Length == 0 ? [SqlOSMfaFactorTypes.Totp] : normalized;
+    }
+
+    private static SqlOSMfaSettingsDto ToMfaSettingsDto(SqlOSMfaSettings settings, bool managedByStartupSeed)
+        => new(
+            settings.Enabled,
+            settings.TotpEnabled,
+            settings.UserSelfEnrollmentEnabled,
+            settings.RecoveryCodesEnabled,
+            settings.RequireForAllUsers,
+            settings.RequireForOwnersAndAdmins,
+            DeserializeStringArray(settings.RequiredRolesJson, ["owner", "admin"]),
+            DeserializeStringArray(settings.AvailableFactorsJson, [SqlOSMfaFactorTypes.Totp, SqlOSMfaFactorTypes.RecoveryCode]),
+            settings.UpdatedAt,
+            managedByStartupSeed);
+
+    private static SqlOSOrganizationMfaPolicyDto ToOrganizationMfaPolicyDto(
+        SqlOSOrganization organization,
+        SqlOSOrganizationMfaPolicy? policy,
+        SqlOSMfaSettings global)
+        => new(
+            organization.Id,
+            organization.Slug,
+            organization.Name,
+            policy?.IsEnabled ?? false,
+            policy?.RequireMfaForAllUsers ?? global.RequireForAllUsers,
+            policy?.RequireMfaForOwnersAndAdmins ?? global.RequireForOwnersAndAdmins,
+            policy?.UserSelfEnrollmentEnabled ?? global.UserSelfEnrollmentEnabled,
+            policy?.RecoveryCodesEnabled ?? global.RecoveryCodesEnabled,
+            DeserializeStringArray(policy?.RequiredRolesJson ?? global.RequiredRolesJson, ["owner", "admin"]),
+            DeserializeStringArray(policy?.AvailableFactorsJson ?? global.AvailableFactorsJson, [SqlOSMfaFactorTypes.Totp, SqlOSMfaFactorTypes.RecoveryCode]),
+            policy?.UpdatedAt ?? global.UpdatedAt);
 
     private static string RequireColor(string value, string name)
     {

--- a/src/SqlOS/AuthServer/Services/SqlOSTotpMfaService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSTotpMfaService.cs
@@ -1,0 +1,545 @@
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using QRCoder;
+using SqlOS.AuthServer.Configuration;
+using SqlOS.AuthServer.Contracts;
+using SqlOS.AuthServer.Interfaces;
+using SqlOS.AuthServer.Models;
+
+namespace SqlOS.AuthServer.Services;
+
+public sealed class SqlOSTotpMfaService
+{
+    public const string EnrollmentPurpose = "mfa_totp_enrollment";
+
+    private static readonly char[] Base32Alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567".ToCharArray();
+
+    private readonly ISqlOSAuthServerDbContext _context;
+    private readonly SqlOSCryptoService _cryptoService;
+    private readonly SqlOSMfaPolicyService _policyService;
+    private readonly SqlOSAuthServerOptions _options;
+
+    public SqlOSTotpMfaService(
+        ISqlOSAuthServerDbContext context,
+        SqlOSCryptoService cryptoService,
+        SqlOSMfaPolicyService policyService,
+        IOptions<SqlOSAuthServerOptions> options)
+    {
+        _context = context;
+        _cryptoService = cryptoService;
+        _policyService = policyService;
+        _options = options.Value;
+    }
+
+    public async Task<SqlOSMfaStatusResult> GetStatusAsync(
+        string userId,
+        string? organizationId = null,
+        CancellationToken cancellationToken = default)
+    {
+        var evaluation = await _policyService.EvaluateAsync(userId, organizationId, authenticationMethod: null, cancellationToken);
+        return new SqlOSMfaStatusResult(
+            evaluation.Enabled,
+            evaluation.RequiresMfa,
+            evaluation.EnrollmentRequired,
+            evaluation.CanSelfEnroll,
+            evaluation.HasTotp,
+            evaluation.RecoveryCodeCount,
+            evaluation.AvailableFactors,
+            evaluation.Reason);
+    }
+
+    public async Task<IReadOnlyList<SqlOSMfaAuthenticatorDto>> ListAuthenticatorsAsync(
+        string userId,
+        CancellationToken cancellationToken = default)
+        => await _context.Set<SqlOSUserAuthenticator>()
+            .AsNoTracking()
+            .Where(x => x.UserId == userId && x.RevokedAt == null)
+            .OrderByDescending(x => x.CreatedAt)
+            .Select(x => new SqlOSMfaAuthenticatorDto(
+                x.Id,
+                x.Type,
+                x.DisplayName,
+                x.IsConfirmed,
+                x.CreatedAt,
+                x.ConfirmedAt,
+                x.LastUsedAt))
+            .ToListAsync(cancellationToken);
+
+    public async Task<SqlOSTotpEnrollmentStartResult> StartEnrollmentAsync(
+        string userId,
+        string? organizationId = null,
+        string? displayName = null,
+        bool requireEnrollmentAllowed = true,
+        CancellationToken cancellationToken = default)
+    {
+        var evaluation = await _policyService.EvaluateAsync(userId, organizationId, authenticationMethod: null, cancellationToken);
+        if (!evaluation.Enabled || !evaluation.AvailableFactors.Contains(SqlOSMfaFactorTypes.Totp, StringComparer.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException("Authenticator app enrollment is not enabled.");
+        }
+
+        if (requireEnrollmentAllowed && !evaluation.CanSelfEnroll && !evaluation.EnrollmentRequired)
+        {
+            throw new InvalidOperationException("Authenticator app enrollment is not available for this account.");
+        }
+
+        var now = DateTime.UtcNow;
+        var stale = await _context.Set<SqlOSUserAuthenticator>()
+            .Where(x =>
+                x.UserId == userId
+                && x.Type == SqlOSMfaFactorTypes.Totp
+                && !x.IsConfirmed
+                && x.RevokedAt == null)
+            .ToListAsync(cancellationToken);
+        foreach (var authenticator in stale)
+        {
+            authenticator.RevokedAt = now;
+            authenticator.RevocationReason = "replaced_unconfirmed";
+        }
+
+        var secret = EncodeBase32(RandomNumberGenerator.GetBytes(_options.Mfa.Totp.SecretBytes));
+        var authenticatorId = _cryptoService.GenerateId("mfa");
+        var authenticatorName = string.IsNullOrWhiteSpace(displayName)
+            ? "Authenticator app"
+            : displayName.Trim();
+        var authenticatorRow = new SqlOSUserAuthenticator
+        {
+            Id = authenticatorId,
+            UserId = userId,
+            Type = SqlOSMfaFactorTypes.Totp,
+            DisplayName = authenticatorName,
+            SecretProtected = _cryptoService.ProtectSecret(secret),
+            SecretVersion = 1,
+            Algorithm = _options.Mfa.Totp.Algorithm,
+            Digits = _options.Mfa.Totp.Digits,
+            PeriodSeconds = _options.Mfa.Totp.PeriodSeconds,
+            IsConfirmed = false,
+            CreatedAt = now
+        };
+        _context.Set<SqlOSUserAuthenticator>().Add(authenticatorRow);
+
+        var user = await _context.Set<SqlOSUser>()
+            .AsNoTracking()
+            .FirstAsync(x => x.Id == userId, cancellationToken);
+        var token = await _cryptoService.CreateTemporaryTokenAsync(
+            EnrollmentPurpose,
+            userId,
+            clientApplicationId: null,
+            organizationId,
+            new TotpEnrollmentPayload(authenticatorId),
+            _options.Mfa.Totp.EnrollmentTokenLifetime,
+            cancellationToken);
+
+        var provisioningUri = BuildProvisioningUri(user, secret);
+
+        return new SqlOSTotpEnrollmentStartResult(
+            token,
+            authenticatorId,
+            secret,
+            provisioningUri,
+            BuildQrCodeDataUrl(provisioningUri),
+            now.Add(_options.Mfa.Totp.EnrollmentTokenLifetime));
+    }
+
+    public async Task<SqlOSTotpEnrollmentVerifyResult> VerifyEnrollmentAsync(
+        SqlOSTotpEnrollmentVerifyRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var temporaryToken = await _cryptoService.FindTemporaryTokenAsync(EnrollmentPurpose, request.EnrollmentToken, cancellationToken)
+            ?? throw new InvalidOperationException("Authenticator enrollment is invalid or expired.");
+        if (temporaryToken.UserId == null)
+        {
+            throw new InvalidOperationException("Authenticator enrollment is invalid.");
+        }
+
+        var payload = _cryptoService.DeserializePayload<TotpEnrollmentPayload>(temporaryToken)
+            ?? throw new InvalidOperationException("Authenticator enrollment payload is invalid.");
+        var authenticator = await _context.Set<SqlOSUserAuthenticator>()
+            .FirstOrDefaultAsync(x =>
+                x.Id == payload.AuthenticatorId
+                && x.UserId == temporaryToken.UserId
+                && x.Type == SqlOSMfaFactorTypes.Totp
+                && x.RevokedAt == null,
+                cancellationToken)
+            ?? throw new InvalidOperationException("Authenticator enrollment is invalid.");
+
+        if (authenticator.IsConfirmed)
+        {
+            throw new InvalidOperationException("Authenticator enrollment has already been confirmed.");
+        }
+
+        var secret = _cryptoService.UnprotectSecret(authenticator.SecretProtected);
+        if (!TryValidateTotp(secret, request.Code, authenticator.PeriodSeconds, authenticator.Digits, out var matchedStep))
+        {
+            throw new InvalidOperationException("Authenticator code is invalid.");
+        }
+
+        authenticator.IsConfirmed = true;
+        authenticator.ConfirmedAt = DateTime.UtcNow;
+        authenticator.LastUsedAt = DateTime.UtcNow;
+        authenticator.LastAcceptedTimeStep = matchedStep;
+        temporaryToken.ConsumedAt = DateTime.UtcNow;
+
+        var recoveryCodes = await ReplaceRecoveryCodesAsync(
+            temporaryToken.UserId,
+            temporaryToken.OrganizationId,
+            cancellationToken);
+        await EnsureUserOptInPolicyAsync(temporaryToken.UserId, cancellationToken);
+        await _context.SaveChangesAsync(cancellationToken);
+
+        return new SqlOSTotpEnrollmentVerifyResult(authenticator.Id, recoveryCodes);
+    }
+
+    public async Task<string> VerifySecondFactorCodeAsync(
+        string userId,
+        string code,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(code))
+        {
+            throw new InvalidOperationException("MFA code is required.");
+        }
+
+        if (await TryVerifyTotpAsync(userId, code, cancellationToken))
+        {
+            return SqlOSMfaFactorTypes.Totp;
+        }
+
+        if (await TryConsumeRecoveryCodeAsync(userId, code, cancellationToken))
+        {
+            return SqlOSMfaFactorTypes.RecoveryCode;
+        }
+
+        throw new InvalidOperationException("MFA code is invalid.");
+    }
+
+    public async Task RevokeAuthenticatorAsync(
+        string userId,
+        string authenticatorId,
+        string reason = "user_removed",
+        CancellationToken cancellationToken = default)
+    {
+        var authenticator = await _context.Set<SqlOSUserAuthenticator>()
+            .FirstOrDefaultAsync(x => x.Id == authenticatorId && x.UserId == userId && x.RevokedAt == null, cancellationToken)
+            ?? throw new InvalidOperationException("Authenticator was not found.");
+        authenticator.RevokedAt = DateTime.UtcNow;
+        authenticator.RevocationReason = reason;
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+
+    internal async Task<SqlOSTemporaryToken> GetPendingMfaTokenAsync(string mfaToken, CancellationToken cancellationToken)
+        => await _cryptoService.FindTemporaryTokenAsync(SqlOSAuthService.MfaChallengePurpose, mfaToken, cancellationToken)
+            ?? throw new InvalidOperationException("MFA challenge is invalid or expired.");
+
+    private async Task<bool> TryVerifyTotpAsync(
+        string userId,
+        string code,
+        CancellationToken cancellationToken)
+    {
+        var authenticators = await _context.Set<SqlOSUserAuthenticator>()
+            .Where(x =>
+                x.UserId == userId
+                && x.Type == SqlOSMfaFactorTypes.Totp
+                && x.IsConfirmed
+                && x.RevokedAt == null)
+            .OrderByDescending(x => x.CreatedAt)
+            .ToListAsync(cancellationToken);
+
+        foreach (var authenticator in authenticators)
+        {
+            var secret = _cryptoService.UnprotectSecret(authenticator.SecretProtected);
+            if (!TryValidateTotp(secret, code, authenticator.PeriodSeconds, authenticator.Digits, out var matchedStep))
+            {
+                continue;
+            }
+
+            if (authenticator.LastAcceptedTimeStep.HasValue && matchedStep <= authenticator.LastAcceptedTimeStep.Value)
+            {
+                continue;
+            }
+
+            authenticator.LastAcceptedTimeStep = matchedStep;
+            authenticator.LastUsedAt = DateTime.UtcNow;
+            try
+            {
+                await _context.SaveChangesAsync(cancellationToken);
+                return true;
+            }
+            catch (DbUpdateConcurrencyException)
+            {
+                throw new InvalidOperationException("MFA code has already been used.");
+            }
+        }
+
+        return false;
+    }
+
+    private async Task<bool> TryConsumeRecoveryCodeAsync(
+        string userId,
+        string code,
+        CancellationToken cancellationToken)
+    {
+        var normalized = NormalizeRecoveryCode(code);
+        if (string.IsNullOrWhiteSpace(normalized))
+        {
+            return false;
+        }
+
+        var hash = _cryptoService.HashToken(normalized);
+        var recoveryCode = await _context.Set<SqlOSRecoveryCode>()
+            .FirstOrDefaultAsync(x =>
+                x.UserId == userId
+                && x.CodeHash == hash
+                && x.ConsumedAt == null
+                && x.RevokedAt == null,
+                cancellationToken);
+        if (recoveryCode == null)
+        {
+            return false;
+        }
+
+        recoveryCode.ConsumedAt = DateTime.UtcNow;
+        try
+        {
+            await _context.SaveChangesAsync(cancellationToken);
+            return true;
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            throw new InvalidOperationException("Recovery code has already been used.");
+        }
+    }
+
+    private async Task<string[]> ReplaceRecoveryCodesAsync(
+        string userId,
+        string? organizationId,
+        CancellationToken cancellationToken)
+    {
+        var evaluation = await _policyService.EvaluateAsync(userId, organizationId, authenticationMethod: null, cancellationToken);
+        if (!evaluation.RecoveryCodesEnabled || !evaluation.AvailableFactors.Contains(SqlOSMfaFactorTypes.RecoveryCode, StringComparer.OrdinalIgnoreCase))
+        {
+            return [];
+        }
+
+        var existing = await _context.Set<SqlOSRecoveryCode>()
+            .Where(x => x.UserId == userId && x.ConsumedAt == null && x.RevokedAt == null)
+            .ToListAsync(cancellationToken);
+        foreach (var recoveryCode in existing)
+        {
+            recoveryCode.RevokedAt = DateTime.UtcNow;
+        }
+
+        var rawCodes = Enumerable.Range(0, _options.Mfa.Totp.RecoveryCodeCount)
+            .Select(_ => FormatRecoveryCode(EncodeBase32(RandomNumberGenerator.GetBytes(8))[..10]))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        foreach (var rawCode in rawCodes)
+        {
+            _context.Set<SqlOSRecoveryCode>().Add(new SqlOSRecoveryCode
+            {
+                Id = _cryptoService.GenerateId("mrc"),
+                UserId = userId,
+                CodeHash = _cryptoService.HashToken(NormalizeRecoveryCode(rawCode)),
+                CreatedAt = DateTime.UtcNow
+            });
+        }
+
+        return rawCodes;
+    }
+
+    private async Task EnsureUserOptInPolicyAsync(string userId, CancellationToken cancellationToken)
+    {
+        var userOverride = await _context.Set<SqlOSUserMfaPolicyOverride>()
+            .FirstOrDefaultAsync(x => x.UserId == userId, cancellationToken);
+        if (userOverride == null)
+        {
+            _context.Set<SqlOSUserMfaPolicyOverride>().Add(new SqlOSUserMfaPolicyOverride
+            {
+                UserId = userId,
+                RequireMfa = true,
+                UpdatedAt = DateTime.UtcNow
+            });
+            return;
+        }
+
+        if (userOverride.RequireMfa == null)
+        {
+            userOverride.RequireMfa = true;
+            userOverride.UpdatedAt = DateTime.UtcNow;
+        }
+    }
+
+    private string BuildProvisioningUri(SqlOSUser user, string secret)
+    {
+        var issuer = string.IsNullOrWhiteSpace(_options.Mfa.Totp.Issuer)
+            ? "SqlOS"
+            : _options.Mfa.Totp.Issuer.Trim();
+        var account = string.IsNullOrWhiteSpace(user.DefaultEmail)
+            ? user.Id
+            : user.DefaultEmail;
+        var label = $"{Uri.EscapeDataString(issuer)}:{Uri.EscapeDataString(account)}";
+        var query = string.Join("&", new[]
+        {
+            $"secret={Uri.EscapeDataString(secret)}",
+            $"issuer={Uri.EscapeDataString(issuer)}",
+            $"algorithm={Uri.EscapeDataString(_options.Mfa.Totp.Algorithm)}",
+            $"digits={_options.Mfa.Totp.Digits.ToString(CultureInfo.InvariantCulture)}",
+            $"period={_options.Mfa.Totp.PeriodSeconds.ToString(CultureInfo.InvariantCulture)}"
+        });
+
+        return $"otpauth://totp/{label}?{query}";
+    }
+
+    private static string BuildQrCodeDataUrl(string value)
+    {
+        using var generator = new QRCodeGenerator();
+        using var data = generator.CreateQrCode(value, QRCodeGenerator.ECCLevel.Q);
+        var svg = new SvgQRCode(data).GetGraphic(5);
+        return $"data:image/svg+xml;charset=utf-8,{Uri.EscapeDataString(svg)}";
+    }
+
+    private bool TryValidateTotp(
+        string secret,
+        string code,
+        int periodSeconds,
+        int digits,
+        out long matchedStep)
+    {
+        matchedStep = 0;
+        var normalizedCode = new string((code ?? string.Empty).Where(char.IsDigit).ToArray());
+        if (normalizedCode.Length != digits)
+        {
+            return false;
+        }
+
+        var secretBytes = DecodeBase32(secret);
+        var nowStep = DateTimeOffset.UtcNow.ToUnixTimeSeconds() / periodSeconds;
+        for (var offset = -_options.Mfa.Totp.AllowedClockSkewSteps; offset <= _options.Mfa.Totp.AllowedClockSkewSteps; offset++)
+        {
+            var step = nowStep + offset;
+            var expected = ComputeTotp(secretBytes, step, digits);
+            if (CryptographicOperations.FixedTimeEquals(
+                    Encoding.ASCII.GetBytes(expected),
+                    Encoding.ASCII.GetBytes(normalizedCode)))
+            {
+                matchedStep = step;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public string GenerateCodeForTesting(string secret, DateTimeOffset? timestamp = null)
+    {
+        var step = (timestamp ?? DateTimeOffset.UtcNow).ToUnixTimeSeconds() / _options.Mfa.Totp.PeriodSeconds;
+        return ComputeTotp(DecodeBase32(secret), step, _options.Mfa.Totp.Digits);
+    }
+
+    private static string ComputeTotp(byte[] secret, long timeStep, int digits)
+    {
+        Span<byte> counter = stackalloc byte[8];
+        BitConverter.TryWriteBytes(counter, timeStep);
+        if (BitConverter.IsLittleEndian)
+        {
+            counter.Reverse();
+        }
+
+        var hash = HMACSHA1.HashData(secret, counter);
+        var offset = hash[^1] & 0x0f;
+        var binary =
+            ((hash[offset] & 0x7f) << 24)
+            | ((hash[offset + 1] & 0xff) << 16)
+            | ((hash[offset + 2] & 0xff) << 8)
+            | (hash[offset + 3] & 0xff);
+        var modulo = (int)Math.Pow(10, digits);
+        return (binary % modulo).ToString(CultureInfo.InvariantCulture).PadLeft(digits, '0');
+    }
+
+    private static string EncodeBase32(byte[] data)
+    {
+        if (data.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        var output = new StringBuilder((data.Length * 8 + 4) / 5);
+        var buffer = data[0] & 0xff;
+        var next = 1;
+        var bitsLeft = 8;
+        while (bitsLeft > 0 || next < data.Length)
+        {
+            if (bitsLeft < 5)
+            {
+                if (next < data.Length)
+                {
+                    buffer <<= 8;
+                    buffer |= data[next++] & 0xff;
+                    bitsLeft += 8;
+                }
+                else
+                {
+                    var pad = 5 - bitsLeft;
+                    buffer <<= pad;
+                    bitsLeft += pad;
+                }
+            }
+
+            var index = 0x1f & (buffer >> (bitsLeft - 5));
+            bitsLeft -= 5;
+            output.Append(Base32Alphabet[index]);
+        }
+
+        return output.ToString();
+    }
+
+    private static byte[] DecodeBase32(string input)
+    {
+        var cleaned = new string((input ?? string.Empty)
+            .Where(char.IsLetterOrDigit)
+            .Select(char.ToUpperInvariant)
+            .ToArray());
+        if (cleaned.Length == 0)
+        {
+            return [];
+        }
+
+        var bytes = new List<byte>();
+        var buffer = 0;
+        var bitsLeft = 0;
+        foreach (var character in cleaned)
+        {
+            var value = Array.IndexOf(Base32Alphabet, character);
+            if (value < 0)
+            {
+                throw new InvalidOperationException("Authenticator secret is invalid.");
+            }
+
+            buffer <<= 5;
+            buffer |= value & 0x1f;
+            bitsLeft += 5;
+            if (bitsLeft >= 8)
+            {
+                bytes.Add((byte)(buffer >> (bitsLeft - 8)));
+                bitsLeft -= 8;
+            }
+        }
+
+        return bytes.ToArray();
+    }
+
+    private static string NormalizeRecoveryCode(string code)
+        => new((code ?? string.Empty)
+            .Where(char.IsLetterOrDigit)
+            .Select(char.ToUpperInvariant)
+            .ToArray());
+
+    private static string FormatRecoveryCode(string code)
+        => $"{code[..5]}-{code[5..10]}";
+
+    private sealed record TotpEnrollmentPayload(string AuthenticatorId);
+}

--- a/src/SqlOS/Dashboard/wwwroot/app.js
+++ b/src/SqlOS/Dashboard/wwwroot/app.js
@@ -46,6 +46,7 @@
         clients: { title: "Applications", description: "Manage owned apps, client metadata, access assignments, and lifecycle actions." },
         oidc: { title: "Social Login", description: "Configure Google, Microsoft, Apple, and custom OIDC providers for authserver-owned social login." },
         security: { title: "Security", description: "Tune refresh, idle, and absolute session lifetimes." },
+        mfa: { title: "MFA", description: "Configure authenticator app enrollment and second-factor requirements." },
         authpage: { title: "Auth Page", description: "Brand the hosted authorization page and publish the login, signup, and PKCE endpoints your app exposes." },
         sessions: { title: "Sessions", description: "Inspect active sessions and authentication methods." },
         audit: { title: "Audit Events", description: "Review recent auth and admin activity." }
@@ -1112,6 +1113,7 @@
                         ${quickLink("auth-users", "Users")}
                         ${quickLink("auth-oidc", "OIDC")}
                         ${quickLink("auth-security", "Security")}
+                        ${quickLink("auth-mfa", "MFA")}
                         ${quickLink("auth-authpage", "Auth Page")}
                     </div>
                 </section>
@@ -1179,6 +1181,11 @@
 
         if (view === "security") {
             await renderAuthSecurity();
+            return;
+        }
+
+        if (view === "mfa") {
+            await renderAuthMfa();
             return;
         }
 
@@ -2905,6 +2912,71 @@
                 })
             });
             setFlash("success", "Security settings saved.");
+        });
+    }
+
+    async function renderAuthMfa() {
+        const config = authViews.mfa;
+        setHeader("Auth Server", config.title, config.description);
+        renderLoading("Loading MFA settings...");
+
+        const settings = await fetchJson(`${authApiBasePath}/settings/mfa`);
+        const factors = Array.isArray(settings.availableFactors) ? settings.availableFactors.join(", ") : "totp, recovery_code";
+        const roles = Array.isArray(settings.requiredRoles) ? settings.requiredRoles.join(", ") : "owner, admin";
+
+        content.innerHTML = `
+            ${consumeFlashHtml()}
+            <div class="panel-grid">
+                <section class="panel">
+                    <h2>MFA Settings</h2>
+                    ${settings.managedByStartupSeed ? `<div class="callout"><strong>Startup managed:</strong> These values are seeded from application startup and will be reapplied on restart.</div>` : ""}
+                    <form id="mfa-settings-form">
+                        <label><input type="checkbox" name="enabled" ${settings.enabled ? "checked" : ""}> Enable MFA</label>
+                        <label><input type="checkbox" name="totpEnabled" ${settings.totpEnabled ? "checked" : ""}> Enable authenticator apps</label>
+                        <label><input type="checkbox" name="userSelfEnrollmentEnabled" ${settings.userSelfEnrollmentEnabled ? "checked" : ""}> Allow users to add MFA voluntarily</label>
+                        <label><input type="checkbox" name="recoveryCodesEnabled" ${settings.recoveryCodesEnabled ? "checked" : ""}> Issue recovery codes</label>
+                        <label><input type="checkbox" name="requireForAllUsers" ${settings.requireForAllUsers ? "checked" : ""}> Require MFA for all users</label>
+                        <label><input type="checkbox" name="requireForOwnersAndAdmins" ${settings.requireForOwnersAndAdmins ? "checked" : ""}> Require MFA for owners and admins</label>
+                        <input name="requiredRoles" placeholder="Required roles, comma separated" value="${esc(roles)}">
+                        <input name="availableFactors" placeholder="Available factors, comma separated" value="${esc(factors)}">
+                        <button type="submit">Save MFA settings</button>
+                    </form>
+                </section>
+                <section class="panel">
+                    <h2>Current Policy</h2>
+                    ${renderMetadataRows([
+                        { label: "MFA", value: settings.enabled ? "Enabled" : "Disabled" },
+                        { label: "Authenticator apps", value: settings.totpEnabled ? "Enabled" : "Disabled" },
+                        { label: "User self-enrollment", value: settings.userSelfEnrollmentEnabled ? "Enabled" : "Disabled" },
+                        { label: "Recovery codes", value: settings.recoveryCodesEnabled ? "Enabled" : "Disabled" },
+                        { label: "All users required", value: settings.requireForAllUsers ? "Yes" : "No" },
+                        { label: "Privileged roles required", value: settings.requireForOwnersAndAdmins ? "Yes" : "No" },
+                        { label: "Updated", value: formatDate(settings.updatedAt) }
+                    ])}
+                </section>
+            </div>
+        `;
+
+        bindForm("mfa-settings-form", async form => {
+            const splitList = value => String(value || "")
+                .split(",")
+                .map(item => item.trim())
+                .filter(Boolean);
+
+            await fetchJson(`${authApiBasePath}/settings/mfa`, {
+                method: "PUT",
+                body: JSON.stringify({
+                    enabled: form.get("enabled") === "on",
+                    totpEnabled: form.get("totpEnabled") === "on",
+                    userSelfEnrollmentEnabled: form.get("userSelfEnrollmentEnabled") === "on",
+                    recoveryCodesEnabled: form.get("recoveryCodesEnabled") === "on",
+                    requireForAllUsers: form.get("requireForAllUsers") === "on",
+                    requireForOwnersAndAdmins: form.get("requireForOwnersAndAdmins") === "on",
+                    requiredRoles: splitList(form.get("requiredRoles")),
+                    availableFactors: splitList(form.get("availableFactors"))
+                })
+            });
+            setFlash("success", "MFA settings saved.");
         });
     }
 

--- a/src/SqlOS/Dashboard/wwwroot/index.html
+++ b/src/SqlOS/Dashboard/wwwroot/index.html
@@ -29,6 +29,7 @@
                     <a href="#" data-route="auth-clients">Applications</a>
                     <a href="#" data-route="auth-oidc">OIDC</a>
                     <a href="#" data-route="auth-security">Security</a>
+                    <a href="#" data-route="auth-mfa">MFA</a>
                     <a href="#" data-route="auth-authpage">Auth Page</a>
                     <a href="#" data-route="auth-sessions">Sessions</a>
                     <a href="#" data-route="auth-audit">Audit Events</a>

--- a/src/SqlOS/Extensions/ServiceCollectionExtensions.cs
+++ b/src/SqlOS/Extensions/ServiceCollectionExtensions.cs
@@ -60,6 +60,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<ISqlOSOtpDeliveryChannel, SqlOSTwilioVerifyOtpChannel>();
         services.AddScoped<SqlOSPhoneOtpService>();
         services.AddScoped<SqlOSMfaPolicyService>();
+        services.AddScoped<SqlOSTotpMfaService>();
         services.AddScoped<SqlOSPasswordLoginAbuseService>();
         services.AddScoped<SqlOSInvitationService>();
         services.AddScoped<SqlOSDeviceAuthorizationService>();

--- a/src/SqlOS/Services/SqlOSBootstrapper.cs
+++ b/src/SqlOS/Services/SqlOSBootstrapper.cs
@@ -52,8 +52,10 @@ public sealed class SqlOSBootstrapper
         await _cryptoService.EnsureActiveSigningKeyAsync(cancellationToken);
         await _settingsService.EnsureDefaultSettingsAsync(cancellationToken);
         await _settingsService.EnsureDefaultAuthPageSettingsAsync(cancellationToken);
+        await _settingsService.EnsureDefaultMfaSettingsAsync(cancellationToken);
         await _settingsService.UpsertSeededAuthPageSettingsAsync(cancellationToken);
         await _settingsService.UpsertSeededAuthEmailSettingsAsync(cancellationToken);
+        await _settingsService.UpsertSeededMfaSettingsAsync(cancellationToken);
         await _emailAdminService.EnsureBuiltInTemplatesAsync(cancellationToken);
         await _adminService.UpsertSeededClientsAsync(cancellationToken);
         await _adminService.CleanupExpiredTemporaryTokensAsync(cancellationToken);

--- a/src/SqlOS/SqlOS.csproj
+++ b/src/SqlOS/SqlOS.csproj
@@ -35,6 +35,7 @@
     <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.0" />
+    <PackageReference Include="QRCoder" Version="1.8.0" />
     <PackageReference Include="Twilio" Version="7.14.9" />
   </ItemGroup>
 

--- a/tests/SqlOS.Tests/SqlOSAuthServiceTests.cs
+++ b/tests/SqlOS.Tests/SqlOSAuthServiceTests.cs
@@ -2,8 +2,10 @@ using FluentAssertions;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IdentityModel.Tokens.Jwt;
 using System.Net;
 using System.Text.RegularExpressions;
 using SqlOS.AuthServer.Configuration;
@@ -51,6 +53,273 @@ public sealed class SqlOSAuthServiceTests
         result.PendingAuthToken.Should().NotBeNullOrWhiteSpace();
         result.Tokens.Should().BeNull();
         result.Organizations.Should().HaveCount(2);
+    }
+
+    [TestMethod]
+    public async Task TotpEnrollment_WithDefaultOptionalPolicy_StoresProtectedSecretAndRecoveryCodes()
+    {
+        var harness = await TestHarness.CreateAsync();
+        var user = await harness.Admin.CreateUserAsync(new SqlOSCreateUserRequest(
+            "Mfa User",
+            $"mfa-{Guid.NewGuid():N}@example.com",
+            "P@ssword123!"));
+
+        var enrollment = await harness.Auth.StartTotpEnrollmentAsync(
+            user.Id,
+            new SqlOSTotpEnrollmentStartRequest("Test Authenticator"));
+        var code = harness.Totp.GenerateCodeForTesting(enrollment.Secret);
+        var result = await harness.Auth.VerifyTotpEnrollmentAsync(
+            new SqlOSTotpEnrollmentVerifyRequest(enrollment.EnrollmentToken, code),
+            CreatePasswordHttpContext("203.0.113.200"));
+
+        result.AuthenticatorId.Should().Be(enrollment.AuthenticatorId);
+        result.RecoveryCodes.Should().HaveCount(harness.Options.Mfa.Totp.RecoveryCodeCount);
+        enrollment.ProvisioningUri.Should().StartWith("otpauth://totp/");
+        enrollment.QrCodeDataUrl.Should().StartWith("data:image/svg+xml;charset=utf-8,");
+        Uri.UnescapeDataString(enrollment.QrCodeDataUrl).Should().Contain("<svg");
+
+        var row = await harness.Context.Set<SqlOSUserAuthenticator>()
+            .SingleAsync(x => x.Id == enrollment.AuthenticatorId);
+        row.IsConfirmed.Should().BeTrue();
+        row.SecretProtected.Should().StartWith("dp:");
+        row.SecretProtected.Should().NotContain(enrollment.Secret);
+
+        var status = await harness.Auth.GetMfaStatusAsync(user.Id);
+        status.MfaEnabled.Should().BeTrue();
+        status.Required.Should().BeTrue();
+        status.EnrollmentRequired.Should().BeFalse();
+        status.HasTotp.Should().BeTrue();
+        status.RecoveryCodeCount.Should().Be(harness.Options.Mfa.Totp.RecoveryCodeCount);
+    }
+
+    [TestMethod]
+    public async Task HeadlessPasswordLogin_WhenMfaEnrollmentRequired_ReturnsTotpEnrollmentQrCode()
+    {
+        var harness = await TestHarness.CreateAsync(configure: options =>
+        {
+            options.Mfa.Enabled = true;
+            options.Mfa.RequireForAllUsersByDefault = true;
+            options.Mfa.AllowUserSelfEnrollmentByDefault = true;
+            options.Mfa.RecoveryCodesEnabledByDefault = true;
+            options.UseHeadlessAuthPage(headless =>
+            {
+                headless.BuildUiUrl = ctx =>
+                    $"https://app.example.test/authorize?request={Uri.EscapeDataString(ctx.RequestId ?? string.Empty)}&view={Uri.EscapeDataString(ctx.View)}";
+            });
+        });
+        var user = await harness.Admin.CreateUserAsync(new SqlOSCreateUserRequest(
+            "Headless MFA",
+            $"headless-mfa-{Guid.NewGuid():N}@example.com",
+            "P@ssword123!"));
+        var authorizationRequest = await harness.Authorization.CreateAuthorizationRequestAsync(
+            new SqlOSAuthorizeRequestInput(
+                "code",
+                "test-client",
+                "https://client.example.test/callback",
+                "headless-mfa",
+                "openid profile email",
+                "challenge-headless-mfa",
+                "S256",
+                null,
+                user.DefaultEmail,
+                null,
+                null,
+                "headless",
+                null));
+
+        var loginResult = await harness.Headless.PasswordLoginAsync(
+            CreatePasswordHttpContext("203.0.113.210"),
+            new SqlOSHeadlessPasswordLoginRequest(
+                authorizationRequest.Id,
+                user.DefaultEmail!,
+                "P@ssword123!"));
+
+        loginResult.Type.Should().Be("view");
+        loginResult.ViewModel.Should().NotBeNull();
+        loginResult.ViewModel!.View.Should().Be("mfa-enroll");
+        loginResult.ViewModel.MfaToken.Should().NotBeNullOrWhiteSpace();
+        loginResult.ViewModel.RequiresMfaEnrollment.Should().BeTrue();
+        loginResult.ViewModel.TotpEnrollment.Should().NotBeNull();
+        loginResult.ViewModel.TotpEnrollment!.QrCodeDataUrl.Should().StartWith("data:image/svg+xml;charset=utf-8,");
+
+        var verificationCode = harness.Totp.GenerateCodeForTesting(loginResult.ViewModel.TotpEnrollment.Secret);
+        var verifyResult = await harness.Headless.VerifyMfaTotpEnrollmentAsync(
+            CreatePasswordHttpContext("203.0.113.210"),
+            new SqlOSHeadlessMfaTotpEnrollmentVerifyRequest(
+                authorizationRequest.Id,
+                loginResult.ViewModel.MfaToken!,
+                loginResult.ViewModel.TotpEnrollment.EnrollmentToken,
+                verificationCode));
+
+        verifyResult.Type.Should().Be("redirect");
+        verifyResult.RedirectUrl.Should().StartWith("https://client.example.test/callback");
+        verifyResult.RedirectUrl.Should().Contain("code=");
+    }
+
+    [TestMethod]
+    public async Task HeadlessPasswordLogin_WhenUserHasTotp_ReturnsMfaChallengeAndCompletes()
+    {
+        var harness = await TestHarness.CreateAsync(configure: options =>
+        {
+            options.Mfa.Enabled = true;
+            options.Mfa.AllowUserSelfEnrollmentByDefault = true;
+            options.Mfa.RecoveryCodesEnabledByDefault = true;
+            options.UseHeadlessAuthPage(headless =>
+            {
+                headless.BuildUiUrl = ctx =>
+                    $"https://app.example.test/authorize?request={Uri.EscapeDataString(ctx.RequestId ?? string.Empty)}&view={Uri.EscapeDataString(ctx.View)}";
+            });
+        });
+        var user = await harness.Admin.CreateUserAsync(new SqlOSCreateUserRequest(
+            "Headless MFA Challenge",
+            $"headless-mfa-challenge-{Guid.NewGuid():N}@example.com",
+            "P@ssword123!"));
+        var enrollment = await harness.Auth.StartTotpEnrollmentAsync(
+            user.Id,
+            new SqlOSTotpEnrollmentStartRequest("Challenge Authenticator"));
+        var enrollmentCode = harness.Totp.GenerateCodeForTesting(enrollment.Secret);
+        await harness.Auth.VerifyTotpEnrollmentAsync(
+            new SqlOSTotpEnrollmentVerifyRequest(enrollment.EnrollmentToken, enrollmentCode),
+            CreatePasswordHttpContext("203.0.113.211"));
+        var authorizationRequest = await harness.Authorization.CreateAuthorizationRequestAsync(
+            new SqlOSAuthorizeRequestInput(
+                "code",
+                "test-client",
+                "https://client.example.test/callback",
+                "headless-mfa-challenge",
+                "openid profile email",
+                "challenge-headless-mfa-challenge",
+                "S256",
+                null,
+                user.DefaultEmail,
+                null,
+                null,
+                "headless",
+                null));
+
+        var loginResult = await harness.Headless.PasswordLoginAsync(
+            CreatePasswordHttpContext("203.0.113.211"),
+            new SqlOSHeadlessPasswordLoginRequest(
+                authorizationRequest.Id,
+                user.DefaultEmail!,
+                "P@ssword123!"));
+
+        loginResult.Type.Should().Be("view");
+        loginResult.ViewModel.Should().NotBeNull();
+        loginResult.ViewModel!.View.Should().Be("mfa");
+        loginResult.ViewModel.MfaToken.Should().NotBeNullOrWhiteSpace();
+        loginResult.ViewModel.RequiresMfaEnrollment.Should().BeFalse();
+        loginResult.ViewModel.TotpEnrollment.Should().BeNull();
+        loginResult.ViewModel.MfaMethods.Should().NotBeNull();
+        loginResult.ViewModel.MfaMethods!.Should().Contain(SqlOSMfaFactorTypes.Totp);
+
+        var challengeCode = harness.Totp.GenerateCodeForTesting(
+            enrollment.Secret,
+            DateTimeOffset.UtcNow.AddSeconds(harness.Options.Mfa.Totp.PeriodSeconds));
+        var verifyResult = await harness.Headless.VerifyMfaAsync(
+            CreatePasswordHttpContext("203.0.113.211"),
+            new SqlOSHeadlessMfaVerifyRequest(
+                authorizationRequest.Id,
+                loginResult.ViewModel.MfaToken!,
+                challengeCode));
+
+        verifyResult.Type.Should().Be("redirect");
+        verifyResult.RedirectUrl.Should().StartWith("https://client.example.test/callback");
+        verifyResult.RedirectUrl.Should().Contain("code=");
+    }
+
+    [TestMethod]
+    public async Task LoginWithPassword_WhenOrganizationRequiresMfa_ForcesEnrollmentBeforeTokens()
+    {
+        var harness = await TestHarness.CreateAsync();
+        var user = await harness.Admin.CreateUserAsync(new SqlOSCreateUserRequest(
+            "Required Mfa User",
+            $"required-mfa-{Guid.NewGuid():N}@example.com",
+            "P@ssword123!"));
+        var org = await harness.Admin.CreateOrganizationAsync(new SqlOSCreateOrganizationRequest("MFA Required Org", null));
+        await harness.Admin.CreateMembershipAsync(org.Id, new SqlOSCreateMembershipRequest(user.Id, "member"));
+        await harness.Settings.UpdateOrganizationMfaPolicyAsync(
+            org.Id,
+            new SqlOSUpdateOrganizationMfaPolicyRequest(
+                IsEnabled: true,
+                RequireMfaForAllUsers: true,
+                RequireMfaForOwnersAndAdmins: false,
+                UserSelfEnrollmentEnabled: true,
+                RecoveryCodesEnabled: true,
+                RequiredRoles: ["owner", "admin"],
+                AvailableFactors: [SqlOSMfaFactorTypes.Totp, SqlOSMfaFactorTypes.RecoveryCode]));
+
+        var login = await harness.Auth.LoginWithPasswordAsync(
+            new SqlOSPasswordLoginRequest(user.DefaultEmail!, "P@ssword123!", "test-client", org.Id),
+            CreatePasswordHttpContext("203.0.113.201"));
+
+        login.RequiresMfa.Should().BeTrue();
+        login.RequiresMfaEnrollment.Should().BeTrue();
+        login.MfaToken.Should().NotBeNullOrWhiteSpace();
+        login.Tokens.Should().BeNull();
+
+        var enrollment = await harness.Auth.StartTotpEnrollmentForChallengeAsync(
+            login.MfaToken!,
+            new SqlOSTotpEnrollmentStartRequest("Required Authenticator"));
+        var code = harness.Totp.GenerateCodeForTesting(enrollment.Secret);
+        var verified = await harness.Auth.VerifyTotpEnrollmentAsync(
+            new SqlOSTotpEnrollmentVerifyRequest(enrollment.EnrollmentToken, code, login.MfaToken),
+            CreatePasswordHttpContext("203.0.113.201"));
+
+        verified.Tokens.Should().NotBeNull();
+        var jwt = new JwtSecurityTokenHandler().ReadJwtToken(verified.Tokens!.AccessToken);
+        jwt.Claims.Where(x => x.Type == "amr").Select(x => x.Value)
+            .Should().BeEquivalentTo("password", "totp");
+    }
+
+    [TestMethod]
+    public async Task RecoveryCode_CanSatisfyMfaOnlyOnce()
+    {
+        var harness = await TestHarness.CreateAsync();
+        var user = await harness.Admin.CreateUserAsync(new SqlOSCreateUserRequest(
+            "Recovery User",
+            $"recovery-{Guid.NewGuid():N}@example.com",
+            "P@ssword123!"));
+        var org = await harness.Admin.CreateOrganizationAsync(new SqlOSCreateOrganizationRequest("Recovery MFA Org", null));
+        await harness.Admin.CreateMembershipAsync(org.Id, new SqlOSCreateMembershipRequest(user.Id, "member"));
+        await harness.Settings.UpdateOrganizationMfaPolicyAsync(
+            org.Id,
+            new SqlOSUpdateOrganizationMfaPolicyRequest(
+                IsEnabled: true,
+                RequireMfaForAllUsers: true,
+                RequireMfaForOwnersAndAdmins: false,
+                UserSelfEnrollmentEnabled: true,
+                RecoveryCodesEnabled: true,
+                RequiredRoles: ["owner", "admin"],
+                AvailableFactors: [SqlOSMfaFactorTypes.Totp, SqlOSMfaFactorTypes.RecoveryCode]));
+
+        var enrollment = await harness.Auth.StartTotpEnrollmentAsync(
+            user.Id,
+            new SqlOSTotpEnrollmentStartRequest("Recovery Authenticator"),
+            org.Id);
+        var enrollmentCode = harness.Totp.GenerateCodeForTesting(enrollment.Secret);
+        var enrollmentResult = await harness.Auth.VerifyTotpEnrollmentAsync(
+            new SqlOSTotpEnrollmentVerifyRequest(enrollment.EnrollmentToken, enrollmentCode),
+            CreatePasswordHttpContext("203.0.113.202"));
+        var recoveryCode = enrollmentResult.RecoveryCodes.First();
+
+        var firstLogin = await harness.Auth.LoginWithPasswordAsync(
+            new SqlOSPasswordLoginRequest(user.DefaultEmail!, "P@ssword123!", "test-client", org.Id),
+            CreatePasswordHttpContext("203.0.113.202"));
+        var firstVerify = await harness.Auth.VerifyMfaChallengeAsync(
+            new SqlOSMfaChallengeVerifyRequest(firstLogin.MfaToken!, recoveryCode),
+            CreatePasswordHttpContext("203.0.113.202"));
+        firstVerify.Tokens.Should().NotBeNull();
+
+        var secondLogin = await harness.Auth.LoginWithPasswordAsync(
+            new SqlOSPasswordLoginRequest(user.DefaultEmail!, "P@ssword123!", "test-client", org.Id),
+            CreatePasswordHttpContext("203.0.113.202"));
+        var act = async () => await harness.Auth.VerifyMfaChallengeAsync(
+            new SqlOSMfaChallengeVerifyRequest(secondLogin.MfaToken!, recoveryCode),
+            CreatePasswordHttpContext("203.0.113.202"));
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("MFA code is invalid.");
     }
 
     [TestMethod]
@@ -1318,8 +1587,12 @@ public sealed class SqlOSAuthServiceTests
         public required TestSqlOSInMemoryDbContext Context { get; init; }
         public required SqlOSAuthService Auth { get; init; }
         public required SqlOSAuthorizationServerService Authorization { get; init; }
+        public required SqlOSHeadlessAuthService Headless { get; init; }
         public required SqlOSAdminService Admin { get; init; }
         public required SqlOSCryptoService Crypto { get; init; }
+        public required SqlOSSettingsService Settings { get; init; }
+        public required SqlOSMfaPolicyService MfaPolicy { get; init; }
+        public required SqlOSTotpMfaService Totp { get; init; }
         public required SqlOSAuthServerOptions Options { get; init; }
 
         public static async Task<TestHarness> CreateAsync(
@@ -1347,6 +1620,8 @@ public sealed class SqlOSAuthServiceTests
             var settings = new SqlOSSettingsService(context, options, emailSender);
             var emailOtp = new SqlOSEmailOtpService(context, admin, crypto, settings, emailSender, options);
             var passwordAbuse = new SqlOSPasswordLoginAbuseService(context, admin, crypto, options);
+            var mfaPolicy = new SqlOSMfaPolicyService(context, settings, options);
+            var totp = new SqlOSTotpMfaService(context, crypto, mfaPolicy, options);
             var auth = new SqlOSAuthService(
                 context,
                 options,
@@ -1354,7 +1629,9 @@ public sealed class SqlOSAuthServiceTests
                 crypto,
                 settings,
                 emailOtp,
-                passwordLoginAbuseService: passwordAbuse);
+                passwordLoginAbuseService: passwordAbuse,
+                mfaPolicyService: mfaPolicy,
+                totpMfaService: totp);
             var authPageSession = new SqlOSAuthPageSessionService(context, crypto, settings);
             var authorization = new SqlOSAuthorizationServerService(
                 context,
@@ -1364,18 +1641,52 @@ public sealed class SqlOSAuthServiceTests
                 settings,
                 authPageSession,
                 options,
-                passwordLoginAbuseService: passwordAbuse);
+                passwordLoginAbuseService: passwordAbuse,
+                mfaPolicyService: mfaPolicy,
+                totpMfaService: totp);
+            var discovery = new SqlOSHomeRealmDiscoveryService(context);
+            var oidcAuth = new SqlOSOidcAuthService(
+                context,
+                admin,
+                crypto,
+                new FakeOidcProviderHttpClientFactory(),
+                NullLogger<SqlOSOidcAuthService>.Instance);
+            var saml = new SqlOSSamlService(context, options, admin, crypto);
+            var oidcBrowserAuth = new SqlOSOidcBrowserAuthService(
+                context,
+                admin,
+                auth,
+                authorization,
+                crypto,
+                oidcAuth,
+                options);
+            var headless = new SqlOSHeadlessAuthService(
+                context,
+                admin,
+                authorization,
+                discovery,
+                oidcBrowserAuth,
+                saml,
+                settings,
+                emailOtp,
+                options,
+                authService: auth);
 
             await crypto.EnsureActiveSigningKeyAsync();
             await admin.UpsertSeededClientsAsync();
+            await settings.UpsertSeededMfaSettingsAsync();
 
             return new TestHarness
             {
                 Context = context,
                 Auth = auth,
                 Authorization = authorization,
+                Headless = headless,
                 Admin = admin,
                 Crypto = crypto,
+                Settings = settings,
+                MfaPolicy = mfaPolicy,
+                Totp = totp,
                 Options = authOptions
             };
         }

--- a/web/content/blog/application-assignments-auth-server-control-plane.mdx
+++ b/web/content/blog/application-assignments-auth-server-control-plane.mdx
@@ -2,7 +2,7 @@
 title: "Application Assignments: The Missing Layer Between Clients and Audiences"
 description: "SqlOS application assignments answer who can use each app, without confusing that decision with OAuth clients or token audiences."
 date: "2026-06-01"
-author: "SqlOS Team"
+author: "Ross Slaney"
 tags: ["AuthServer", "OAuth", "Applications", "SqlOS"]
 ---
 

--- a/web/content/blog/developers-guide-to-hierarchical-rbac.mdx
+++ b/web/content/blog/developers-guide-to-hierarchical-rbac.mdx
@@ -2,7 +2,7 @@
 title: "The Developer's Guide to Hierarchical RBAC"
 description: "Learn how hierarchical role-based access control works and why it's essential for modern multi-tenant applications."
 date: "2026-03-01"
-author: "SqlOS Team"
+author: "Ross Slaney"
 tags: ["RBAC", "Authorization", "Architecture"]
 ---
 

--- a/web/content/blog/headless-auth-server-mode.mdx
+++ b/web/content/blog/headless-auth-server-mode.mdx
@@ -2,7 +2,7 @@
 title: "Headless Auth Server Mode: Keep OAuth, Own the UI"
 description: "Hosted login is the fast default. When you need your own authorize UI, SqlOS headless keeps OAuth in SqlOS and the pixels in your app."
 date: "2026-03-17"
-author: "SqlOS Team"
+author: "Ross Slaney"
 tags: ["OAuth", "AuthServer", "SqlOS", "Headless UI"]
 ---
 

--- a/web/content/blog/mfa-totp-policy-auth-server.mdx
+++ b/web/content/blog/mfa-totp-policy-auth-server.mdx
@@ -1,0 +1,185 @@
+---
+title: "MFA Policy: The Auth Server Has to Own the Second Step"
+description: "SqlOS MFA starts optional, can be disabled, and can be required globally or per tenant without making every app rebuild the same TOTP state machine."
+date: "2026-06-05T12:00:00-07:00"
+author: "Ross Slaney"
+tags: ["AuthServer", "MFA", "Security", "SqlOS"]
+---
+
+Authenticator-app MFA looks small until you try to productize it.
+
+The first screen is easy: show a QR code, ask for a 6-digit code.
+
+The hard part is deciding who is allowed to enroll, who is required to enroll, what happens when policy changes, what a headless login page should render, and how a tenant admin can enforce the rule without rewriting the application.
+
+SqlOS now treats MFA as auth-server policy, not as a one-off form.
+
+## Optional by default
+
+Most products should not start by forcing every user through MFA.
+
+They should start by allowing it.
+
+SqlOS defaults to:
+
+| Setting | Default |
+| --- | --- |
+| MFA available | yes |
+| User self-enrollment | yes |
+| Recovery codes | yes |
+| Required for every user | no |
+| Required for owners/admins | no |
+| Factor | authenticator app TOTP |
+
+That gives users the security option without surprising every tenant on day one.
+
+Admins can still disable MFA completely. A developer can also disable it in startup code if the product is not ready to expose it.
+
+## Policy before tokens
+
+MFA is enforced at the auth server boundary.
+
+After the primary credential succeeds, SqlOS evaluates policy before it issues an authorization code or token.
+
+That matters because every login surface gets the same decision:
+
+- hosted OAuth pages
+- headless authorize pages
+- direct password APIs
+- organization selection
+- signup and OTP completion paths
+
+The app should not have to remember to check MFA in five different places.
+
+## Global and tenant policy
+
+There are two policy levels:
+
+| Level | Use it for |
+| --- | --- |
+| Global MFA settings | Product-wide defaults and availability |
+| Organization MFA policy | Tenant-specific enforcement |
+
+A tenant can require MFA for everyone. Another tenant can require it only for owners and admins. A third tenant can leave it optional.
+
+That is the shape SaaS products usually need.
+
+## The two runtime states
+
+Required MFA has two different states.
+
+The user may already have a confirmed authenticator:
+
+```json
+{
+  "requiresMfa": true,
+  "requiresMfaEnrollment": false,
+  "mfaMethods": ["totp", "recovery_code"]
+}
+```
+
+That becomes a challenge screen.
+
+Or the user may have no factor yet:
+
+```json
+{
+  "requiresMfa": true,
+  "requiresMfaEnrollment": true,
+  "mfaMethods": ["totp"]
+}
+```
+
+That becomes forced enrollment. Hosted auth renders the QR code. Headless auth returns the same enrollment payload so the app can render it.
+
+## Headless still means state machine
+
+Headless auth does not mean your React app owns authentication rules.
+
+It means your app owns the pixels.
+
+SqlOS still owns the state machine:
+
+```text
+login -> password -> mfa
+login -> password -> mfa-enroll
+login -> password -> organization -> mfa
+```
+
+The headless page renders `mfa` or `mfa-enroll` when the view model says so. It posts the code back to SqlOS. SqlOS decides whether to redirect back to the OAuth client.
+
+That is the same contract as password, Email OTP, SSO, invitations, and organization selection.
+
+## Recovery codes are not a reset plan
+
+Recovery codes are single-use bypass codes for a user who loses access to the authenticator app.
+
+They are not a reason to re-display the original TOTP secret.
+
+For a new phone, the clean paths are:
+
+- transfer codes inside the authenticator app when the old phone is available;
+- sign in with an existing factor and enroll a replacement;
+- sign in with a recovery code and re-secure the account;
+- have an administrator reset MFA if the user has neither the authenticator nor recovery codes.
+
+SqlOS V1 lands the challenge, forced enrollment, recovery-code login, and policy foundation. Richer factor management -- add another device, remove a device, admin reset, and forced re-enrollment after recovery-code login -- belongs on top of this foundation.
+
+## The developer path
+
+The simple configuration is small:
+
+```csharp
+builder.AddSqlOS<AppDbContext>(options =>
+{
+    options.AuthServer.ConfigureMfa(mfa =>
+    {
+        mfa.Enabled = true;
+        mfa.AllowUserSelfEnrollmentByDefault = true;
+        mfa.RecoveryCodesEnabledByDefault = true;
+        mfa.Totp.Issuer = "Acme";
+    });
+});
+```
+
+Require it for privileged users:
+
+```csharp
+options.AuthServer.SeedMfaPolicy(mfa =>
+{
+    mfa.Enabled = true;
+    mfa.UserSelfEnrollmentEnabled = true;
+    mfa.RecoveryCodesEnabled = true;
+    mfa.RequireForOwnersAndAdmins = true;
+    mfa.RequiredRoles = ["owner", "admin"];
+});
+```
+
+Tenant-specific policy is available through the admin API.
+
+## Why this belongs in SqlOS
+
+An auth server already knows:
+
+- which client is asking for login
+- which user authenticated
+- which organization was selected
+- which roles the user has in that organization
+- which credential method was used
+- whether tokens or auth codes are about to be issued
+
+MFA policy needs all of that context.
+
+Putting the decision in SqlOS keeps the application side small:
+
+1. Configure policy.
+2. Render the state SqlOS returns.
+3. Never issue tokens before the second step is complete.
+
+That is the right boundary for an embedded auth server.
+
+Next reading:
+
+- [MFA and TOTP](/docs/authserver/mfa-totp)
+- [Require Authenticator MFA](/docs/guides/mfa-totp)
+- [Headless Auth How-To](/docs/authserver/headless-auth-how-to)

--- a/web/content/blog/row-level-security-ef-core-sql-server-tvfs.mdx
+++ b/web/content/blog/row-level-security-ef-core-sql-server-tvfs.mdx
@@ -2,7 +2,7 @@
 title: "Row-Level Security with EF Core, SQL Server, and Table-Valued Functions"
 description: "How to implement database-level row-level security in .NET using SQL Server TVFs composed into EF Core LINQ queries — no post-load filtering, no external service calls."
 date: "2026-03-15"
-author: "SqlOS Team"
+author: "Ross Slaney"
 tags: ["Row-Level Security", "EF Core", "SQL Server", "TVF", "FGA", "RBAC", "Authorization"]
 ---
 

--- a/web/content/blog/single-application-mode-workos-style-setup.mdx
+++ b/web/content/blog/single-application-mode-workos-style-setup.mdx
@@ -2,7 +2,7 @@
 title: "Single-Application Mode: WorkOS-Style Defaults Without Giving Up SqlOS"
 description: "Most teams start with one app. SqlOS single-application mode creates the safe client, audience, redirect, scopes, and branding defaults from one product-level declaration."
 date: "2026-06-01"
-author: "SqlOS Team"
+author: "Ross Slaney"
 tags: ["AuthServer", "OAuth", "Developer Experience", "SqlOS"]
 ---
 

--- a/web/content/blog/what-an-authorization-server-needs-for-oauth-powered-mcp-servers.mdx
+++ b/web/content/blog/what-an-authorization-server-needs-for-oauth-powered-mcp-servers.mdx
@@ -2,7 +2,7 @@
 title: "What an Authorization Server Needs for OAuth-Powered MCP Servers"
 description: "If you want an MCP server to work with modern OAuth clients, your authorization server needs more than a token endpoint. Here is the practical checklist and how SqlOS maps to it today."
 date: "2026-03-15"
-author: "SqlOS Team"
+author: "Ross Slaney"
 tags: ["MCP", "OAuth", "AuthServer", "SqlOS"]
 ---
 

--- a/web/content/docs/authserver/dashboard-overview.mdx
+++ b/web/content/docs/authserver/dashboard-overview.mdx
@@ -32,6 +32,7 @@ Password mode includes dashboard-specific per-IP throttling, global backoff for 
 | OIDC | `/sqlos/admin/auth/oidc` | Configure social login providers |
 | SSO | `/sqlos/admin/auth/sso` | Set up SAML enterprise SSO |
 | Auth Page | `/sqlos/admin/auth/settings` | Configure hosted/headless credential types, AuthPage branding, and email branding |
+| MFA | `/sqlos/admin/auth/mfa` | Configure global MFA availability, TOTP, self-enrollment, recovery codes, and global requirement policy |
 | Security | `/sqlos/admin/auth/security` | Configure session and token lifetimes |
 | Sessions | `/sqlos/admin/auth/sessions` | View and manage active sessions |
 | Audit Events | `/sqlos/admin/auth/audit` | Review authentication events |
@@ -41,6 +42,24 @@ Password mode includes dashboard-specific per-IP throttling, global backoff for 
 The Auth Page settings screen includes email branding for built-in OTP and invitation emails. It stores the application name, logo data URL, primary color, accent color, and background color used by the default templates.
 
 For setup details, see [Email OTP](/docs/authserver/email-otp), [Email Invitations](/docs/authserver/invitations), and [Email Branding](/docs/authserver/email-branding).
+
+## MFA policy
+
+The MFA page controls application-wide authenticator-app policy:
+
+- enable or disable MFA;
+- enable authenticator apps;
+- allow voluntary user self-enrollment;
+- issue recovery codes;
+- require MFA for all users;
+- require MFA for owners, admins, or custom role names;
+- edit the available factor list.
+
+If MFA settings are managed by a startup seed, the dashboard shows a startup-managed callout because code/config will reapply those values on restart.
+
+Organization-specific MFA policy is available through the admin API and startup seeding in this release. Use it when one tenant requires MFA and another tenant leaves it optional.
+
+For setup details, see [MFA and TOTP](/docs/authserver/mfa-totp) and [Require Authenticator MFA](/docs/guides/mfa-totp).
 
 ## FGA pages
 

--- a/web/content/docs/authserver/headless-auth-how-to.mdx
+++ b/web/content/docs/authserver/headless-auth-how-to.mdx
@@ -228,6 +228,42 @@ await postAction("/oauth/headless/password/login", {
 });
 ```
 
+If the user or selected organization requires MFA, this call can return `view: "mfa"` or `view: "mfa-enroll"` instead of a final redirect.
+
+### MFA challenge
+
+Render this state when `model.view === "mfa"`.
+
+```tsx
+await postAction("/oauth/headless/mfa/verify", {
+  requestId: model.requestId,
+  mfaToken: model.mfaToken,
+  code,
+});
+```
+
+Use one input for both authenticator codes and recovery codes. SqlOS validates the code against the user's available factors and returns the final redirect on success.
+
+### Forced MFA enrollment
+
+Render this state when `model.view === "mfa-enroll"`.
+
+```tsx
+const enrollment = model.totpEnrollment;
+
+// Show enrollment.qrCodeDataUrl as an image.
+// Show enrollment.secret as manual setup fallback.
+
+await postAction("/oauth/headless/mfa/totp/enroll/verify", {
+  requestId: model.requestId,
+  mfaToken: model.mfaToken,
+  enrollmentToken: enrollment.enrollmentToken,
+  code,
+});
+```
+
+SqlOS starts forced enrollment before issuing the authorization code. Your UI only renders the QR code, manual setup value, and verification input.
+
 ### Email OTP sign in
 
 Use Email OTP when `model.settings.enabledCredentialTypes` includes `email_otp`. Keep home realm discovery in the loop so SSO-required domains still redirect to SSO.

--- a/web/content/docs/authserver/headless-auth.mdx
+++ b/web/content/docs/authserver/headless-auth.mdx
@@ -79,6 +79,9 @@ Your UI calls these SqlOS endpoints:
 | `POST /sqlos/auth/headless/device/approve` | Approve a CLI device request after sign-in |
 | `POST /sqlos/auth/headless/device/deny` | Deny a CLI device request |
 | `POST /sqlos/auth/headless/organization/select` | Select org for multi-org users |
+| `POST /sqlos/auth/headless/mfa/verify` | Verify a TOTP or recovery-code challenge |
+| `POST /sqlos/auth/headless/mfa/totp/enroll/start` | Start forced TOTP enrollment for an MFA challenge |
+| `POST /sqlos/auth/headless/mfa/totp/enroll/verify` | Verify forced TOTP enrollment and continue authorization |
 | `POST /sqlos/auth/headless/provider/start` | Start OIDC or SSO flow |
 
 ## CLI device flow
@@ -157,8 +160,20 @@ if (result.requiresOrganizationSelection) {
   await headlessSelectOrganization(requestId, orgId);
 }
 
-// 6. SqlOS issues the auth code and redirects back to the OAuth client
+// 6. If policy requires MFA, render request.view === "mfa" or "mfa-enroll"
+
+// 7. SqlOS issues the auth code and redirects back to the OAuth client
 ```
+
+## MFA views
+
+Headless MFA uses the same result contract as every other step.
+
+When `viewModel.view` is `mfa`, render an input for a 6-digit authenticator code or a recovery code. Post it to `/headless/mfa/verify` with `requestId`, `mfaToken`, and `code`.
+
+When `viewModel.view` is `mfa-enroll`, render authenticator setup. The view model includes `totpEnrollment` with `qrCodeDataUrl`, `secret`, `provisioningUri`, `enrollmentToken`, and `expiresAt`. Post the verification code to `/headless/mfa/totp/enroll/verify`.
+
+If your headless app does not render these views, required-MFA users will authenticate their primary credential and then stop at an unhandled state.
 
 ## Invitations
 

--- a/web/content/docs/authserver/mfa-totp.mdx
+++ b/web/content/docs/authserver/mfa-totp.mdx
@@ -1,0 +1,289 @@
+---
+title: "MFA and TOTP"
+description: "Configure authenticator-app MFA, recovery codes, and tenant enforcement."
+order: 12
+section: authserver
+---
+
+SqlOS MFA adds authenticator-app second factor checks to the AuthServer login path. The first supported strong factor is TOTP, the 6-digit code format used by Google Authenticator, Microsoft Authenticator, 1Password, Authy, and other compatible apps.
+
+The default is intentionally conservative:
+
+- MFA is enabled as an available capability.
+- Users can voluntarily enroll by default.
+- Recovery codes are issued after TOTP enrollment by default.
+- MFA is not required globally unless you configure it.
+- Admins can fully disable MFA for the application.
+- Tenant-specific requirements can override the global defaults.
+
+## Policy model
+
+SqlOS evaluates MFA after the primary authentication step and after an organization context is known.
+
+| Layer | What it controls |
+| --- | --- |
+| Code defaults | First persisted defaults for MFA availability, TOTP settings, self-enrollment, recovery codes, and global requirements |
+| Startup seed | Reapplied policy values for environments where code/config owns the setting |
+| Dashboard global settings | Live admin control for application-wide MFA settings |
+| Organization policy | Tenant-specific requirement and enrollment policy through admin API or startup seed |
+| User state | Whether the user already has a confirmed authenticator and recovery codes |
+
+If MFA is required and the user already has a confirmed authenticator, SqlOS returns a second-factor challenge. If MFA is required and the user has no confirmed authenticator, SqlOS returns a forced enrollment step before tokens or authorization codes are issued.
+
+## Configure code defaults
+
+Use `ConfigureMfa` for defaults that create the persisted MFA settings row on first boot:
+
+```csharp
+builder.AddSqlOS<AppDbContext>(options =>
+{
+    options.AuthServer.ConfigureMfa(mfa =>
+    {
+        mfa.Enabled = true;
+        mfa.AllowUserSelfEnrollmentByDefault = true;
+        mfa.RecoveryCodesEnabledByDefault = true;
+        mfa.RequireForAllUsersByDefault = false;
+        mfa.RequireForOwnersAndAdminsByDefault = false;
+        mfa.Totp.Issuer = "Contoso";
+    });
+});
+```
+
+Turn MFA off completely:
+
+```csharp
+builder.AddSqlOS<AppDbContext>(options =>
+{
+    options.AuthServer.ConfigureMfa(mfa => mfa.Disable());
+});
+```
+
+## Seed managed policy
+
+SqlOS follows the same code-defaults plus dashboard pattern used by AuthPage and email settings. Defaults initialize the row once. A seed reapplies values on each boot.
+
+Use `SeedMfaPolicy` when app configuration should own the live values:
+
+```csharp
+builder.AddSqlOS<AppDbContext>(options =>
+{
+    options.AuthServer.SeedMfaPolicy(mfa =>
+    {
+        mfa.Enabled = true;
+        mfa.TotpEnabled = true;
+        mfa.UserSelfEnrollmentEnabled = true;
+        mfa.RecoveryCodesEnabled = true;
+        mfa.RequireForAllUsers = false;
+        mfa.RequireForOwnersAndAdmins = true;
+        mfa.RequiredRoles = ["owner", "admin"];
+        mfa.AvailableFactors = ["totp", "recovery_code"];
+    });
+});
+```
+
+When a startup seed is active, the dashboard labels the MFA screen as startup managed because edits will be overwritten on restart.
+
+## Require MFA for an organization
+
+Organization MFA policies inherit global settings until overridden. Use the admin API or startup seed for tenant-specific policy.
+
+```bash
+curl -X PUT http://localhost:5062/sqlos/admin/auth/api/organizations/org_123/mfa-policy \
+  -H "Content-Type: application/json" \
+  -d '{
+    "isEnabled": true,
+    "requireMfaForAllUsers": true,
+    "requireMfaForOwnersAndAdmins": false,
+    "userSelfEnrollmentEnabled": true,
+    "recoveryCodesEnabled": true,
+    "requiredRoles": ["owner", "admin"],
+    "availableFactors": ["totp", "recovery_code"]
+  }'
+```
+
+Use role-based enforcement for privileged users:
+
+```json
+{
+  "isEnabled": true,
+  "requireMfaForAllUsers": false,
+  "requireMfaForOwnersAndAdmins": true,
+  "requiredRoles": ["owner", "admin"]
+}
+```
+
+## Dashboard settings
+
+Open **Auth Server > MFA** in the dashboard.
+
+The global MFA screen controls:
+
+- Enable MFA
+- Enable authenticator apps
+- Allow users to add MFA voluntarily
+- Issue recovery codes
+- Require MFA for all users
+- Require MFA for owners and admins
+- Required roles
+- Available factors
+
+Organization-specific MFA policy is available through the admin API and startup seeding in this release. The dashboard global MFA screen is the operator UI for application-wide settings.
+
+## Hosted auth behavior
+
+Hosted authorization-code login enforces MFA automatically. You do not write the challenge page.
+
+After password, Email OTP, OIDC, SAML, signup, or organization selection:
+
+1. SqlOS evaluates global and organization MFA policy.
+2. If no second factor is required, SqlOS continues to token or code issuance.
+3. If the user has TOTP or recovery codes, SqlOS renders `Two-step verification`.
+4. If the user must enroll, SqlOS renders `Add authenticator app` with a QR code and manual setup secret.
+5. Successful MFA appends the second factor to the authentication methods.
+
+Issued tokens include `amr` claims for the primary and second factor:
+
+```text
+amr: password
+amr: totp
+```
+
+Recovery-code login records:
+
+```text
+amr: password
+amr: recovery_code
+```
+
+## Headless auth behavior
+
+Headless auth uses the same state machine. Your UI must render the new views.
+
+When a headless action returns a view model with `view: "mfa"`, render a code input and post:
+
+```http
+POST /sqlos/auth/headless/mfa/verify
+{
+  "requestId": "req_123",
+  "mfaToken": "tmp_...",
+  "code": "123456"
+}
+```
+
+When it returns `view: "mfa-enroll"`, render the QR code and enrollment fields. Forced enrollment view models include `totpEnrollment` with:
+
+- `enrollmentToken`
+- `authenticatorId`
+- `secret`
+- `provisioningUri`
+- `qrCodeDataUrl`
+- `expiresAt`
+
+Verify enrollment:
+
+```http
+POST /sqlos/auth/headless/mfa/totp/enroll/verify
+{
+  "requestId": "req_123",
+  "mfaToken": "tmp_...",
+  "enrollmentToken": "tmp_...",
+  "code": "123456"
+}
+```
+
+On success SqlOS returns the same redirect result shape used by the rest of headless auth.
+
+## Direct API login behavior
+
+Direct password and signup APIs return MFA state instead of tokens when policy requires it.
+
+```json
+{
+  "requiresOrganizationSelection": false,
+  "pendingAuthToken": null,
+  "organizations": [],
+  "tokens": null,
+  "requiresMfa": true,
+  "mfaToken": "tmp_...",
+  "requiresMfaEnrollment": false,
+  "mfaMethods": ["totp", "recovery_code"]
+}
+```
+
+Verify an existing factor:
+
+```http
+POST /sqlos/auth/mfa/challenge/verify
+{
+  "mfaToken": "tmp_...",
+  "code": "123456"
+}
+```
+
+For forced enrollment:
+
+```http
+POST /sqlos/auth/mfa/challenge/totp/enroll/start
+{
+  "mfaToken": "tmp_...",
+  "displayName": "Authenticator app"
+}
+```
+
+Then verify:
+
+```http
+POST /sqlos/auth/mfa/challenge/totp/enroll/verify
+{
+  "mfaToken": "tmp_...",
+  "enrollmentToken": "tmp_...",
+  "code": "123456"
+}
+```
+
+## Account self-enrollment
+
+SqlOS exposes service methods for account pages in your app. The Retail example wires these through `/api/mfa/*` endpoints.
+
+```csharp
+var status = await authService.GetMfaStatusAsync(userId, organizationId, ct);
+
+var enrollment = await authService.StartTotpEnrollmentAsync(
+    userId,
+    new SqlOSTotpEnrollmentStartRequest("Authenticator app"),
+    organizationId,
+    ct);
+
+var result = await authService.VerifyTotpEnrollmentAsync(
+    new SqlOSTotpEnrollmentVerifyRequest(enrollment.EnrollmentToken, code),
+    httpContext,
+    ct);
+```
+
+After enrollment, show `result.RecoveryCodes` once and tell the user to store them. Recovery codes are single-use.
+
+## Device changes and recovery
+
+SqlOS does not re-display confirmed TOTP secrets. That is deliberate.
+
+For a new phone:
+
+- If the user still has the old authenticator app, they can transfer codes inside the authenticator app if that app supports it.
+- If the user can still sign in, your app can offer a factor replacement flow built on a new TOTP enrollment.
+- If the user lost the old device, they can sign in with a saved recovery code when recovery codes are enabled.
+- If neither the authenticator nor recovery codes are available, an administrator should reset the user's MFA state before re-enrollment. Full dashboard reset/remove factor controls are a follow-on management feature after this V1 challenge/enrollment path.
+
+Do not implement recovery by showing the existing secret again. Treat replacement as a new enrollment.
+
+## Secret custody
+
+TOTP secrets are protected with `SqlOSCryptoService.ProtectSecret`, which uses ASP.NET Data Protection when available.
+
+Production deployments should configure a durable Data Protection key ring outside the application database. If Data Protection keys are lost, existing protected TOTP secrets cannot be unprotected.
+
+## Next reading
+
+- [Headless Auth](/docs/authserver/headless-auth)
+- [Headless Auth How-To](/docs/authserver/headless-auth-how-to)
+- [Security Settings](/docs/authserver/security-settings)
+- [AuthServer API Reference](/docs/reference/authserver-api)

--- a/web/content/docs/authserver/overview.mdx
+++ b/web/content/docs/authserver/overview.mdx
@@ -19,8 +19,9 @@ AuthServer is SqlOS's identity piece. Users, orgs, sessions, tokens, OIDC, and S
 <Callout type="info" title="Recommended reading order">
   1. [Dashboard](/docs/authserver/dashboard-overview) → [Organizations](/docs/authserver/organizations) → [Hosted vs headless](/docs/authserver/hosted-vs-headless)
   2. [Password login](/docs/authserver/password-login) or [Email OTP](/docs/authserver/email-otp) → [OIDC](/docs/authserver/oidc-auth) / [SAML](/docs/authserver/saml-sso)
-  3. One app: [Single-Application Setup](/docs/authserver/single-application)
-  4. Advanced: [Clients](/docs/authserver/clients), [Application Access](/docs/authserver/application-access), [CIMD](/docs/authserver/client-id-metadata-documents), [DCR](/docs/authserver/dynamic-client-registration) -- only when you need them
+  3. Security policy: [MFA and TOTP](/docs/authserver/mfa-totp) and [Security Settings](/docs/authserver/security-settings)
+  4. One app: [Single-Application Setup](/docs/authserver/single-application)
+  5. Advanced: [Clients](/docs/authserver/clients), [Application Access](/docs/authserver/application-access), [CIMD](/docs/authserver/client-id-metadata-documents), [DCR](/docs/authserver/dynamic-client-registration) -- only when you need them
 </Callout>
 
 ## What you get
@@ -29,6 +30,7 @@ AuthServer is SqlOS's identity piece. Users, orgs, sessions, tokens, OIDC, and S
   <Card title="Organizations" description="Multi-tenant orgs, memberships, and roles." />
   <Card title="Users" description="Email/password, email OTP, SSO-provisioned, or OIDC-linked identities." />
   <Card title="Sessions" description="JWT access tokens, refresh token rotation, and replay detection." />
+  <Card title="MFA and recovery codes" description="Optional self-enrollment, tenant-required TOTP, and recovery-code challenges." />
   <Card title="OIDC" description="Google, Microsoft, Apple, and custom providers." />
   <Card title="SAML SSO" description="Enterprise SSO with provisioning and hosted flows." />
   <Card title="Invitations" description="Email-bound organization invites with hosted, headless, and SDK acceptance." />
@@ -53,8 +55,9 @@ Typical browser login:
 2. User enters email. [Home realm discovery](/docs/authserver/home-realm-discovery) picks password, Email OTP, or SSO.
 3. User signs in (password, Email OTP, OIDC, or SAML).
 4. Multiple orgs? User picks one.
-5. SqlOS returns an auth code.
-6. App trades the code for access and refresh tokens.
+5. MFA required? SqlOS renders or returns a TOTP challenge or forced enrollment step.
+6. SqlOS returns an auth code.
+7. App trades the code for access and refresh tokens.
 
 <Callout type="tip" title="Start with owned clients first">
   For most teams, the first production flow should use a seeded or dashboard-created owned client. Add `CIMD`, `DCR`, and resource indicators only when you actually need portable or compatibility clients.
@@ -94,7 +97,7 @@ Open `/sqlos/admin/auth/`. Manage orgs, users, memberships, clients, OIDC, SSO, 
   </AccordionItem>
 </Accordion>
 
-[Headless Auth](/docs/authserver/headless-auth) · [Email OTP](/docs/authserver/email-otp) · [Email Invitations](/docs/authserver/invitations) · [CLI OAuth](/docs/authserver/cli-oauth) · [Hosted vs Headless](/docs/authserver/hosted-vs-headless)
+[Headless Auth](/docs/authserver/headless-auth) · [Email OTP](/docs/authserver/email-otp) · [MFA and TOTP](/docs/authserver/mfa-totp) · [Email Invitations](/docs/authserver/invitations) · [CLI OAuth](/docs/authserver/cli-oauth) · [Hosted vs Headless](/docs/authserver/hosted-vs-headless)
 
 ## Client guides
 

--- a/web/content/docs/guides/index.mdx
+++ b/web/content/docs/guides/index.mdx
@@ -18,6 +18,7 @@ You'll learn which guide to pick for your next integration task.
 
 <CardGrid cols={2}>
   <Card title="Password login" description="Add hosted password auth to an existing ASP.NET app." href="/docs/guides/password-login" />
+  <Card title="Authenticator MFA" description="Enable TOTP, recovery codes, and tenant-required MFA." href="/docs/guides/mfa-totp" />
   <Card title="Google & Microsoft sign-in" description="Configure social OIDC from the dashboard." href="/docs/guides/social-oidc" />
   <Card title="SAML SSO for an org" description="Enterprise SSO with Entra or any SAML IdP." href="/docs/guides/saml-sso" />
   <Card title="Model FGA" description="Design a multi-tenant resource hierarchy." href="/docs/guides/model-fga" />
@@ -34,3 +35,4 @@ You'll learn which guide to pick for your next integration task.
 - [MCP and authorization servers](/blog/what-an-authorization-server-needs-for-oauth-powered-mcp-servers)
 - [Single-Application Mode: WorkOS-Style Defaults Without Giving Up SqlOS](/blog/single-application-mode-workos-style-setup)
 - [Application Assignments: The Missing Layer Between Clients and Audiences](/blog/application-assignments-auth-server-control-plane)
+- [MFA Policy: The Auth Server Has to Own the Second Step](/blog/mfa-totp-policy-auth-server)

--- a/web/content/docs/guides/mfa-totp.mdx
+++ b/web/content/docs/guides/mfa-totp.mdx
@@ -1,0 +1,185 @@
+---
+title: "Require Authenticator MFA"
+description: "Enable TOTP, let users self-enroll, and require MFA for a tenant."
+order: 4
+section: guides
+---
+
+This guide enables authenticator-app MFA and tests both voluntary enrollment and forced organization policy.
+
+## Goal
+
+You will configure SqlOS so:
+
+- users can add an authenticator app to their own account;
+- admins can require MFA globally or for one organization;
+- hosted and headless auth force enrollment before issuing tokens when policy requires MFA;
+- recovery codes are generated after TOTP enrollment.
+
+## Configure defaults
+
+Keep the first version optional unless your product needs an immediate tenant-wide requirement.
+
+```csharp
+builder.AddSqlOS<AppDbContext>(options =>
+{
+    options.AuthServer.ConfigureMfa(mfa =>
+    {
+        mfa.Enabled = true;
+        mfa.AllowUserSelfEnrollmentByDefault = true;
+        mfa.RecoveryCodesEnabledByDefault = true;
+        mfa.RequireForAllUsersByDefault = false;
+        mfa.Totp.Issuer = "Acme";
+    });
+});
+```
+
+To let configuration own the value across restarts, seed the policy:
+
+```csharp
+builder.AddSqlOS<AppDbContext>(options =>
+{
+    options.AuthServer.SeedMfaPolicy(mfa =>
+    {
+        mfa.Enabled = true;
+        mfa.TotpEnabled = true;
+        mfa.UserSelfEnrollmentEnabled = true;
+        mfa.RecoveryCodesEnabled = true;
+        mfa.RequireForAllUsers = false;
+    });
+});
+```
+
+## Verify dashboard settings
+
+Open `/sqlos/admin/auth/` and go to **MFA**.
+
+Confirm:
+
+- MFA is enabled.
+- Authenticator apps are enabled.
+- User self-enrollment is enabled.
+- Recovery codes are enabled.
+- Tenant-wide requirement is off unless you are intentionally testing forced MFA for everyone.
+
+If the screen says the values are startup managed, changes made in the dashboard are overwritten on restart.
+
+## Require MFA for one organization
+
+Use the organization policy API when one tenant requires MFA:
+
+```bash
+curl -X PUT http://localhost:5062/sqlos/admin/auth/api/organizations/org_123/mfa-policy \
+  -H "Content-Type: application/json" \
+  -d '{
+    "isEnabled": true,
+    "requireMfaForAllUsers": true,
+    "requireMfaForOwnersAndAdmins": false,
+    "userSelfEnrollmentEnabled": true,
+    "recoveryCodesEnabled": true,
+    "requiredRoles": ["owner", "admin"],
+    "availableFactors": ["totp", "recovery_code"]
+  }'
+```
+
+Use `requireMfaForOwnersAndAdmins` instead when only privileged tenant roles need MFA.
+
+## Add account self-enrollment
+
+Expose protected app endpoints that call `SqlOSAuthService`.
+
+```csharp
+app.MapGet("/api/mfa/status", async (
+    SqlOSAuthService authService,
+    ClaimsPrincipal user,
+    CancellationToken ct) =>
+{
+    var userId = user.FindFirstValue("sub")!;
+    var organizationId = user.FindFirstValue("org_id");
+    return await authService.GetMfaStatusAsync(userId, organizationId, ct);
+});
+
+app.MapPost("/api/mfa/totp/enroll/start", async (
+    SqlOSTotpEnrollmentStartRequest request,
+    SqlOSAuthService authService,
+    ClaimsPrincipal user,
+    CancellationToken ct) =>
+{
+    var userId = user.FindFirstValue("sub")!;
+    var organizationId = user.FindFirstValue("org_id");
+    return await authService.StartTotpEnrollmentAsync(userId, request, organizationId, ct);
+});
+
+app.MapPost("/api/mfa/totp/enroll/verify", async (
+    SqlOSTotpEnrollmentVerifyRequest request,
+    SqlOSAuthService authService,
+    HttpContext httpContext,
+    CancellationToken ct) =>
+    await authService.VerifyTotpEnrollmentAsync(request, httpContext, ct));
+```
+
+Render `qrCodeDataUrl` as an image, keep `secret` available for manual setup, and verify the 6-digit TOTP code with the enrollment token. Show recovery codes once after verification.
+
+## Handle login-time MFA
+
+Hosted auth handles this automatically.
+
+For headless auth, render these view names:
+
+| View | UI |
+| --- | --- |
+| `mfa` | Code input for authenticator code or recovery code |
+| `mfa-enroll` | QR code, manual setup secret, and TOTP verification input |
+
+Post the challenge code:
+
+```http
+POST /sqlos/auth/headless/mfa/verify
+{
+  "requestId": "req_123",
+  "mfaToken": "tmp_...",
+  "code": "123456"
+}
+```
+
+Post forced enrollment verification:
+
+```http
+POST /sqlos/auth/headless/mfa/totp/enroll/verify
+{
+  "requestId": "req_123",
+  "mfaToken": "tmp_...",
+  "enrollmentToken": "tmp_...",
+  "code": "123456"
+}
+```
+
+## Test the Retail example
+
+The example stack includes both optional self-enrollment and a seeded Retail org that requires MFA.
+
+```bash
+dotnet run --project examples/SqlOS.Example.AppHost/SqlOS.Example.AppHost.csproj
+```
+
+Then:
+
+1. Open `http://localhost:3010`.
+2. Sign up for Retail.
+3. Go to `/retail/account`.
+4. Add an authenticator app, scan the QR code, verify the code, and save recovery codes.
+5. Sign out and sign back in. Expect `Two-step verification`.
+6. Sign in as `admin@retail.demo` with `RetailDemo1!`. Expect forced authenticator enrollment before entering the app.
+
+## Common mistakes
+
+- In headless/direct API flows, treat `requiresMfa` or `requiresMfaEnrollment` as the next auth state and post the MFA step back to SqlOS. Tokens are intentionally absent until SqlOS completes the second factor.
+- Do not re-display confirmed TOTP secrets to solve device changes.
+- Do not forget to render `mfa` and `mfa-enroll` in headless UIs.
+- Do not treat recovery codes as reusable backup passwords; each code is single-use.
+
+## Next reading
+
+- [MFA and TOTP](/docs/authserver/mfa-totp)
+- [Headless Auth How-To](/docs/authserver/headless-auth-how-to)
+- [Dashboard](/docs/authserver/dashboard-overview)

--- a/web/content/docs/reference/api-reference.mdx
+++ b/web/content/docs/reference/api-reference.mdx
@@ -26,6 +26,28 @@ Call `app.MapSqlOS()` to mount OAuth. Default base: `{DashboardBasePath}/auth` (
 | POST | `/sqlos/auth/token` | Token exchange (code or refresh) |
 | GET | `/sqlos/auth/login` | Hosted login page |
 | GET | `/sqlos/auth/signup` | Hosted signup page |
+| POST | `/sqlos/auth/mfa/challenge/verify` | Verify TOTP or recovery code for a direct MFA challenge |
+| POST | `/sqlos/auth/mfa/challenge/totp/enroll/start` | Start TOTP enrollment for a direct MFA challenge |
+| POST | `/sqlos/auth/mfa/challenge/totp/enroll/verify` | Verify TOTP enrollment for a direct MFA challenge |
+
+## Headless Auth Endpoints
+
+Base path: `/sqlos/auth/headless`.
+
+| Method | Endpoint | Description |
+| --- | --- | --- |
+| GET | `/requests/{requestId}` | Load the current authorization request view model |
+| POST | `/identify` | Submit email for home realm discovery |
+| POST | `/password/login` | Submit email and password |
+| POST | `/email-otp/start` | Start email OTP sign-in |
+| POST | `/email-otp/verify` | Verify email OTP sign-in |
+| POST | `/signup` | Create a password user and complete authorization |
+| POST | `/signup/email-otp/start` | Start passwordless signup |
+| POST | `/signup/email-otp/verify` | Verify passwordless signup |
+| POST | `/organization/select` | Select an organization after primary login |
+| POST | `/mfa/verify` | Verify TOTP or recovery code |
+| POST | `/mfa/totp/enroll/start` | Start forced TOTP enrollment |
+| POST | `/mfa/totp/enroll/verify` | Verify forced TOTP enrollment and continue authorization |
 
 ## Auth API (Example)
 
@@ -171,6 +193,40 @@ curl http://localhost:5062/sqlos/admin/auth/api/settings/security
 # Update
 curl -X PUT http://localhost:5062/sqlos/admin/auth/api/settings/security \
   -d '{"refreshTokenLifetimeMinutes": 10080, "sessionIdleTimeoutMinutes": 1440, "sessionAbsoluteLifetimeMinutes": 43200}'
+```
+
+### MFA Settings
+
+```bash
+# Get global MFA settings
+curl http://localhost:5062/sqlos/admin/auth/api/settings/mfa
+
+# Update global MFA settings
+curl -X PUT http://localhost:5062/sqlos/admin/auth/api/settings/mfa \
+  -H "Content-Type: application/json" \
+  -d '{
+    "enabled": true,
+    "totpEnabled": true,
+    "userSelfEnrollmentEnabled": true,
+    "recoveryCodesEnabled": true,
+    "requireForAllUsers": false,
+    "requireForOwnersAndAdmins": true,
+    "requiredRoles": ["owner", "admin"],
+    "availableFactors": ["totp", "recovery_code"]
+  }'
+
+# Update one organization's MFA policy
+curl -X PUT http://localhost:5062/sqlos/admin/auth/api/organizations/org_123/mfa-policy \
+  -H "Content-Type: application/json" \
+  -d '{
+    "isEnabled": true,
+    "requireMfaForAllUsers": true,
+    "requireMfaForOwnersAndAdmins": false,
+    "userSelfEnrollmentEnabled": true,
+    "recoveryCodesEnabled": true,
+    "requiredRoles": ["owner", "admin"],
+    "availableFactors": ["totp", "recovery_code"]
+  }'
 ```
 
 ### Sessions

--- a/web/content/docs/reference/authserver-api.mdx
+++ b/web/content/docs/reference/authserver-api.mdx
@@ -21,6 +21,7 @@ Complete reference for every public method in the AuthServer module.
 | Task | Start here |
 | --- | --- |
 | Login / signup | `SqlOSAuthService` — password and Email OTP sections below |
+| MFA / TOTP | `SqlOSAuthService` MFA methods and `SqlOSSettingsService` MFA policy methods |
 | Token validation | `ValidateAccessTokenAsync` |
 | Admin CRUD | `SqlOSAdminService` |
 | OIDC social | `SqlOSOidcAuthService` |
@@ -126,6 +127,88 @@ return Results.Ok(result.Tokens);
 | `PendingAuthToken` | `string?` | Temporary token for `SelectOrganizationAsync`. |
 | `Organizations` | `IReadOnlyList<SqlOSOrganizationOption>` | Available organizations. |
 | `Tokens` | `SqlOSTokenResponse?` | Issued tokens (null if org selection required). |
+| `RequiresMfa` | `bool` | `true` if a second-factor challenge is required before tokens can be issued. |
+| `MfaToken` | `string?` | Temporary token for the MFA challenge or forced enrollment flow. |
+| `RequiresMfaEnrollment` | `bool` | `true` if the user must enroll a TOTP authenticator before continuing. |
+| `MfaMethods` | `IReadOnlyList<string>?` | Available factors such as `totp` and `recovery_code`. |
+
+---
+
+### MFA / TOTP methods
+
+Inspect the user's MFA status:
+
+```csharp
+var status = await authService.GetMfaStatusAsync(userId, organizationId, ct);
+```
+
+List confirmed and pending authenticators:
+
+```csharp
+var authenticators = await authService.ListMfaAuthenticatorsAsync(userId, ct);
+```
+
+Start voluntary account enrollment:
+
+```csharp
+var enrollment = await authService.StartTotpEnrollmentAsync(
+    userId,
+    new SqlOSTotpEnrollmentStartRequest("Authenticator app"),
+    organizationId,
+    ct);
+```
+
+`SqlOSTotpEnrollmentStartResult` includes `Secret`, `ProvisioningUri`, `QrCodeDataUrl`, `EnrollmentToken`, and `ExpiresAt`.
+
+Verify enrollment:
+
+```csharp
+var result = await authService.VerifyTotpEnrollmentAsync(
+    new SqlOSTotpEnrollmentVerifyRequest(enrollment.EnrollmentToken, code),
+    httpContext,
+    ct);
+```
+
+`SqlOSTotpEnrollmentVerifyResult` includes the confirmed `AuthenticatorId` and one-time `RecoveryCodes`.
+
+When `LoginWithPasswordAsync`, `SignUpAsync`, Email OTP verification, hosted OAuth, or headless OAuth returns `RequiresMfa = true`, finish the challenge with:
+
+```csharp
+var result = await authService.VerifyMfaChallengeAsync(
+    new SqlOSMfaChallengeVerifyRequest(mfaToken, code),
+    httpContext,
+    ct);
+```
+
+For forced enrollment:
+
+```csharp
+var enrollment = await authService.StartTotpEnrollmentForChallengeAsync(
+    mfaToken,
+    new SqlOSTotpEnrollmentStartRequest("Authenticator app"),
+    ct);
+
+var result = await authService.VerifyTotpEnrollmentAsync(
+    new SqlOSTotpEnrollmentVerifyRequest(
+        enrollment.EnrollmentToken,
+        code,
+        mfaToken),
+    httpContext,
+    ct);
+```
+
+Direct HTTP endpoints:
+
+| Endpoint | Purpose |
+| --- | --- |
+| `POST /sqlos/auth/mfa/challenge/verify` | Verify TOTP or recovery code for an MFA token |
+| `POST /sqlos/auth/mfa/challenge/totp/enroll/start` | Start forced TOTP enrollment for an MFA token |
+| `POST /sqlos/auth/mfa/challenge/totp/enroll/verify` | Verify forced TOTP enrollment and complete the MFA challenge |
+| `POST /sqlos/auth/headless/mfa/verify` | Headless MFA challenge verification |
+| `POST /sqlos/auth/headless/mfa/totp/enroll/start` | Headless forced TOTP enrollment start |
+| `POST /sqlos/auth/headless/mfa/totp/enroll/verify` | Headless forced TOTP enrollment verification |
+
+See [MFA and TOTP](/docs/authserver/mfa-totp).
 
 ---
 
@@ -1220,6 +1303,57 @@ await settingsService.UpdateSecuritySettingsAsync(
 
 ---
 
+### MFA policy settings
+
+Read and update global MFA settings:
+
+```csharp
+var settings = await settingsService.GetMfaSettingsAsync(ct);
+
+await settingsService.UpdateMfaSettingsAsync(
+    new SqlOSUpdateMfaSettingsRequest(
+        Enabled: true,
+        TotpEnabled: true,
+        UserSelfEnrollmentEnabled: true,
+        RecoveryCodesEnabled: true,
+        RequireForAllUsers: false,
+        RequireForOwnersAndAdmins: true,
+        RequiredRoles: ["owner", "admin"],
+        AvailableFactors: ["totp", "recovery_code"]),
+    ct);
+```
+
+Read and update organization MFA policy:
+
+```csharp
+var policy = await settingsService.GetOrganizationMfaPolicyAsync(
+    organizationId,
+    ct);
+
+await settingsService.UpdateOrganizationMfaPolicyAsync(
+    organizationId,
+    new SqlOSUpdateOrganizationMfaPolicyRequest(
+        IsEnabled: true,
+        RequireMfaForAllUsers: true,
+        RequireMfaForOwnersAndAdmins: false,
+        UserSelfEnrollmentEnabled: true,
+        RecoveryCodesEnabled: true,
+        RequiredRoles: ["owner", "admin"],
+        AvailableFactors: ["totp", "recovery_code"]),
+    ct);
+```
+
+Admin HTTP endpoints:
+
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /sqlos/admin/auth/api/settings/mfa` | Read global MFA settings |
+| `PUT /sqlos/admin/auth/api/settings/mfa` | Update global MFA settings |
+| `GET /sqlos/admin/auth/api/organizations/{organizationId}/mfa-policy` | Read an organization's MFA policy |
+| `PUT /sqlos/admin/auth/api/organizations/{organizationId}/mfa-policy` | Update an organization's MFA policy |
+
+---
+
 ## Key Contracts
 
 ### SqlOSTokenResponse
@@ -1246,7 +1380,11 @@ public sealed record SqlOSLoginResult(
     bool RequiresOrganizationSelection,
     string? PendingAuthToken,
     IReadOnlyList<SqlOSOrganizationOption> Organizations,
-    SqlOSTokenResponse? Tokens);
+    SqlOSTokenResponse? Tokens,
+    bool RequiresMfa = false,
+    string? MfaToken = null,
+    bool RequiresMfaEnrollment = false,
+    IReadOnlyList<string>? MfaMethods = null);
 ```
 
 ### SqlOSValidatedToken

--- a/web/src/components/marketing/AuthSection.tsx
+++ b/web/src/components/marketing/AuthSection.tsx
@@ -1,5 +1,4 @@
 import AuthPageViz from "@/components/AuthPageViz";
-import ProductScreenshot from "@/components/ProductScreenshot";
 import { authHighlights } from "@/components/marketing/constants";
 
 export default function AuthSection() {
@@ -25,10 +24,6 @@ export default function AuthSection() {
           </div>
 
           <div className="space-y-6 lg:mt-8">
-            <ProductScreenshot
-              src="/docs/auth-signin-page.png"
-              alt="SqlOS hosted sign-in page"
-            />
             <AuthPageViz />
           </div>
         </div>


### PR DESCRIPTION
## Summary

Addresses #21 by adding the V1 MFA/TOTP policy foundation and wiring it through the central AuthServer login gates.

- Adds persisted global and organization MFA policy settings, startup seeding, dashboard settings, and schema migration `019_MfaTotp.sql`.
- Adds TOTP authenticator enrollment with QR-code setup, manual setup fallback, protected secret storage through `SqlOSCryptoService.ProtectSecret`, recovery codes, replay protection, and `amr` claims for primary + second factor.
- Gates direct API login, hosted OAuth login, headless login responses, and organization selection through pending MFA challenges before tokens/auth codes are issued.
- Adds hosted MFA/enrollment pages plus direct/headless MFA challenge endpoints.
- Adds headless UI states for MFA challenge, forced TOTP enrollment, password recovery, and password reset so Retail headless auth no longer lands on a blank shell after password login.
- Adds Retail example account MFA UI and seeds the Retail demo org with required MFA so forced enrollment can be tested locally.
- Documents the feature set across `/web`: full AuthServer docs, setup guide, dashboard/admin docs, headless docs, API reference updates, and a new blog post.

## Notes

This intentionally does not use a `Closes #21` keyword because the issue also tracks follow-on hardening such as device-authorization-specific MFA transactions, richer factor admin/reset UX, lost-device factor replacement flows, dedicated MFA abuse throttling, and expanded admin factor management. This PR lands the core V1 TOTP policy/enrollment/challenge path and keeps the issue open for those remaining items.

## Verification

- `dotnet build SqlOS.sln`
- `dotnet test SqlOS.sln -m:1`
- `dotnet test tests/SqlOS.Tests/SqlOS.Tests.csproj --filter "HeadlessPasswordLogin_WhenMfaEnrollmentRequired_ReturnsTotpEnrollmentQrCode|HeadlessPasswordLogin_WhenUserHasTotp_ReturnsMfaChallengeAndCompletes"`
- `npm run build` in `examples/SqlOS.Example.Web`
- `npm run build` in `web`
- `npm run lint` in `web`
- Browser regression: fresh Retail sign-in as `admin@retail.demo` with password `RetailDemo1!` renders the headless `Add authenticator app` forced-enrollment screen with a QR code after password login.
- Browser docs check: `/docs/authserver/mfa-totp`, `/docs/guides/mfa-totp`, dashboard docs, AuthServer API reference, public API reference, and `/blog/mfa-totp-policy-auth-server` all render locally.