### PR TITLE
Fix hosted SSO portal shell route

### DIFF
--- a/examples/SqlOS.Example.IntegrationTests/SqlOSExampleApiIntegrationTests.cs
+++ b/examples/SqlOS.Example.IntegrationTests/SqlOSExampleApiIntegrationTests.cs
@@ -304,6 +304,14 @@ public sealed class SqlOSExampleApiIntegrationTests
         var portalCookie = startResponse.Headers.GetValues("Set-Cookie").Single().Split(';', 2)[0];
         portalCookie.Should().StartWith("sqlos_sso_portal=");
 
+        foreach (var path in new[] { "/sqlos/admin/auth/sso-portal", "/sqlos/admin/auth/sso-portal/" })
+        {
+            var shellResponse = await PortalGetAsync(path, portalCookie);
+            shellResponse.EnsureSuccessStatusCode();
+            var shellHtml = await shellResponse.Content.ReadAsStringAsync();
+            shellHtml.Should().Contain("Organization SSO setup");
+        }
+
         var stateResponse = await PortalGetAsync("/sqlos/admin/auth/sso-portal/api/state", portalCookie);
         stateResponse.EnsureSuccessStatusCode();
         var stateJson = JsonDocument.Parse(await stateResponse.Content.ReadAsStringAsync());

--- a/src/SqlOS/AuthServer/Extensions/EndpointRouteBuilderExtensions.cs
+++ b/src/SqlOS/AuthServer/Extensions/EndpointRouteBuilderExtensions.cs
@@ -3204,9 +3204,6 @@ public static class EndpointRouteBuilderExtensions
         portal.MapGet("", (SqlOSSsoPortalService portalService) => portalService.IsHostedPortalEnabled
             ? Results.Content(SqlOSSsoPortalPageRenderer.RenderShell(), "text/html; charset=utf-8")
             : Results.NotFound());
-        portal.MapGet("/", (SqlOSSsoPortalService portalService) => portalService.IsHostedPortalEnabled
-            ? Results.Content(SqlOSSsoPortalPageRenderer.RenderShell(), "text/html; charset=utf-8")
-            : Results.NotFound());
 
         var api = portal.MapGroup("/api");
 

--- a/src/SqlOS/SqlOS.csproj
+++ b/src/SqlOS/SqlOS.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>SqlOS</PackageId>
-    <Version>3.13.2</Version>
+    <Version>3.13.3</Version>
     <Authors>Ross Slaney</Authors>
     <Description>Embedded auth server and fine-grained authorization runtime for .NET + SQL Server + EF Core.</Description>
     <PackageTags>authentication;authorization;fga;saml;jwt;sessions;efcore;sqlserver</PackageTags>


### PR DESCRIPTION
Fixes the hosted SSO setup portal 500 under net10 hosts by removing the duplicate empty/slash shell route mapping that can normalize to the same endpoint and throw AmbiguousMatchException.\n\nValidation:\n- dotnet test SqlOS.sln --no-restore --verbosity minimal\n- emcy net10 integration repro: CreateSsoSetupSession_WithOwnerRole_ReturnsHeadlessAndHostedSetupUrls with hosted shell assertion