### PR TITLE
Add one-app growth blog series

### DIFF
--- a/web/content/blog/auth-for-one-dotnet-app-with-sqlos.mdx
+++ b/web/content/blog/auth-for-one-dotnet-app-with-sqlos.mdx
@@ -1,0 +1,248 @@
+---
+title: "Auth for One .NET App with SqlOS"
+description: "The default path for a B2B SaaS app on SQL Server: hosted login, orgs, OAuth tokens, sessions, and SqlOS routes inside your ASP.NET host."
+date: "2026-06-03"
+author: "Ross Slaney"
+tags: ["AuthServer", "OAuth", "B2B SaaS", "SqlOS", ".NET"]
+---
+
+You have one web app.
+
+Not six customer portals. Not an identity platform. Not a vendor comparison spreadsheet. One B2B SaaS product on SQL Server, with a browser frontend and an API.
+
+You need people to sign in, join an organization, invite a teammate, and call your API with a real OAuth access token. Later, one customer may ask for SSO. You do not want to run Keycloak, wire Auth0, or build an auth microservice before the product exists.
+
+This is the default SqlOS path: host auth inside the ASP.NET app you already operate, keep the auth tables in SQL Server, and start with the hosted AuthPage.
+
+<BlogVisual kind="one-app-topology" />
+
+## The shape
+
+For a first B2B app, keep the topology boring:
+
+| Piece | Default |
+| --- | --- |
+| Product | One web app |
+| OAuth client | One first-party public PKCE client |
+| Database | One SQL Server database |
+| Auth UI | SqlOS hosted AuthPage |
+| API | Your ASP.NET routes plus SqlOS routes |
+| Admin | SqlOS dashboard at `/sqlos` |
+
+That gives you the important thing: a standards-based login flow without making auth a second service.
+
+The browser redirects to `/sqlos/auth/authorize`. SqlOS renders the AuthPage, handles the credential flow, stores sessions and refresh tokens, and redirects back with an authorization code. Your frontend exchanges the code, then calls your API with a bearer token.
+
+## Minimal setup
+
+Install the package:
+
+```bash
+dotnet add package SqlOS
+```
+
+Your host registers the same `DbContext` your app already uses. This example seeds one browser client and turns on local password login for the first version:
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using SqlOS.Extensions;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddDbContext<AppDbContext>(options =>
+    options.UseSqlServer(
+        builder.Configuration.GetConnectionString("DefaultConnection")));
+
+builder.AddSqlOS<AppDbContext>(options =>
+{
+    options.DashboardBasePath = "/sqlos";
+
+    options.AuthServer.Issuer = "https://app.example.com/sqlos/auth";
+    options.AuthServer.PublicOrigin = "https://app.example.com";
+    options.AuthServer.DefaultAudience = "https://app.example.com/api";
+    options.AuthServer.EnableLocalPasswordAuth = true;
+
+    options.AuthServer.SeedClient(client =>
+    {
+        client.ClientId = "app-web";
+        client.Name = "App Web";
+        client.Audience = "https://app.example.com/api";
+        client.RedirectUris = ["https://app.example.com/auth/callback"];
+        client.AllowedScopes =
+        [
+            "openid",
+            "profile",
+            "email",
+            "offline_access"
+        ];
+        client.ClientType = "public_pkce";
+        client.RequirePkce = true;
+        client.IsFirstParty = true;
+    });
+});
+
+var app = builder.Build();
+app.MapSqlOS();
+app.Run();
+```
+
+That is enough to mount the hosted auth routes and the dashboard. For a newer app that wants one product declaration instead of explicit client fields, use the single-application helper:
+
+```csharp
+builder.AddSqlOS<AppDbContext>(options =>
+{
+    options.UseSingleApplication("Todo", app =>
+    {
+        app.Origin = "https://todo.example.com";
+        app.EnabledCredentialTypes = ["password", "email_otp"];
+    });
+});
+```
+
+Single-application mode expands into normal SqlOS client and AuthPage settings. It is still one OAuth client, one issuer, and one set of routes.
+
+## Wire the DbContext
+
+Your context implements the AuthServer and FGA interfaces, then calls `UseSqlOS` in `OnModelCreating`. Even if you do not use resource authorization on day one, this is the clean setup for the combined SqlOS runtime:
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using SqlOS.AuthServer.Interfaces;
+using SqlOS.Extensions;
+using SqlOS.Fga.Interfaces;
+using SqlOS.Fga.Models;
+
+public sealed class AppDbContext(DbContextOptions<AppDbContext> options)
+    : DbContext(options), ISqlOSAuthServerDbContext, ISqlOSFgaDbContext
+{
+    public DbSet<Project> Projects => Set<Project>();
+
+    public IQueryable<SqlOSFgaAccessibleResource> IsResourceAccessible(
+        string resourceId,
+        string subjectIds,
+        string permissionId)
+        => FromExpression(() =>
+            IsResourceAccessible(resourceId, subjectIds, permissionId));
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+        modelBuilder.UseSqlOS(GetType());
+    }
+}
+```
+
+SqlOS owns its own tables. Your app owns your business tables. Both live in the same SQL Server database, which means you can inspect, back up, and deploy the whole application as one operational unit.
+
+## Start with the hosted AuthPage
+
+The fastest useful path is not a custom login screen. It is the hosted AuthPage with your app name, colors, credential options, and redirect URI already aligned.
+
+<BlogScreenshot
+  src="/docs/auth-signin-page.png"
+  alt="SqlOS hosted sign-in page"
+  caption="Hosted AuthPage keeps the first login flow inside SqlOS while your application keeps the same origin and OAuth issuer."
+/>
+
+Use headless auth later if your product needs a fully custom login UI. The hosted page is better for the first version because it removes the easy mistakes: mismatched redirect URIs, a credential form that does not match the OAuth transaction, and signup state that bypasses the auth server.
+
+## What routes you get
+
+Calling `app.MapSqlOS()` mounts the auth and admin surface:
+
+| Route | Purpose |
+| --- | --- |
+| `/sqlos` | Dashboard entry point |
+| `/sqlos/auth/*` | OAuth, hosted AuthPage, token, refresh, logout, invitations |
+| `/sqlos/admin/auth` | Users, organizations, clients, sessions |
+| `/sqlos/admin/fga` | Resources, grants, roles, permissions, access tester |
+
+Your API routes keep their normal shape:
+
+```csharp
+app.MapGet("/api/me", (ClaimsPrincipal user) =>
+{
+    return Results.Ok(new
+    {
+        userId = user.FindFirst("sub")?.Value,
+        email = user.FindFirst("email")?.Value
+    });
+});
+```
+
+The important boundary is simple: `/api/*` is your product, `/sqlos/auth/*` is the authorization server, and `/sqlos` is the operator dashboard.
+
+## Organizations when you need them
+
+Most B2B apps need organizations before they need a full identity platform. The first version usually needs:
+
+- create an organization during signup
+- invite a teammate
+- pick an organization at login if the user belongs to more than one
+- include organization context in the token
+- add SAML or OIDC later for an enterprise customer
+
+SqlOS keeps those objects in your database and exposes them in the same dashboard as the clients and sessions. That means support can answer ordinary questions without jumping between your admin UI, a vendor dashboard, and SQL queries.
+
+<BlogScreenshot
+  src="/docs/dashboard-organizations.png"
+  alt="SqlOS organizations dashboard"
+  caption="Organizations and memberships are part of the same SqlOS admin surface as users, clients, and sessions."
+/>
+
+The organization choice also affects tokens. For a one-app product, the frontend should not be guessing which tenant is active from local storage or a route parameter alone. The login flow should establish the user, the organization context, the client, and the audience together.
+
+That lets the API treat the token as an input to authorization instead of a loose profile blob:
+
+```csharp
+app.MapGet("/api/projects", async (
+    ClaimsPrincipal user,
+    AppDbContext dbContext,
+    CancellationToken cancellationToken) =>
+{
+    var organizationId = user.FindFirst("org_id")?.Value;
+    if (string.IsNullOrWhiteSpace(organizationId))
+    {
+        return Results.Forbid();
+    }
+
+    var projects = await dbContext.Projects
+        .Where(x => x.OrganizationId == organizationId)
+        .OrderBy(x => x.Name)
+        .ToListAsync(cancellationToken);
+
+    return Results.Ok(projects);
+});
+```
+
+That example is still only organization scoping. It is not full row-level authorization. The point is that login, organization selection, token validation, and API data access now line up around the same issuer and database.
+
+## Add FGA only when the app needs row-level access
+
+You do not have to solve every authorization problem in the first week. Start with login, orgs, and tokens. When you need list endpoints that only return rows the user can see, use SqlOS FGA with EF query filters. That is the next post in this series: [List endpoints that only return authorized rows](/blog/authorized-list-queries-ef-core-sqlos).
+
+## Why this is the default path
+
+The default path works because it refuses to make the first app look like a platform.
+
+You do not need application assignments when there is only one application. You do not need a multi-app control plane when the customer portal is the product. You do not need to compare every IdP feature before you have a production login.
+
+You need a small set of primitives that will not collapse later:
+
+- OAuth authorization code with PKCE
+- access tokens for the API
+- refresh tokens and sessions
+- organizations and memberships
+- invitations
+- an admin dashboard
+- SSO paths when an enterprise customer arrives
+- optional FGA that composes with EF queries
+
+That is what SqlOS gives a one-app .NET team: a real auth server colocated with the API, not a weekend login form and not a second platform.
+
+Next reading:
+
+- [Getting Started](/docs/getting-started)
+- [Single-Application Setup](/docs/authserver/single-application)
+- [Todo Sample](/docs/authserver/todo-sample)
+- [Hosted vs Headless Auth](/docs/authserver/hosted-vs-headless)

