### PR TITLE
Add SSO enrollment policy controls

### DIFF
--- a/src/SqlOS/AuthServer/Contracts/SqlOSSsoPortalContracts.cs
+++ b/src/SqlOS/AuthServer/Contracts/SqlOSSsoPortalContracts.cs
@@ -11,6 +11,12 @@ public sealed record SqlOSRevokeSsoPortalSessionRequest(string? Reason = null);
 
 public sealed record SqlOSUpdateSsoPortalProviderRequest(string Provider);
 
+public sealed record SqlOSSsoPortalEnrollmentPolicyRequest(
+    bool RequireSsoForExistingMembers,
+    bool AllowJitProvisioning);
+
+public sealed record SqlOSSsoPortalRevokeOrganizationSessionsRequest(bool Confirm);
+
 public sealed record SqlOSSsoPortalDomainRequest(string Domain);
 
 public sealed record SqlOSSsoPortalMetadataRequest(string MetadataXml);
@@ -61,7 +67,19 @@ public sealed record SqlOSSsoPortalConnectionResult(
     bool AutoProvisionUsers,
     bool AutoLinkByEmail,
     DateTime CreatedAt,
-    DateTime UpdatedAt);
+    DateTime UpdatedAt,
+    SqlOSSsoPortalEnrollmentPolicyResult? EnrollmentPolicy = null);
+
+public sealed record SqlOSSsoPortalEnrollmentPolicyResult(
+    bool RequireSsoForExistingMembers,
+    bool AllowJitProvisioning);
+
+public sealed record SqlOSSsoPortalRevokeOrganizationSessionsResult(
+    string OrganizationId,
+    string ConnectionId,
+    string Domain,
+    int RevokedSessions,
+    DateTime RevokedAt);
 
 public sealed record SqlOSSsoProviderGuide(
     string Key,
@@ -108,7 +126,9 @@ public sealed record SqlOSSsoSetupAllowedActions(
     bool CanActivate,
     bool CanDisable,
     bool CanTest,
-    bool CanSignOut);
+    bool CanSignOut,
+    bool CanUpdateEnrollmentPolicy = true,
+    bool CanRevokeOrganizationSessions = false);
 
 public sealed record SqlOSSsoSetupViewModel(
     string View,

--- a/src/SqlOS/AuthServer/Extensions/EndpointRouteBuilderExtensions.cs
+++ b/src/SqlOS/AuthServer/Extensions/EndpointRouteBuilderExtensions.cs
@@ -3243,6 +3243,29 @@ public static class EndpointRouteBuilderExtensions
             }
         });
 
+        api.MapPut("/enrollment-policy", async (HttpContext context, SqlOSSsoPortalEnrollmentPolicyRequest request, SqlOSSsoPortalService portalService, CancellationToken cancellationToken) =>
+        {
+            if (!portalService.IsApiEnabled)
+            {
+                return Results.NotFound();
+            }
+
+            var session = await portalService.TryGetSessionAsync(context, cancellationToken);
+            if (session == null)
+            {
+                return Results.Json(new { message = "Portal session is invalid or expired." }, statusCode: StatusCodes.Status401Unauthorized);
+            }
+
+            try
+            {
+                return Results.Ok(await portalService.UpdateEnrollmentPolicyAsync(session, request, context, cancellationToken));
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.BadRequest(new { message = ex.Message });
+            }
+        });
+
         api.MapPost("/domain", async (HttpContext context, SqlOSSsoPortalDomainRequest request, SqlOSSsoPortalService portalService, CancellationToken cancellationToken) =>
         {
             if (!portalService.IsApiEnabled)
@@ -3374,6 +3397,29 @@ public static class EndpointRouteBuilderExtensions
             }
         });
 
+        api.MapPost("/organization-sessions/revoke", async (HttpContext context, SqlOSSsoPortalRevokeOrganizationSessionsRequest request, SqlOSSsoPortalService portalService, CancellationToken cancellationToken) =>
+        {
+            if (!portalService.IsApiEnabled)
+            {
+                return Results.NotFound();
+            }
+
+            var session = await portalService.TryGetSessionAsync(context, cancellationToken);
+            if (session == null)
+            {
+                return Results.Json(new { message = "Portal session is invalid or expired." }, statusCode: StatusCodes.Status401Unauthorized);
+            }
+
+            try
+            {
+                return Results.Ok(await portalService.RevokeOrganizationSessionsAsync(session, request, context, cancellationToken));
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.BadRequest(new { message = ex.Message });
+            }
+        });
+
         api.MapPost("/test", async (HttpContext context, SqlOSSsoPortalTestRequest request, SqlOSSsoPortalService portalService, SqlOSSamlService samlService, CancellationToken cancellationToken) =>
         {
             if (!portalService.IsApiEnabled)
@@ -3462,6 +3508,19 @@ public static class EndpointRouteBuilderExtensions
                 : Results.Ok(await portalService.SetProviderActionAsync(session, request, context, cancellationToken));
         });
 
+        setupApi.MapPut("/enrollment-policy", async (HttpContext context, SqlOSSsoPortalEnrollmentPolicyRequest request, SqlOSSsoPortalService portalService, CancellationToken cancellationToken) =>
+        {
+            if (!portalService.IsApiEnabled)
+            {
+                return Results.NotFound();
+            }
+
+            var session = await portalService.TryGetSessionAsync(context, cancellationToken);
+            return session == null
+                ? Results.Json(new { message = "Portal session is invalid or expired." }, statusCode: StatusCodes.Status401Unauthorized)
+                : Results.Ok(await portalService.UpdateEnrollmentPolicyActionAsync(session, request, context, cancellationToken));
+        });
+
         setupApi.MapPost("/domain", async (HttpContext context, SqlOSSsoPortalDomainRequest request, SqlOSSsoPortalService portalService, CancellationToken cancellationToken) =>
         {
             if (!portalService.IsApiEnabled)
@@ -3538,6 +3597,29 @@ public static class EndpointRouteBuilderExtensions
             return session == null
                 ? Results.Json(new { message = "Portal session is invalid or expired." }, statusCode: StatusCodes.Status401Unauthorized)
                 : Results.Ok(await portalService.DisableActionAsync(session, context, cancellationToken));
+        });
+
+        setupApi.MapPost("/organization-sessions/revoke", async (HttpContext context, SqlOSSsoPortalRevokeOrganizationSessionsRequest request, SqlOSSsoPortalService portalService, CancellationToken cancellationToken) =>
+        {
+            if (!portalService.IsApiEnabled)
+            {
+                return Results.NotFound();
+            }
+
+            var session = await portalService.TryGetSessionAsync(context, cancellationToken);
+            if (session == null)
+            {
+                return Results.Json(new { message = "Portal session is invalid or expired." }, statusCode: StatusCodes.Status401Unauthorized);
+            }
+
+            try
+            {
+                return Results.Ok(await portalService.RevokeOrganizationSessionsAsync(session, request, context, cancellationToken));
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.BadRequest(new { message = ex.Message });
+            }
         });
 
         setupApi.MapPost("/test", async (HttpContext context, SqlOSSsoPortalTestRequest request, SqlOSSsoPortalService portalService, SqlOSSamlService samlService, CancellationToken cancellationToken) =>

--- a/src/SqlOS/AuthServer/Services/SqlOSHomeRealmDiscoveryService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSHomeRealmDiscoveryService.cs
@@ -22,7 +22,11 @@ public sealed class SqlOSHomeRealmDiscoveryService
             return new SqlOSHomeRealmDiscoveryResult("password", null, null, null, null);
         }
 
-        var verifiedMatch = await _context.Set<SqlOSOrganizationDomain>()
+        var normalizedEmail = string.IsNullOrWhiteSpace(request.Email)
+            ? null
+            : SqlOSAdminService.NormalizeEmail(request.Email);
+
+        var verifiedMatches = await _context.Set<SqlOSOrganizationDomain>()
             .Where(domain => domain.Domain == normalizedDomain
                 && domain.Status == SqlOSOrganizationDomainStatuses.Active
                 && domain.RevokedAt == null)
@@ -44,18 +48,28 @@ public sealed class SqlOSHomeRealmDiscoveryService
                     OrganizationId = match.Organization.Id,
                     OrganizationName = match.Organization.Name,
                     PrimaryDomain = match.Domain.Domain,
-                    ConnectionId = connection.Id
+                    ConnectionId = connection.Id,
+                    connection.AutoLinkByEmail,
+                    connection.AutoProvisionUsers
                 })
-            .FirstOrDefaultAsync(cancellationToken);
+            .ToListAsync(cancellationToken);
 
-        if (verifiedMatch != null)
+        foreach (var verifiedMatch in verifiedMatches)
         {
-            return new SqlOSHomeRealmDiscoveryResult(
-                "sso",
+            if (await ShouldRouteToSsoAsync(
                 verifiedMatch.OrganizationId,
-                verifiedMatch.OrganizationName,
-                verifiedMatch.PrimaryDomain,
-                verifiedMatch.ConnectionId);
+                normalizedEmail,
+                verifiedMatch.AutoLinkByEmail,
+                verifiedMatch.AutoProvisionUsers,
+                cancellationToken))
+            {
+                return new SqlOSHomeRealmDiscoveryResult(
+                    "sso",
+                    verifiedMatch.OrganizationId,
+                    verifiedMatch.OrganizationName,
+                    verifiedMatch.PrimaryDomain,
+                    verifiedMatch.ConnectionId);
+            }
         }
 
         var match = await _context.Set<SqlOSOrganization>()
