### PR TITLE
Add standalone identity server content

### DIFF
--- a/web/content/blog/standalone-sqlos-identity-server-multi-app.mdx
+++ b/web/content/blog/standalone-sqlos-identity-server-multi-app.mdx
@@ -1,0 +1,238 @@
+---
+title: "Standalone SqlOS Identity Server for Multiple Apps"
+description: "The advanced SqlOS topology: one dedicated auth host serving several web, mobile, CLI, and API surfaces with shared users, orgs, SSO, and application access policy."
+date: "2026-06-08"
+author: "Ross Slaney"
+tags: ["AuthServer", "OAuth", "Applications", "Platform", "SqlOS"]
+---
+
+If you have one web app, do not start here.
+
+Read [Auth for One .NET App with SqlOS](/blog/auth-for-one-dotnet-app-with-sqlos) and use single-application mode. That path is smaller, easier to deploy, and correct for most teams.
+
+This post is for the advanced case: a platform team or ISV that wants one SqlOS identity server for several applications. Customer Portal, Admin Console, Angular app, Expo app, CLI, MCP integration, and resource APIs all share the same users, organizations, SSO connections, sessions, and application access policy.
+
+<BlogVisual kind="standalone-multi-app" />
+
+## The topology
+
+The standalone shape looks like the SqlOS example stack:
+
+- `SqlOS.Example.Api` hosts SqlOS AuthServer and the admin dashboard.
+- `SqlOS.Example.Web` is a separate Next.js frontend.
+- `SqlOS.Example.AngularWeb` is another browser frontend.
+- `SqlOS.Example.ExpoApp` is a mobile-style native client.
+- A CLI or MCP client can use device flow or portable public-client metadata.
+- Resource APIs validate tokens issued by the same SqlOS host.
+
+The auth host is not "just login." It owns:
+
+- OAuth endpoints under `/sqlos/auth/*`
+- users, organizations, memberships, invitations, and sessions
+- SAML/OIDC connections
+- hosted AuthPage or headless request orchestration
+- application/client records
+- application access assignments
+- refresh token rotation and revocation
+
+Your product apps own their UI and business data. SqlOS owns the identity protocol and shared identity data.
+
+## Multiple clients, not one magic client
+
+Each application surface gets its own OAuth client. That keeps redirect URIs, client IDs, and product policy separate:
+
+```csharp
+builder.AddSqlOS<ExampleAppDbContext>(options =>
+{
+    var auth = options.AuthServer;
+    auth.Issuer = "https://auth.example.com/sqlos/auth";
+    auth.DefaultAudience = "https://api.example.com";
+
+    auth.SeedBrowserClient(
+        "customer-portal",
+        "Customer Portal",
+        "https://app.example.com/auth/callback");
+
+    auth.SeedBrowserClient(
+        "admin-console",
+        "Admin Console",
+        "https://admin.example.com/auth/callback");
+
+    auth.SeedBrowserClient(
+        "mobile-app",
+        "Mobile App",
+        "sqlos-mobile://auth-callback");
+
+    auth.SeedCliClient(
+        "support-cli",
+        "Support CLI",
+        "https://api.example.com",
+        "openid",
+        "profile",
+        "email",
+        "offline_access");
+});
+```
+
+The client is "which app is signing in." The audience is "which resource API should accept the token." Those are related, but not the same.
+
+Two applications can mint tokens for the same API. Customer Portal and Admin Console might both call `https://api.example.com`, but only some users should be allowed to use Admin Console.
+
+That is where application assignments matter.
+
+## Application assignments are the control plane
+
+Application access answers:
+
+> Can this user, in this organization, use this application?
+
+For a standalone identity server, this is the missing layer between OAuth clients and API audiences.
+
+Example policy:
+
+| Application | Access mode | Assignment |
+| --- | --- | --- |
+| Customer Portal | `all_organizations` | Every active customer organization |
+| Admin Console | `selected_users_groups_roles` | Internal support group and tenant admins |
+| Partner App | `selected_organizations` | Only assigned pilot organizations |
+| Support CLI | `internal_only` | Named support operators or FGA user group |
+
+Set Admin Console to explicit assignments:
+
+```bash
+curl -X POST https://auth.example.com/sqlos/admin/auth/api/applications/admin-console/access-mode \
+  -H "Content-Type: application/json" \
+  -d '{ "accessMode": "selected_users_groups_roles" }'
+```
+
+Allow an organization's admins:
+
+```bash
+curl -X POST https://auth.example.com/sqlos/admin/auth/api/applications/admin-console/assignments \
+  -H "Content-Type: application/json" \
+  -d '{
+    "principalType": "role",
+    "organizationId": "org_123",
+    "roleKey": "admin",
+    "access": "allowed",
+    "reason": "Tenant admins may use Admin Console"
+  }'
+```
+
+Explain a support case:
+
+```bash
+curl "https://auth.example.com/sqlos/admin/auth/api/applications/admin-console/access/check?organizationId=org_123&userId=usr_123"
+```
+
+This is not audience validation. The protected API still validates issuer, signature, expiry, and audience. Assignments decide whether the user should reach the application in the first place.
+
+<BlogScreenshot
+  src="/docs/dashboard-clients.png"
+  alt="SqlOS clients dashboard"
+  caption="Clients become application records. In the advanced topology, each app surface can have its own redirect URIs, audience, and access mode."
+/>
+
+## Headless mode for app-owned UI
+
+Standalone does not mean every app must use the hosted SqlOS AuthPage.
+
+If each frontend owns its login experience, configure headless mode. The browser still starts at `/sqlos/auth/authorize`, but SqlOS redirects to the app-owned UI with a request ID:
+
+```csharp
+auth.UseHeadlessAuthPage(headless =>
+{
+    headless.BuildUiUrl = ctx =>
+        QueryHelpers.AddQueryString(
+            "https://app.example.com/auth/authorize",
+            new Dictionary<string, string?>
+            {
+                ["request"] = ctx.RequestId,
+                ["view"] = ctx.View,
+                ["email"] = ctx.Email,
+                ["pendingToken"] = ctx.PendingToken,
+                ["ui_context"] = ctx.UiContext?.ToJsonString()
+            });
+});
+```
+
+The app renders the UI. SqlOS keeps the protocol state: PKCE, SSO callbacks, invitations, OTP, MFA, organization selection, and the final authorization code.
+
+That is the key boundary. Do not let each app invent its own login lifecycle. Let each app own UI while SqlOS owns the protocol.
+
+More detail: [Headless auth with SqlOS](/blog/headless-auth-server-mode) and [Headless Auth](/docs/authserver/headless-auth).
+
+## SDK flows without a browser
+
+Standalone identity servers usually have server-side jobs and non-browser clients too. The SDK/reference services cover those flows:
+
+```csharp
+var invite = await authService.CreateEmailInvitationAsync(
+    new SqlOSCreateEmailInvitationRequest(
+        organizationId,
+        email: "alex@example.com",
+        role: "admin",
+        clientId: "admin-console",
+        redirectUri: "https://admin.example.com/auth/callback"),
+    httpContext,
+    ct);
+```
+
+For email OTP login from a trusted server path:
+
+```csharp
+var otpStart = await authService.RequestEmailOtpAsync(
+    new SqlOSEmailOtpStartRequest(
+        email: "alex@example.com",
+        clientId: "customer-portal",
+        organizationId: "org_123"),
+    httpContext,
+    ct);
+
+var otpLogin = await authService.VerifyEmailOtpAsync(
+    new SqlOSEmailOtpVerifyRequest(
+        otpStart.ChallengeToken,
+        code),
+    httpContext,
+    ct);
+```
+
+For a CLI:
+
+```csharp
+var deviceStart = await authService.StartDeviceAuthorizationAsync(
+    new SqlOSDeviceAuthorizationStartRequest(
+        clientId: "support-cli",
+        scope: "openid profile email offline_access",
+        resource: "https://api.example.com"),
+    httpContext,
+    ct);
+```
+
+The CLI displays the user code. The user signs in through SqlOS, application access is checked when approval happens, and the CLI receives tokens only after approval. The Todo CLI sample uses the same device-flow shape for a smaller app.
+
+## When this is worth it
+
+Use standalone SqlOS when you have real platform needs:
+
+- an ISV suite with customer portal, admin console, mobile app, and CLI
+- an internal platform team that wants one identity host for several product teams
+- MCP, web, and CLI clients that must share users and organizations
+- SSO and invitations that should work across several application surfaces
+- operator workflows that need "who can use which app?" in one dashboard
+
+Do not use it just because other standalone IdPs exist. Duende, Keycloak, Entra External ID, Auth0, and WorkOS all have places where they make sense. The SqlOS standalone path is for teams that want the identity server inside their .NET and SQL Server operating model, not a separate identity platform comparison exercise.
+
+## The rule
+
+Start with one app.
+
+Graduate to standalone when you can name the second and third application surfaces, explain why they need distinct clients, and define who is allowed to use each one.
+
+Next reading:
+
+- [Standalone Identity Server Guide](/docs/guides/standalone-identity-server)
+- [Standalone Identity Server Reference](/docs/reference/standalone-identity-server)
+- [Application Access](/docs/authserver/application-access)
+- [Clients](/docs/authserver/clients)
+- [Headless Auth](/docs/authserver/headless-auth)

