### PR TITLE
Bump version to 3.12.0

### DIFF
--- a/src/SqlOS/SqlOS.csproj
+++ b/src/SqlOS/SqlOS.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>SqlOS</PackageId>
-    <Version>3.11.0</Version>
+    <Version>3.12.0</Version>
     <Authors>Ross Slaney</Authors>
     <Description>Embedded auth server and fine-grained authorization runtime for .NET + SQL Server + EF Core.</Description>
     <PackageTags>authentication;authorization;fga;saml;jwt;sessions;efcore;sqlserver</PackageTags>


### PR DESCRIPTION
## Summary

- Bump the SqlOS package version from 3.11.0 to 3.12.0.

## Validation

- ./scripts/build.sh
- ./scripts/unit-tests.sh
- ASPIRE_ALLOW_UNSECURED_TRANSPORT=true ./scripts/integration-tests.sh
- ./scripts/docs-check.sh

## AuthServer Checklist

This PR only changes package metadata; no AuthServer behavior changed.

- [x] Hosted auth page: not applicable
- [x] Seed configuration and admin configuration: not applicable
- [x] Headless mode: not applicable
- [x] SDK / API-driven mode: not applicable