@@ -65,18 +79,51 @@ public sealed class SqlOSHomeRealmDiscoveryService
                 x.Id,
                 x.Name,
                 x.PrimaryDomain,
-                ConnectionId = x.SsoConnections
+                Connection = x.SsoConnections
                     .Where(c => c.IsEnabled && c.IdentityProviderEntityId != "" && c.SingleSignOnUrl != "" && c.X509CertificatePem != "")
-                    .Select(c => c.Id)
+                    .Select(c => new
+                    {
+                        c.Id,
+                        c.AutoLinkByEmail,
+                        c.AutoProvisionUsers
+                    })
                     .FirstOrDefault()
             })
             .FirstOrDefaultAsync(cancellationToken);
 
-        if (match?.ConnectionId == null)
+        if (match?.Connection == null
+            || !await ShouldRouteToSsoAsync(
+                match.Id,
+                normalizedEmail,
+                match.Connection.AutoLinkByEmail,
+                match.Connection.AutoProvisionUsers,
+                cancellationToken))
         {
             return new SqlOSHomeRealmDiscoveryResult("password", null, null, null, null);
         }
 
-        return new SqlOSHomeRealmDiscoveryResult("sso", match.Id, match.Name, match.PrimaryDomain, match.ConnectionId);
+        return new SqlOSHomeRealmDiscoveryResult("sso", match.Id, match.Name, match.PrimaryDomain, match.Connection.Id);
+    }
+
+    private async Task<bool> ShouldRouteToSsoAsync(
+        string organizationId,
+        string? normalizedEmail,
+        bool requireSsoForExistingMembers,
+        bool allowJitProvisioning,
+        CancellationToken cancellationToken)
+    {
+        var hasExistingMember = !string.IsNullOrWhiteSpace(normalizedEmail)
+            && await _context.Set<SqlOSUserEmail>()
+                .Where(email => email.NormalizedEmail == normalizedEmail && email.IsVerified)
+                .Join(
+                    _context.Set<SqlOSMembership>().Where(membership => membership.OrganizationId == organizationId && membership.IsActive),
+                    email => email.UserId,
+                    membership => membership.UserId,
+                    (_, _) => true)
+                .AnyAsync(cancellationToken);
+
+        return hasExistingMember
+            ? requireSsoForExistingMembers
+            : allowJitProvisioning;
     }
 }

--- a/src/SqlOS/AuthServer/Services/SqlOSSamlService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSSamlService.cs
@@ -124,14 +124,9 @@ public sealed class SqlOSSamlService
         }
 
         var email = principal.Attributes.TryGetValue(connection.EmailAttributeName, out var emailValue) ? emailValue : authorizationRequest.LoginHintEmail;
-        var user = await ResolveUserAsync(connection, principal, email, cancellationToken)
-            ?? throw new InvalidOperationException("No user could be resolved from the SAML assertion.");
-
         var organizationId = authorizationRequest.OrganizationId ?? connection.OrganizationId;
-        if (!await _adminService.UserHasMembershipAsync(user.Id, organizationId, cancellationToken))
-        {
-            await _adminService.CreateMembershipAsync(organizationId, new SqlOSCreateMembershipRequest(user.Id, "member"), cancellationToken);
-        }
+        var user = await ResolveUserAsync(connection, principal, email, organizationId, cancellationToken)
+            ?? throw new InvalidOperationException("No user could be resolved from the SAML assertion.");
 
         if (_authorizationServerService != null)
         {
@@ -194,13 +189,8 @@ public sealed class SqlOSSamlService
         CancellationToken cancellationToken)
     {
         var email = principal.Attributes.TryGetValue(connection.EmailAttributeName, out var emailValue) ? emailValue : null;
-        var user = await ResolveUserAsync(connection, principal, email, cancellationToken)
+        var user = await ResolveUserAsync(connection, principal, email, connection.OrganizationId, cancellationToken)
             ?? throw new InvalidOperationException("No user could be resolved from the SAML assertion.");
-
-        if (!await _adminService.UserHasMembershipAsync(user.Id, connection.OrganizationId, cancellationToken))
-        {
-            await _adminService.CreateMembershipAsync(connection.OrganizationId, new SqlOSCreateMembershipRequest(user.Id, "member"), cancellationToken);
-        }
 
         var code = await _cryptoService.CreateTemporaryTokenAsync(
             "auth_code",
@@ -311,61 +301,90 @@ public sealed class SqlOSSamlService
         SqlOSSsoConnection connection,
         SqlOSSamlPrincipal principal,
         string? email,
+        string organizationId,
         CancellationToken cancellationToken)
     {
         var externalIdentity = await _context.Set<SqlOSExternalIdentity>()
             .FirstOrDefaultAsync(x => x.SsoConnectionId == connection.Id && x.Subject == principal.Subject, cancellationToken);
-        if (externalIdentity != null)
-        {
-            return await _context.Set<SqlOSUser>().FirstAsync(x => x.Id == externalIdentity.UserId, cancellationToken);
-        }
-
-        SqlOSUser? user = null;
+        SqlOSUser? user = externalIdentity == null
+            ? null
+            : await _context.Set<SqlOSUser>().FirstAsync(x => x.Id == externalIdentity.UserId, cancellationToken);
         string? normalizedEmail = null;
-        if (!string.IsNullOrWhiteSpace(email))
+
+        if (user != null)
+        {
+            var hasMembership = await UserHasActiveMembershipAsync(user.Id, organizationId, cancellationToken);
+            if (!hasMembership)
+            {
+                if (!connection.AutoProvisionUsers)
+                {
+                    return null;
+                }
+
+                await EnsureMembershipAsync(organizationId, user.Id, cancellationToken);
+            }
+        }
+        else if (!string.IsNullOrWhiteSpace(email))
         {
             normalizedEmail = SqlOSAdminService.NormalizeEmail(email);
             var existingEmail = await _context.Set<SqlOSUserEmail>().FirstOrDefaultAsync(x => x.NormalizedEmail == normalizedEmail, cancellationToken);
             if (existingEmail != null)
             {
-                if (!connection.AutoLinkByEmail && !connection.AutoProvisionUsers)
+                user = await _context.Set<SqlOSUser>().FirstAsync(x => x.Id == existingEmail.UserId, cancellationToken);
+                var hasMembership = await UserHasActiveMembershipAsync(user.Id, organizationId, cancellationToken);
+                if (hasMembership)
                 {
-                    return null;
+                    if (!connection.AutoLinkByEmail || !existingEmail.IsVerified)
+                    {
+                        return null;
+                    }
+                }
+                else
+                {
+                    if (!connection.AutoProvisionUsers)
+                    {
+                        return null;
+                    }
+
+                    if (!existingEmail.IsVerified)
+                    {
+                        existingEmail.IsVerified = true;
+                        existingEmail.VerifiedAt = DateTime.UtcNow;
+                    }
+
+                    await EnsureMembershipAsync(organizationId, user.Id, cancellationToken);
+                }
+            }
+            else if (connection.AutoProvisionUsers)
+            {
+                var displayName = $"{principal.Attributes.GetValueOrDefault(connection.FirstNameAttributeName, string.Empty)} {principal.Attributes.GetValueOrDefault(connection.LastNameAttributeName, string.Empty)}".Trim();
+                if (string.IsNullOrWhiteSpace(displayName))
+                {
+                    displayName = email;
                 }
 
-                user = await _context.Set<SqlOSUser>().FirstAsync(x => x.Id == existingEmail.UserId, cancellationToken);
+                user = new SqlOSUser
+                {
+                    Id = _cryptoService.GenerateId("usr"),
+                    DisplayName = displayName,
+                    DefaultEmail = email,
+                    CreatedAt = DateTime.UtcNow,
+                    UpdatedAt = DateTime.UtcNow
+                };
+                _context.Set<SqlOSUser>().Add(user);
+                _context.Set<SqlOSUserEmail>().Add(new SqlOSUserEmail
+                {
+                    Id = _cryptoService.GenerateId("eml"),
+                    UserId = user.Id,
+                    Email = email,
+                    NormalizedEmail = normalizedEmail ?? SqlOSAdminService.NormalizeEmail(email),
+                    IsPrimary = true,
+                    IsVerified = true,
+                    VerifiedAt = DateTime.UtcNow,
+                    CreatedAt = DateTime.UtcNow
+                });
+                await EnsureMembershipAsync(organizationId, user.Id, cancellationToken);
             }
-        }
-
-        if (user == null && connection.AutoProvisionUsers && !string.IsNullOrWhiteSpace(email))
-        {
-            var displayName = $"{principal.Attributes.GetValueOrDefault(connection.FirstNameAttributeName, string.Empty)} {principal.Attributes.GetValueOrDefault(connection.LastNameAttributeName, string.Empty)}".Trim();
-            if (string.IsNullOrWhiteSpace(displayName))
-            {
-                displayName = email;
-            }
-
-            user = new SqlOSUser
-            {
-                Id = _cryptoService.GenerateId("usr"),
-                DisplayName = displayName,
-                DefaultEmail = email,
-                CreatedAt = DateTime.UtcNow,
-                UpdatedAt = DateTime.UtcNow
-            };
-            _context.Set<SqlOSUser>().Add(user);
-            _context.Set<SqlOSUserEmail>().Add(new SqlOSUserEmail
-            {
-                Id = _cryptoService.GenerateId("eml"),
-                UserId = user.Id,
-                Email = email,
-                NormalizedEmail = normalizedEmail ?? SqlOSAdminService.NormalizeEmail(email),
-                IsPrimary = true,
-                IsVerified = true,
-                VerifiedAt = DateTime.UtcNow,
-                CreatedAt = DateTime.UtcNow
-            });
-            await _context.SaveChangesAsync(cancellationToken);
         }
 
         if (user == null)
@@ -373,18 +392,53 @@ public sealed class SqlOSSamlService
             return null;
         }
 
-        _context.Set<SqlOSExternalIdentity>().Add(new SqlOSExternalIdentity
+        if (externalIdentity == null)
         {
-            Id = _cryptoService.GenerateId("ext"),
-            UserId = user.Id,
-            SsoConnectionId = connection.Id,
-            Issuer = principal.Issuer,
-            Subject = principal.Subject,
-            Email = email,
-            CreatedAt = DateTime.UtcNow
-        });
+            _context.Set<SqlOSExternalIdentity>().Add(new SqlOSExternalIdentity
+            {
+                Id = _cryptoService.GenerateId("ext"),
+                UserId = user.Id,
+                SsoConnectionId = connection.Id,
+                Issuer = principal.Issuer,
+                Subject = principal.Subject,
+                Email = email,
+                CreatedAt = DateTime.UtcNow
+            });
+        }
+
         await _context.SaveChangesAsync(cancellationToken);
         return user;