--- a/web/content/docs/guides/index.mdx
+++ b/web/content/docs/guides/index.mdx
@@ -24,6 +24,7 @@ You'll learn which guide to pick for your next integration task.
   <Card title="Model FGA" description="Design a multi-tenant resource hierarchy." href="/docs/guides/model-fga" />
   <Card title="Filter EF queries" description="Authorization as a LINQ WHERE clause." href="/docs/guides/ef-query-filters" />
   <Card title="Audit logs" description="Record application events and review them in the dashboard." href="/docs/guides/audit-logs" />
+  <Card title="Standalone identity server" description="Run one SqlOS auth host for several app surfaces." href="/docs/guides/standalone-identity-server" />
   <Card title="Configuration" description="Service registration, dashboard, and client modes." href="/docs/guides/configuration" />
   <Card title="Testing" description="Run unit, integration, and docs checks locally." href="/docs/guides/testing" />
   <Card title="Troubleshooting" description="Common setup failures and how to fix them." href="/docs/guides/troubleshooting" />
@@ -38,3 +39,4 @@ You'll learn which guide to pick for your next integration task.
 - [Application Assignments: The Missing Layer Between Clients and Audiences](/blog/application-assignments-auth-server-control-plane)
 - [MFA Policy: The Auth Server Has to Own the Second Step](/blog/mfa-totp-policy-auth-server)
 - [Audit Logs for Multi-Tenant Products](/blog/audit-logs-for-multi-tenant-products)
