### PR TITLE
Add startup seeding for social/OIDC connections

### DIFF
--- a/examples/SqlOS.Example.Api/Program.cs
+++ b/examples/SqlOS.Example.Api/Program.cs
@@ -51,6 +51,12 @@ builder.AddSqlOS<ExampleAppDbContext>(options =>
     var phoneOtpDefaultRegion = builder.Configuration["SqlOS:PhoneOtp:DefaultRegion"]
         ?? builder.Configuration["TWILIO_DEFAULT_REGION"];
 
+    // "Continue with Microsoft" social login. Secrets are never committed: the AppHost forwards
+    // them as environment variables (SqlOS__Oidc__Microsoft__*) when configured for the developer.
+    var microsoftOidcClientId = builder.Configuration["SqlOS:Oidc:Microsoft:ClientId"];
+    var microsoftOidcClientSecret = builder.Configuration["SqlOS:Oidc:Microsoft:ClientSecret"];
+    var microsoftOidcTenant = builder.Configuration["SqlOS:Oidc:Microsoft:Tenant"];
+
     if (Enum.TryParse<SqlOSDashboardAuthMode>(builder.Configuration["SqlOS:Dashboard:AuthMode"], ignoreCase: true, out var authMode))
     {
         options.Dashboard.AuthMode = authMode;
@@ -134,6 +140,23 @@ builder.AddSqlOS<ExampleAppDbContext>(options =>
         "example-expo",
         "Example Expo Client",
         "sqlos-expo://auth-callback");
+
+    // Seed the Microsoft social connection only when credentials are supplied so a fresh checkout
+    // without Azure configured still boots cleanly (the button simply does not appear).
+    if (!string.IsNullOrWhiteSpace(microsoftOidcClientId) && !string.IsNullOrWhiteSpace(microsoftOidcClientSecret))
+    {
+        var oidcCallbackOrigin = builder.Configuration["SqlOS:Oidc:CallbackBaseUrl"]
+            ?? (Uri.TryCreate(auth.Issuer, UriKind.Absolute, out var issuerUri)
+                ? issuerUri.GetLeftPart(UriPartial.Authority)
+                : "http://localhost:5062");
+        var microsoftCallbackUri = $"{oidcCallbackOrigin.TrimEnd('/')}/api/v1/auth/oidc/callback/{{connectionId}}";
+
+        auth.SeedMicrosoftConnection(
+            microsoftOidcClientId,
+            microsoftOidcClientSecret,
+            microsoftOidcTenant,
+            microsoftCallbackUri);
+    }
 
     if (enableHeadlessAuthPage)
     {

--- a/examples/SqlOS.Example.AppHost/Program.cs
+++ b/examples/SqlOS.Example.AppHost/Program.cs
@@ -22,6 +22,14 @@ var twilioVerifyServiceSid = builder.Configuration["SqlOS:PhoneOtp:TwilioVerifyS
     ?? builder.Configuration["TWILIO_VERIFY_SERVICE_SID"];
 var phoneOtpDefaultRegion = builder.Configuration["SqlOS:PhoneOtp:DefaultRegion"]
     ?? builder.Configuration["TWILIO_DEFAULT_REGION"];
+// "Continue with Microsoft" social login secrets for the example app. Set these on the AppHost
+// (user-secrets or environment), never in source. They are forwarded to the API as env vars below.
+var microsoftOidcClientId = builder.Configuration["SqlOS:Oidc:Microsoft:ClientId"]
+    ?? builder.Configuration["AZURE_OIDC_MICROSOFT_CLIENT_ID"];
+var microsoftOidcClientSecret = builder.Configuration["SqlOS:Oidc:Microsoft:ClientSecret"]
+    ?? builder.Configuration["AZURE_OIDC_MICROSOFT_CLIENT_SECRET"];
+var microsoftOidcTenant = builder.Configuration["SqlOS:Oidc:Microsoft:Tenant"]
+    ?? builder.Configuration["AZURE_OIDC_MICROSOFT_TENANT"];
 var sqlPassword = builder.AddParameter("sql-password", value: "LocalDevPassword123!");
 
 var sql = builder.AddSqlServer("sql", password: sqlPassword, port: 1434)
@@ -74,6 +82,18 @@ if (!string.IsNullOrWhiteSpace(twilioVerifyServiceSid))
 if (!string.IsNullOrWhiteSpace(phoneOtpDefaultRegion))
 {
     api.WithEnvironment("SqlOS__PhoneOtp__DefaultRegion", phoneOtpDefaultRegion);
+}
+
+if (!string.IsNullOrWhiteSpace(microsoftOidcClientId) && !string.IsNullOrWhiteSpace(microsoftOidcClientSecret))
+{
+    api
+        .WithEnvironment("SqlOS__Oidc__Microsoft__ClientId", microsoftOidcClientId)
+        .WithEnvironment("SqlOS__Oidc__Microsoft__ClientSecret", microsoftOidcClientSecret);
+
+    if (!string.IsNullOrWhiteSpace(microsoftOidcTenant))
+    {
+        api.WithEnvironment("SqlOS__Oidc__Microsoft__Tenant", microsoftOidcTenant);
+    }
 }
 
 var todoApi = builder.AddProject<Projects.SqlOS_Todo_Api>("todo-api")

--- a/examples/SqlOS.Example.IntegrationTests/SqlOSExampleOidcSeedingIntegrationTests.cs
+++ b/examples/SqlOS.Example.IntegrationTests/SqlOSExampleOidcSeedingIntegrationTests.cs
@@ -1,0 +1,69 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SqlOS.Example.IntegrationTests.Infrastructure;
+
+namespace SqlOS.Example.IntegrationTests;
+
+[TestClass]
+public sealed class SqlOSExampleOidcSeedingIntegrationTests
+{
+    private const string SeededClientId = "seeded-microsoft-client-id";
+
+    [TestMethod]
+    public async Task SeededMicrosoftConnection_AppearsAsEnabledProvider()
+    {
+        using var factory = CreateSeededFactory();
+        using var client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false
+        });
+
+        var providersResponse = await client.GetAsync("/api/v1/auth/oidc/providers");
+        providersResponse.EnsureSuccessStatusCode();
+        var providers = JsonDocument.Parse(await providersResponse.Content.ReadAsStringAsync());
+
+        var microsoft = providers.RootElement.EnumerateArray()
+            .Single(x => x.GetProperty("providerType").GetString() == "Microsoft");
+        microsoft.GetProperty("displayName").GetString().Should().Be("Microsoft");
+        microsoft.GetProperty("logoDataUrl").GetString().Should().StartWith("data:image/svg+xml");
+    }
+
+    [TestMethod]
+    public async Task SeededMicrosoftConnection_PersistsConfiguredValues()
+    {
+        using var factory = CreateSeededFactory();
+        using var client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false
+        });
+
+        var connectionsResponse = await client.GetAsync("/sqlos/admin/auth/api/oidc-connections");
+        connectionsResponse.EnsureSuccessStatusCode();
+        var connections = JsonDocument.Parse(await connectionsResponse.Content.ReadAsStringAsync());
+
+        var microsoft = connections.RootElement.EnumerateArray()
+            .Single(x => x.GetProperty("providerType").GetString() == "Microsoft");
+
+        microsoft.GetProperty("clientId").GetString().Should().Be(SeededClientId);
+        microsoft.GetProperty("microsoftTenant").GetString().Should().Be("common");
+        microsoft.GetProperty("useDiscovery").GetBoolean().Should().BeTrue();
+        microsoft.GetProperty("isEnabled").GetBoolean().Should().BeTrue();
+
+        // The {connectionId} placeholder is replaced with the generated connection id.
+        var connectionId = microsoft.GetProperty("id").GetString()!;
+        var callbacks = JsonSerializer.Deserialize<List<string>>(microsoft.GetProperty("allowedCallbackUris").GetString()!)!;
+        callbacks.Should().Contain($"http://localhost:5062/api/v1/auth/oidc/callback/{connectionId}");
+    }
+
+    private static WebApplicationFactory<Program> CreateSeededFactory()
+        => ExampleApiFixture.CreateFactory(builder =>
+        {
+            builder.UseSetting("SqlOS:Issuer", "http://localhost:5062/sqlos/auth");
+            builder.UseSetting("SqlOS:Oidc:Microsoft:ClientId", SeededClientId);
+            builder.UseSetting("SqlOS:Oidc:Microsoft:ClientSecret", "seeded-microsoft-secret");
+            builder.UseSetting("SqlOS:Oidc:Microsoft:Tenant", "common");
+        });
+}