+    }
+
+    private async Task<bool> UserHasActiveMembershipAsync(
+        string userId,
+        string organizationId,
+        CancellationToken cancellationToken)
+        => await _context.Set<SqlOSMembership>()
+            .AnyAsync(x => x.UserId == userId && x.OrganizationId == organizationId && x.IsActive, cancellationToken);
+
+    private async Task EnsureMembershipAsync(
+        string organizationId,
+        string userId,
+        CancellationToken cancellationToken)
+    {
+        var existing = await _context.Set<SqlOSMembership>()
+            .FirstOrDefaultAsync(x => x.OrganizationId == organizationId && x.UserId == userId, cancellationToken);
+        if (existing != null)
+        {
+            existing.IsActive = true;
+            existing.Role = "member";
+            return;
+        }
+
+        _context.Set<SqlOSMembership>().Add(new SqlOSMembership
+        {
+            OrganizationId = organizationId,
+            UserId = userId,
+            Role = "member",
+            CreatedAt = DateTime.UtcNow,
+            IsActive = true
+        });
     }
 
     private sealed record SsoRequestPayload(string ClientId, string RedirectUri, string ConnectionId);

--- a/src/SqlOS/AuthServer/Services/SqlOSSamlService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSSamlService.cs
@@ -321,12 +321,18 @@ public sealed class SqlOSSamlService
         }
 
         SqlOSUser? user = null;
-        if (connection.AutoLinkByEmail && !string.IsNullOrWhiteSpace(email))
+        string? normalizedEmail = null;
+        if (!string.IsNullOrWhiteSpace(email))
         {
-            var normalizedEmail = SqlOSAdminService.NormalizeEmail(email);
+            normalizedEmail = SqlOSAdminService.NormalizeEmail(email);
             var existingEmail = await _context.Set<SqlOSUserEmail>().FirstOrDefaultAsync(x => x.NormalizedEmail == normalizedEmail, cancellationToken);
             if (existingEmail != null)
             {
+                if (!connection.AutoLinkByEmail && !connection.AutoProvisionUsers)
+                {
+                    return null;
+                }
+
                 user = await _context.Set<SqlOSUser>().FirstAsync(x => x.Id == existingEmail.UserId, cancellationToken);
             }
         }
@@ -353,7 +359,7 @@ public sealed class SqlOSSamlService
                 Id = _cryptoService.GenerateId("eml"),
                 UserId = user.Id,
                 Email = email,
-                NormalizedEmail = SqlOSAdminService.NormalizeEmail(email),
+                NormalizedEmail = normalizedEmail ?? SqlOSAdminService.NormalizeEmail(email),
                 IsPrimary = true,
                 IsVerified = true,
                 VerifiedAt = DateTime.UtcNow,

--- a/src/SqlOS/AuthServer/Services/SqlOSSsoPortalPageRenderer.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSSsoPortalPageRenderer.cs
@@ -54,6 +54,8 @@ public static class SqlOSSsoPortalPageRenderer
                 button.danger { background: #991b1b; }
                 button:disabled { opacity: .45; cursor: not-allowed; }
                 .row { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
+                .check-row { display: flex; gap: 10px; align-items: flex-start; padding: 8px 0; }
+                .check-row input { width: auto; margin-top: 2px; }
                 .field-grid { display: grid; gap: 10px; }
                 label { display: grid; gap: 6px; font-size: 12px; color: var(--muted); font-weight: 700; }
                 input, textarea { width: 100%; border: 1px solid var(--line); border-radius: 8px; padding: 10px; font: inherit; background: #fff; color: var(--ink); }
@@ -125,6 +127,29 @@ public static class SqlOSSsoPortalPageRenderer
                         <section class="panel">
                             <h2 id="guide-title">Setup Steps</h2>
                             <ol id="guide-steps"></ol>
+                        </section>
+                        <section class="panel">
+                            <h2>Access Policy</h2>
+                            <div class="field-grid">
+                                <label class="check-row">
+                                    <input id="require-sso" type="checkbox">
+                                    <span>
+                                        <strong>Require SSO for existing members</strong><br>
+                                        Existing organization members with verified email on this domain must use SSO on their next sign-in.
+                                    </span>
+                                </label>
+                                <label class="check-row">
+                                    <input id="allow-jit" type="checkbox">
+                                    <span>
+                                        <strong>Allow JIT provisioning from SSO</strong><br>
+                                        Successful SSO sign-ins can create missing user access for this organization.
+                                    </span>
+                                </label>
+                                <div class="row">
+                                    <button id="save-policy" type="button" class="secondary">Save policy</button>
+                                    <button id="revoke-sessions" type="button" class="danger">Sign out existing sessions</button>
+                                </div>
+                            </div>
                         </section>
                         <section class="panel">
                             <h2>Domain Verification</h2>
@@ -212,6 +237,13 @@ public static class SqlOSSsoPortalPageRenderer
                     return state.providers.find((item) => item.key === state.provider) || state.providers[0];
                 }
 
+                function enrollmentPolicy() {
+                    return state.connection.enrollmentPolicy || {
+                        requireSsoForExistingMembers: state.connection.autoLinkByEmail,
+                        allowJitProvisioning: state.connection.autoProvisionUsers
+                    };
+                }
+
                 function render() {
                     $("expired").classList.add("hidden");
                     $("app").classList.remove("hidden");
@@ -253,6 +285,11 @@ public static class SqlOSSsoPortalPageRenderer
 
                     $("guide-title").textContent = `${selected.label} setup`;
                     $("guide-steps").innerHTML = selected.steps.map((step) => `<li>${esc(step)}</li>`).join("");
+                    const policy = enrollmentPolicy();
+                    $("require-sso").checked = !!policy.requireSsoForExistingMembers;
+                    $("allow-jit").checked = !!policy.allowJitProvisioning;
+                    $("save-policy").disabled = !(state.allowedActions?.canUpdateEnrollmentPolicy ?? true);
+                    $("revoke-sessions").disabled = !(state.allowedActions?.canRevokeOrganizationSessions ?? false);
                     renderDomain();
                     $("activate").disabled = !(state.allowedActions?.canActivate ?? true);
                     $("disable").disabled = !(state.allowedActions?.canDisable ?? false);
@@ -337,6 +374,17 @@ public static class SqlOSSsoPortalPageRenderer
                     else showBanner(state.domain?.lastError || "Domain record was not found yet.", "bad");
                     render();
                 });
+                $("save-policy").addEventListener("click", async () => {
+                    state = await request("/enrollment-policy", {
+                        method: "PUT",
+                        body: JSON.stringify({
+                            requireSsoForExistingMembers: $("require-sso").checked,
+                            allowJitProvisioning: $("allow-jit").checked
+                        })
+                    });
+                    showBanner("Access policy saved.");
+                    render();
+                });
                 $("activate").addEventListener("click", async () => {
                     state = await request("/activate", { method: "POST", body: "{}" });
                     showBanner("Connection activated.");
@@ -353,6 +401,11 @@ public static class SqlOSSsoPortalPageRenderer
                         body: JSON.stringify({ clientId: $("client-id").value || null, redirectUri: $("redirect-uri").value || null })
                     });
                     showTest(result);
+                });
+                $("revoke-sessions").addEventListener("click", async () => {
+                    if (!confirm("Sign out active sessions for this organization and SSO domain?")) return;
+                    const result = await request("/organization-sessions/revoke", { method: "POST", body: JSON.stringify({ confirm: true }) });
+                    showBanner(`${result.revokedSessions} active session${result.revokedSessions === 1 ? "" : "s"} signed out.`);
                 });
                 $("signout").addEventListener("click", async () => {
                     await request("/signout", { method: "POST", body: "{}" });

--- a/src/SqlOS/AuthServer/Services/SqlOSSsoPortalService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSSsoPortalService.cs
@@ -335,6 +335,33 @@ public sealed class SqlOSSsoPortalService
         return await GetStateAsync(session, cancellationToken);
     }
 
+    public async Task<SqlOSSsoPortalStateResult> UpdateEnrollmentPolicyAsync(
+        SqlOSSsoPortalSession session,
+        SqlOSSsoPortalEnrollmentPolicyRequest request,
+        HttpContext? httpContext = null,
+        CancellationToken cancellationToken = default)
+    {
+        var connection = await RequirePortalConnectionAsync(session, cancellationToken);
+        connection.AutoLinkByEmail = request.RequireSsoForExistingMembers;
+        connection.AutoProvisionUsers = request.AllowJitProvisioning;
+        connection.UpdatedAt = DateTime.UtcNow;
+        await _context.SaveChangesAsync(cancellationToken);
+
+        await RecordPortalAuditAsync(
+            "sso.portal.enrollment_policy.updated",
+            session,
+            httpContext,
+            new
+            {
+                connectionId = connection.Id,
+                request.RequireSsoForExistingMembers,
+                request.AllowJitProvisioning
+            },
+            cancellationToken);
+
+        return await GetStateAsync(session, cancellationToken);
+    }
+
     public SqlOSSsoMetadataValidationResult ValidateMetadata(SqlOSSsoPortalMetadataRequest request)
         => _adminService.ValidateSsoMetadata(new SqlOSImportSsoMetadataRequest(request.MetadataXml));
 
@@ -431,6 +458,85 @@ public sealed class SqlOSSsoPortalService
             cancellationToken);
 
         return await GetStateAsync(session, cancellationToken);