--- a/web/content/blog/auth0-fga-vs-sqlos-shrbac.mdx
+++ b/web/content/blog/auth0-fga-vs-sqlos-shrbac.mdx
@@ -1,0 +1,175 @@
+---
+title: "Auth0 FGA vs SqlOS SHRBAC"
+description: "A focused comparison for one .NET app: Auth0 FGA as an external relationship store and SqlOS SHRBAC as SQL Server-native authorization for EF list queries."
+date: "2026-06-05"
+author: "Ross Slaney"
+tags: ["Auth0 FGA", "OpenFGA", "SHRBAC", "FGA", "SqlOS"]
+---
+
+Auth0 FGA and SqlOS SHRBAC (scoped hierarchical RBAC) both answer authorization questions. They do not put the authorization data in the same place.
+
+That is the comparison that matters for a single .NET SaaS app on SQL Server.
+
+Auth0 FGA is a managed fine-grained authorization service based on OpenFGA. You define an authorization model, write relationship tuples, and call APIs like Check and ListObjects. Auth0 describes FGA as a fast, scalable authorization service inspired by Zanzibar and based on relationship-based access control. The official docs are here: [Auth0 FGA introduction](https://docs.fga.dev/fga), [FGA concepts](https://docs.fga.dev/fga-concepts), and [relationship queries](https://docs.fga.dev/writing-data/advanced/check-read-expand).
+
+SqlOS SHRBAC keeps a hierarchical resource tree, roles, permissions, and grants in SQL Server. EF Core list endpoints compose an authorization predicate into the same query that loads app rows.
+
+<BlogVisual kind="auth0-vs-sqlos" />
+
+## The short version
+
+| Question | Auth0 FGA | SqlOS SHRBAC |
+| --- | --- | --- |
+| Where do resources live? | Relationship tuples in an FGA store | Resource rows in your SQL Server database |
+| Model style | ReBAC relations in an authorization model DSL | Tree + flat roles + scoped grants |
+| Point check | Check API | DB-backed FGA service |
+| List page of authorized rows | ListObjects or Batch Check plus app query logic | LINQ filter with `GetAuthorizationFilterAsync` |
+| App data writes | App DB write plus FGA tuple write | App row plus resource/grant rows in the same DB |
+| Operations | Managed service, credentials, stores, billing | SQL Server you already run |
+| Pairs with | Auth0 login or another identity system | SqlOS AuthServer in the same package |
+
+Neither architecture is universally better. They optimize for different boundaries.
+
+## What Auth0 FGA is good at
+
+Auth0 FGA shines when authorization is a graph you want outside application code and outside one database. The model can express relationships like owners, writers, viewers, parent folders, inherited access, groups, and contextual tuples.
+
+A tiny model looks like this:
+
+```text
+model
+  schema 1.1
+
+type user
+
+type document
+  relations
+    define writer: [user]
+    define reader: [user] or writer
+```
+
+Then a service can ask the FGA API whether a relationship exists:
+
+```bash
+curl --request POST \
+  --url "$FGA_API_URL/stores/$FGA_STORE_ID/check" \
+  --header "authorization: Bearer $FGA_API_TOKEN" \
+  --header "content-type: application/json" \
+  --data '{
+    "tuple_key": {
+      "user": "user:bob",
+      "relation": "reader",
+      "object": "document:planning"
+    }
+  }'
+```
+
+That is a clean boundary if many services need the same centralized authorization model, if the object graph is not naturally stored in one relational database, or if you already use Auth0 and want a managed FGA product.
+
+## Where the single-app question changes
+
+The single-app .NET question is narrower:
+
+> I have EF Core list endpoints over SQL Server tables. How do I make those endpoints return only authorized rows?
+
+Auth0 FGA has ListObjects for "which objects can this user access?" and Batch Check for batches of candidate objects. In both cases, the app still has to connect the authorization answer back to its data tables. In practice, a list page may need:
+
+1. decide whether SQL Server or Auth0 FGA supplies the candidate object IDs first
+2. query or check the matching object IDs
+3. apply product filters, sort, and pagination without dropping or duplicating rows
+4. handle cases where the product query and FGA object list do not line up cleanly
+
+That can be correct, but it is an application orchestration problem. It is not the same shape as a LINQ query that composes one authorization predicate with the rest of the SQL.
+
+SqlOS optimizes for that EF query:
+
+```csharp
+var filter = await fgaAuthService.GetAuthorizationFilterAsync<TodoItem>(
+    subjectId,
+    "TODO_READ");
+
+var todos = await dbContext.TodoItems
+    .Where(filter)
+    .OrderBy(x => x.CreatedAt)
+    .Take(20)
+    .ToListAsync(cancellationToken);
+```
+
+The filter calls the SQL Server function that walks resource ancestors and matches grants. The database handles authorization and pagination together.
+
+## Resource writes and consistency
+
+With Auth0 FGA, app data and authorization data are deliberately separate. When a document is created, the app writes its row to SQL Server and writes a tuple or relationship to FGA. For many systems, that decoupling is the point.
+
+With SqlOS, the resource can be created beside the row:
+
+```csharp
+var document = new Document
+{
+    Id = Guid.NewGuid(),
+    ProjectId = project.Id,
+    Title = request.Title
+};
+
+document.ResourceId = dbContext.CreateResource(
+    parentId: project.ResourceId,
+    name: document.Title,
+    resourceTypeId: "document",
+    id: $"document::{document.Id:D}");
+
+dbContext.Documents.Add(document);
+await dbContext.SaveChangesAsync(cancellationToken);
+```
+
+That is less flexible than a global relationship service, but it is very strong for one app: the business row and authorization resource commit together.
+
+## Expressiveness
+
+Do not claim SHRBAC replaces every ReBAC model. It does not.
+
+Auth0 FGA is a relationship system. It can model parent-child inheritance, usersets, group membership, contextual tuples, conditions, and more graph-shaped access patterns. If your product authorization naturally reads like "viewer from parent folder or member of group or relation through another object," Auth0 FGA is closer to that mental model.
+
+SqlOS SHRBAC is intentionally narrower:
+
+- resources form a hierarchy
+- roles are reusable permission bundles
+- grants attach a subject and role to one resource
+- access inherits down descendants
+- list filtering composes with SQL Server queries
+
+That narrower shape is a feature when the app data already has a hierarchy: organization, workspace, project, item.
+
+## Decision scenarios
+
+Choose Auth0 FGA when:
+
+- you already use Auth0 login and want an Auth0-hosted authorization service
+- authorization is shared across multiple services or databases
+- you need graph-native ReBAC expressiveness
+- you want managed authorization operations and can pay per the service model
+- ListObjects or Batch Check orchestration fits your list pages
+
+Choose SqlOS when:
+
+- you are building a greenfield .NET app on SQL Server
+- your resource hierarchy matches your domain
+- EF Core list endpoints are the hard part
+- you want app rows and authorization rows in the same transaction
+- you want auth, orgs, sessions, and FGA in one package
+
+<BlogCallout title="A practical rule">
+  If your hardest question is "can this user perform this action on this object across many systems," Auth0 FGA is a strong fit. If your hardest question is "which rows should this EF query return," SqlOS is shaped for that path.
+</BlogCallout>
+
+## The honest single-app answer
+
+For one B2B app, Auth0 FGA is not "wrong." It may be the right decision if you already chose Auth0 for login, expect multiple services quickly, or need graph expressiveness that SHRBAC does not attempt.
+
+SqlOS is the tighter fit when you want one ASP.NET host, one SQL Server database, OAuth login, organizations, sessions, and row-level authorization for EF queries without a second authorization service.
+
+Next reading:
+
+- [List endpoints that only return authorized rows](/blog/authorized-list-queries-ef-core-sqlos)
+- [FGA Overview](/docs/fga/overview)
+- [Auth0 FGA docs](https://docs.fga.dev/fga)
+- [Auth0 FGA relationship queries](https://docs.fga.dev/writing-data/advanced/check-read-expand)

--- a/web/content/blog/authorized-list-queries-ef-core-sqlos.mdx
+++ b/web/content/blog/authorized-list-queries-ef-core-sqlos.mdx
@@ -1,0 +1,264 @@
+---
+title: "List Endpoints That Only Return Authorized Rows"
+description: "How SqlOS FGA turns EF Core list queries into authorized SQL Server queries, using the Todo sample resource tree and GetAuthorizationFilterAsync."
+date: "2026-06-04"
+author: "Ross Slaney"
+tags: ["FGA", "EF Core", "Authorization", "SQL Server", "SqlOS"]
+---
+
+Most authorization bugs do not start with a dramatic exploit. They start with a list endpoint.
+
+The detail endpoint has a check:
+
+```csharp
+if (!await CanEdit(userId, documentId))
+    return Results.Forbid();
+```
+
+But the list endpoint quietly returns too much:
+
+```csharp
+var todos = await db.TodoItems
+    .Where(x => x.SqlOSUserId == userId)
+    .OrderBy(x => x.CreatedAt)
+    .ToListAsync();
+```
+
+That works until the product adds teams, shared workspaces, organization admins, contractors, or nested resources. Then `owner_id = @uid` turns into copied filters, special cases, and post-query trimming. The user should only see rows they can access, and pagination should still be done by the database.
+
+SqlOS FGA is built for that exact list endpoint.
+
+<BlogVisual kind="fga-list-query" />
+
+## Point checks are not enough
+
+A point check answers one question:
+
+> Can this user edit this one todo?
+
+A list filter answers a different question:
+
+> Which todos can this user read, sorted and paged like any other query?
+
+Those are not interchangeable. If you load 500 rows and then call a permission service 500 times, you have already over-fetched data and broken pagination. Page 1 might shrink to three visible rows. Page 2 might include records that should have been on page 1. Search counts become misleading.
+
+The authorization predicate has to be inside the query.
+
+## Why owner_id breaks
+
+The Todo sample starts intentionally small, but even it models the problem better than `owner_id`.
+
+The resource hierarchy is:
+
+```text
+root
+  tenant::{userId}
+    todo::{todoId}
+```
+
+The grant is on the tenant root:
+
+```text
+subject user_123
+  has role tenant_owner
+  on resource tenant::user_123
+```
+
+The role includes:
+
+```text
+TENANT_CREATE_TODO
+TODO_READ
+TODO_WRITE
+```
+
+Every child todo inherits access from the tenant resource. The sample could add shared projects or organization workspaces later without changing the list endpoint shape. The row points to a resource, and the resource tree explains who can see it.
+
+## The Todo item carries a ResourceId
+
+Every protected entity implements `IHasResourceId`:
+
+```csharp
+using SqlOS.Fga.Interfaces;
+
+public sealed class TodoItem : IHasResourceId
+{
+    public Guid Id { get; set; }
+    public string ResourceId { get; set; } = string.Empty;
+    public string SqlOSUserId { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public bool IsCompleted { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime? CompletedAt { get; set; }
+}
+```
+
+The `ResourceId` is the bridge between business data and authorization data. The todo row can still have app-specific columns, indexes, and constraints. SqlOS only needs the resource ID to compose the authorization predicate.
+
+## The DbContext maps the SQL function
+
+The Todo sample context implements both SqlOS interfaces and exposes `IsResourceAccessible`:
+
+```csharp
+public sealed class TodoSampleDbContext(
+    DbContextOptions<TodoSampleDbContext> options)
+    : DbContext(options), ISqlOSAuthServerDbContext, ISqlOSFgaDbContext
+{
+    public DbSet<TodoItem> TodoItems => Set<TodoItem>();
+
+    public IQueryable<SqlOSFgaAccessibleResource> IsResourceAccessible(
+        string resourceId,
+        string subjectIds,
+        string permissionId)
+        => FromExpression(() =>
+            IsResourceAccessible(resourceId, subjectIds, permissionId));
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+        modelBuilder.UseSqlOS(Database.IsRelational() ? GetType() : null);
+    }
+}
+```
+
+SqlOS creates the backing SQL Server function during host startup. EF Core can then translate a normal LINQ expression into SQL that calls the inline table-valued function.
+
+## Before and after
+
+The fragile version asks the app table to carry all authorization meaning:
+
+```csharp
+var items = await dbContext.TodoItems
+    .AsNoTracking()
+    .Where(x => x.SqlOSUserId == currentUserId)
+    .OrderBy(x => x.IsCompleted)
+    .ThenBy(x => x.CreatedAt)
+    .ToListAsync();
+```
+
+That is okay only while each todo has one owner and no sharing. The SqlOS version asks FGA for a query predicate:
+
+```csharp
+var filter = await fgaAuthService.GetAuthorizationFilterAsync<TodoItem>(
+    subjectId,
+    TodoFgaService.TodoReadPermission);
+
+var items = await dbContext.TodoItems
+    .AsNoTracking()
+    .Where(filter)
+    .OrderBy(x => x.IsCompleted)
+    .ThenBy(x => x.CreatedAt)
+    .Select(x => new
+    {
+        x.Id,
+        x.ResourceId,
+        x.Title,
+        x.IsCompleted,
+        x.CreatedAt,
+        x.CompletedAt
+    })
+    .ToListAsync(cancellationToken);
+```
+
+That filter composes with search, sort, projection, and pagination. It does not load unauthorized rows into memory first.
+
+## Creating rows and resources together
+
+When a todo is created, the app creates a domain row and an FGA resource in the same `DbContext` unit of work:
+
+```csharp
+var item = new TodoItem
+{
+    Id = Guid.NewGuid(),
+    SqlOSUserId = todoContext.SubjectId,
+    Title = request.Title.Trim(),
+    CreatedAt = DateTime.UtcNow
+};
+
+item.ResourceId = todoFgaService.CreateTodoResource(
+    item,
+    todoContext.TenantResourceId);
+
+dbContext.TodoItems.Add(item);
+await dbContext.SaveChangesAsync(cancellationToken);
+```
+
+The helper creates `todo::{todoId}` under the tenant resource:
+
+```csharp
+public string CreateTodoResource(TodoItem item, string tenantResourceId)
+{
+    var resourceId = GetTodoResourceId(item.Id);
+
+    _context.CreateResource(
+        tenantResourceId,
+        item.Title,
+        TodoResourceTypeId,
+        resourceId);
+
+    return resourceId;
+}
+```
+
+That is the practical advantage of keeping app data and authorization data in the same database. If the business write fails, the resource write fails with it. If the resource cannot be created, the todo is not silently created with no authorization node.
+
+## Mutations use point checks
+
+List endpoints use filters. Mutations still use explicit checks against one resource:
+
+```csharp
+var access = await fgaAuthService.CheckAccessAsync(
+    todoContext.SubjectId,
+    TodoFgaService.TodoWritePermission,
+    item.ResourceId);
+
+if (!access.Allowed)
+{
+    return Results.Json(
+        new { error = "Permission denied" },
+        statusCode: 403);
+}
+
+item.IsCompleted = !item.IsCompleted;
+await dbContext.SaveChangesAsync(cancellationToken);
+```
+
+The model is the same either way: subjects, resources, roles, permissions, grants. The list endpoint and the mutation endpoint do not invent separate authorization systems.
+
+## The dashboard makes it inspectable
+
+Because the resources and grants are real rows, the dashboard can show the tree, the grants, and a traceable access decision.
+
+<BlogScreenshot
+  src="/docs/dashboard-grants.png"
+  alt="SqlOS grants dashboard"
+  caption="Grants are scoped to resources. A role granted on a parent resource applies to descendants without copying grants to every row."
+/>
+
+<BlogScreenshot
+  src="/docs/dashboard-access-tester.png"
+  alt="SqlOS access tester dashboard"
+  caption="The access tester is the 30-second sanity check: subject, resource, permission, and the decision path."
+/>
+
+This is useful during development and support. If a customer says, "I should see that project," you do not have to reverse engineer a pile of `WHERE` clauses. You can inspect the resource path and the grants that do or do not match.
+
+## What this solves
+
+SqlOS FGA is not just a more expressive `CanEdit` helper. It solves the list problem:
+
+- list only authorized rows
+- keep authorization inside the SQL query
+- combine auth with search, sorting, and pagination
+- support inherited access through a resource tree
+- avoid per-row HTTP checks
+- keep resource writes in the same transaction as business writes
+
+If you are evaluating Auth0 FGA or WorkOS FGA, the next posts compare the architecture tradeoffs. This post is the SqlOS problem statement: your .NET app needs authorized list queries, and those list queries already live in EF Core.
+
+Next reading:
+
+- [Todo Sample](/docs/authserver/todo-sample)
+- [List Filtering](/docs/fga/list-filter)
+- [FGA Overview](/docs/fga/overview)
+- [Row-Level Security with EF Core, SQL Server, and TVFs](/blog/row-level-security-ef-core-sql-server-tvfs)

--- a/web/content/blog/managed-b2b-login-vs-sqlos-one-app.mdx
+++ b/web/content/blog/managed-b2b-login-vs-sqlos-one-app.mdx
@@ -1,0 +1,185 @@
+---
+title: "Managed B2B Login vs SqlOS for One App"
+description: "Auth0, WorkOS, Clerk, or SqlOS? A focused first-fork guide for a single .NET SaaS app that needs login, organizations, SSO later, and row-level authorization."
+date: "2026-06-07"
+author: "Ross Slaney"
+tags: ["B2B SaaS", "Auth0", "WorkOS", "Clerk", "SqlOS"]
+---
+
+The first auth decision for a B2B SaaS app is not "which identity platform is best?"
+
+It is smaller:
+
+> Should I pay Auth0, WorkOS, or Clerk for login and organizations, or run SqlOS inside my one .NET app and own the data?
+
+Both answers can be right. The mistake is comparing six vendors as if you are buying an enterprise identity platform when you are actually shipping one product.
+
+<BlogVisual kind="managed-vs-sqlos" />
+
+## The relatable timeline
+
+The first weekend is easy: add hosted login, get a callback, store a user ID.
+
+Then the first B2B customer asks for an organization. The second asks for SAML. The third wants to invite contractors. Meanwhile, your API list endpoints are growing `owner_id` filters and `if (!CanEdit)` checks after queries. At some point you realize "auth" means login, orgs, sessions, SSO, and authorization over rows.
+
+That is the fork.
+
+## What managed login products optimize for
+
+Managed providers are strongest when speed and outsourced operations matter most.
+
+Auth0 Organizations can be configured through the dashboard or Management API, with support for organization connections, invitations, member assignment, roles, and organization-aware token flows. Auth0 notes that availability varies by plan in its [Organizations docs](https://auth0.com/docs/manage-users/organizations/configure-organizations).
+
+WorkOS AuthKit treats organizations as a first-class concept and pairs them with SSO, Directory Sync, Admin Portal, invitations, and now FGA. Its docs describe organizations as both customer-controlled user collections and collaboration workspaces: [WorkOS users and organizations](https://workos.com/docs/authkit/users-organizations).
+
+Clerk Organizations gives application teams organization roles, permissions, membership management, verified domains, and prebuilt UI components. Its roles and permissions docs also note production plan requirements: [Clerk Organizations roles and permissions](https://clerk.com/docs/guides/organizations/control-access/roles-and-permissions).
+
+The managed path usually looks like this:
+
+```text
+Browser app
+  -> hosted login at vendor
+  -> callback to your app
+  -> vendor-issued session/JWT
+  -> your API stores vendor user_id and org_id
+```
+
+That is an excellent first path when you want to outsource:
+
+- hosted login UI
+- credential security operations
+- social login
+- org membership screens
+- enterprise SSO setup flows
+- vendor-hosted admin surfaces
+
+## What SqlOS optimizes for
+
+SqlOS optimizes for a different starting point:
+
+> I already run an ASP.NET API and SQL Server. I want auth, orgs, SSO, and resource authorization in that stack.
+
+The setup is ordinary .NET:
+
+```csharp
+builder.Services.AddDbContext<AppDbContext>(options =>
+    options.UseSqlServer(
+        builder.Configuration.GetConnectionString("DefaultConnection")));
+
+builder.AddSqlOS<AppDbContext>(options =>
+{
+    options.UseSingleApplication("Acme Portal", app =>
+    {
+        app.Origin = "https://portal.acme.example";
+        app.EnabledCredentialTypes = ["password", "email_otp"];
+    });
+});
+
+var app = builder.Build();
+app.MapSqlOS();
+```
+
+That mounts the SqlOS auth routes and dashboard inside your app. Users, organizations, clients, sessions, refresh tokens, SSO configuration, and FGA data live in SQL Server.
+
+<BlogScreenshot
+  src="/docs/dashboard-home.png"
+  alt="SqlOS dashboard home"
+  caption="SqlOS puts AuthServer and FGA operations in the same dashboard mounted by your ASP.NET app."
+/>
+
+## Compare only the first-app axes
+
+| Question | Managed login | SqlOS |
+| --- | --- | --- |
+| Fastest hosted login | Strong | Strong with hosted AuthPage |
+| Own auth data in SQL Server | No | Yes |
+| Organizations and invites | Yes | Yes |
+| SSO later | Yes, usually paid or plan-gated | Yes, configured in your deployment |
+| Resource-level authorization | Vendor product or custom app logic | SqlOS FGA in the same package |
+| List filtering in EF | Usually custom | Built around `GetAuthorizationFilterAsync` |
+| Operations | Vendor operates auth service | You operate the ASP.NET host and SQL Server |
+| Pricing shape | MAU, org, SSO, add-ons, or contracts | MIT plus infrastructure |
+
+Do not turn this into a giant feature matrix. For one app, the deciding question is usually data boundary and authorization shape.
+
+## The authorization gap
+
+Managed login solves identity. It does not automatically solve every row-level authorization problem in your API.
+
+Clerk organization roles and permissions are useful for org-scoped features. Auth0 Organizations and WorkOS AuthKit can put org context into tokens. WorkOS FGA and Auth0 FGA can handle resource-level authorization as separate products.
+
+But your API still has to answer:
+
+```csharp
+var projects = await dbContext.Projects
+    .Where(x => x.OrganizationId == orgId)
+    .OrderBy(x => x.Name)
+    .ToListAsync(cancellationToken);
+```
+
+Who should see which projects? What if a user is a workspace admin in one workspace and a viewer in another? What if a project inherits access from a parent?
+
+With SqlOS, that becomes:
+
+```csharp
+var filter = await fgaAuthService.GetAuthorizationFilterAsync<Project>(
+    subjectId,
+    "PROJECT_VIEW");
+
+var projects = await dbContext.Projects
+    .Where(x => x.OrganizationId == orgId)
+    .Where(filter)
+    .OrderBy(x => x.Name)
+    .ToListAsync(cancellationToken);
+```
+
+The login and authorization models are not separate vendors or separate services. They are one SqlOS runtime in your app.
+
+## Decision scenarios
+
+Choose managed login when:
+
+- you are a solo founder and want the least auth operations this month
+- your app is mostly frontend and does not have deep SQL-backed authorization yet
+- you already use Clerk, Auth0, or WorkOS and the bill is fine
+- enterprise SSO setup and vendor-hosted admin flows are more important than data ownership
+- you expect to integrate many identity features before building deep app authorization
+
+Choose SqlOS when:
+
+- you are building a .NET app on SQL Server
+- customers care that auth data stays in your database or deployment
+- you need SSO plus row-level authorization in the same app stack
+- EF list filtering is a first-class requirement
+- you do not want MAU pricing or per-org add-ons to shape your product model
+
+Stay where you are when:
+
+- you already built on a managed provider and it is working
+- the migration would distract from product work
+- your authorization needs are simple org-role checks in the token
+- your support and enterprise workflows are already built around the vendor dashboard
+
+<BlogCallout title="The real tradeoff">
+  Managed auth buys outsourced operations. SqlOS buys data ownership and SQL-native authorization. Pick the constraint you actually have, not the one a comparison table makes look important.
+</BlogCallout>
+
+## What this series argues
+
+For one .NET app, the SqlOS bet is:
+
+- hosted AuthPage first
+- organizations and invitations in SQL Server
+- SAML/OIDC when customers ask for SSO
+- sessions and refresh tokens in your database
+- FGA resources and grants in the same stack
+- EF list queries that only return authorized rows
+
+That is not the right answer for every team. It is the right answer when your app is already a SQL-backed backend application and auth should be part of the product's data boundary, not a detached SaaS dependency.
+
+Next reading:
+
+- [Auth for one .NET app with SqlOS](/blog/auth-for-one-dotnet-app-with-sqlos)
+- [List endpoints that only return authorized rows](/blog/authorized-list-queries-ef-core-sqlos)
+- [Auth0 FGA vs SqlOS SHRBAC](/blog/auth0-fga-vs-sqlos-shrbac)
+- [WorkOS FGA vs SqlOS SHRBAC](/blog/workos-fga-vs-sqlos-shrbac)

--- a/web/content/blog/workos-fga-vs-sqlos-shrbac.mdx
+++ b/web/content/blog/workos-fga-vs-sqlos-shrbac.mdx
@@ -1,0 +1,180 @@
+---
+title: "WorkOS FGA vs SqlOS SHRBAC"
+description: "WorkOS FGA and SqlOS both use hierarchical RBAC ideas. The difference is whether resource authorization lives in WorkOS or in your SQL Server database."
+date: "2026-06-06"
+author: "Ross Slaney"
+tags: ["WorkOS", "FGA", "SHRBAC", "B2B SaaS", "SqlOS"]
+---
+
+WorkOS FGA is the closest mental-model comparison to SqlOS SHRBAC (scoped hierarchical RBAC).
+
+It is not a pure graph DSL like Auth0 FGA. WorkOS describes FGA as hierarchical, resource-scoped access control that extends its existing RBAC system. Resources are arranged in a hierarchy and permissions flow down that hierarchy. The official docs are worth reading before making this decision: [WorkOS FGA overview](https://workos.com/docs/fga/index), [resources](https://workos.com/docs/fga/resources), and [resource discovery](https://workos.com/docs/fga/resource-discovery).
+
+SqlOS agrees with that mental model. The difference is the data boundary.
+
+<BlogVisual kind="workos-vs-sqlos" />
+
+## The short version
+
+| Question | WorkOS FGA | SqlOS SHRBAC |
+| --- | --- | --- |
+| Resource instances | Registered through WorkOS API | Created by your app or FGA admin in SQL Server |
+| Resource hierarchy | WorkOS-managed hierarchy | SqlOS resource table in your database |
+| List filtering | Authorization checks and discovery plus app query logic | EF predicate with `GetAuthorizationFilterAsync` |
+| Mental model | RBAC + hierarchy | RBAC + hierarchy |
+| Auth coupling | AuthKit, SSO, Directory Sync, organization-scoped IdP role assignment | SqlOS AuthServer in the same host |
+| High-volume rows | Usually stay in your DB with parent references | Can be modeled as resources when list filtering needs it |
+| Cost | SaaS pricing | MIT license plus your infrastructure |
+
+The comparison is not "hierarchy vs no hierarchy." Both have hierarchy. The comparison is "external authorization API vs SQL Server-native authorization rows."
+
+## What WorkOS FGA gives you
+
+WorkOS FGA keeps the RBAC vocabulary: roles, permissions, assignments. It adds resource types and resource instances so roles can be assigned at a specific level of your product hierarchy.
+
+The WorkOS docs use examples like organization -> workspace -> project. In that model, a workspace admin can inherit permissions over projects inside the workspace. WorkOS also documents sub-50ms p95 access checks, strong consistency for role changes, and integration with AuthKit, SSO, Directory Sync, and organization-scoped IdP role assignment.
+
+That is compelling if you want to outsource both identity and authorization API operations.
+
+Creating a WorkOS FGA resource is an API operation:
+
+```bash
+curl https://api.workos.com/authorization/resources \
+  -X POST \
+  -H "Authorization: Bearer $WORKOS_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "resource_type_slug": "project",
+    "external_id": "project_02H",
+    "organization_id": "org_01HXYZ",
+    "parent_resource_type_slug": "workspace",
+    "parent_resource_external_id": "workspace_01H",
+    "name": "API Backend"
+  }'
+```
+
+Then checks go through the Authorization API:
+
+```bash
+curl https://api.workos.com/authorization/organization_memberships/om_01HXYZ/check \
+  -X POST \
+  -H "Authorization: Bearer $WORKOS_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "permission_slug": "project:edit",
+    "resource_type_slug": "project",
+    "resource_external_id": "project_02H"
+  }'
+```
+
+That is a clean, managed boundary.
+
+## The sync question
+
+WorkOS is explicit that resources should mirror your application's data. When entities are created, updated, deleted, or reparented in your app, the corresponding WorkOS resources should change too.
+
+That is reasonable for structural resources:
+
+- workspaces
+- projects
+- repositories
+- environments
+- dashboards
+
+It is less attractive for high-volume rows:
+
+- documents
+- messages
+- tasks
+- comments
+- individual records in a list view
+
+WorkOS documentation recommends keeping very high-cardinality content in your database with a reference to a parent FGA resource. That avoids syncing millions of leaf records, but it means the authorization decision is often about the parent, while the actual rows still live in your database.
+
+SqlOS takes the opposite default for a SQL Server app. Resources are database rows, so creating a resource beside a domain row is just part of the app write:
+
+```csharp
+project.ResourceId = dbContext.CreateResource(
+    parentId: workspace.ResourceId,
+    name: project.Name,
+    resourceTypeId: "project",
+    id: $"project::{project.Id:D}");
+
+dbContext.Projects.Add(project);
+await dbContext.SaveChangesAsync(cancellationToken);
+```
+
+There is no vendor sync API for the resource instance because the resource instance is already in your database.
+
+## List filtering is the practical fork
+
+WorkOS FGA answers checks and provides discovery endpoints. Those are useful for member lists, sharing dialogs, scoped navigation, and point authorization.
+
+SqlOS focuses heavily on EF list filtering:
+
+```csharp
+var filter = await authService
+    .GetAuthorizationFilterAsync<Project>(subjectId, "PROJECT_VIEW");
+
+var page = await dbContext.Projects
+    .Where(x => x.WorkspaceId == workspaceId)
+    .Where(filter)
+    .OrderBy(x => x.Name)
+    .Take(25)
+    .ToListAsync(cancellationToken);
+```
+
+The query stays a SQL query. Product filtering, authorization filtering, sorting, and pagination remain in one execution plan.
+
+If your app has many list pages and those pages are backed by EF Core over SQL Server, this is not a small implementation detail. It determines where your authorization complexity lives.
+
+## Dashboard and support workflow
+
+WorkOS gives you a vendor dashboard and APIs. That is useful when your support and IT workflows already live around WorkOS organizations, SSO, and Directory Sync.
+
+SqlOS gives you an in-app dashboard:
+
+<BlogScreenshot
+  src="/docs/dashboard-fga-resources.png"
+  alt="SqlOS FGA resources dashboard"
+  caption="SqlOS resources, grants, roles, permissions, and access tests sit beside the AuthServer dashboard in your own app."
+/>
+
+That is useful when support needs to debug a customer row in the same environment where the data exists. The operator can inspect the app row, the resource row, the grant, and the access trace without leaving the deployment.
+
+## Decision scenarios
+
+Choose WorkOS FGA when:
+
+- you want AuthKit, SSO, Directory Sync, Admin Portal, and FGA from one SaaS provider
+- your top-level authorization model is organization, workspace, project, and similar structural resources
+- you are comfortable registering resource instances with WorkOS
+- you want documented sub-50ms p95 managed access checks and vendor operations
+- IdP group to organization role mapping matters today
+
+Choose SqlOS when:
+
+- you are a SQL Server shop building one .NET product
+- you want auth and FGA data colocated with app data
+- EF list filtering is more important than an external Authorization API
+- you do not want to sync every app-created resource to a vendor
+- you want MIT-licensed infrastructure under your deployment boundary
+
+<BlogCallout title="A practical rule">
+  If you want a managed B2B identity platform with mature SSO, Directory Sync, Admin Portal, and authorization APIs, WorkOS belongs on the shortlist. If your product's hardest authorization path is a SQL-backed list endpoint, SqlOS keeps that work inside EF and SQL Server.
+</BlogCallout>
+
+## The honest single-app answer
+
+WorkOS FGA and SqlOS SHRBAC are philosophically closer than Auth0 FGA and SqlOS. Both treat hierarchy as first-class. Both avoid role explosion by letting permissions flow down a tree.
+
+The difference is ownership. WorkOS owns the authorization API and resource registry. SqlOS lets your app own the authorization rows.
+
+For many teams, outsourcing that is the point. For a .NET team already committed to SQL Server, colocating it may be the simpler long-term choice.
+
+Next reading:
+
+- [WorkOS FGA overview](https://workos.com/docs/fga/index)
+- [WorkOS FGA resources](https://workos.com/docs/fga/resources)
+- [FGA Overview](/docs/fga/overview)
+- [List Filtering](/docs/fga/list-filter)

--- a/web/src/app/(marketing)/blog/[slug]/page.tsx
+++ b/web/src/app/(marketing)/blog/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { getAllPosts, getPostBySlug } from "@/lib/blog";
 import { MDXRemote } from "next-mdx-remote/rsc";
 import remarkGfm from "remark-gfm";
 import Link from "next/link";
+import { blogMdxComponents } from "@/components/blog/BlogMdxComponents";
 
 interface PageProps {
   params: Promise<{ slug: string }>;
@@ -79,6 +80,7 @@ export default async function BlogPostPage({ params }: PageProps) {
         <div className="prose prose-zinc dark:prose-invert max-w-none prose-headings:font-semibold prose-a:text-indigo-600 dark:prose-a:text-indigo-400 prose-pre:bg-zinc-900 prose-pre:text-zinc-300 prose-code:text-indigo-600 dark:prose-code:text-indigo-400 prose-code:before:content-none prose-code:after:content-none">
           <MDXRemote
             source={post.content}
+            components={blogMdxComponents}
             options={{ mdxOptions: { remarkPlugins: [remarkGfm] } }}
           />
         </div>

--- a/web/src/components/blog/BlogMdxComponents.tsx
+++ b/web/src/components/blog/BlogMdxComponents.tsx
@@ -1,0 +1,251 @@
+import Image from "next/image";
+import type { TableHTMLAttributes } from "react";
+
+type VisualKind =
+  | "one-app-topology"
+  | "fga-list-query"
+  | "auth0-vs-sqlos"
+  | "workos-vs-sqlos"
+  | "managed-vs-sqlos";
+
+const visualCopy: Record<
+  VisualKind,
+  {
+    title: string;
+    caption: string;
+    lanes: {
+      label: string;
+      tone: "primary" | "neutral" | "accent";
+      nodes: string[];
+    }[];
+  }
+> = {
+  "one-app-topology": {
+    title: "One app, one database, one auth surface",
+    caption:
+      "SqlOS lives inside the ASP.NET host. Your browser app gets OAuth tokens from /sqlos/auth, your API handles business routes, and SQL Server stores both app data and SqlOS tables.",
+    lanes: [
+      {
+        label: "Browser app",
+        tone: "accent",
+        nodes: ["Hosted AuthPage", "PKCE client", "Bearer API calls"],
+      },
+      {
+        label: "ASP.NET API",
+        tone: "primary",
+        nodes: ["/api/*", "/sqlos/auth/*", "/sqlos admin"],
+      },
+      {
+        label: "SQL Server",
+        tone: "neutral",
+        nodes: ["Users + orgs", "Sessions + refresh tokens", "FGA resources + grants"],
+      },
+    ],
+  },
+  "fga-list-query": {
+    title: "Authorized rows are filtered before pagination",
+    caption:
+      "The endpoint builds a normal EF query, then adds a SqlOS authorization expression. SQL Server evaluates the TVF predicate with your business filters, sort, and page size.",
+    lanes: [
+      {
+        label: "Token subject",
+        tone: "accent",
+        nodes: ["sub: user_123", "org: acme", "permission: TODO_READ"],
+      },
+      {
+        label: "EF Core",
+        tone: "primary",
+        nodes: [".Where(filter)", ".OrderBy(...)", ".Take(20)"],
+      },
+      {
+        label: "SQL Server",
+        tone: "neutral",
+        nodes: ["Walk resource ancestors", "Match active grants", "Return authorized rows"],
+      },
+    ],
+  },
+  "auth0-vs-sqlos": {
+    title: "Two authorization architectures for one app",
+    caption:
+      "Auth0 FGA centralizes relationship-based authorization in a separate FGA store. SqlOS keeps the resource tree and grants beside the EF data that list pages already query.",
+    lanes: [
+      {
+        label: "Auth0 FGA",
+        tone: "accent",
+        nodes: ["Authorization model DSL", "Relationship tuples", "Check / ListObjects API"],
+      },
+      {
+        label: "Your app",
+        tone: "neutral",
+        nodes: ["Sync object relationships", "Join FGA object IDs to rows", "Handle app data separately"],
+      },
+      {
+        label: "SqlOS",
+        tone: "primary",
+        nodes: ["Resource rows in SQL Server", "Grants in the same transaction", "LINQ filter composes with rows"],
+      },
+    ],
+  },
+  "workos-vs-sqlos": {
+    title: "Same hierarchy shape, different data boundary",
+    caption:
+      "WorkOS FGA is an external authorization API with resource instances registered in WorkOS. SqlOS uses the same hierarchy idea but keeps resource rows local to your database.",
+    lanes: [
+      {
+        label: "WorkOS FGA",
+        tone: "accent",
+        nodes: ["Resource types in dashboard", "Register resource instances", "Authorization API checks"],
+      },
+      {
+        label: "Shared model",
+        tone: "neutral",
+        nodes: ["Org -> workspace -> project", "Roles scoped to resources", "Permissions inherit downward"],
+      },
+      {
+        label: "SqlOS",
+        tone: "primary",
+        nodes: ["Resource table in SQL Server", "EF query filters for lists", "FGA dashboard in your app"],
+      },
+    ],
+  },
+  "managed-vs-sqlos": {
+    title: "The first fork for a B2B SaaS app",
+    caption:
+      "Managed identity products optimize for speed and outsourced operations. SqlOS optimizes for a .NET app that wants auth, orgs, SSO, and row-level authorization data under the same host and database.",
+    lanes: [
+      {
+        label: "Managed login",
+        tone: "accent",
+        nodes: ["Hosted UI", "Vendor org dashboard", "SSO and MAU pricing"],
+      },
+      {
+        label: "Your product",
+        tone: "neutral",
+        nodes: ["Org data model", "API authorization", "Customer data boundary"],
+      },
+      {
+        label: "SqlOS",
+        tone: "primary",
+        nodes: ["Hosted AuthPage", "Orgs + invites in SQL Server", "FGA in EF queries"],
+      },
+    ],
+  },
+};
+
+function toneClasses(tone: "primary" | "neutral" | "accent") {
+  switch (tone) {
+    case "primary":
+      return "border-indigo-300 bg-indigo-50 text-indigo-950 dark:border-indigo-700/70 dark:bg-indigo-950/40 dark:text-indigo-100";
+    case "accent":
+      return "border-emerald-300 bg-emerald-50 text-emerald-950 dark:border-emerald-700/70 dark:bg-emerald-950/30 dark:text-emerald-100";
+    default:
+      return "border-zinc-300 bg-zinc-50 text-zinc-950 dark:border-zinc-700 dark:bg-zinc-900/70 dark:text-zinc-100";
+  }
+}
+
+export function BlogVisual({ kind }: { kind: VisualKind }) {
+  const visual = visualCopy[kind];
+
+  return (
+    <figure className="not-prose my-10 overflow-hidden rounded-lg border border-zinc-200 bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-950">
+      <div className="border-b border-zinc-200 bg-zinc-50 px-5 py-4 dark:border-zinc-800 dark:bg-zinc-900">
+        <h3 className="text-base font-semibold text-zinc-950 dark:text-white">
+          {visual.title}
+        </h3>
+        <p className="mt-1 text-sm leading-6 text-zinc-600 dark:text-zinc-400">
+          {visual.caption}
+        </p>
+      </div>
+      <div className="grid gap-3 p-4 md:grid-cols-3">
+        {visual.lanes.map((lane, index) => (
+          <div
+            key={lane.label}
+            className={`relative rounded-lg border p-4 ${toneClasses(lane.tone)}`}
+          >
+            <div className="flex items-center gap-2">
+              <span className="flex h-6 w-6 items-center justify-center rounded-full bg-white/75 text-xs font-semibold text-zinc-800 ring-1 ring-black/10 dark:bg-black/20 dark:text-zinc-100 dark:ring-white/10">
+                {index + 1}
+              </span>
+              <h4 className="text-sm font-semibold">{lane.label}</h4>
+            </div>
+            <ul className="mt-4 space-y-2">
+              {lane.nodes.map((node) => (
+                <li
+                  key={node}
+                  className="rounded-md bg-white/70 px-3 py-2 text-sm ring-1 ring-black/5 dark:bg-black/20 dark:ring-white/10"
+                >
+                  {node}
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </figure>
+  );
+}
+
+export function BlogScreenshot({
+  src,
+  alt,
+  caption,
+}: {
+  src: string;
+  alt: string;
+  caption?: string;
+}) {
+  return (
+    <figure className="not-prose my-10 overflow-hidden rounded-lg border border-zinc-200 bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-950">
+      <Image
+        src={src}
+        alt={alt}
+        width={1440}
+        height={900}
+        unoptimized
+        className="h-auto w-full"
+      />
+      {caption ? (
+        <figcaption className="border-t border-zinc-200 bg-zinc-50 px-5 py-3 text-sm text-zinc-600 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-400">
+          {caption}
+        </figcaption>
+      ) : null}
+    </figure>
+  );
+}
+
+export function BlogCallout({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <aside className="not-prose my-8 rounded-lg border border-indigo-200 bg-indigo-50 p-5 text-indigo-950 dark:border-indigo-800 dark:bg-indigo-950/40 dark:text-indigo-100">
+      <h3 className="text-sm font-semibold uppercase tracking-wide">{title}</h3>
+      <div className="mt-2 text-sm leading-6 text-indigo-900 dark:text-indigo-100">
+        {children}
+      </div>
+    </aside>
+  );
+}
+
+function BlogTable(props: TableHTMLAttributes<HTMLTableElement>) {
+  const { className, ...tableProps } = props;
+
+  return (
+    <div className="not-prose my-8 overflow-x-auto rounded-lg border border-zinc-200 dark:border-zinc-800">
+      <table
+        {...tableProps}
+        className={`min-w-full border-collapse bg-white text-sm dark:bg-zinc-950 [&_td]:border-t [&_td]:border-zinc-200 [&_td]:px-4 [&_td]:py-3 [&_td]:align-top [&_td]:text-zinc-700 dark:[&_td]:border-zinc-800 dark:[&_td]:text-zinc-300 [&_th]:bg-zinc-50 [&_th]:px-4 [&_th]:py-3 [&_th]:text-left [&_th]:font-semibold [&_th]:text-zinc-950 dark:[&_th]:bg-zinc-900 dark:[&_th]:text-zinc-100 ${className ?? ""}`}
+      />
+    </div>
+  );
+}
+
+export const blogMdxComponents = {
+  BlogCallout,
+  BlogScreenshot,
+  table: BlogTable,
+  BlogVisual,
+};


### PR DESCRIPTION
## Summary
- Add five focused growth posts for the one-app SqlOS path, EF/FGA list filtering, Auth0 FGA comparison, WorkOS FGA comparison, and managed B2B login comparison.
- Add blog MDX components for rendered visuals, screenshots, callouts, and mobile-safe tables.
- Wire the blog renderer to use the new MDX component map.

## Verification
- npm run lint
- npm run build
- In-app browser desktop check across all five new posts
- In-app browser mobile overflow check across all five new posts
- Subagent editor/fact-check pass
- Subagent tester pass

Closes #77
Closes #78
Closes #72
Closes #73
Closes #74