--- a/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerOptions.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerOptions.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
+using SqlOS.AuthServer.Contracts;
 using SqlOS.Configuration;
 
 namespace SqlOS.AuthServer.Configuration;
@@ -49,6 +50,7 @@ public class SqlOSAuthServerOptions
     public SqlOSAuthEmailSeedOptions? AuthEmailSeed { get; private set; }
     public SqlOSSingleApplicationOptions? SingleApplication { get; private set; }
     public List<SqlOSClientSeedOptions> ClientSeeds { get; } = [];
+    public List<SqlOSOidcConnectionSeedOptions> OidcConnectionSeeds { get; } = [];
 
     public SqlOSAuthServerOptions UseHeadlessAuthPage(Action<SqlOSHeadlessAuthOptions> configure)
     {
@@ -79,6 +81,61 @@ public class SqlOSAuthServerOptions
         ClientSeeds.Add(seed);
         return this;
     }
+
+    /// <summary>
+    /// Seed a social/OIDC login connection (Google, Microsoft, Apple, or custom). The connection is
+    /// reconciled into the database on startup, matched by provider type (and display name for custom
+    /// providers). Callback URIs may include the <c>{connectionId}</c> placeholder.
+    /// </summary>
+    public SqlOSAuthServerOptions SeedOidcConnection(Action<SqlOSOidcConnectionSeedOptions> configure)
+    {
+        var seed = new SqlOSOidcConnectionSeedOptions();
+        configure(seed);
+        OidcConnectionSeeds.Add(seed);
+        return this;
+    }
+
+    /// <summary>
+    /// Seed a "Continue with Microsoft" (Microsoft Entra) social login connection. When no callback URIs
+    /// are supplied, the SqlOS-owned callback URI (<c>{connectionId}</c> placeholder) is used so the
+    /// connection works against the host's own origin.
+    /// </summary>
+    public SqlOSAuthServerOptions SeedMicrosoftConnection(
+        string clientId,
+        string clientSecret,
+        string? tenant = null,
+        params string[] allowedCallbackUris)
+        => SeedOidcConnection(oidc =>
+        {
+            oidc.ProviderType = SqlOSOidcProviderType.Microsoft;
+            oidc.DisplayName = "Microsoft";
+            oidc.ClientId = clientId;
+            oidc.ClientSecret = clientSecret;
+            oidc.MicrosoftTenant = tenant;
+            oidc.AllowedCallbackUris = allowedCallbackUris
+                .Where(static uri => !string.IsNullOrWhiteSpace(uri))
+                .Select(static uri => uri.Trim())
+                .ToList();
+        });
+
+    /// <summary>
+    /// Seed a "Continue with Google" social login connection.
+    /// </summary>
+    public SqlOSAuthServerOptions SeedGoogleConnection(
+        string clientId,
+        string clientSecret,
+        params string[] allowedCallbackUris)
+        => SeedOidcConnection(oidc =>
+        {
+            oidc.ProviderType = SqlOSOidcProviderType.Google;
+            oidc.DisplayName = "Google";
+            oidc.ClientId = clientId;
+            oidc.ClientSecret = clientSecret;
+            oidc.AllowedCallbackUris = allowedCallbackUris
+                .Where(static uri => !string.IsNullOrWhiteSpace(uri))
+                .Select(static uri => uri.Trim())
+                .ToList();
+        });
 
     public SqlOSAuthServerOptions UseSingleApplication(string name, Action<SqlOSSingleApplicationOptions>? configure = null)
     {

--- a/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerSeedOptions.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerSeedOptions.cs
@@ -1,3 +1,5 @@
+using SqlOS.AuthServer.Contracts;
+
 namespace SqlOS.AuthServer.Configuration;
 
 public sealed class SqlOSSingleApplicationOptions
@@ -51,4 +53,51 @@ public sealed class SqlOSClientSeedOptions
     public bool AllowNativeHeadlessAuth { get; set; }
     public bool AllowDeviceAuthorization { get; set; }
     public bool IsActive { get; set; } = true;
+}
+
+/// <summary>
+/// Declarative seed for a social/OIDC login connection (Google, Microsoft, Apple, or custom).
+/// Seeds are reconciled into the database on startup, matched by <see cref="ProviderType"/>
+/// (and <see cref="DisplayName"/> for <see cref="SqlOSOidcProviderType.Custom"/>).
+/// Callback URIs may contain the <c>{connectionId}</c> placeholder, which is replaced with the
+/// generated connection id so the SqlOS-owned callback URL can be seeded without knowing the id up front.
+/// </summary>
+public sealed class SqlOSOidcConnectionSeedOptions
+{
+    public SqlOSOidcProviderType ProviderType { get; set; } = SqlOSOidcProviderType.Custom;
+    public string DisplayName { get; set; } = string.Empty;
+    public string ClientId { get; set; } = string.Empty;
+    public string? ClientSecret { get; set; }
+
+    /// <summary>
+    /// Allowed callback URIs. Supports the <c>{connectionId}</c> placeholder, which is replaced
+    /// with the generated connection id at seed time.
+    /// </summary>
+    public List<string> AllowedCallbackUris { get; set; } = [];
+
+    public bool UseDiscovery { get; set; } = true;
+    public string? DiscoveryUrl { get; set; }
+    public string? Issuer { get; set; }
+    public string? AuthorizationEndpoint { get; set; }
+    public string? TokenEndpoint { get; set; }
+    public string? UserInfoEndpoint { get; set; }
+    public string? JwksUri { get; set; }
+
+    /// <summary>Azure AD tenant id (Microsoft only). Defaults to <c>common</c> when omitted.</summary>
+    public string? MicrosoftTenant { get; set; }
+
+    public List<string>? Scopes { get; set; }
+    public SqlOSOidcClaimMapping? ClaimMapping { get; set; }
+    public SqlOSOidcClientAuthMethod? ClientAuthMethod { get; set; }
+    public bool? UseUserInfo { get; set; }
+    public string? AppleTeamId { get; set; }
+    public string? AppleKeyId { get; set; }
+    public string? ApplePrivateKeyPem { get; set; }
+    public string? LogoDataUrl { get; set; }
+
+    /// <summary>
+    /// Whether the connection should be enabled when first seeded. After the connection exists,
+    /// manual enable/disable from the dashboard is preserved across restarts.
+    /// </summary>
+    public bool IsEnabled { get; set; } = true;
 }