+    }
+
+    public async Task<SqlOSSsoPortalRevokeOrganizationSessionsResult> RevokeOrganizationSessionsAsync(
+        SqlOSSsoPortalSession session,
+        SqlOSSsoPortalRevokeOrganizationSessionsRequest request,
+        HttpContext? httpContext = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (!request.Confirm)
+        {
+            throw new InvalidOperationException("Confirm session revocation before signing out existing sessions.");
+        }
+
+        var connection = await RequirePortalConnectionAsync(session, cancellationToken);
+        if (!connection.IsEnabled)
+        {
+            throw new InvalidOperationException("Activate the SSO connection before signing out existing sessions.");
+        }
+
+        var domain = await _domainService.GetPreferredDomainAsync(session.OrganizationId, cancellationToken);
+        if (domain == null || domain.Status != SqlOSOrganizationDomainStatuses.Active)
+        {
+            throw new InvalidOperationException("Verify an SSO domain before signing out existing sessions.");
+        }
+
+        var now = DateTime.UtcNow;
+        var normalizedDomainSuffix = "@" + domain.Domain.ToUpperInvariant();
+        var eligibleUserIds = await _context.Set<SqlOSUserEmail>()
+            .AsNoTracking()
+            .Where(x => x.IsVerified && x.NormalizedEmail.EndsWith(normalizedDomainSuffix))
+            .Select(x => x.UserId)
+            .Distinct()
+            .ToListAsync(cancellationToken);
+
+        var sessions = eligibleUserIds.Count == 0
+            ? []
+            : await _context.Set<SqlOSSession>()
+                .Where(x => x.OrganizationId == session.OrganizationId
+                    && x.RevokedAt == null
+                    && eligibleUserIds.Contains(x.UserId))
+                .ToListAsync(cancellationToken);
+
+        var sessionIds = sessions.Select(x => x.Id).ToList();
+        var refreshTokens = sessionIds.Count == 0
+            ? []
+            : await _context.Set<SqlOSRefreshToken>()
+                .Where(x => sessionIds.Contains(x.SessionId) && x.RevokedAt == null)
+                .ToListAsync(cancellationToken);
+
+        foreach (var activeSession in sessions)
+        {
+            activeSession.RevokedAt = now;
+            activeSession.RevocationReason = "sso_required";
+        }
+
+        foreach (var refreshToken in refreshTokens)
+        {
+            refreshToken.RevokedAt = now;
+        }
+
+        await _context.SaveChangesAsync(cancellationToken);
+        await RecordPortalAuditAsync(
+            "sso.portal.organization_sessions.revoked",
+            session,
+            httpContext,
+            new
+            {
+                connectionId = connection.Id,
+                domain = domain.Domain,
+                revokedSessions = sessions.Count
+            },
+            cancellationToken);
+
+        return new SqlOSSsoPortalRevokeOrganizationSessionsResult(
+            session.OrganizationId,
+            connection.Id,
+            domain.Domain,
+            sessions.Count,
+            now);
     }
 
     public async Task<SqlOSSsoPortalTestResult> RecordTestAsync(
@@ -537,6 +643,23 @@ public sealed class SqlOSSsoPortalService
                 ex.Message,
                 new Dictionary<string, string> { ["provider"] = ex.Message },
                 cancellationToken);
+        }
+    }
+
+    public async Task<SqlOSSsoSetupActionResult> UpdateEnrollmentPolicyActionAsync(
+        SqlOSSsoPortalSession session,
+        SqlOSSsoPortalEnrollmentPolicyRequest request,
+        HttpContext? httpContext = null,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await UpdateEnrollmentPolicyAsync(session, request, httpContext, cancellationToken);
+            return await ViewActionAsync(session, "policy", null, null, cancellationToken);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return await ViewActionAsync(session, "policy", ex.Message, null, cancellationToken);
         }
     }
 
@@ -735,7 +858,7 @@ public sealed class SqlOSSsoPortalService
             IdentityProviderEntityId = string.Empty,
             SingleSignOnUrl = string.Empty,
             X509CertificatePem = string.Empty,
-            AutoProvisionUsers = true,
+            AutoProvisionUsers = false,
             AutoLinkByEmail = true,
             EmailAttributeName = "email",
             FirstNameAttributeName = "first_name",
@@ -802,7 +925,10 @@ public sealed class SqlOSSsoPortalService
             connection.AutoProvisionUsers,
             connection.AutoLinkByEmail,
             connection.CreatedAt,
-            connection.UpdatedAt);
+            connection.UpdatedAt,
+            new SqlOSSsoPortalEnrollmentPolicyResult(
+                connection.AutoLinkByEmail,
+                connection.AutoProvisionUsers));
 
     private SqlOSSsoSetupAllowedActions BuildAllowedActions(
         SqlOSOrganization organization,
@@ -833,7 +959,9 @@ public sealed class SqlOSSsoPortalService
             CanActivate: !connection.IsEnabled && hasMetadata && domainReady,
             CanDisable: connection.IsEnabled,
             CanTest: connection.IsEnabled,
-            CanSignOut: true);
+            CanSignOut: true,
+            CanUpdateEnrollmentPolicy: true,
+            CanRevokeOrganizationSessions: connection.IsEnabled && domain?.Status == SqlOSOrganizationDomainStatuses.Active);
     }
 
     private bool IsDomainReadyForActivation(string? primaryDomain, SqlOSOrganizationDomainResult? domain)

--- a/src/SqlOS/AuthServer/Services/SqlOSSsoPortalService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSSsoPortalService.cs
@@ -736,7 +736,7 @@ public sealed class SqlOSSsoPortalService
             SingleSignOnUrl = string.Empty,
             X509CertificatePem = string.Empty,
             AutoProvisionUsers = true,
-            AutoLinkByEmail = false,
+            AutoLinkByEmail = true,
             EmailAttributeName = "email",
             FirstNameAttributeName = "first_name",
             LastNameAttributeName = "last_name",

--- a/src/SqlOS/SqlOS.csproj
+++ b/src/SqlOS/SqlOS.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>SqlOS</PackageId>
-    <Version>3.14.0</Version>
+    <Version>3.14.1</Version>
     <Authors>Ross Slaney</Authors>
     <Description>Embedded auth server and fine-grained authorization runtime for .NET + SQL Server + EF Core.</Description>
     <PackageTags>authentication;authorization;fga;saml;jwt;sessions;efcore;sqlserver</PackageTags>

--- a/tests/SqlOS.IntegrationTests/SamlServiceIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/SamlServiceIntegrationTests.cs
@@ -7,9 +7,11 @@ using System.Xml;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SqlOS.AuthServer.Contracts;
+using SqlOS.AuthServer.Models;
 using SqlOS.AuthServer.Services;
 using SqlOS.IntegrationTests.Infrastructure;
 
@@ -133,6 +135,58 @@ public sealed class SamlServiceIntegrationTests
 
         tokens.OrganizationId.Should().Be(org.Id);
         tokens.AccessToken.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [TestMethod]
