### PR TITLE
Add brandable SSO domain verification records

### DIFF
--- a/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerOptions.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerOptions.cs
@@ -434,6 +434,7 @@ public sealed class SqlOSSsoPortalOptions
     public string? HeadlessApiBasePath { get; set; }
     public Func<SqlOSSsoSetupUiRouteContext, string>? BuildUiUrl { get; set; }
     public string DomainVerificationRecordPrefix { get; set; } = "_sqlos-verify";
+    public string DomainVerificationRecordValuePrefix { get; set; } = "sqlos-domain-verification";
     public List<string> ReservedDomainRoots { get; } = [];
 
     public string ResolveHeadlessApiBasePath(string adminBasePath)

--- a/src/SqlOS/AuthServer/Services/SqlOSDomainOwnershipVerification.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSDomainOwnershipVerification.cs
@@ -15,6 +15,9 @@ public static class SqlOSDomainOwnershipVerification
     public static string CreateVerificationToken(SqlOSCryptoService cryptoService)
         => $"{VerificationTokenPrefix}{cryptoService.GenerateOpaqueToken(24)}";
 
+    public static string CreateVerificationToken(SqlOSCryptoService cryptoService, SqlOSSsoPortalOptions options)
+        => $"{NormalizeValuePrefix(options.DomainVerificationRecordValuePrefix)}{cryptoService.GenerateOpaqueToken(24)}";
+
     public static SqlOSDomainOwnershipRecord BuildOwnershipRecord(
         string domain,
         string verificationToken,
@@ -22,7 +25,10 @@ public static class SqlOSDomainOwnershipVerification
         => new(
             "TXT",
             $"{NormalizeRecordPrefix(options.DomainVerificationRecordPrefix)}.{domain}",
-            verificationToken);
+            BuildVerificationValue(verificationToken, options));
+
+    public static string BuildVerificationValue(string verificationToken, SqlOSSsoPortalOptions options)
+        => $"{NormalizeValuePrefix(options.DomainVerificationRecordValuePrefix)}{ExtractVerificationTokenSuffix(verificationToken)}";
 
     public static string NormalizeDomain(string? value, SqlOSSsoPortalOptions options)
     {
@@ -183,6 +189,26 @@ public static class SqlOSDomainOwnershipVerification
         }
 
         return prefix.ToLowerInvariant();
+    }
+
+    private static string NormalizeValuePrefix(string? value)
+    {
+        var prefix = string.IsNullOrWhiteSpace(value) ? "sqlos-domain-verification" : value.Trim().TrimEnd('=');
+        if (string.IsNullOrWhiteSpace(prefix))
+        {
+            return VerificationTokenPrefix;
+        }
+
+        return $"{prefix}=";
+    }
+
+    private static string ExtractVerificationTokenSuffix(string value)
+    {
+        var token = value.Trim();
+        var separatorIndex = token.IndexOf('=');
+        return separatorIndex >= 0 && separatorIndex < token.Length - 1
+            ? token[(separatorIndex + 1)..]
+            : token;
     }
 
     private static string? NormalizeReservedRoot(string? value)

--- a/src/SqlOS/AuthServer/Services/SqlOSOrganizationDomainService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSOrganizationDomainService.cs
@@ -90,7 +90,7 @@ public sealed class SqlOSOrganizationDomainService
                 OrganizationId = organization.Id,
                 Domain = domain,
                 Status = SqlOSOrganizationDomainStatuses.PendingOwnership,
-                VerificationToken = SqlOSDomainOwnershipVerification.CreateVerificationToken(_cryptoService),
+                VerificationToken = SqlOSDomainOwnershipVerification.CreateVerificationToken(_cryptoService, _options.SsoPortal),
                 CreatedByUserId = userId,
                 CreatedAt = now,
                 UpdatedAt = now