--- a/src/SqlOS/AuthServer/Services/SqlOSAdminService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSAdminService.cs
@@ -173,6 +173,132 @@ public sealed class SqlOSAdminService
         await _context.SaveChangesAsync(cancellationToken);
     }
 
+    public async Task UpsertSeededOidcConnectionsAsync(CancellationToken cancellationToken = default)
+    {
+        if (_options.OidcConnectionSeeds.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var seed in _options.OidcConnectionSeeds)
+        {
+            var displayName = (seed.DisplayName ?? string.Empty).Trim();
+
+            SqlOSOidcConnection? existing;
+            if (seed.ProviderType == SqlOSOidcProviderType.Custom)
+            {
+                existing = await _context.Set<SqlOSOidcConnection>()
+                    .FirstOrDefaultAsync(
+                        x => x.ProviderType == SqlOSOidcProviderType.Custom && x.DisplayName == displayName,
+                        cancellationToken);
+            }
+            else
+            {
+                existing = await _context.Set<SqlOSOidcConnection>()
+                    .FirstOrDefaultAsync(x => x.ProviderType == seed.ProviderType, cancellationToken);
+            }
+
+            var connectionId = existing?.Id ?? _cryptoService.GenerateId("oidc");
+            var callbacks = NormalizeCallbackUris(seed.AllowedCallbackUris, connectionId);
+            if (callbacks.Count == 0)
+            {
+                throw new InvalidOperationException(
+                    $"Seeded OIDC connection '{(string.IsNullOrWhiteSpace(displayName) ? seed.ProviderType.ToString() : displayName)}' requires at least one callback URI.");
+            }
+
+            var normalized = NormalizeOidcConfiguration(
+                seed.ProviderType,
+                seed.UseDiscovery,
+                seed.DiscoveryUrl,
+                seed.Issuer,
+                seed.AuthorizationEndpoint,
+                seed.TokenEndpoint,
+                seed.UserInfoEndpoint,
+                seed.JwksUri,
+                seed.MicrosoftTenant,
+                seed.Scopes,
+                seed.ClaimMapping,
+                seed.ClientAuthMethod,
+                seed.UseUserInfo,
+                seed.AppleTeamId,
+                seed.AppleKeyId);
+
+            if (existing == null)
+            {
+                var connection = new SqlOSOidcConnection
+                {
+                    Id = connectionId,
+                    ProviderType = seed.ProviderType,
+                    DisplayName = displayName,
+                    LogoDataUrl = SqlOSOidcProviderLogoCatalog.NormalizeCustomLogoDataUrl(seed.LogoDataUrl),
+                    ClientId = seed.ClientId.Trim(),
+                    ClientSecretEncrypted = string.IsNullOrWhiteSpace(seed.ClientSecret) ? null : _cryptoService.ProtectSecret(seed.ClientSecret.Trim()),
+                    AllowedCallbackUrisJson = JsonSerializer.Serialize(callbacks),
+                    UseDiscovery = normalized.UseDiscovery,
+                    DiscoveryUrl = normalized.DiscoveryUrl,
+                    Issuer = normalized.Issuer,
+                    AuthorizationEndpoint = normalized.AuthorizationEndpoint,
+                    TokenEndpoint = normalized.TokenEndpoint,
+                    UserInfoEndpoint = normalized.UserInfoEndpoint,
+                    JwksUri = normalized.JwksUri,
+                    MicrosoftTenant = normalized.MicrosoftTenant,
+                    ScopesJson = JsonSerializer.Serialize(normalized.Scopes),
+                    ClaimMappingJson = JsonSerializer.Serialize(normalized.ClaimMapping),
+                    ClientAuthMethod = normalized.ClientAuthMethod,
+                    UseUserInfo = normalized.UseUserInfo,
+                    AppleTeamId = normalized.AppleTeamId,
+                    AppleKeyId = normalized.AppleKeyId,
+                    ApplePrivateKeyEncrypted = string.IsNullOrWhiteSpace(seed.ApplePrivateKeyPem) ? null : _cryptoService.ProtectSecret(NormalizePrivateKey(seed.ApplePrivateKeyPem)),
+                    IsEnabled = seed.IsEnabled,
+                    CreatedAt = DateTime.UtcNow,
+                    UpdatedAt = DateTime.UtcNow
+                };
+
+                ValidateOidcSecretRequirements(connection);
+                _context.Set<SqlOSOidcConnection>().Add(connection);
+                continue;
+            }
+
+            existing.DisplayName = displayName;
+            existing.LogoDataUrl = SqlOSOidcProviderLogoCatalog.NormalizeCustomLogoDataUrl(seed.LogoDataUrl);
+            existing.ClientId = seed.ClientId.Trim();
+            existing.AllowedCallbackUrisJson = JsonSerializer.Serialize(callbacks);
+            existing.UseDiscovery = normalized.UseDiscovery;
+            existing.DiscoveryUrl = normalized.DiscoveryUrl;
+            existing.Issuer = normalized.Issuer;
+            existing.AuthorizationEndpoint = normalized.AuthorizationEndpoint;
+            existing.TokenEndpoint = normalized.TokenEndpoint;
+            existing.UserInfoEndpoint = normalized.UserInfoEndpoint;
+            existing.JwksUri = normalized.JwksUri;
+            existing.MicrosoftTenant = normalized.MicrosoftTenant;
+            existing.ScopesJson = JsonSerializer.Serialize(normalized.Scopes);
+            existing.ClaimMappingJson = JsonSerializer.Serialize(normalized.ClaimMapping);
+            existing.ClientAuthMethod = normalized.ClientAuthMethod;
+            existing.UseUserInfo = normalized.UseUserInfo;
+            existing.AppleTeamId = normalized.AppleTeamId;
+            existing.AppleKeyId = normalized.AppleKeyId;
+            existing.UpdatedAt = DateTime.UtcNow;
+
+            // Only overwrite secrets when the seed supplies them, so config without a secret
+            // (e.g. a rotated value kept out of source) never clears an existing credential.
+            if (!string.IsNullOrWhiteSpace(seed.ClientSecret))
+            {
+                existing.ClientSecretEncrypted = _cryptoService.ProtectSecret(seed.ClientSecret.Trim());
+            }
+
+            if (!string.IsNullOrWhiteSpace(seed.ApplePrivateKeyPem))
+            {
+                existing.ApplePrivateKeyEncrypted = _cryptoService.ProtectSecret(NormalizePrivateKey(seed.ApplePrivateKeyPem));
+            }
+
+            // Enable/disable is owner-managed once the connection exists: respect dashboard changes
+            // across restarts instead of forcing the seeded value on every boot.
+            ValidateOidcSecretRequirements(existing);
+        }
+
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+
     public async Task<SqlOSUser> CreateUserAsync(SqlOSCreateUserRequest request, CancellationToken cancellationToken = default)
     {
         var normalizedEmail = NormalizeEmail(request.Email);

--- a/src/SqlOS/Services/SqlOSBootstrapper.cs
+++ b/src/SqlOS/Services/SqlOSBootstrapper.cs
@@ -56,6 +56,7 @@ public sealed class SqlOSBootstrapper
         await _settingsService.UpsertSeededAuthEmailSettingsAsync(cancellationToken);
         await _emailAdminService.EnsureBuiltInTemplatesAsync(cancellationToken);
         await _adminService.UpsertSeededClientsAsync(cancellationToken);
+        await _adminService.UpsertSeededOidcConnectionsAsync(cancellationToken);
         await _adminService.CleanupExpiredTemporaryTokensAsync(cancellationToken);
         await _adminService.CleanupExpiredEmailOtpChallengesAsync(cancellationToken);
         await _adminService.CleanupExpiredPhoneOtpChallengesAsync(cancellationToken);

--- a/tests/SqlOS.Tests/SqlOSOidcConnectionSeedingTests.cs
+++ b/tests/SqlOS.Tests/SqlOSOidcConnectionSeedingTests.cs
@@ -1,0 +1,282 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SqlOS.AuthServer.Configuration;
+using SqlOS.AuthServer.Contracts;
+using SqlOS.AuthServer.Models;
+using SqlOS.AuthServer.Services;
+using SqlOS.Tests.Infrastructure;
+
+namespace SqlOS.Tests;
+
+[TestClass]
+public sealed class SqlOSOidcConnectionSeedingTests
+{
+    [TestMethod]
+    public async Task UpsertSeededOidcConnectionsAsync_SeedsMicrosoftConnection()
+    {
+        using var context = CreateContext();
+        var optionsValue = new SqlOSAuthServerOptions();
+        optionsValue.SeedMicrosoftConnection(
+            "microsoft-client",
+            "microsoft-secret",
+            tenant: "common",
+            "http://localhost:5062/api/v1/auth/oidc/callback/{connectionId}");
+
+        var (admin, _) = CreateServices(context, optionsValue);
+
+        await admin.UpsertSeededOidcConnectionsAsync();
+
+        var connection = await context.Set<SqlOSOidcConnection>().SingleAsync();
+        connection.ProviderType.Should().Be(SqlOSOidcProviderType.Microsoft);
+        connection.DisplayName.Should().Be("Microsoft");
+        connection.ClientId.Should().Be("microsoft-client");
+        connection.IsEnabled.Should().BeTrue();
+        connection.UseDiscovery.Should().BeTrue();
+        connection.MicrosoftTenant.Should().Be("common");
+        connection.DiscoveryUrl.Should().Be("https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration");
+        connection.ClientSecretEncrypted.Should().NotBeNullOrWhiteSpace();
+
+        // The {connectionId} placeholder is replaced with the generated id.
+        var callbacks = JsonSerializer.Deserialize<List<string>>(connection.AllowedCallbackUrisJson)!;
+        callbacks.Should().ContainSingle()
+            .Which.Should().Be($"http://localhost:5062/api/v1/auth/oidc/callback/{connection.Id}");
+    }
+
+    [TestMethod]
+    public async Task UpsertSeededOidcConnectionsAsync_SeededConnectionAppearsAsEnabledProvider()
+    {
+        using var context = CreateContext();
+        var optionsValue = new SqlOSAuthServerOptions();
+        optionsValue.SeedMicrosoftConnection(
+            "microsoft-client",
+            "microsoft-secret",
+            tenant: null,
+            "http://localhost:5062/api/v1/auth/oidc/callback/{connectionId}");
+
+        var (admin, oidc) = CreateServices(context, optionsValue);
+        await admin.UpsertSeededOidcConnectionsAsync();
+
+        var providers = await oidc.ListEnabledProvidersAsync();
+
+        providers.Should().ContainSingle(x => x.ProviderType == "Microsoft" && x.DisplayName == "Microsoft");
+    }
+
+    [TestMethod]
+    public async Task UpsertSeededOidcConnectionsAsync_IsIdempotent_AndReconcilesFields()
+    {
+        using var context = CreateContext();
+        var optionsValue = new SqlOSAuthServerOptions();
+        optionsValue.SeedMicrosoftConnection(
+            "microsoft-client",
+            "microsoft-secret",
+            tenant: "common",
+            "http://localhost:5062/api/v1/auth/oidc/callback/{connectionId}");
+
+        var (admin, _) = CreateServices(context, optionsValue);
+
+        await admin.UpsertSeededOidcConnectionsAsync();
+        var firstId = (await context.Set<SqlOSOidcConnection>().SingleAsync()).Id;
+
+        // Mutate the seed to simulate a config change, then re-run startup seeding.
+        optionsValue.OidcConnectionSeeds[0].ClientId = "microsoft-client-rotated";
+        optionsValue.OidcConnectionSeeds[0].MicrosoftTenant = "contoso.onmicrosoft.com";
+
+        await admin.UpsertSeededOidcConnectionsAsync();
+
+        var connection = await context.Set<SqlOSOidcConnection>().SingleAsync();
+        connection.Id.Should().Be(firstId, "re-seeding must update in place, not create a duplicate");
+        connection.ClientId.Should().Be("microsoft-client-rotated");
+        connection.MicrosoftTenant.Should().Be("contoso.onmicrosoft.com");
+        connection.DiscoveryUrl.Should().Be("https://login.microsoftonline.com/contoso.onmicrosoft.com/v2.0/.well-known/openid-configuration");
+    }
+
+    [TestMethod]
+    public async Task UpsertSeededOidcConnectionsAsync_PreservesManualDisable()
+    {
+        using var context = CreateContext();
+        var optionsValue = new SqlOSAuthServerOptions();
+        optionsValue.SeedMicrosoftConnection(
+            "microsoft-client",
+            "microsoft-secret",
+            tenant: "common",
+            "http://localhost:5062/api/v1/auth/oidc/callback/{connectionId}");
+
+        var (admin, _) = CreateServices(context, optionsValue);
+        await admin.UpsertSeededOidcConnectionsAsync();
+
+        var connection = await context.Set<SqlOSOidcConnection>().SingleAsync();
+        await admin.SetOidcConnectionEnabledAsync(connection.Id, false);
+
+        // Re-run seeding: a manual disable from the dashboard must survive restart.
+        await admin.UpsertSeededOidcConnectionsAsync();
+
+        var reloaded = await context.Set<SqlOSOidcConnection>().SingleAsync();
+        reloaded.IsEnabled.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public async Task UpsertSeededOidcConnectionsAsync_DoesNotClearSecretWhenSeedOmitsIt()
+    {
+        using var context = CreateContext();
+        var optionsValue = new SqlOSAuthServerOptions();
+        optionsValue.SeedMicrosoftConnection(
+            "microsoft-client",
+            "microsoft-secret",
+            tenant: "common",
+            "http://localhost:5062/api/v1/auth/oidc/callback/{connectionId}");
+
+        var (admin, _) = CreateServices(context, optionsValue);
+        await admin.UpsertSeededOidcConnectionsAsync();
+        var original = (await context.Set<SqlOSOidcConnection>().SingleAsync()).ClientSecretEncrypted;
+
+        // Config without a secret (kept out of source) must not wipe the stored credential.
+        optionsValue.OidcConnectionSeeds[0].ClientSecret = null;
+        await admin.UpsertSeededOidcConnectionsAsync();
+
+        var connection = await context.Set<SqlOSOidcConnection>().SingleAsync();
+        connection.ClientSecretEncrypted.Should().Be(original);
+    }
+
+    [TestMethod]
+    public async Task UpsertSeededOidcConnectionsAsync_SeedsGoogleConnection()
+    {
+        using var context = CreateContext();
+        var optionsValue = new SqlOSAuthServerOptions();
+        optionsValue.SeedGoogleConnection(
+            "google-client",
+            "google-secret",
+            "http://localhost:5062/api/v1/auth/oidc/callback/{connectionId}");
+
+        var (admin, _) = CreateServices(context, optionsValue);
+
+        await admin.UpsertSeededOidcConnectionsAsync();
+
+        var connection = await context.Set<SqlOSOidcConnection>().SingleAsync();
+        connection.ProviderType.Should().Be(SqlOSOidcProviderType.Google);
+        connection.DisplayName.Should().Be("Google");
+        connection.ClientId.Should().Be("google-client");
+        connection.IsEnabled.Should().BeTrue();
+        connection.UseDiscovery.Should().BeTrue();
+        connection.DiscoveryUrl.Should().Be("https://accounts.google.com/.well-known/openid-configuration");
+        connection.MicrosoftTenant.Should().BeNull();
+        connection.ClientSecretEncrypted.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [TestMethod]
+    public async Task UpsertSeededOidcConnectionsAsync_MatchesCustomConnectionByDisplayName()
+    {
+        using var context = CreateContext();
+        var optionsValue = new SqlOSAuthServerOptions();
+        optionsValue
+            .SeedOidcConnection(oidc =>
+            {
+                oidc.ProviderType = SqlOSOidcProviderType.Custom;
+                oidc.DisplayName = "Acme Identity";
+                oidc.ClientId = "acme-client";
+                oidc.ClientSecret = "acme-secret";
+                oidc.UseDiscovery = true;
+                oidc.DiscoveryUrl = "https://oidc.example.local/.well-known/openid-configuration";
+                oidc.AllowedCallbackUris = ["https://app.example.local/callback/{connectionId}"];
+            })
+            .SeedOidcConnection(oidc =>
+            {
+                oidc.ProviderType = SqlOSOidcProviderType.Custom;
+                oidc.DisplayName = "Globex Identity";
+                oidc.ClientId = "globex-client";
+                oidc.ClientSecret = "globex-secret";
+                oidc.UseDiscovery = true;
+                oidc.DiscoveryUrl = "https://oidc.globex.local/.well-known/openid-configuration";
+                oidc.AllowedCallbackUris = ["https://app.example.local/callback/{connectionId}"];
+            });
+
+        var (admin, _) = CreateServices(context, optionsValue);
+
+        await admin.UpsertSeededOidcConnectionsAsync();
+        await admin.UpsertSeededOidcConnectionsAsync();
+
+        var connections = await context.Set<SqlOSOidcConnection>().ToListAsync();
+        connections.Should().HaveCount(2);
+        connections.Select(x => x.DisplayName).Should().BeEquivalentTo(["Acme Identity", "Globex Identity"]);
+    }
+
+    [TestMethod]
+    public async Task UpsertSeededOidcConnectionsAsync_ThrowsWhenCallbackMissing()
+    {
+        using var context = CreateContext();
+        var optionsValue = new SqlOSAuthServerOptions();
+        optionsValue.SeedOidcConnection(oidc =>
+        {
+            oidc.ProviderType = SqlOSOidcProviderType.Microsoft;
+            oidc.DisplayName = "Microsoft";
+            oidc.ClientId = "microsoft-client";
+            oidc.ClientSecret = "microsoft-secret";
+            oidc.AllowedCallbackUris = [];
+        });
+
+        var (admin, _) = CreateServices(context, optionsValue);
+
+        await FluentActions.Awaiting(() => admin.UpsertSeededOidcConnectionsAsync())
+            .Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*callback URI*");
+    }
+
+    [TestMethod]
+    public async Task UpsertSeededOidcConnectionsAsync_ThrowsWhenSecretMissing()
+    {
+        using var context = CreateContext();
+        var optionsValue = new SqlOSAuthServerOptions();
+        optionsValue.SeedOidcConnection(oidc =>
+        {
+            oidc.ProviderType = SqlOSOidcProviderType.Microsoft;
+            oidc.DisplayName = "Microsoft";
+            oidc.ClientId = "microsoft-client";
+            oidc.ClientSecret = null;
+            oidc.AllowedCallbackUris = ["http://localhost:5062/api/v1/auth/oidc/callback/{connectionId}"];
+        });
+
+        var (admin, _) = CreateServices(context, optionsValue);
+
+        await FluentActions.Awaiting(() => admin.UpsertSeededOidcConnectionsAsync())
+            .Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*client secret*");
+    }
+
+    [TestMethod]
+    public async Task UpsertSeededOidcConnectionsAsync_NoSeeds_IsNoOp()
+    {
+        using var context = CreateContext();
+        var (admin, _) = CreateServices(context, new SqlOSAuthServerOptions());
+
+        await admin.UpsertSeededOidcConnectionsAsync();
+
+        (await context.Set<SqlOSOidcConnection>().CountAsync()).Should().Be(0);
+    }
+
+    private static (SqlOSAdminService admin, SqlOSOidcAuthService oidc) CreateServices(
+        TestSqlOSInMemoryDbContext context,
+        SqlOSAuthServerOptions optionsValue)
+    {
+        var options = Options.Create(optionsValue);
+        var crypto = new SqlOSCryptoService(context, options, new EphemeralDataProtectionProvider());
+        var admin = new SqlOSAdminService(context, options, crypto);
+        var oidc = new SqlOSOidcAuthService(
+            context,
+            admin,
+            crypto,
+            new FakeOidcProviderHttpClientFactory(),
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<SqlOSOidcAuthService>.Instance);
+        return (admin, oidc);
+    }
+
+    private static TestSqlOSInMemoryDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<TestSqlOSInMemoryDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .Options;
+        return new TestSqlOSInMemoryDbContext(options);
+    }
+}

--- a/web/content/docs/authserver/microsoft-oidc.mdx
+++ b/web/content/docs/authserver/microsoft-oidc.mdx
@@ -34,4 +34,18 @@ curl -X POST http://localhost:5062/sqlos/admin/auth/api/oidc-connections \
 curl -X POST http://localhost:5062/sqlos/admin/auth/api/oidc-connections/{id}/enable
 ```
 
+## Seed from code
+
+To create the connection from a fresh database without the dashboard or curl, seed it at startup:
+
+```csharp
+options.AuthServer.SeedMicrosoftConnection(
+    clientId: builder.Configuration["SqlOS:Oidc:Microsoft:ClientId"]!,
+    clientSecret: builder.Configuration["SqlOS:Oidc:Microsoft:ClientSecret"]!,
+    tenant: "common",
+    "http://localhost:5062/api/v1/auth/oidc/callback/{connectionId}");
+```
+
+See [Google and Microsoft sign-in](/docs/guides/social-oidc#seed-from-startup) for seeding behavior and the general `SeedOidcConnection` form.
+
 See [OIDC Social Login](/docs/authserver/oidc-auth) for the complete auth flow.

--- a/web/content/docs/guides/social-oidc.mdx
+++ b/web/content/docs/guides/social-oidc.mdx
@@ -42,6 +42,52 @@ See [Google OIDC](/docs/authserver/google-oidc) for curl-based setup and failure
 
 See [Microsoft OIDC](/docs/authserver/microsoft-oidc).
 
+## Seed from startup
+
+Instead of clicking through the dashboard, you can seed a connection from code so it exists on a fresh database. This is consistent with `SeedAuthPage`, `SeedAuthEmails`, and client seeding: the bootstrapper reconciles the connection on startup, matched by provider type (and display name for custom providers).
+
+```csharp
+builder.AddSqlOS<AppDbContext>(options =>
+{
+    var auth = options.AuthServer;
+
+    // "Continue with Microsoft". Keep secrets in configuration/user-secrets, never in source.
+    auth.SeedMicrosoftConnection(
+        clientId: builder.Configuration["SqlOS:Oidc:Microsoft:ClientId"]!,
+        clientSecret: builder.Configuration["SqlOS:Oidc:Microsoft:ClientSecret"]!,
+        tenant: "common",
+        // {connectionId} is replaced with the generated connection id at seed time.
+        "https://your-app.example.com/api/v1/auth/oidc/callback/{connectionId}");
+
+    // "Continue with Google".
+    auth.SeedGoogleConnection(
+        clientId: builder.Configuration["SqlOS:Oidc:Google:ClientId"]!,
+        clientSecret: builder.Configuration["SqlOS:Oidc:Google:ClientSecret"]!,
+        "https://your-app.example.com/api/v1/auth/oidc/callback/{connectionId}");
+});
+```
+
+For Apple or fully custom providers, use the general form:
+
+```csharp
+auth.SeedOidcConnection(oidc =>
+{
+    oidc.ProviderType = SqlOSOidcProviderType.Custom;
+    oidc.DisplayName = "Acme Identity";
+    oidc.ClientId = builder.Configuration["SqlOS:Oidc:Acme:ClientId"]!;
+    oidc.ClientSecret = builder.Configuration["SqlOS:Oidc:Acme:ClientSecret"];
+    oidc.DiscoveryUrl = "https://id.acme.com/.well-known/openid-configuration";
+    oidc.AllowedCallbackUris = ["https://your-app.example.com/api/v1/auth/oidc/callback/{connectionId}"];
+});
+```
+
+<Callout type="info" title="Seeding behavior">
+  - Seeds are reconciled on every startup. Client id, callbacks, scopes, and endpoints are kept in sync with your code.
+  - A client secret is only overwritten when the seed supplies one, so configuration without a secret never clears a stored credential.
+  - Enable/disable is owner-managed once the connection exists: a manual disable from the dashboard survives restarts.
+  - Add the same SqlOS-owned callback URI to the provider (Entra, Google, etc.). The connection id is shown in the dashboard after the first boot.
+</Callout>
+
 ## Test
 
 1. Open your app’s login entry point (or `/sqlos/auth/login`).


### PR DESCRIPTION
## Summary

Social login (Google / Microsoft / Apple / custom) was the **only** auth surface in SqlOS without a code-seeding path. Clients (`SeedClient`/`SeedBrowserClient`), the AuthPage (`SeedAuthPage`), email branding (`SeedAuthEmails`), and FGA (`Fga.Seed`) all reconcile from `AddSqlOS(...)` options on startup, but OIDC connections could only be created at runtime via the dashboard or admin API. That meant a "Continue with Microsoft" button could not be reproduced from a fresh database in code.

This PR closes that gap with a first-class, consistent seeding path.

### Library
- `SqlOSOidcConnectionSeedOptions` (new declarative seed type) in `SqlOSAuthServerSeedOptions.cs`.
- `SqlOSAuthServerOptions.SeedOidcConnection(...)` plus `SeedMicrosoftConnection(...)` and `SeedGoogleConnection(...)` convenience helpers (mirrors the `SeedBrowserClient`/`SeedOwnedWebApp` style).
- `SqlOSAdminService.UpsertSeededOidcConnectionsAsync(...)` — idempotent upsert that reuses the existing `NormalizeOidcConfiguration` / `NormalizeCallbackUris` / `ValidateOidcSecretRequirements` logic.
- Wired into `SqlOSBootstrapper.InitializeAsync()` right after `UpsertSeededClientsAsync`.

### Behavior (pragmatic, matches existing seed conventions)
- Reconciled on every startup; matched by **provider type** (and **display name** for `Custom`).
- Callback URIs support the `{connectionId}` placeholder, replaced with the generated id at seed time — so the SqlOS-owned callback can be seeded without knowing the id up front.
- A client secret is **only** overwritten when the seed supplies one, so config without a secret never clears a stored credential.
- Enable/disable is owner-managed once the connection exists: a manual dashboard disable survives restarts.
- Fails fast at startup on misconfiguration (missing callback / missing secret), consistent with AuthPage seed validation.

### Retail example (no secrets in source)
- The example API seeds a "Continue with Microsoft" connection **only when** credentials are present.
- The Example AppHost reads the values from its own configuration/user-secrets (or `AZURE_OIDC_MICROSOFT_*`) and forwards them to the API as `SqlOS__Oidc__Microsoft__*` environment variables. Nothing secret is committed.

### Docs
- `docs/guides/social-oidc.mdx`: new "Seed from startup" section.
- `docs/authserver/microsoft-oidc.mdx`: "Seed from code" snippet.

## Test plan
- [x] `scripts/build.sh` (full solution, Release) — 0 warnings/errors
- [x] Unit tests: `tests/SqlOS.Tests` — 166 passing, incl. new `SqlOSOidcConnectionSeedingTests` (insert, idempotency, manual-disable preserved, secret-not-cleared, custom-by-display-name, missing-callback/secret throws, Google + Microsoft)
- [x] Example integration tests: new `SqlOSExampleOidcSeedingIntegrationTests` + existing `SqlOSExampleOidcAuthIntegrationTests` — 8 passing (no shared-DB interference)
- [x] `node scripts/validate-doc-links.mjs` — clean
- [x] Web lint + build (docs-check parity) — OK

### Local config to try it
On the Example AppHost:
```bash
cd examples/SqlOS.Example.AppHost
dotnet user-secrets set "SqlOS:Oidc:Microsoft:ClientId" "<entra-app-id>"
dotnet user-secrets set "SqlOS:Oidc:Microsoft:ClientSecret" "<entra-secret>"
```
Add `http://localhost:5062/api/v1/auth/oidc/callback/{connectionId}` as the Entra redirect URI (connection id shown in `/sqlos/admin/auth/oidc` after first boot).

Made with [Cursor](https://cursor.com)