+    public async Task SignedSamlResponse_WithExistingEmail_ReusesUserWhenAutoProvisioning()
+    {
+        var options = Options.Create(AspireFixture.Options);
+        var crypto = new SqlOSCryptoService(AspireFixture.SharedContext, options);
+        var admin = new SqlOSAdminService(AspireFixture.SharedContext, options, crypto);
+        var saml = new SqlOSSamlService(AspireFixture.SharedContext, options, admin, crypto);
+
+        var email = $"existing-saml-{Guid.NewGuid():N}@example.com";
+        var existingUser = await admin.CreateUserAsync(new SqlOSCreateUserRequest("Existing SAML User", email, "P@ssword123!"));
+        var org = await admin.CreateOrganizationAsync(new SqlOSCreateOrganizationRequest($"Existing SAML {Guid.NewGuid():N}", null));
+        var client = await admin.CreateClientAsync(new SqlOSCreateClientRequest(
+            $"existing-saml-{Guid.NewGuid():N}"[..20],
+            "Existing SAML Client",
+            "sqlos-tests",
+            new List<string> { "https://client.example.local/callback" }));
+
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest("CN=SqlOSExistingSamlIdP", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        var certificate = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(30));
+        var connection = await admin.CreateSsoConnectionAsync(new SqlOSCreateSsoConnectionRequest(
+            org.Id,
+            "Existing User SSO",
+            "urn:existing:idp",
+            "https://idp.example.test/sso",
+            certificate.ExportCertificatePem(),
+            true,
+            false,
+            "email",
+            "first_name",
+            "last_name"));
+
+        var authUrl = await saml.CreateAuthorizationUrlAsync(new SqlOSAuthorizationUrlRequest(connection.Id, client.ClientId, "https://client.example.local/callback"));
+        var requestToken = QueryHelpers.ParseQuery(new Uri($"https://localhost{authUrl}").Query)["requestToken"].ToString();
+        requestToken.Should().NotBeNull();
+
+        var samlResponse = BuildSignedSamlResponse(certificate, "urn:existing:idp", email, "Existing", "User");
+        var redirectUrl = await saml.HandleAcsAsync(connection.Id, samlResponse, requestToken!, default);
+        redirectUrl.Should().StartWith("https://client.example.local/callback?code=");
+
+        var normalizedEmail = SqlOSAdminService.NormalizeEmail(email);
+        var matchingEmails = await AspireFixture.SharedContext.Set<SqlOSUserEmail>()
+            .Where(x => x.NormalizedEmail == normalizedEmail)
+            .ToListAsync();
+        matchingEmails.Should().ContainSingle();
+        matchingEmails.Single().UserId.Should().Be(existingUser.Id);
+
+        var externalIdentity = await AspireFixture.SharedContext.Set<SqlOSExternalIdentity>()
+            .SingleAsync(x => x.SsoConnectionId == connection.Id && x.Subject == email);
+        externalIdentity.UserId.Should().Be(existingUser.Id);
     }
 
     [TestMethod]

--- a/tests/SqlOS.IntegrationTests/SamlServiceIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/SamlServiceIntegrationTests.cs
@@ -187,6 +187,130 @@ public sealed class SamlServiceIntegrationTests
         var externalIdentity = await AspireFixture.SharedContext.Set<SqlOSExternalIdentity>()
             .SingleAsync(x => x.SsoConnectionId == connection.Id && x.Subject == email);
         externalIdentity.UserId.Should().Be(existingUser.Id);
+
+        (await AspireFixture.SharedContext.Set<SqlOSMembership>()
+            .AnyAsync(x => x.OrganizationId == org.Id && x.UserId == existingUser.Id && x.IsActive))
+            .Should().BeTrue();
+    }
+
+    [TestMethod]
+    public async Task SignedSamlResponse_WithExistingOrgMemberAndRequireSso_LinksExternalIdentityWithoutCreatingUser()
+    {
+        var (_, admin, saml) = CreateSamlServices();
+        var email = $"existing-member-{Guid.NewGuid():N}@example.com";
+        var existingUser = await admin.CreateUserAsync(new SqlOSCreateUserRequest("Existing Member", email, "P@ssword123!"));
+        await MarkEmailVerifiedAsync(existingUser.Id);
+        var org = await admin.CreateOrganizationAsync(new SqlOSCreateOrganizationRequest($"Existing Member {Guid.NewGuid():N}", null));
+        AspireFixture.SharedContext.Set<SqlOSMembership>().Add(new SqlOSMembership
+        {
+            OrganizationId = org.Id,
+            UserId = existingUser.Id,
+            Role = "member",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow
+        });
+        await AspireFixture.SharedContext.SaveChangesAsync();
+        var client = await CreateSamlClientAsync(admin, "existing-member");
+
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest("CN=SqlOSExistingMemberSamlIdP", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        var certificate = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(30));
+        var connection = await admin.CreateSsoConnectionAsync(new SqlOSCreateSsoConnectionRequest(
+            org.Id,
+            "Existing Member SSO",
+            "urn:existing-member:idp",
+            "https://idp.example.test/sso",
+            certificate.ExportCertificatePem(),
+            false,
+            true,
+            "email",
+            "first_name",
+            "last_name"));
+
+        var requestToken = await CreateRequestTokenAsync(saml, connection.Id, client.ClientId);
+        var samlResponse = BuildSignedSamlResponse(certificate, "urn:existing-member:idp", email, "Existing", "Member");
+        var redirectUrl = await saml.HandleAcsAsync(connection.Id, samlResponse, requestToken, default);
+
+        redirectUrl.Should().StartWith("https://client.example.local/callback?code=");
+        var normalizedEmail = SqlOSAdminService.NormalizeEmail(email);
+        (await AspireFixture.SharedContext.Set<SqlOSUserEmail>().CountAsync(x => x.NormalizedEmail == normalizedEmail))
+            .Should().Be(1);
+        (await AspireFixture.SharedContext.Set<SqlOSMembership>().CountAsync(x => x.OrganizationId == org.Id && x.UserId == existingUser.Id))
+            .Should().Be(1);
+        var externalIdentity = await AspireFixture.SharedContext.Set<SqlOSExternalIdentity>()
+            .SingleAsync(x => x.SsoConnectionId == connection.Id && x.Subject == email);
+        externalIdentity.UserId.Should().Be(existingUser.Id);
+    }
+
+    [TestMethod]
+    public async Task SignedSamlResponse_WithExistingNonMemberAndJitOff_IsDenied()
+    {
+        var (_, admin, saml) = CreateSamlServices();
+        var email = $"existing-nonmember-{Guid.NewGuid():N}@example.com";
+        var existingUser = await admin.CreateUserAsync(new SqlOSCreateUserRequest("Existing Nonmember", email, "P@ssword123!"));
+        await MarkEmailVerifiedAsync(existingUser.Id);
+        var org = await admin.CreateOrganizationAsync(new SqlOSCreateOrganizationRequest($"Existing Nonmember {Guid.NewGuid():N}", null));
+        var client = await CreateSamlClientAsync(admin, "existing-nonmember");
+
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest("CN=SqlOSExistingNonmemberSamlIdP", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        var certificate = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(30));
+        var connection = await admin.CreateSsoConnectionAsync(new SqlOSCreateSsoConnectionRequest(
+            org.Id,
+            "Existing Nonmember SSO",
+            "urn:existing-nonmember:idp",
+            "https://idp.example.test/sso",
+            certificate.ExportCertificatePem(),
+            false,
+            true,
+            "email",
+            "first_name",
+            "last_name"));
+
+        var requestToken = await CreateRequestTokenAsync(saml, connection.Id, client.ClientId);
+        var samlResponse = BuildSignedSamlResponse(certificate, "urn:existing-nonmember:idp", email, "Existing", "Nonmember");
+        var action = async () => await saml.HandleAcsAsync(connection.Id, samlResponse, requestToken, default);
+
+        await action.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("No user could be resolved from the SAML assertion.");
+        (await AspireFixture.SharedContext.Set<SqlOSMembership>().AnyAsync(x => x.OrganizationId == org.Id && x.UserId == existingUser.Id))
+            .Should().BeFalse();
+        (await AspireFixture.SharedContext.Set<SqlOSExternalIdentity>().AnyAsync(x => x.SsoConnectionId == connection.Id && x.Subject == email))
+            .Should().BeFalse();
+    }
+
+    [TestMethod]
+    public async Task SignedSamlResponse_WithMissingUserAndJitOff_IsDenied()
+    {
+        var (_, admin, saml) = CreateSamlServices();
+        var email = $"missing-jit-off-{Guid.NewGuid():N}@example.com";
+        var org = await admin.CreateOrganizationAsync(new SqlOSCreateOrganizationRequest($"Missing JIT Off {Guid.NewGuid():N}", null));
+        var client = await CreateSamlClientAsync(admin, "missing-jit-off");
+
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest("CN=SqlOSMissingJitOffSamlIdP", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        var certificate = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(30));
+        var connection = await admin.CreateSsoConnectionAsync(new SqlOSCreateSsoConnectionRequest(
+            org.Id,
+            "Missing JIT Off SSO",
+            "urn:missing-jit-off:idp",
+            "https://idp.example.test/sso",
+            certificate.ExportCertificatePem(),
+            false,
+            true,
+            "email",
+            "first_name",
+            "last_name"));
+
+        var requestToken = await CreateRequestTokenAsync(saml, connection.Id, client.ClientId);
+        var samlResponse = BuildSignedSamlResponse(certificate, "urn:missing-jit-off:idp", email, "Missing", "User");
+        var action = async () => await saml.HandleAcsAsync(connection.Id, samlResponse, requestToken, default);
+
+        await action.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("No user could be resolved from the SAML assertion.");
+        var normalizedEmail = SqlOSAdminService.NormalizeEmail(email);
+        (await AspireFixture.SharedContext.Set<SqlOSUserEmail>().AnyAsync(x => x.NormalizedEmail == normalizedEmail))
+            .Should().BeFalse();
     }
 
     [TestMethod]
@@ -235,6 +359,39 @@ public sealed class SamlServiceIntegrationTests
         xml.Should().Contain("<samlp:AuthnRequest");
         xml.Should().Contain("AssertionConsumerServiceURL=");
         xml.Should().Contain(connection.SingleSignOnUrl);