@@ -100,7 +100,7 @@ public sealed class SqlOSOrganizationDomainService
         else if (claim.Status != SqlOSOrganizationDomainStatuses.Active)
         {
             claim.Status = SqlOSOrganizationDomainStatuses.PendingOwnership;
-            claim.VerificationToken ??= SqlOSDomainOwnershipVerification.CreateVerificationToken(_cryptoService);
+            claim.VerificationToken ??= SqlOSDomainOwnershipVerification.CreateVerificationToken(_cryptoService, _options.SsoPortal);
             claim.LastError = null;
             claim.UpdatedAt = now;
         }

--- a/src/SqlOS/Configuration/SqlOSOptionsValidator.cs
+++ b/src/SqlOS/Configuration/SqlOSOptionsValidator.cs
@@ -162,6 +162,11 @@ internal static class SqlOSOptionsValidator
         {
             errors.Add("AuthServer.SsoPortal.DomainVerificationRecordPrefix is required.");
         }
+
+        if (string.IsNullOrWhiteSpace(options.DomainVerificationRecordValuePrefix))
+        {
+            errors.Add("AuthServer.SsoPortal.DomainVerificationRecordValuePrefix is required.");
+        }
     }
 
     private static void ValidatePasswordLoginAbuseOptions(SqlOSPasswordLoginAbuseOptions options, List<string> errors)

--- a/src/SqlOS/SqlOS.csproj
+++ b/src/SqlOS/SqlOS.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>SqlOS</PackageId>
-    <Version>3.13.3</Version>
+    <Version>3.13.4</Version>
     <Authors>Ross Slaney</Authors>
     <Description>Embedded auth server and fine-grained authorization runtime for .NET + SQL Server + EF Core.</Description>
     <PackageTags>authentication;authorization;fga;saml;jwt;sessions;efcore;sqlserver</PackageTags>

--- a/tests/SqlOS.Tests/SqlOSSsoPortalServiceTests.cs
+++ b/tests/SqlOS.Tests/SqlOSSsoPortalServiceTests.cs
@@ -172,6 +172,31 @@ public sealed class SqlOSSsoPortalServiceTests
     }
 
     [TestMethod]
+    public async Task DomainVerificationAsync_UsesConfiguredOwnershipRecordBranding()
+    {
+        using var harness = await PortalHarness.CreateAsync(options =>
+            options.ConfigureSsoPortal(portal =>
+            {
+                portal.DomainVerificationRecordPrefix = "_mcpstack-verify";
+                portal.DomainVerificationRecordValuePrefix = "mcpstack-domain-verification";
+            }));
+        var org = await harness.Admin.CreateOrganizationAsync(new SqlOSCreateOrganizationRequest("Branded Org", null));
+        var created = await harness.Portal.CreateSessionAsync(new SqlOSCreateSsoPortalSessionRequest(org.Id), harness.Http);
+        var session = await harness.Context.Set<SqlOSSsoPortalSession>().SingleAsync(x => x.Id == created.Id);
+
+        var state = await harness.Portal.StartDomainVerificationAsync(
+            session,
+            new SqlOSSsoPortalDomainRequest("branded.test"),
+            harness.Http);
+
+        state.Domain.Should().NotBeNull();
+        state.Domain!.OwnershipRecord.Should().NotBeNull();
+        state.Domain.OwnershipRecord!.Name.Should().Be("_mcpstack-verify.branded.test");
+        state.Domain.OwnershipRecord.Value.Should().StartWith("mcpstack-domain-verification=");
+        state.Domain.OwnershipRecord.Value.Should().NotContain("sqlos");
+    }
+
+    [TestMethod]
     public async Task ActivateAsync_BlocksPendingSelfServeDomainUntilOwnershipIsVerified()
     {
         using var harness = await PortalHarness.CreateAsync();
@@ -281,6 +306,7 @@ public sealed class SqlOSSsoPortalServiceTests
                 portal.AllowLocalhostDomainVerification = true;
                 portal.HeadlessApiBasePath = "/custom/sso/setup";
                 portal.DomainVerificationRecordPrefix = "_custom-verify";
+                portal.DomainVerificationRecordValuePrefix = "custom-domain-verification";
             });
 
         options.SsoPortal.DefaultLinkLifetime.Should().Be(TimeSpan.FromHours(12));