+- [Standalone SqlOS Identity Server for Multiple Apps](/blog/standalone-sqlos-identity-server-multi-app)

--- a/web/content/docs/guides/standalone-identity-server.mdx
+++ b/web/content/docs/guides/standalone-identity-server.mdx
@@ -1,0 +1,263 @@
+---
+title: "Run a standalone identity server"
+description: "Configure SqlOS as a dedicated auth host for several web, mobile, CLI, and API surfaces."
+order: 10
+section: guides
+---
+
+<Banner
+  eyebrow="Advanced setup"
+  title="Use one SqlOS auth host for several applications"
+  href="/blog/standalone-sqlos-identity-server-multi-app"
+  actionLabel="Read the architecture post"
+>
+  Use this guide when SqlOS is a dedicated identity host for multiple app surfaces. If you have one app, use single-application mode instead.
+</Banner>
+
+<Callout type="warning" title="Not the default path">
+  Standalone SqlOS adds a control plane: multiple clients, assignments, headless UI routing, and resource API validation. Start with [single-application setup](/docs/authserver/single-application) unless you already have more than one app surface.
+</Callout>
+
+## Goal
+
+By the end of this guide you will have:
+
+- one ASP.NET host running SqlOS AuthServer
+- multiple preregistered clients
+- optional headless UI routing
+- application assignments for app availability
+- resource APIs validating SqlOS tokens
+- links to SDK flows for invitations, OTP, and CLI device flow
+
+## Topology
+
+<Files title="Standalone SqlOS topology">
+  <Folder name="SqlOS.Example.Api (auth host)">
+    <File name="/sqlos/auth/*" meta="OAuth, AuthPage, token, device flow" />
+    <File name="/sqlos/admin/auth" meta="users, orgs, clients, assignments" />
+    <File name="SQL Server" meta="identity, sessions, SSO, FGA" />
+  </Folder>
+  <Folder name="Application clients">
+    <File name="Example.Web" meta="Next.js customer portal" />
+    <File name="Example.AngularWeb" meta="Angular app" />
+    <File name="Example.ExpoApp" meta="mobile/native callback" />
+    <File name="CLI / MCP client" meta="device flow or CIMD" />
+  </Folder>
+  <Folder name="Resource APIs">
+    <File name="api.example.com" meta="validates issuer and audience" />
+  </Folder>
+</Files>
+
+## 1. Configure the auth host
+
+Register SqlOS in the ASP.NET host that will act as the identity server.
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using SqlOS.Extensions;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddDbContext<ExampleAppDbContext>(options =>
+    options.UseSqlServer(
+        builder.Configuration.GetConnectionString("DefaultConnection")));
+
+builder.AddSqlOS<ExampleAppDbContext>(options =>
+{
+    options.DashboardBasePath = "/sqlos";
+
+    var auth = options.AuthServer;
+    auth.Issuer = "https://auth.example.com/sqlos/auth";
+    auth.PublicOrigin = "https://auth.example.com";
+    auth.DefaultAudience = "https://api.example.com";
+});
+
+var app = builder.Build();
+app.MapSqlOS();
+app.Run();
+```
+
+The public issuer must be stable. Resource APIs validate tokens against this issuer.
+
+## 2. Register each client
+
+Give every app surface its own client ID and redirect URI.
+
+```csharp
+builder.AddSqlOS<ExampleAppDbContext>(options =>
+{
+    var auth = options.AuthServer;
+
+    auth.SeedBrowserClient(
+        "customer-portal",
+        "Customer Portal",
+        "https://app.example.com/auth/callback");
+
+    auth.SeedBrowserClient(
+        "admin-console",
+        "Admin Console",
+        "https://admin.example.com/auth/callback");
+
+    auth.SeedBrowserClient(
+        "mobile-app",
+        "Mobile App",
+        "sqlos-mobile://auth-callback");
+
+    auth.SeedCliClient(
+        "support-cli",
+        "Support CLI",
+        "https://api.example.com",
+        "openid",
+        "profile",
+        "email",
+        "offline_access");
+});
+```
+
+<Callout type="info" title="Client and audience are different">
+  Client IDs identify the app asking for login. Audience identifies the resource API that should accept the access token. Two clients can use the same audience and still have different application access policy.
+</Callout>
+
+## 3. Choose hosted or headless login
+
+Use hosted AuthPage when a shared login page is acceptable.
+
+Use headless when each frontend should own the login UI while SqlOS owns OAuth state.
+
+```csharp
+auth.UseHeadlessAuthPage(headless =>
+{
+    headless.BuildUiUrl = ctx =>
+        QueryHelpers.AddQueryString(
+            "https://app.example.com/auth/authorize",
+            new Dictionary<string, string?>
+            {
+                ["request"] = ctx.RequestId,
+                ["view"] = ctx.View,
+                ["email"] = ctx.Email,
+                ["pendingToken"] = ctx.PendingToken,
+                ["ui_context"] = ctx.UiContext?.ToJsonString()
+            });
+});
+```
+
+See [Headless Auth](/docs/authserver/headless-auth) and [Hosted vs Headless](/docs/authserver/hosted-vs-headless).
+
+## 4. Configure application access
+
+Start with open access for the customer-facing app. Restrict sensitive surfaces.
+
+```bash
+curl -X POST https://auth.example.com/sqlos/admin/auth/api/applications/admin-console/access-mode \
+  -H "Content-Type: application/json" \
+  -d '{ "accessMode": "selected_users_groups_roles" }'
+```
+
+Allow tenant admins for one organization:
+
+```bash
+curl -X POST https://auth.example.com/sqlos/admin/auth/api/applications/admin-console/assignments \
+  -H "Content-Type: application/json" \
+  -d '{
+    "principalType": "role",
+    "organizationId": "org_123",
+    "roleKey": "admin",
+    "access": "allowed",
+    "reason": "Tenant admins may use Admin Console"
+  }'
+```
+
+Explain a decision:
+
+```bash
+curl "https://auth.example.com/sqlos/admin/auth/api/applications/admin-console/access/check?organizationId=org_123&userId=usr_123"
+```
+
+## 5. Validate tokens in resource APIs
+
+Resource APIs should validate issuer, signature, expiry, and audience. They should not rely on application access checks alone.
+
+```csharp
+app.UseSqlOSAccessTokenValidation(options =>
+{
+    options.ExpectedAudience = "https://api.example.com";
+});
+```
+
+Use FGA or app policy after token validation when the API needs row-level or resource-level authorization.
+
+## 6. Add server-side flows
+
+Use the SDK services for flows that are not just browser redirect login.
+
+<Tabs defaultValue="invite">
+  <TabsList>
+    <TabsTrigger value="invite">Invitations</TabsTrigger>
+    <TabsTrigger value="device">Device flow</TabsTrigger>
+    <TabsTrigger value="otp">Email OTP</TabsTrigger>
+  </TabsList>
+
+  <TabsContent value="invite">
+    ```csharp
+    var invite = await authService.CreateEmailInvitationAsync(
+        new SqlOSCreateEmailInvitationRequest(
+            organizationId,
+            email: "alex@example.com",
+            role: "admin",
+            clientId: "admin-console",
+            redirectUri: "https://admin.example.com/auth/callback"),
+        httpContext,
+        ct);
+    ```
+  </TabsContent>
+
+  <TabsContent value="device">
+    ```csharp
+    var deviceStart = await authService.StartDeviceAuthorizationAsync(
+        new SqlOSDeviceAuthorizationStartRequest(
+            clientId: "support-cli",
+            scope: "openid profile email offline_access",
+            resource: "https://api.example.com"),
+        httpContext,
+        ct);
+    ```
+  </TabsContent>
+
+  <TabsContent value="otp">
+    ```csharp
+    var otpStart = await authService.RequestEmailOtpAsync(
+        new SqlOSEmailOtpStartRequest(
+            email: "alex@example.com",
+            clientId: "customer-portal",
+            organizationId: "org_123"),
+        httpContext,
+        ct);
+    ```
+  </TabsContent>
+</Tabs>
+
+## 7. Verify the setup
+
+<Steps>
+  <Step title="Open the dashboard">
+    Open `/sqlos/admin/auth`, confirm all expected clients exist, and check their access modes.
+  </Step>
+  <Step title="Sign in through each app">
+    Use Customer Portal, Admin Console, mobile callback, and CLI/device flow separately.
+  </Step>
+  <Step title="Test assignment decisions">
+    Use the access check endpoint before and after revoking an assignment.
+  </Step>
+  <Step title="Validate API audience">
+    Call the resource API with a token minted for the correct audience and with one minted for the wrong audience.
+  </Step>
+</Steps>
+
+## Next steps
+
+<CardGrid cols={2}>
+  <Card title="Standalone reference" description="Tables for clients, access modes, assignment targets, endpoints, and enforcement points." href="/docs/reference/standalone-identity-server" />
+  <Card title="Application access" description="Assign applications to organizations, users, groups, and roles." href="/docs/authserver/application-access" />
+  <Card title="Clients" description="Owned apps, CLI clients, CIMD, and DCR paths." href="/docs/authserver/clients" />
+  <Card title="SDK reference" description="AuthService, admin service, OTP, invitations, device flow, and token validation." href="/docs/reference/sdk-reference" />
+</CardGrid>

--- a/web/content/docs/reference/standalone-identity-server.mdx
+++ b/web/content/docs/reference/standalone-identity-server.mdx
@@ -1,0 +1,171 @@
+---
+title: "Standalone Identity Server Reference"
+description: "Reference tables for using SqlOS as a dedicated identity host for multiple applications."
+order: 13
+section: reference
+---
+
+This reference covers the advanced multi-application topology. Use [Single-Application Setup](/docs/authserver/single-application) if your product has one app.
+
+## Concept map
+
+| Concept | Meaning | Primary docs |
+| --- | --- | --- |
+| Auth host | ASP.NET app that runs `AddSqlOS` and `MapSqlOS` | [Getting Started](/docs/getting-started) |
+| Client application | OAuth client representing one app surface | [Clients](/docs/authserver/clients) |
+| Audience | Resource/API identifier placed in access tokens | [Token Validation](/docs/authserver/token-validation) |
+| Application access | Policy for who may use a client application | [Application Access](/docs/authserver/application-access) |
+| Headless auth | App-owned UI with SqlOS-owned protocol state | [Headless Auth](/docs/authserver/headless-auth) |
+| Device flow | CLI/native flow without a redirect listener | [CLI OAuth](/docs/authserver/cli-oauth) |
+
+## Required host settings
+
+| Setting | Purpose | Example |
+| --- | --- | --- |
+| `DashboardBasePath` | Mounts dashboard and auth routes | `/sqlos` |
+| `AuthServer.Issuer` | Public issuer used in tokens and discovery | `https://auth.example.com/sqlos/auth` |
+| `AuthServer.PublicOrigin` | Public origin for generated links | `https://auth.example.com` |
+| `AuthServer.DefaultAudience` | Fallback API/resource audience | `https://api.example.com` |
+
+```csharp
+builder.AddSqlOS<AppDbContext>(options =>
+{
+    options.DashboardBasePath = "/sqlos";
+    options.AuthServer.Issuer = "https://auth.example.com/sqlos/auth";
+    options.AuthServer.PublicOrigin = "https://auth.example.com";
+    options.AuthServer.DefaultAudience = "https://api.example.com";
+});
+```
+
+## Client seed methods
+
+| Method | Use for | Notes |
+| --- | --- | --- |
+| `SeedBrowserClient` | Browser SPA/web apps and custom-scheme callbacks | Public PKCE client |
+| `SeedOwnedWebApp` | First-party hosted web apps | Convenience wrapper for owned web clients |
+| `SeedCliClient` | Terminal apps | Enables device flow and refresh token |
+| Dashboard-created client | Operators create or adjust clients after deploy | Not startup managed |
+| CIMD | Portable public clients with HTTPS metadata `client_id` | See [Client ID Metadata Documents](/docs/authserver/client-id-metadata-documents) |
+| DCR | Compatibility public clients that expect runtime registration | See [Dynamic Client Registration](/docs/authserver/dynamic-client-registration) |
+
+## Example client set
+
+```csharp
+auth.SeedBrowserClient(
+    "customer-portal",
+    "Customer Portal",
+    "https://app.example.com/auth/callback");
+
+auth.SeedBrowserClient(
+    "admin-console",
+    "Admin Console",
+    "https://admin.example.com/auth/callback");
+
+auth.SeedBrowserClient(
+    "mobile-app",
+    "Mobile App",
+    "sqlos-mobile://auth-callback");
+
+auth.SeedCliClient(
+    "support-cli",
+    "Support CLI",
+    "https://api.example.com",
+    "openid",
+    "profile",
+    "email",
+    "offline_access");
+```
+
+## Application access modes
+
+| Mode | Behavior |
+| --- | --- |
+| `all_organizations` | Any authenticated user with active organization context can use the app. |
+| `selected_organizations` | Only directly assigned organizations can use the app. |
+| `selected_users_groups_roles` | User, FGA user group, organization role, service account, or agent assignment required. |
+| `internal_only` | Explicit trusted assignment required. |
+| `disabled` | App cannot be used. Existing sessions fail refresh. |
+
+Explicit `denied` assignments take precedence over allowed assignments.
+
+## Assignment principal types
+
+| `principalType` | Required fields | Typical use |
+| --- | --- | --- |
+| `organization` | `organizationId` or `principalId` | Enable one customer tenant for an app |
+| `user` | `principalId` | Allow or deny a named user |
+| `group` | `principalId` | Allow an FGA user group |
+| `role` | `organizationId`, `roleKey` | Allow tenant admins or members |
+| `service_account` | `principalId` | Allow a machine principal |
+| `agent` | `principalId` | Allow an agent principal |
+
+## Admin endpoints
+
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /sqlos/admin/auth/api/applications/{applicationId}/assignments` | List assignments |
+| `POST /sqlos/admin/auth/api/applications/{applicationId}/access-mode` | Set access mode |
+| `POST /sqlos/admin/auth/api/applications/{applicationId}/assignments` | Create allow or deny assignment |
+| `DELETE /sqlos/admin/auth/api/applications/{applicationId}/assignments/{assignmentId}` | Revoke assignment |
+| `GET /sqlos/admin/auth/api/applications/{applicationId}/access/check` | Explain access decision |
+| `GET /sqlos/admin/auth/api/organizations/{organizationId}/applications` | Apps available to an organization |
+| `GET /sqlos/admin/auth/api/users/{userId}/applications` | Apps available to a user |
+
+## Enforcement points
+
+SqlOS checks application access when a concrete application and subject context are known:
+
+- hosted authorization before issuing an auth code
+- headless authorization before issuing an auth code
+- Email OTP and signup completion through the shared session path
+- SAML and OIDC callbacks before issuing an auth code
+- device authorization approval before releasing CLI tokens
+- refresh token rotation before minting a new access token
+
+Public errors use generic denial text. Audit events and the access-check endpoint carry the operator detail.
+
+## Resource API validation
+
+Resource APIs should validate the token independently:
+
+```csharp
+app.UseSqlOSAccessTokenValidation(options =>
+{
+    options.ExpectedAudience = "https://api.example.com";
+});
+```
+
+Application access decides whether a user may use an app. Audience validation decides whether an API should accept a token.
+
+## Headless request parameters
+
+When `UseHeadlessAuthPage` is configured, SqlOS redirects to the app-owned UI with request state:
+
+| Parameter | Meaning |
+| --- | --- |
+| `request` | SqlOS authorization request ID |
+| `view` | Current view (`login`, `signup`, `organization`, `mfa`, `device`, etc.) |
+| `email` | Known email when already identified |
+| `pendingToken` | Token for intermediate auth state |
+| `ui_context` | Context for invitations, CLI, or specialized flows |
+
+The app should call [headless endpoints](/docs/authserver/headless-auth) with the request ID instead of inventing separate login state.
+
+## Decision checklist
+
+Use standalone SqlOS when all of these are true:
+
+- you can name multiple app surfaces
+- each app needs distinct client IDs, redirect URIs, or access policy
+- users and organizations should be shared
+- SSO and invitations should work across apps
+- resource APIs can validate SqlOS tokens
+
+Stay on single-application mode when those statements are not true.
+
+Related:
+
+- [Run a standalone identity server](/docs/guides/standalone-identity-server)
+- [Standalone SqlOS identity server for multiple apps](/blog/standalone-sqlos-identity-server-multi-app)
+- [Application Access](/docs/authserver/application-access)
+- [Clients](/docs/authserver/clients)

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -237,3 +237,9 @@ pre code {
 .sqlos-docs-shell .emcydocs-prose pre [data-line] {
   min-height: 1.72em;
 }
+
+.sqlos-docs-shell .emcydocs-prose table {
+  display: block;
+  max-width: 100%;
+  overflow-x: auto;
+}

--- a/web/src/components/blog/BlogMdxComponents.tsx
+++ b/web/src/components/blog/BlogMdxComponents.tsx
@@ -6,7 +6,8 @@ type VisualKind =
   | "fga-list-query"
   | "auth0-vs-sqlos"
   | "workos-vs-sqlos"
-  | "managed-vs-sqlos";
+  | "managed-vs-sqlos"
+  | "standalone-multi-app";
 
 const visualCopy: Record<
   VisualKind,
@@ -127,6 +128,28 @@ const visualCopy: Record<
         label: "SqlOS",
         tone: "primary",
         nodes: ["Hosted AuthPage", "Orgs + invites in SQL Server", "FGA in EF queries"],
+      },
+    ],
+  },
+  "standalone-multi-app": {
+    title: "One SqlOS host, many application surfaces",
+    caption:
+      "The advanced topology moves SqlOS into a dedicated auth host. Multiple clients share users, organizations, sessions, SSO, and application access policy while resource APIs validate the tokens they receive.",
+    lanes: [
+      {
+        label: "Client apps",
+        tone: "accent",
+        nodes: ["Customer portal", "Admin console", "Mobile app / CLI"],
+      },
+      {
+        label: "SqlOS auth host",
+        tone: "primary",
+        nodes: ["/sqlos/auth/*", "Users + orgs + SSO", "Application assignments"],
+      },
+      {
+        label: "Resource APIs",
+        tone: "neutral",
+        nodes: ["Validate issuer + audience", "Call FGA / app policy", "Return protected data"],
       },
     ],
   },


### PR DESCRIPTION
## Summary
- Add Blog 6/6 for the advanced standalone SqlOS identity-server topology across multiple app surfaces.
- Add a task guide for running SqlOS as a standalone identity host.
- Add a reference page covering host settings, clients, application access modes, assignments, endpoints, and enforcement points.
- Add a standalone topology blog visual and docs table overflow handling for mobile.

## Verification
- npm run lint
- npm run build
- In-app browser desktop check for the new blog, guide, reference page, and guides index
- In-app browser mobile overflow check for the new blog and reference page

Closes #75