+    }
+
+    private static (SqlOSCryptoService Crypto, SqlOSAdminService Admin, SqlOSSamlService Saml) CreateSamlServices()
+    {
+        var options = Options.Create(AspireFixture.Options);
+        var crypto = new SqlOSCryptoService(AspireFixture.SharedContext, options);
+        var admin = new SqlOSAdminService(AspireFixture.SharedContext, options, crypto);
+        var saml = new SqlOSSamlService(AspireFixture.SharedContext, options, admin, crypto);
+        return (crypto, admin, saml);
+    }
+
+    private static async Task<SqlOSClientApplication> CreateSamlClientAsync(SqlOSAdminService admin, string prefix)
+        => await admin.CreateClientAsync(new SqlOSCreateClientRequest(
+            $"{prefix}-{Guid.NewGuid():N}"[..20],
+            $"{prefix} client",
+            "sqlos-tests",
+            new List<string> { "https://client.example.local/callback" }));
+
+    private static async Task<string> CreateRequestTokenAsync(SqlOSSamlService saml, string connectionId, string clientId)
+    {
+        var authUrl = await saml.CreateAuthorizationUrlAsync(new SqlOSAuthorizationUrlRequest(
+            connectionId,
+            clientId,
+            "https://client.example.local/callback"));
+        return QueryHelpers.ParseQuery(new Uri($"https://localhost{authUrl}").Query)["requestToken"].ToString();
+    }
+
+    private static async Task MarkEmailVerifiedAsync(string userId)
+    {
+        var email = await AspireFixture.SharedContext.Set<SqlOSUserEmail>().SingleAsync(x => x.UserId == userId);
+        email.IsVerified = true;
+        email.VerifiedAt = DateTime.UtcNow;
+        await AspireFixture.SharedContext.SaveChangesAsync();
     }
 
     private static string BuildSignedSamlResponse(

--- a/tests/SqlOS.Tests/SqlOSDiscoveryAndSettingsTests.cs
+++ b/tests/SqlOS.Tests/SqlOSDiscoveryAndSettingsTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SqlOS.AuthServer.Configuration;
 using SqlOS.AuthServer.Contracts;
+using SqlOS.AuthServer.Models;
 using SqlOS.AuthServer.Services;
 using SqlOS.Tests.Infrastructure;
 
@@ -43,6 +44,110 @@ public sealed class SqlOSDiscoveryAndSettingsTests
     }
 
     [TestMethod]
+    public async Task DiscoverAsync_ReturnsSso_ForExistingVerifiedMemberWhenRequireSsoIsEnabled()
+    {
+        await using var context = CreateContext();
+        var options = Options.Create(new SqlOSAuthServerOptions());
+        var crypto = new SqlOSCryptoService(context, options);
+        var admin = new SqlOSAdminService(context, options, crypto);
+        var discovery = new SqlOSHomeRealmDiscoveryService(context);
+
+        var organization = await admin.CreateOrganizationAsync(new SqlOSCreateOrganizationRequest("Member Org", null, "member.test"));
+        var user = await CreateVerifiedUserAsync(context, admin, "Member User", "user@member.test");
+        context.Set<SqlOSMembership>().Add(new SqlOSMembership
+        {
+            OrganizationId = organization.Id,
+            UserId = user.Id,
+            Role = "member",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow
+        });
+        await admin.CreateSsoConnectionAsync(new SqlOSCreateSsoConnectionRequest(
+            organization.Id,
+            "Member SSO",
+            "urn:member:idp",
+            "https://idp.member.test/sso",
+            "-----BEGIN CERTIFICATE-----\nTEST\n-----END CERTIFICATE-----",
+            false,
+            true,
+            "email",
+            "first_name",
+            "last_name"));
+        await context.SaveChangesAsync();
+
+        var result = await discovery.DiscoverAsync(new SqlOSHomeRealmDiscoveryRequest("user@member.test"));
+
+        result.Mode.Should().Be("sso");
+        result.OrganizationId.Should().Be(organization.Id);
+    }
+
+    [TestMethod]
+    public async Task DiscoverAsync_ReturnsPassword_ForMissingMemberWhenJitIsDisabled()
+    {
+        await using var context = CreateContext();
+        var options = Options.Create(new SqlOSAuthServerOptions());
+        var crypto = new SqlOSCryptoService(context, options);
+        var admin = new SqlOSAdminService(context, options, crypto);
+        var discovery = new SqlOSHomeRealmDiscoveryService(context);
+
+        var organization = await admin.CreateOrganizationAsync(new SqlOSCreateOrganizationRequest("No JIT Org", null, "nojit.test"));
+        await admin.CreateSsoConnectionAsync(new SqlOSCreateSsoConnectionRequest(
+            organization.Id,
+            "No JIT SSO",
+            "urn:nojit:idp",
+            "https://idp.nojit.test/sso",
+            "-----BEGIN CERTIFICATE-----\nTEST\n-----END CERTIFICATE-----",
+            false,
+            true,
+            "email",
+            "first_name",
+            "last_name"));
+
+        var result = await discovery.DiscoverAsync(new SqlOSHomeRealmDiscoveryRequest("new@nojit.test"));
+
+        result.Mode.Should().Be("password");
+        result.OrganizationId.Should().BeNull();
+    }
+
+    [TestMethod]
+    public async Task DiscoverAsync_ReturnsPassword_ForExistingMemberWhenRequireSsoIsDisabledAndJitIsDisabled()
+    {
+        await using var context = CreateContext();
+        var options = Options.Create(new SqlOSAuthServerOptions());
+        var crypto = new SqlOSCryptoService(context, options);
+        var admin = new SqlOSAdminService(context, options, crypto);
+        var discovery = new SqlOSHomeRealmDiscoveryService(context);
+
+        var organization = await admin.CreateOrganizationAsync(new SqlOSCreateOrganizationRequest("Password Org", null, "password.test"));
+        var user = await CreateVerifiedUserAsync(context, admin, "Password User", "user@password.test");
+        context.Set<SqlOSMembership>().Add(new SqlOSMembership
+        {
+            OrganizationId = organization.Id,
+            UserId = user.Id,
+            Role = "member",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow
+        });
+        await admin.CreateSsoConnectionAsync(new SqlOSCreateSsoConnectionRequest(
+            organization.Id,
+            "Password SSO",
+            "urn:password:idp",
+            "https://idp.password.test/sso",
+            "-----BEGIN CERTIFICATE-----\nTEST\n-----END CERTIFICATE-----",
+            false,
+            false,
+            "email",
+            "first_name",
+            "last_name"));
+        await context.SaveChangesAsync();
+
+        var result = await discovery.DiscoverAsync(new SqlOSHomeRealmDiscoveryRequest("user@password.test"));
+
+        result.Mode.Should().Be("password");
+        result.OrganizationId.Should().BeNull();
+    }
+
+    [TestMethod]
     public async Task SettingsService_SeedsDefaults_AndCanBeUpdated()
     {
         await using var context = CreateContext();
@@ -74,5 +179,19 @@ public sealed class SqlOSDiscoveryAndSettingsTests
             .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
             .Options;
         return new TestSqlOSInMemoryDbContext(options);
+    }
+
+    private static async Task<SqlOSUser> CreateVerifiedUserAsync(
+        TestSqlOSInMemoryDbContext context,
+        SqlOSAdminService admin,
+        string displayName,
+        string email)
+    {
+        var user = await admin.CreateUserAsync(new SqlOSCreateUserRequest(displayName, email, "P@ssword123!"));
+        var userEmail = await context.Set<SqlOSUserEmail>().SingleAsync(x => x.UserId == user.Id);
+        userEmail.IsVerified = true;
+        userEmail.VerifiedAt = DateTime.UtcNow;
+        await context.SaveChangesAsync();
+        return user;
     }
 }

--- a/tests/SqlOS.Tests/SqlOSSsoPortalServiceTests.cs
+++ b/tests/SqlOS.Tests/SqlOSSsoPortalServiceTests.cs
@@ -42,11 +42,42 @@ public sealed class SqlOSSsoPortalServiceTests
         var connection = await harness.Context.Set<SqlOSSsoConnection>().SingleAsync();
         connection.OrganizationId.Should().Be(org.Id);
         connection.IsEnabled.Should().BeFalse();
-        connection.AutoProvisionUsers.Should().BeTrue();
+        connection.AutoProvisionUsers.Should().BeFalse();
         connection.AutoLinkByEmail.Should().BeTrue();
         SqlOSAdminService.GetSsoSetupStatus(connection).Should().Be("draft");
 
+        var state = await harness.Portal.GetStateAsync(session: stored);
+        state.Connection.EnrollmentPolicy.Should().NotBeNull();
+        state.Connection.EnrollmentPolicy!.RequireSsoForExistingMembers.Should().BeTrue();
+        state.Connection.EnrollmentPolicy.AllowJitProvisioning.Should().BeFalse();
+
         (await harness.Context.Set<SqlOSAuditEvent>().AnyAsync(x => x.EventType == "sso.portal.session.created"))
+            .Should().BeTrue();
+    }
+
+    [TestMethod]
+    public async Task UpdateEnrollmentPolicyAsync_PersistsConnectionFlagsAndReturnsState()
+    {
+        using var harness = await PortalHarness.CreateAsync();
+        var org = await harness.Admin.CreateOrganizationAsync(new SqlOSCreateOrganizationRequest("Policy Org", null, "policy.test"));
+        var created = await harness.Portal.CreateSessionAsync(new SqlOSCreateSsoPortalSessionRequest(org.Id), harness.Http);
+        var session = await harness.Context.Set<SqlOSSsoPortalSession>().SingleAsync(x => x.Id == created.Id);
+
+        var state = await harness.Portal.UpdateEnrollmentPolicyAsync(
+            session,
+            new SqlOSSsoPortalEnrollmentPolicyRequest(false, true),
+            harness.Http);
+
+        state.Connection.AutoLinkByEmail.Should().BeFalse();
+        state.Connection.AutoProvisionUsers.Should().BeTrue();
+        state.Connection.EnrollmentPolicy.Should().NotBeNull();
+        state.Connection.EnrollmentPolicy!.RequireSsoForExistingMembers.Should().BeFalse();
+        state.Connection.EnrollmentPolicy.AllowJitProvisioning.Should().BeTrue();
+
+        var stored = await harness.Context.Set<SqlOSSsoConnection>().SingleAsync(x => x.Id == state.Connection.Id);
+        stored.AutoLinkByEmail.Should().BeFalse();
+        stored.AutoProvisionUsers.Should().BeTrue();
+        (await harness.Context.Set<SqlOSAuditEvent>().AnyAsync(x => x.EventType == "sso.portal.enrollment_policy.updated"))
             .Should().BeTrue();
     }
 