@@ -292,6 +318,7 @@ public sealed class SqlOSSsoPortalServiceTests
         options.SsoPortal.AllowLocalhostDomainVerification.Should().BeTrue();
         options.SsoPortal.ResolveHeadlessApiBasePath("/sqlos/admin/auth").Should().Be("/custom/sso/setup");
         options.SsoPortal.DomainVerificationRecordPrefix.Should().Be("_custom-verify");
+        options.SsoPortal.DomainVerificationRecordValuePrefix.Should().Be("custom-domain-verification");
     }
 
     private static string ExtractToken(string setupUrl)

--- a/web/content/docs/authserver/saml-sso.mdx
+++ b/web/content/docs/authserver/saml-sso.mdx
@@ -185,6 +185,7 @@ State-machine endpoints:
 | `SsoPortal.HeadlessApiBasePath` | `/sqlos/admin/auth/sso-portal/api/setup` | Base path for the headless setup API |
 | `SsoPortal.RequireVerifiedDomainForActivation` | `true` | Require a verified domain before activating self-serve SSO |
 | `SsoPortal.DomainVerificationRecordPrefix` | `_sqlos-verify` | TXT record name prefix |
+| `SsoPortal.DomainVerificationRecordValuePrefix` | `sqlos-domain-verification` | TXT record value prefix |
 | `SsoPortal.ReservedDomainRoots` | empty | Domain roots customers cannot claim |
 
 ## Provider notes

--- a/web/content/docs/reference/api-reference.mdx
+++ b/web/content/docs/reference/api-reference.mdx
@@ -302,7 +302,7 @@ The headless setup API defaults to `/sqlos/admin/auth/sso-portal/api/setup`, can
 | POST | `/test` | Run or record a readiness test |
 | POST | `/signout` | Close the portal session |
 
-The setup view model includes `domain`, `serviceProvider`, `providers`, `latestTest`, and `allowedActions`. Domain ownership uses a TXT record shaped like `_sqlos-verify.acme.com = sqlos-domain-verification=...`.
+The setup view model includes `domain`, `serviceProvider`, `providers`, `latestTest`, and `allowedActions`. Domain ownership uses a TXT record shaped like `_sqlos-verify.acme.com = sqlos-domain-verification=...` by default. Hosts can customize both prefixes with `SsoPortal.DomainVerificationRecordPrefix` and `SsoPortal.DomainVerificationRecordValuePrefix`.
 
 ---
 

--- a/web/content/docs/reference/authserver-api.mdx
+++ b/web/content/docs/reference/authserver-api.mdx
@@ -1083,6 +1083,8 @@ The ownership record is shaped as:
 | `Name` | `_sqlos-verify.acme.com` |
 | `Value` | `sqlos-domain-verification=...` |
 
+Hosts can customize the TXT record name and value prefixes with `SsoPortal.DomainVerificationRecordPrefix` and `SsoPortal.DomainVerificationRecordValuePrefix`.
+
 ### ConfirmOwnershipAsync
 
 Check the TXT record and mark the claim active when the expected value is present.


### PR DESCRIPTION
## Summary
- add a configurable SSO domain verification TXT value prefix alongside the record-name prefix
- preserve the existing SqlOS defaults while allowing hosts to brand DNS records
- bump SqlOS to 3.13.4 and document the new option

## Tests
- dotnet test tests/SqlOS.Tests/SqlOS.Tests.csproj --filter "DomainVerificationAsync|ConfigureSsoPortal" --no-restore --verbosity minimal
- dotnet test SqlOS.sln --no-restore --verbosity minimal