@@ -122,6 +153,17 @@ public sealed class SqlOSSsoPortalServiceTests
         state = await harness.Portal.ActivateAsync(session, harness.Http);
         state.Connection.SetupStatus.Should().Be("active");
 
+        var user = await CreateVerifiedUserAsync(harness, "Portal User", "user@portal.test");
+        harness.Context.Set<SqlOSMembership>().Add(new SqlOSMembership
+        {
+            OrganizationId = org.Id,
+            UserId = user.Id,
+            Role = "member",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow
+        });
+        await harness.Context.SaveChangesAsync();
+
         var hrd = await new SqlOSHomeRealmDiscoveryService(harness.Context)
             .DiscoverAsync(new SqlOSHomeRealmDiscoveryRequest("user@portal.test"));
         hrd.Mode.Should().Be("sso");
@@ -165,6 +207,17 @@ public sealed class SqlOSSsoPortalServiceTests
         await harness.Portal.ImportMetadataAsync(session, new SqlOSSsoPortalMetadataRequest(metadataXml), harness.Http);
         state = await harness.Portal.ActivateAsync(session, harness.Http);
         state.Connection.SetupStatus.Should().Be("active");
+
+        var user = await CreateVerifiedUserAsync(harness, "Verified User", "user@verified.test");
+        harness.Context.Set<SqlOSMembership>().Add(new SqlOSMembership
+        {
+            OrganizationId = org.Id,
+            UserId = user.Id,
+            Role = "member",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow
+        });
+        await harness.Context.SaveChangesAsync();
 
         var hrd = await new SqlOSHomeRealmDiscoveryService(harness.Context)
             .DiscoverAsync(new SqlOSHomeRealmDiscoveryRequest("user@verified.test"));
@@ -216,6 +269,73 @@ public sealed class SqlOSSsoPortalServiceTests
         var action = async () => await harness.Portal.ActivateAsync(session, harness.Http);
         await action.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("Verify domain ownership before activating SSO for home realm discovery.");
+    }
+
+    [TestMethod]
+    public async Task RevokeOrganizationSessionsAsync_RevokesOnlyActiveSessionsForOrgAndDomain()
+    {
+        using var harness = await PortalHarness.CreateAsync();
+        var org = await harness.Admin.CreateOrganizationAsync(new SqlOSCreateOrganizationRequest("Revoke Sessions Org", null));
+        var otherOrg = await harness.Admin.CreateOrganizationAsync(new SqlOSCreateOrganizationRequest("Other Sessions Org", null));
+        var created = await harness.Portal.CreateSessionAsync(new SqlOSCreateSsoPortalSessionRequest(org.Id), harness.Http);
+        var session = await harness.Context.Set<SqlOSSsoPortalSession>().SingleAsync(x => x.Id == created.Id);
+        var connection = await harness.Context.Set<SqlOSSsoConnection>().SingleAsync(x => x.OrganizationId == org.Id);
+        connection.IsEnabled = true;
+        connection.IdentityProviderEntityId = "urn:revoke:idp";
+        connection.SingleSignOnUrl = "https://idp.revoke.test/sso";
+        connection.X509CertificatePem = "-----BEGIN CERTIFICATE-----\nTEST\n-----END CERTIFICATE-----";
+        harness.Context.Set<SqlOSOrganizationDomain>().Add(new SqlOSOrganizationDomain
+        {
+            Id = "dom_revoke",
+            OrganizationId = org.Id,
+            Domain = "revoke.test",
+            Status = SqlOSOrganizationDomainStatuses.Active,
+            VerificationToken = "verified",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+            VerifiedAt = DateTime.UtcNow
+        });
+
+        var matching = await CreateVerifiedUserAsync(harness, "Matching User", "member@revoke.test");
+        var unrelatedDomain = await CreateVerifiedUserAsync(harness, "Other Domain User", "member@else.test");
+        var otherOrganizationUser = await CreateVerifiedUserAsync(harness, "Other Org User", "other@revoke.test");
+        AddSession(harness, "sess_revoke_match", matching.Id, org.Id);
+        AddSession(harness, "sess_revoke_domain_miss", unrelatedDomain.Id, org.Id);
+        AddSession(harness, "sess_revoke_other_org", otherOrganizationUser.Id, otherOrg.Id);
+        await harness.Context.SaveChangesAsync();
+
+        var blocked = async () => await harness.Portal.RevokeOrganizationSessionsAsync(
+            session,
+            new SqlOSSsoPortalRevokeOrganizationSessionsRequest(false),
+            harness.Http);
+        await blocked.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Confirm session revocation before signing out existing sessions.");
+
+        var result = await harness.Portal.RevokeOrganizationSessionsAsync(
+            session,
+            new SqlOSSsoPortalRevokeOrganizationSessionsRequest(true),
+            harness.Http);
+
+        result.OrganizationId.Should().Be(org.Id);
+        result.ConnectionId.Should().Be(connection.Id);
+        result.Domain.Should().Be("revoke.test");
+        result.RevokedSessions.Should().Be(1);
+
+        var matchingSession = await harness.Context.Set<SqlOSSession>().SingleAsync(x => x.Id == "sess_revoke_match");
+        matchingSession.RevokedAt.Should().NotBeNull();
+        matchingSession.RevocationReason.Should().Be("sso_required");
+        (await harness.Context.Set<SqlOSRefreshToken>().SingleAsync(x => x.SessionId == matchingSession.Id)).RevokedAt
+            .Should().NotBeNull();
+
+        (await harness.Context.Set<SqlOSSession>().SingleAsync(x => x.Id == "sess_revoke_domain_miss")).RevokedAt
+            .Should().BeNull();
+        (await harness.Context.Set<SqlOSSession>().SingleAsync(x => x.Id == "sess_revoke_other_org")).RevokedAt
+            .Should().BeNull();
+        (await harness.Context.Set<SqlOSAuditEvent>().AnyAsync(x => x.EventType == "sso.portal.organization_sessions.revoked"
+            && x.OrganizationId == org.Id
+            && x.MetadataJson != null
+            && x.MetadataJson.Contains("\"revokedSessions\":1", StringComparison.Ordinal)))
+            .Should().BeTrue();
     }
 
     [TestMethod]
@@ -277,6 +397,8 @@ public sealed class SqlOSSsoPortalServiceTests
         html.Should().Contain("./api");
         html.Should().Contain("Domain Verification");
         html.Should().Contain("Confirm TXT record");
+        html.Should().Contain("Access Policy");
+        html.Should().Contain("Sign out existing sessions");
         html.Should().Contain("Validate metadata");
         html.Should().Contain("Activate connection");
         html.Should().Contain("Run test");
@@ -336,6 +458,40 @@ public sealed class SqlOSSsoPortalServiceTests
         }
 
         return Uri.UnescapeDataString(token);
+    }
+
+    private static async Task<SqlOSUser> CreateVerifiedUserAsync(PortalHarness harness, string displayName, string email)
+    {
+        var user = await harness.Admin.CreateUserAsync(new SqlOSCreateUserRequest(displayName, email, "P@ssword123!"));
+        var userEmail = await harness.Context.Set<SqlOSUserEmail>().SingleAsync(x => x.UserId == user.Id);
+        userEmail.IsVerified = true;
+        userEmail.VerifiedAt = DateTime.UtcNow;
+        await harness.Context.SaveChangesAsync();
+        return user;
+    }
+
+    private static void AddSession(PortalHarness harness, string sessionId, string userId, string organizationId)
+    {
+        harness.Context.Set<SqlOSSession>().Add(new SqlOSSession
+        {
+            Id = sessionId,
+            UserId = userId,
+            OrganizationId = organizationId,
+            AuthenticationMethod = "password",
+            CreatedAt = DateTime.UtcNow,
+            LastSeenAt = DateTime.UtcNow,
+            IdleExpiresAt = DateTime.UtcNow.AddHours(1),
+            AbsoluteExpiresAt = DateTime.UtcNow.AddHours(8)
+        });
+        harness.Context.Set<SqlOSRefreshToken>().Add(new SqlOSRefreshToken
+        {
+            Id = $"rt_{sessionId}",
+            SessionId = sessionId,
+            TokenHash = $"hash_{sessionId}",
+            FamilyId = $"family_{sessionId}",
+            CreatedAt = DateTime.UtcNow,
+            ExpiresAt = DateTime.UtcNow.AddDays(30)
+        });
     }
 
     private static string BuildMetadata(string entityId, string singleSignOnUrl)

--- a/tests/SqlOS.Tests/SqlOSSsoPortalServiceTests.cs
+++ b/tests/SqlOS.Tests/SqlOSSsoPortalServiceTests.cs
@@ -42,6 +42,8 @@ public sealed class SqlOSSsoPortalServiceTests
         var connection = await harness.Context.Set<SqlOSSsoConnection>().SingleAsync();
         connection.OrganizationId.Should().Be(org.Id);
         connection.IsEnabled.Should().BeFalse();
+        connection.AutoProvisionUsers.Should().BeTrue();
+        connection.AutoLinkByEmail.Should().BeTrue();
         SqlOSAdminService.GetSsoSetupStatus(connection).Should().Be("draft");
 
         (await harness.Context.Set<SqlOSAuditEvent>().AnyAsync(x => x.EventType == "sso.portal.session.created"))

--- a/web/content/docs/authserver/home-realm-discovery.mdx
+++ b/web/content/docs/authserver/home-realm-discovery.mdx
@@ -12,10 +12,13 @@ Home realm discovery inspects an email address and returns the appropriate login
 1. Extract the email domain
 2. Check active verified organization-domain claims with active SSO connections
 3. If no verified claim matches, check the legacy operator-managed organization `PrimaryDomain`
-4. If a match has enabled SSO metadata, return `sso` with the organization and connection details
-5. If no match is found, return `password`, meaning local credentials are allowed
+4. If a match has enabled SSO metadata, check the connection enrollment policy
+5. Return `sso` when either the email belongs to an existing verified organization member and existing-member SSO is required, or no existing member matches and JIT provisioning is enabled
+6. Otherwise return `password`, meaning local credentials are allowed
 
 Verified domains are created by delegated SSO setup. The customer admin publishes a TXT record such as `_sqlos-verify.acme.com` with a `sqlos-domain-verification=...` value. SqlOS verifies that record before the domain participates in home realm discovery. Existing dashboard-managed `PrimaryDomain` values continue to work as a fallback.
+
+Portal-created SSO connections default to requiring SSO for existing verified members and leaving JIT provisioning off. That means unknown users at a verified SSO domain continue to get the default local credential flow until an admin enables JIT provisioning or creates the membership another way.
 
 ## SDK
 

--- a/web/content/docs/authserver/saml-sso.mdx
+++ b/web/content/docs/authserver/saml-sso.mdx
@@ -67,7 +67,7 @@ curl -X POST http://localhost:5062/sqlos/admin/auth/api/sso-connections/{connect
   -d '{"metadataXml": "<?xml version=\"1.0\" ...>"}'
 ```
 
-The connection is now active. Users with `@acme.com` emails will be routed to Entra for authentication.
+The connection is now active. By default, existing organization members with verified `@acme.com` email addresses will be routed to Entra on their next sign-in. New users are not JIT-provisioned unless you explicitly enable that policy.
 
 ## Delegated org-admin portal
 
@@ -89,9 +89,11 @@ The portal is scoped to one organization and supports:
 - provider guides for Microsoft Entra, Okta, Google Workspace, and generic SAML
 - copy-ready SP Entity ID and ACS URL values
 - DNS TXT verification for self-serve organization email domains
+- access-policy controls for existing-member SSO enrollment and optional JIT provisioning
 - metadata XML paste or file upload
 - validation before activation
 - activation, disable, metadata replacement, and retest
+- an explicit, confirm-gated action to sign out existing sessions after activation
 
 Hosts can expose the same launch behavior from their own admin surfaces by wrapping `SqlOSSsoPortalService.CreateSessionAsync`, as the example app does with `POST /api/sso-portal-links`.
 
@@ -129,6 +131,24 @@ options.AuthServer.ConfigureSsoPortal(portal =>
 });
 ```
 
+## Enrollment policy
+
+Portal-created connections default to:
+
+- `RequireSsoForExistingMembers = true`
+- `AllowJitProvisioning = false`
+
+Internally these map to the existing connection flags:
+
+- `RequireSsoForExistingMembers` maps to `AutoLinkByEmail`
+- `AllowJitProvisioning` maps to `AutoProvisionUsers`
+
+When `RequireSsoForExistingMembers` is enabled, a user who already belongs to the organization and has a verified email on the SSO domain is sent to SSO. The first successful SAML sign-in links the IdP subject to that existing user. SqlOS does not create a user or membership on this path.
+
+When `AllowJitProvisioning` is enabled, a successful SAML sign-in may create the missing user or organization membership when no existing organization member matches the SAML email. Keep this disabled when access should be invitation- or admin-managed.
+
+Activation only enables the SSO connection and HRD behavior. It does not revoke active sessions. Use the separate session revocation action when an admin intentionally wants existing matching-domain sessions to sign in again through SSO.
+
 ## Headless setup state machine
 
 The hosted portal is optional. Configure `BuildUiUrl` to hand the opened portal session to your own admin UI, and call the setup API for state transitions.
@@ -164,12 +184,14 @@ State-machine endpoints:
 | --- | --- | --- |
 | GET | `/` | Current setup view |
 | PUT | `/provider` | Select SAML provider |
+| PUT | `/enrollment-policy` | Update existing-member SSO and JIT provisioning policy |
 | POST | `/domain` | Start DNS TXT domain verification |
 | POST | `/domains/{domainId}/confirm` | Check the TXT record and activate the claim |
 | POST | `/metadata/validate` | Validate SAML metadata XML |
 | POST | `/metadata` | Import metadata without activating |
 | POST | `/activate` | Activate when metadata and domain state allow it |
 | POST | `/disable` | Disable the connection |
+| POST | `/organization-sessions/revoke` | Confirm-gated revocation for active org sessions on the verified SSO domain |
 | POST | `/test` | Record readiness or generate a test redirect |
 | POST | `/signout` | Clear the portal session |
 
@@ -177,8 +199,8 @@ State-machine endpoints:
 
 | Option | Default | Description |
 | --- | --- | --- |
-| `autoProvisionUsers` | `false` | Create SqlOS users from SAML assertions on first login |
-| `autoLinkByEmail` | `false` | Link SAML logins to existing users by email match |
+| `autoProvisionUsers` | `false` for portal-created connections | Create SqlOS users or memberships from SAML assertions on first login |
+| `autoLinkByEmail` | `true` for portal-created connections | Require existing verified org members to enroll and sign in through SSO |
 | `SsoPortal.EnableApi` | `true` | Expose portal and headless setup APIs |
 | `SsoPortal.UseHostedPortal` | `true` | Serve the bundled setup portal |
 | `SsoPortal.BuildUiUrl` | `null` | Redirect opened setup sessions to a host-owned UI |
@@ -202,8 +224,8 @@ For metadata rotation, open the delegated portal again or use the dashboard, pas
 ## SSO login flow
 
 1. User enters email on the login page
-2. [Home realm discovery](/docs/authserver/home-realm-discovery) detects the `@acme.com` domain matches an SSO connection
+2. [Home realm discovery](/docs/authserver/home-realm-discovery) detects the `@acme.com` domain and checks the connection enrollment policy
 3. AuthServer generates a SAML AuthnRequest and redirects to the IdP
 4. User authenticates at the IdP
 5. IdP POSTs a SAML Response to the ACS URL
-6. AuthServer validates the assertion, provisions/links the user, and creates a session
+6. AuthServer validates the assertion, links the existing user or provisions access only when policy allows it, and creates a session

--- a/web/content/docs/guides/saml-sso.mdx
+++ b/web/content/docs/guides/saml-sso.mdx
@@ -21,7 +21,7 @@ You'll learn how to create a SAML connection, share metadata with your customer�
 
 ## Goal
 
-Users with `@acme.com` email automatically use Acme’s SAML IdP instead of password login.
+Existing organization members with verified `@acme.com` email automatically use Acme’s SAML IdP instead of password login. New users are only created from SSO if you enable JIT provisioning.
 
 ## Steps
 
@@ -29,12 +29,13 @@ Users with `@acme.com` email automatically use Acme’s SAML IdP instead of pass
 2. Create a **draft** SAML connection. Note the **Entity ID** and **ACS URL** SqlOS generates.
 3. Send those values to the customer’s IT admin (or use the [Admin Portal pattern](/docs/authserver/saml-sso) from your product).
 4. Import the IdP **metadata XML** (or paste certificate and endpoints manually).
-5. Enable the connection and set the org **primary domain** to match user emails (e.g. `acme.com`).
-6. Test with [home realm discovery](/docs/authserver/home-realm-discovery): sign in with `user@acme.com` and confirm redirect to the IdP.
+5. Review the **Access policy**. The portal default requires SSO for existing members and leaves JIT provisioning off.
+6. Enable the connection and set or verify the org email domain (e.g. `acme.com`).
+7. Test with [home realm discovery](/docs/authserver/home-realm-discovery): sign in as an existing member with `user@acme.com` and confirm redirect to the IdP.
 
 ## Expected outcome
 
-- SAML assertion maps to a SqlOS user and org membership
+- SAML assertion links to an existing SqlOS user, or provisions access only when JIT is enabled
 - Audit log shows SSO sign-in events
 - Non-matching domains still use password, OTP, or social login
 


### PR DESCRIPTION
## Summary
- add explicit SSO enrollment policy state: require SSO for existing members and optional JIT provisioning
- add headless/hosted portal policy update and scoped organization-session revocation actions
- make SAML callback and HRD policy-aware so existing members link cleanly and JIT is the only membership-creation path
- document policy defaults, HRD behavior, headless endpoints, and explicit session revocation

## Tests
- dotnet test SqlOS.sln --no-restore --verbosity minimal
- npm run build (web)