### PR TITLE
Harden SAML and FGA security paths

### DIFF
--- a/examples/SqlOS.Example.IntegrationTests/SqlOSExampleApiIntegrationTests.cs
+++ b/examples/SqlOS.Example.IntegrationTests/SqlOSExampleApiIntegrationTests.cs
@@ -1,4 +1,6 @@
 using System.Net.Http.Json;
+using System.IO.Compression;
+using System.Security;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Security.Cryptography.Xml;
@@ -220,15 +222,17 @@ public sealed class SqlOSExampleApiIntegrationTests
         authUrlResponse.EnsureSuccessStatusCode();
         var authUrlJson = JsonDocument.Parse(await authUrlResponse.Content.ReadAsStringAsync());
         var authUrl = authUrlJson.RootElement.GetProperty("authorizationUrl").GetString()!;
-        var relayState = QueryHelpers.ParseQuery(new Uri($"https://localhost{authUrl}").Query)["requestToken"].ToString();
+        var loginResponse = await ExampleApiFixture.Client.GetAsync(authUrl);
+        loginResponse.StatusCode.Should().Be(System.Net.HttpStatusCode.Redirect);
+        var flow = ParseSamlFlow(loginResponse.Headers.Location!.ToString());
 
-        var samlResponse = BuildSignedSamlResponse(certificate, "urn:example:idp", "saml-user@example.com", "Saml", "User");
+        var samlResponse = BuildSignedSamlResponse(certificate, "urn:example:idp", "saml-user@example.com", "Saml", "User", flow);
         var acsResponse = await ExampleApiFixture.Client.PostAsync(
             $"/sqlos/auth/saml/acs/{connectionId}",
             new FormUrlEncodedContent(new Dictionary<string, string>
             {
                 ["SAMLResponse"] = samlResponse,
-                ["RelayState"] = relayState
+                ["RelayState"] = flow.RelayState
             }));
 
         acsResponse.StatusCode.Should().Be(System.Net.HttpStatusCode.Redirect);
@@ -832,23 +836,33 @@ public sealed class SqlOSExampleApiIntegrationTests
         string issuer,
         string email,
         string firstName,
-        string lastName)
+        string lastName,
+        SamlFlow flow)
     {
         var responseId = $"_{Guid.NewGuid():N}";
+        var assertionId = $"_{Guid.NewGuid():N}";
         var issueInstant = DateTime.UtcNow.ToString("o");
+        var notBefore = DateTime.UtcNow.AddMinutes(-1).ToString("o");
+        var notOnOrAfter = DateTime.UtcNow.AddMinutes(5).ToString("o");
         var xml = $"""
-        <samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="{responseId}" Version="2.0" IssueInstant="{issueInstant}">
-          <saml:Issuer>{issuer}</saml:Issuer>
+        <samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="{responseId}" Version="2.0" IssueInstant="{issueInstant}" Destination="{SecurityElement.Escape(flow.AssertionConsumerServiceUrl)}" InResponseTo="{SecurityElement.Escape(flow.RequestId)}">
+          <saml:Issuer>{SecurityElement.Escape(issuer)}</saml:Issuer>
           <samlp:Status><samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success" /></samlp:Status>
-          <saml:Assertion ID="_{Guid.NewGuid():N}" Version="2.0" IssueInstant="{issueInstant}">
-            <saml:Issuer>{issuer}</saml:Issuer>
+          <saml:Assertion ID="{assertionId}" Version="2.0" IssueInstant="{issueInstant}">
+            <saml:Issuer>{SecurityElement.Escape(issuer)}</saml:Issuer>
             <saml:Subject>
-              <saml:NameID>{email}</saml:NameID>
+              <saml:NameID>{SecurityElement.Escape(email)}</saml:NameID>
+              <saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+                <saml:SubjectConfirmationData InResponseTo="{SecurityElement.Escape(flow.RequestId)}" Recipient="{SecurityElement.Escape(flow.AssertionConsumerServiceUrl)}" NotOnOrAfter="{notOnOrAfter}" />
+              </saml:SubjectConfirmation>
             </saml:Subject>
+            <saml:Conditions NotBefore="{notBefore}" NotOnOrAfter="{notOnOrAfter}">
+              <saml:AudienceRestriction><saml:Audience>https://localhost/sqlos/auth</saml:Audience></saml:AudienceRestriction>
+            </saml:Conditions>
             <saml:AttributeStatement>
-              <saml:Attribute Name="email"><saml:AttributeValue>{email}</saml:AttributeValue></saml:Attribute>
-              <saml:Attribute Name="first_name"><saml:AttributeValue>{firstName}</saml:AttributeValue></saml:Attribute>
-              <saml:Attribute Name="last_name"><saml:AttributeValue>{lastName}</saml:AttributeValue></saml:Attribute>
+              <saml:Attribute Name="email"><saml:AttributeValue>{SecurityElement.Escape(email)}</saml:AttributeValue></saml:Attribute>
+              <saml:Attribute Name="first_name"><saml:AttributeValue>{SecurityElement.Escape(firstName)}</saml:AttributeValue></saml:Attribute>
+              <saml:Attribute Name="last_name"><saml:AttributeValue>{SecurityElement.Escape(lastName)}</saml:AttributeValue></saml:Attribute>
             </saml:AttributeStatement>
           </saml:Assertion>
         </samlp:Response>
@@ -865,7 +879,7 @@ public sealed class SqlOSExampleApiIntegrationTests
         };
         signedXml.SignedInfo!.CanonicalizationMethod = SignedXml.XmlDsigExcC14NTransformUrl;
         signedXml.SignedInfo.SignatureMethod = SignedXml.XmlDsigRSASHA256Url;
-        var reference = new Reference { Uri = $"#{responseId}" };
+        var reference = new Reference { Uri = $"#{responseId}", DigestMethod = SignedXml.XmlDsigSHA256Url };
         reference.AddTransform(new XmlDsigEnvelopedSignatureTransform());
         reference.AddTransform(new XmlDsigExcC14NTransform());
         signedXml.AddReference(reference);
@@ -875,6 +889,35 @@ public sealed class SqlOSExampleApiIntegrationTests
         responseElement.InsertAfter(xmlDoc.ImportNode(signedXml.GetXml(), true), responseElement.FirstChild);
         return Convert.ToBase64String(Encoding.UTF8.GetBytes(xmlDoc.OuterXml));
     }
+
+    private static SamlFlow ParseSamlFlow(string loginUrl)
+    {
+        var query = QueryHelpers.ParseQuery(new Uri(loginUrl).Query);
+        var relayState = query["RelayState"].ToString();
+        var samlRequest = query["SAMLRequest"].ToString();
+        relayState.Should().NotBeNullOrWhiteSpace();
+        samlRequest.Should().NotBeNullOrWhiteSpace();
+
+        var xml = InflateSamlRequest(samlRequest!);
+        var xmlDoc = new XmlDocument { XmlResolver = null };
+        xmlDoc.LoadXml(xml);
+        var root = xmlDoc.DocumentElement!;
+        return new SamlFlow(
+            relayState!,
+            root.GetAttribute("ID"),
+            root.GetAttribute("AssertionConsumerServiceURL"));
+    }
+
+    private static string InflateSamlRequest(string samlRequest)
+    {
+        var bytes = Convert.FromBase64String(samlRequest);
+        using var compressed = new MemoryStream(bytes);
+        using var inflater = new DeflateStream(compressed, CompressionMode.Decompress);
+        using var reader = new StreamReader(inflater, Encoding.UTF8);
+        return reader.ReadToEnd();
+    }
+
+    private sealed record SamlFlow(string RelayState, string RequestId, string AssertionConsumerServiceUrl);
 
     private static string BuildFederationMetadata(string entityId, string singleSignOnUrl, X509Certificate2 certificate)
     {

--- a/src/SqlOS/AuthServer/Services/SqlOSCryptoService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSCryptoService.cs
@@ -56,12 +56,24 @@ public sealed class SqlOSCryptoService
             return string.Empty;
         }
 
-        if (_secretProtector == null || !protectedSecret.StartsWith("dp:", StringComparison.Ordinal))
+        if (!protectedSecret.StartsWith("dp:", StringComparison.Ordinal))
         {
             return protectedSecret;
         }
 
-        return _secretProtector.Unprotect(protectedSecret[3..]);
+        if (_secretProtector == null)
+        {
+            throw new InvalidOperationException("This secret is protected with ASP.NET Core Data Protection, but no Data Protection provider is available.");
+        }
+
+        try
+        {
+            return _secretProtector.Unprotect(protectedSecret[3..]);
+        }
+        catch (CryptographicException ex)
+        {
+            throw new InvalidOperationException("This secret could not be unprotected. Ensure the ASP.NET Core Data Protection key ring is persisted and available to this application instance.", ex);
+        }
     }
 
     public bool VerifyPassword(string hashedPassword, string password)
@@ -170,6 +182,7 @@ public sealed class SqlOSCryptoService
             .FirstOrDefaultAsync(x => x.IsActive, cancellationToken);
         if (activeKey != null)
         {
+            await ProtectSigningKeyAtRestIfNeededAsync(activeKey, cancellationToken);
             return activeKey;
         }
 
@@ -179,7 +192,7 @@ public sealed class SqlOSCryptoService
             Id = GenerateId("key"),
             Kid = GenerateOpaqueToken(16),
             PublicKeyPem = rsa.ExportRSAPublicKeyPem(),
-            PrivateKeyPem = rsa.ExportPkcs8PrivateKeyPem(),
+            PrivateKeyPem = ProtectSecret(rsa.ExportPkcs8PrivateKeyPem()),
             ActivatedAt = DateTime.UtcNow,
             IsActive = true
         };
@@ -214,7 +227,7 @@ public sealed class SqlOSCryptoService
             Id = GenerateId("key"),
             Kid = GenerateOpaqueToken(16),
             PublicKeyPem = rsa.ExportRSAPublicKeyPem(),
-            PrivateKeyPem = rsa.ExportPkcs8PrivateKeyPem(),
+            PrivateKeyPem = ProtectSecret(rsa.ExportPkcs8PrivateKeyPem()),
             ActivatedAt = now,
             IsActive = true
         };
@@ -259,7 +272,7 @@ public sealed class SqlOSCryptoService
     {
         var key = await EnsureActiveSigningKeyAsync(cancellationToken);
         using var rsa = RSA.Create();
-        rsa.ImportFromPem(key.PrivateKeyPem);
+        rsa.ImportFromPem(UnprotectSecret(key.PrivateKeyPem));
         var signingKey = new RsaSecurityKey(rsa.ExportParameters(true)) { KeyId = key.Kid };
 
         var now = DateTime.UtcNow;
@@ -414,5 +427,22 @@ public sealed class SqlOSCryptoService
         rsa.ImportFromPem(key.PublicKeyPem);
         var parameters = rsa.ExportParameters(false);
         return new RsaSecurityKey(parameters) { KeyId = key.Kid };
+    }
+
+    private async Task ProtectSigningKeyAtRestIfNeededAsync(SqlOSSigningKey key, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(key.PrivateKeyPem) || key.PrivateKeyPem.StartsWith("dp:", StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        var protectedPrivateKey = ProtectSecret(key.PrivateKeyPem);
+        if (string.Equals(protectedPrivateKey, key.PrivateKeyPem, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        key.PrivateKeyPem = protectedPrivateKey;
+        await _context.SaveChangesAsync(cancellationToken);
     }
 }

--- a/src/SqlOS/AuthServer/Services/SqlOSSamlService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSSamlService.cs
@@ -2,6 +2,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Security.Cryptography.Xml;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Security;
 using System.IO.Compression;
 using System.Xml;
@@ -19,6 +20,31 @@ public sealed class SqlOSSamlService
 {
     private const string SamlProtocolNs = "urn:oasis:names:tc:SAML:2.0:protocol";
     private const string SamlAssertionNs = "urn:oasis:names:tc:SAML:2.0:assertion";
+    private const string SamlBearerConfirmationMethod = "urn:oasis:names:tc:SAML:2.0:cm:bearer";
+    private const string SamlStatePropertyName = "__sqlosSaml";
+    private static readonly TimeSpan SamlClockSkew = TimeSpan.FromMinutes(5);
+    private static readonly HashSet<string> AllowedSignatureMethods = new(StringComparer.Ordinal)
+    {
+        SignedXml.XmlDsigRSASHA256Url,
+        SignedXml.XmlDsigRSASHA384Url,
+        SignedXml.XmlDsigRSASHA512Url,
+        "http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha256",
+        "http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha384",
+        "http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha512"
+    };
+    private static readonly HashSet<string> AllowedDigestMethods = new(StringComparer.Ordinal)
+    {
+        SignedXml.XmlDsigSHA256Url,
+        SignedXml.XmlDsigSHA384Url,
+        SignedXml.XmlDsigSHA512Url
+    };
+    private static readonly HashSet<string> AllowedReferenceTransforms = new(StringComparer.Ordinal)
+    {
+        SignedXml.XmlDsigEnvelopedSignatureTransformUrl,
+        SignedXml.XmlDsigC14NTransformUrl,
+        SignedXml.XmlDsigExcC14NTransformUrl
+    };
+
     private readonly ISqlOSAuthServerDbContext _context;
     private readonly SqlOSAuthServerOptions _options;
     private readonly SqlOSAdminService _adminService;
@@ -51,7 +77,7 @@ public sealed class SqlOSSamlService
             null,
             client.Id,
             connection.OrganizationId,
-            new SsoRequestPayload(client.ClientId, request.RedirectUri, connection.Id),
+            new SsoRequestPayload(client.ClientId, request.RedirectUri, connection.Id, null, null),
             TimeSpan.FromMinutes(10),
             cancellationToken);
 
@@ -64,9 +90,18 @@ public sealed class SqlOSSamlService
             ?? throw new InvalidOperationException("SAML connection not found or disabled.");
         var requestState = await _cryptoService.FindTemporaryTokenAsync("sso_request", requestToken, cancellationToken)
             ?? throw new InvalidOperationException("SSO request token is invalid or expired.");
+        var requestPayload = _cryptoService.DeserializePayload<SsoRequestPayload>(requestState)
+            ?? throw new InvalidOperationException("SSO request payload is invalid.");
+        var samlRequest = BuildAuthnRequest(connection);
 
-        _ = requestState;
-        return BuildIdentityProviderRedirectUrl(connection, requestToken);
+        requestState.PayloadJson = JsonSerializer.Serialize(requestPayload with
+        {
+            SamlRequestId = samlRequest.Id,
+            AssertionConsumerServiceUrl = samlRequest.AssertionConsumerServiceUrl
+        });
+        await _context.SaveChangesAsync(cancellationToken);
+
+        return BuildIdentityProviderRedirectUrl(connection, requestToken, samlRequest.EncodedRequest);
     }
 
     public async Task<string> BuildIdentityProviderRedirectForAuthorizationRequestAsync(string authorizationRequestId, CancellationToken cancellationToken = default)
@@ -87,19 +122,35 @@ public sealed class SqlOSSamlService
             throw new InvalidOperationException("SAML connection not found or disabled.");
         }
 
-        return BuildIdentityProviderRedirectUrl(connection, authorizationRequest.Id);
+        var samlRequest = BuildAuthnRequest(connection);
+        authorizationRequest.UiContextJson = StoreSamlRequestState(
+            authorizationRequest.UiContextJson,
+            new SamlRequestState(samlRequest.Id, samlRequest.AssertionConsumerServiceUrl));
+        await _context.SaveChangesAsync(cancellationToken);
+
+        return BuildIdentityProviderRedirectUrl(connection, authorizationRequest.Id, samlRequest.EncodedRequest);
     }
 
     public async Task<string> HandleAcsAsync(string connectionId, string samlResponse, string relayState, HttpContext? httpContext = null, CancellationToken cancellationToken = default)
     {
         var connection = await _context.Set<SqlOSSsoConnection>().FirstOrDefaultAsync(x => x.Id == connectionId && x.IsEnabled, cancellationToken)
             ?? throw new InvalidOperationException("SAML connection not found or disabled.");
-        var principal = ParseAndValidateAssertion(samlResponse, connection);
         var authorizationRequest = await _context.Set<SqlOSAuthorizationRequest>()
             .FirstOrDefaultAsync(x => x.Id == relayState && x.ConnectionId == connectionId, cancellationToken);
 
         if (authorizationRequest != null)
         {
+            if (authorizationRequest.CancelledAt != null || authorizationRequest.CompletedAt != null || authorizationRequest.ExpiresAt <= DateTime.UtcNow)
+            {
+                throw new InvalidOperationException("Authorization request is no longer active.");
+            }
+
+            var samlState = ReadSamlRequestState(authorizationRequest.UiContextJson)
+                ?? throw new InvalidOperationException("SAML request state is missing.");
+            var principal = ParseAndValidateAssertion(
+                samlResponse,
+                connection,
+                new SamlValidationContext(samlState.RequestId, samlState.AssertionConsumerServiceUrl, _adminService.GetServiceProviderEntityId()));
             return await HandleAuthorizationRequestAcsAsync(connection, authorizationRequest, principal, httpContext, cancellationToken);
         }
 
@@ -107,8 +158,17 @@ public sealed class SqlOSSamlService
             ?? throw new InvalidOperationException("SSO request token is invalid or expired.");
         var requestPayload = _cryptoService.DeserializePayload<SsoRequestPayload>(requestToken)
             ?? throw new InvalidOperationException("SSO request payload is invalid.");
+        if (string.IsNullOrWhiteSpace(requestPayload.SamlRequestId) || string.IsNullOrWhiteSpace(requestPayload.AssertionConsumerServiceUrl))
+        {
+            throw new InvalidOperationException("SAML request state is missing.");
+        }
 
-        return await HandleRequestTokenAcsAsync(connection, requestToken, requestPayload, principal, cancellationToken);
+        var requestPrincipal = ParseAndValidateAssertion(
+            samlResponse,
+            connection,
+            new SamlValidationContext(requestPayload.SamlRequestId, requestPayload.AssertionConsumerServiceUrl, _adminService.GetServiceProviderEntityId()));
+
+        return await HandleRequestTokenAcsAsync(connection, requestToken, requestPayload, requestPrincipal, cancellationToken);
     }
 
     private async Task<string> HandleAuthorizationRequestAcsAsync(
@@ -206,8 +266,9 @@ public sealed class SqlOSSamlService
         return $"{requestPayload.RedirectUri}{separator}code={Uri.EscapeDataString(code)}";
     }
 
-    private string BuildAuthnRequest(SqlOSSsoConnection connection, string acsUrl)
+    private SamlAuthnRequest BuildAuthnRequest(SqlOSSsoConnection connection)
     {
+        var acsUrl = _adminService.GetAssertionConsumerServiceUrl(connection.Id);
         var requestId = $"_{Guid.NewGuid():N}";
         var issueInstant = DateTime.UtcNow.ToString("o");
 
@@ -224,43 +285,76 @@ public sealed class SqlOSSamlService
             deflater.Write(bytes, 0, bytes.Length);
         }
 
-        return Convert.ToBase64String(output.ToArray());
+        return new SamlAuthnRequest(requestId, acsUrl, Convert.ToBase64String(output.ToArray()));
     }
 
-    private string BuildIdentityProviderRedirectUrl(SqlOSSsoConnection connection, string relayState)
+    private static string BuildIdentityProviderRedirectUrl(SqlOSSsoConnection connection, string relayState, string encodedAuthnRequest)
     {
-        var authnRequest = BuildAuthnRequest(connection, _adminService.GetAssertionConsumerServiceUrl(connection.Id));
-        var query = $"SAMLRequest={Uri.EscapeDataString(authnRequest)}&RelayState={Uri.EscapeDataString(relayState)}";
+        var query = $"SAMLRequest={Uri.EscapeDataString(encodedAuthnRequest)}&RelayState={Uri.EscapeDataString(relayState)}";
         var separator = connection.SingleSignOnUrl.Contains('?', StringComparison.Ordinal) ? "&" : "?";
         return $"{connection.SingleSignOnUrl}{separator}{query}";
     }
 
-    private SqlOSSamlPrincipal ParseAndValidateAssertion(string base64Response, SqlOSSsoConnection connection)
+    private SqlOSSamlPrincipal ParseAndValidateAssertion(
+        string base64Response,
+        SqlOSSsoConnection connection,
+        SamlValidationContext validationContext)
     {
         var xml = Encoding.UTF8.GetString(Convert.FromBase64String(base64Response));
-        var xmlDoc = new XmlDocument { PreserveWhitespace = true };
-        xmlDoc.LoadXml(xml);
+        var xmlDoc = LoadSamlDocument(xml);
 
         var ns = new XmlNamespaceManager(xmlDoc.NameTable);
         ns.AddNamespace("samlp", SamlProtocolNs);
         ns.AddNamespace("saml", SamlAssertionNs);
         ns.AddNamespace("ds", SignedXml.XmlDsigNamespaceUrl);
 
-        ValidateSignature(xmlDoc, connection.X509CertificatePem, ns);
+        var responseElement = xmlDoc.DocumentElement;
+        if (responseElement == null
+            || responseElement.LocalName != "Response"
+            || responseElement.NamespaceURI != SamlProtocolNs)
+        {
+            throw new InvalidOperationException("SAML response is invalid.");
+        }
 
-        var issuer = xmlDoc.SelectSingleNode("/samlp:Response/saml:Issuer", ns)?.InnerText
-            ?? xmlDoc.SelectSingleNode("/samlp:Response/saml:Assertion/saml:Issuer", ns)?.InnerText
-            ?? throw new InvalidOperationException("SAML response issuer missing.");
+        var assertionNodes = responseElement.SelectNodes("saml:Assertion", ns);
+        if (assertionNodes == null || assertionNodes.Count != 1 || assertionNodes[0] is not XmlElement assertionElement)
+        {
+            throw new InvalidOperationException("SAML response must contain exactly one assertion.");
+        }
+
+        var signedElement = ValidateSignature(xmlDoc, connection.X509CertificatePem, ns);
+        if (!ReferenceEquals(signedElement, responseElement) && !ReferenceEquals(signedElement, assertionElement))
+        {
+            throw new InvalidOperationException("SAML signature does not cover the consumed assertion.");
+        }
+
+        if (ReferenceEquals(signedElement, responseElement) && !ReferenceEquals(assertionElement.ParentNode, responseElement))
+        {
+            throw new InvalidOperationException("SAML signature does not cover the consumed assertion.");
+        }
+
+        var responseIssuer = responseElement.SelectSingleNode("saml:Issuer", ns)?.InnerText;
+        if (!string.IsNullOrWhiteSpace(responseIssuer)
+            && !string.Equals(responseIssuer, connection.IdentityProviderEntityId, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("SAML response issuer mismatch.");
+        }
+
+        var issuer = assertionElement.SelectSingleNode("saml:Issuer", ns)?.InnerText
+            ?? throw new InvalidOperationException("SAML assertion issuer missing.");
         if (!string.Equals(issuer, connection.IdentityProviderEntityId, StringComparison.Ordinal))
         {
             throw new InvalidOperationException("SAML response issuer mismatch.");
         }
 
-        var nameId = xmlDoc.SelectSingleNode("//saml:Assertion/saml:Subject/saml:NameID", ns)?.InnerText
+        ValidateResponseCorrelation(responseElement, validationContext);
+        ValidateAssertionConditions(assertionElement, validationContext, ns);
+
+        var nameId = assertionElement.SelectSingleNode("saml:Subject/saml:NameID", ns)?.InnerText
             ?? throw new InvalidOperationException("SAML assertion NameID missing.");
 
         var attributes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        var attributeNodes = xmlDoc.SelectNodes("//saml:AttributeStatement/saml:Attribute", ns);
+        var attributeNodes = assertionElement.SelectNodes("saml:AttributeStatement/saml:Attribute", ns);
         if (attributeNodes != null)
         {
             foreach (XmlNode attribute in attributeNodes)
@@ -277,23 +371,268 @@ public sealed class SqlOSSamlService
         return new SqlOSSamlPrincipal(issuer, nameId, attributes);
     }
 
-    private static void ValidateSignature(XmlDocument xmlDocument, string certificatePem, XmlNamespaceManager ns)
+    private static XmlDocument LoadSamlDocument(string xml)
     {
-        var signatureNode = xmlDocument.SelectSingleNode("/samlp:Response/ds:Signature", ns)
-            ?? xmlDocument.SelectSingleNode("//saml:Assertion/ds:Signature", ns);
-        if (signatureNode is not XmlElement signatureElement)
+        var settings = new XmlReaderSettings
+        {
+            DtdProcessing = DtdProcessing.Prohibit,
+            XmlResolver = null
+        };
+        var xmlDocument = new XmlDocument
+        {
+            PreserveWhitespace = true,
+            XmlResolver = null
+        };
+
+        using var stringReader = new StringReader(xml);
+        using var reader = XmlReader.Create(stringReader, settings);
+        xmlDocument.Load(reader);
+        return xmlDocument;
+    }
+
+    private static XmlElement ValidateSignature(XmlDocument xmlDocument, string certificatePem, XmlNamespaceManager ns)
+    {
+        var signatureNodes = xmlDocument.SelectNodes("/samlp:Response/ds:Signature | /samlp:Response/saml:Assertion/ds:Signature", ns);
+        if (signatureNodes == null || signatureNodes.Count != 1 || signatureNodes[0] is not XmlElement signatureElement)
         {
             throw new InvalidOperationException("SAML response signature missing.");
         }
 
         var signedElement = signatureElement.ParentNode as XmlElement
             ?? throw new InvalidOperationException("Signed SAML element missing.");
-        var signedXml = new SignedXml(signedElement);
+        var signedXml = new SignedXmlWithIdResolution(signedElement);
         signedXml.LoadXml(signatureElement);
+        ValidateSignedInfo(signedXml);
+
         var certificate = X509Certificate2.CreateFromPem(certificatePem);
         if (!signedXml.CheckSignature(certificate, true))
         {
             throw new InvalidOperationException("SAML response signature is invalid.");
+        }
+
+        var reference = (Reference)signedXml.SignedInfo!.References[0]!;
+        var referenceUri = reference.Uri
+            ?? throw new InvalidOperationException("SAML signature reference must identify a signed element.");
+        var referencedElement = ResolveSignedReference(xmlDocument, referenceUri);
+        if (!ReferenceEquals(referencedElement, signedElement))
+        {
+            throw new InvalidOperationException("SAML signature reference does not match the signed element.");
+        }
+
+        return referencedElement;
+    }
+
+    private static void ValidateSignedInfo(SignedXml signedXml)
+    {
+        if (signedXml.SignedInfo == null
+            || string.IsNullOrWhiteSpace(signedXml.SignedInfo.SignatureMethod)
+            || !AllowedSignatureMethods.Contains(signedXml.SignedInfo.SignatureMethod))
+        {
+            throw new InvalidOperationException("SAML signature algorithm is not allowed.");
+        }
+
+        if (signedXml.SignedInfo.References.Count != 1 || signedXml.SignedInfo.References[0] is not Reference reference)
+        {
+            throw new InvalidOperationException("SAML signature must contain exactly one reference.");
+        }
+
+        if (string.IsNullOrWhiteSpace(reference.Uri) || !reference.Uri.StartsWith("#", StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("SAML signature reference must identify a signed element.");
+        }
+
+        if (string.IsNullOrWhiteSpace(reference.DigestMethod) || !AllowedDigestMethods.Contains(reference.DigestMethod))
+        {
+            throw new InvalidOperationException("SAML signature digest algorithm is not allowed.");
+        }
+
+        var transforms = new List<Transform>();
+        for (var i = 0; i < reference.TransformChain.Count; i++)
+        {
+            transforms.Add((Transform)reference.TransformChain[i]);
+        }
+        if (transforms.Count != 2
+            || !transforms.Any(t => string.Equals(t.Algorithm, SignedXml.XmlDsigEnvelopedSignatureTransformUrl, StringComparison.Ordinal))
+            || !transforms.Any(t => string.Equals(t.Algorithm, SignedXml.XmlDsigC14NTransformUrl, StringComparison.Ordinal)
+                || string.Equals(t.Algorithm, SignedXml.XmlDsigExcC14NTransformUrl, StringComparison.Ordinal))
+            || transforms.Any(t => string.IsNullOrWhiteSpace(t.Algorithm) || !AllowedReferenceTransforms.Contains(t.Algorithm)))
+        {
+            throw new InvalidOperationException("SAML signature transform is not allowed.");
+        }
+    }
+
+    private static XmlElement ResolveSignedReference(XmlDocument document, string uri)
+    {
+        var id = Uri.UnescapeDataString(uri[1..]);
+        if (string.IsNullOrWhiteSpace(id))
+        {
+            throw new InvalidOperationException("SAML signature reference is invalid.");
+        }
+
+        XmlElement? match = null;
+        foreach (var element in EnumerateElements(document.DocumentElement))
+        {
+            if (ElementHasId(element, id))
+            {
+                if (match != null)
+                {
+                    throw new InvalidOperationException("SAML signature reference ID is ambiguous.");
+                }
+
+                match = element;
+            }
+        }
+
+        return match ?? throw new InvalidOperationException("SAML signature reference target is missing.");
+    }
+
+    private static IEnumerable<XmlElement> EnumerateElements(XmlElement? root)
+    {
+        if (root == null)
+        {
+            yield break;
+        }
+
+        yield return root;
+        foreach (XmlNode child in root.ChildNodes)
+        {
+            if (child is XmlElement childElement)
+            {
+                foreach (var descendant in EnumerateElements(childElement))
+                {
+                    yield return descendant;
+                }
+            }
+        }
+    }
+
+    private static bool ElementHasId(XmlElement element, string id)
+        => string.Equals(element.GetAttribute("ID"), id, StringComparison.Ordinal)
+           || string.Equals(element.GetAttribute("Id"), id, StringComparison.Ordinal)
+           || string.Equals(element.GetAttribute("id"), id, StringComparison.Ordinal)
+           || string.Equals(element.GetAttribute("xml:id"), id, StringComparison.Ordinal);
+
+    private static void ValidateResponseCorrelation(XmlElement responseElement, SamlValidationContext validationContext)
+    {
+        var responseInResponseTo = responseElement.GetAttribute("InResponseTo");
+        if (!string.IsNullOrWhiteSpace(responseInResponseTo)
+            && !string.Equals(responseInResponseTo, validationContext.RequestId, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("SAML response InResponseTo mismatch.");
+        }
+
+        var destination = responseElement.GetAttribute("Destination");
+        if (!string.IsNullOrWhiteSpace(destination)
+            && !string.Equals(destination, validationContext.AssertionConsumerServiceUrl, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("SAML response destination mismatch.");
+        }
+    }
+
+    private static void ValidateAssertionConditions(XmlElement assertionElement, SamlValidationContext validationContext, XmlNamespaceManager ns)
+    {
+        var now = DateTime.UtcNow;
+        var conditions = assertionElement.SelectSingleNode("saml:Conditions", ns) as XmlElement
+            ?? throw new InvalidOperationException("SAML assertion conditions missing.");
+
+        var notBefore = ParseSamlDateTimeOrNull(conditions.GetAttribute("NotBefore"));
+        if (notBefore.HasValue && now + SamlClockSkew < notBefore.Value)
+        {
+            throw new InvalidOperationException("SAML assertion is not yet valid.");
+        }
+
+        var notOnOrAfter = ParseSamlDateTimeOrNull(conditions.GetAttribute("NotOnOrAfter"))
+            ?? throw new InvalidOperationException("SAML assertion expiration missing.");
+        if (now - SamlClockSkew >= notOnOrAfter)
+        {
+            throw new InvalidOperationException("SAML assertion has expired.");
+        }
+
+        var audiences = conditions.SelectNodes("saml:AudienceRestriction/saml:Audience", ns);
+        if (audiences == null
+            || audiences.Count == 0
+            || !audiences.Cast<XmlNode>().Any(a => string.Equals(a.InnerText, validationContext.Audience, StringComparison.Ordinal)))
+        {
+            throw new InvalidOperationException("SAML assertion audience mismatch.");
+        }
+
+        var subjectConfirmationData = assertionElement.SelectNodes(
+            "saml:Subject/saml:SubjectConfirmation/saml:SubjectConfirmationData",
+            ns);
+        if (subjectConfirmationData == null
+            || !subjectConfirmationData.Cast<XmlNode>().OfType<XmlElement>().Any(data => IsValidSubjectConfirmation(data, validationContext, now)))
+        {
+            throw new InvalidOperationException("SAML subject confirmation mismatch.");
+        }
+    }
+
+    private static bool IsValidSubjectConfirmation(XmlElement subjectConfirmationData, SamlValidationContext validationContext, DateTime now)
+    {
+        if (subjectConfirmationData.ParentNode is XmlElement confirmation)
+        {
+            var method = confirmation.GetAttribute("Method");
+            if (!string.Equals(method, SamlBearerConfirmationMethod, StringComparison.Ordinal))
+            {
+                return false;
+            }
+        }
+
+        if (!string.Equals(subjectConfirmationData.GetAttribute("Recipient"), validationContext.AssertionConsumerServiceUrl, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (!string.Equals(subjectConfirmationData.GetAttribute("InResponseTo"), validationContext.RequestId, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var notOnOrAfter = ParseSamlDateTimeOrNull(subjectConfirmationData.GetAttribute("NotOnOrAfter"));
+        return !notOnOrAfter.HasValue || now - SamlClockSkew < notOnOrAfter.Value;
+    }
+
+    private static DateTime? ParseSamlDateTimeOrNull(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        return XmlConvert.ToDateTime(value, XmlDateTimeSerializationMode.Utc);
+    }
+
+    private static string StoreSamlRequestState(string? uiContextJson, SamlRequestState state)
+    {
+        var uiContext = SqlOSHeadlessAuthService.ParseUiContext(uiContextJson) ?? new JsonObject();
+        uiContext[SamlStatePropertyName] = JsonSerializer.SerializeToNode(state);
+        return uiContext.ToJsonString();
+    }
+
+    private static SamlRequestState? ReadSamlRequestState(string? uiContextJson)
+    {
+        var uiContext = SqlOSHeadlessAuthService.ParseUiContext(uiContextJson);
+        if (uiContext == null || !uiContext.TryGetPropertyValue(SamlStatePropertyName, out var value) || value == null)
+        {
+            return null;
+        }
+
+        return value.Deserialize<SamlRequestState>();
+    }
+
+    private sealed class SignedXmlWithIdResolution : SignedXml
+    {
+        public SignedXmlWithIdResolution(XmlElement element) : base(element)
+        {
+        }
+
+        public override XmlElement? GetIdElement(XmlDocument? document, string idValue)
+        {
+            if (document?.DocumentElement == null)
+            {
+                return null;
+            }
+
+            return EnumerateElements(document.DocumentElement).FirstOrDefault(element => ElementHasId(element, idValue));
         }
     }
 
@@ -441,7 +780,16 @@ public sealed class SqlOSSamlService
         });
     }
 
-    private sealed record SsoRequestPayload(string ClientId, string RedirectUri, string ConnectionId);
+    private sealed record SsoRequestPayload(
+        string ClientId,
+        string RedirectUri,
+        string ConnectionId,
+        string? SamlRequestId,
+        string? AssertionConsumerServiceUrl);
+
+    private sealed record SamlAuthnRequest(string Id, string AssertionConsumerServiceUrl, string EncodedRequest);
+    private sealed record SamlRequestState(string RequestId, string AssertionConsumerServiceUrl);
+    private sealed record SamlValidationContext(string RequestId, string AssertionConsumerServiceUrl, string Audience);
     private sealed record AuthCodePayload(string ClientId, string RedirectUri, string AuthenticationMethod);
     private sealed record SqlOSSamlPrincipal(string Issuer, string Subject, Dictionary<string, string> Attributes);
 }

--- a/src/SqlOS/Fga/Configuration/SqlOSFgaOptions.cs
+++ b/src/SqlOS/Fga/Configuration/SqlOSFgaOptions.cs
@@ -14,6 +14,7 @@ public class SqlOSFgaOptions
     public string RootResourceName { get; set; } = "Root";
     public bool InitializeFunctions { get; set; } = true;
     public bool SeedCoreData { get; set; } = true;
+    public int MaxResourceHierarchyDepth { get; set; } = 10;
     public SqlOSDashboardOptions Dashboard { get; set; } = new();
     public SqlOSFgaTableNames TableNames { get; set; } = new();
     public SqlOSFgaSeedData? StartupSeedData { get; private set; }

--- a/src/SqlOS/Fga/Dashboard/SqlOSFgaDashboardMiddleware.cs
+++ b/src/SqlOS/Fga/Dashboard/SqlOSFgaDashboardMiddleware.cs
@@ -23,6 +23,7 @@ public class SqlOSFgaDashboardMiddleware
     private readonly IFileProvider _fileProvider;
     private const int DefaultPageSize = 25;
     private const int MaxPageSize = 100;
+    private const int MaxAncestorTraversalDepth = 50;
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
@@ -462,16 +463,21 @@ public class SqlOSFgaDashboardMiddleware
         // Build breadcrumb path from root to this resource
         var breadcrumbs = new List<object>();
         var currentId = resource.ParentId;
-        while (!string.IsNullOrEmpty(currentId))
+        var visited = new HashSet<string>(StringComparer.Ordinal) { resource.Id };
+        for (var depth = 0; !string.IsNullOrEmpty(currentId) && depth <= MaxAncestorTraversalDepth; depth++)
         {
+            if (!visited.Add(currentId))
+            {
+                break;
+            }
+
             var parent = await dbContext.Set<SqlOSFgaResource>()
                 .Where(r => r.Id == currentId)
-                .Select(r => new { r.Id, r.Name })
+                .Select(r => new { r.Id, r.Name, r.ParentId })
                 .FirstOrDefaultAsync();
             if (parent == null) break;
-            breadcrumbs.Insert(0, parent);
-            var res = await dbContext.Set<SqlOSFgaResource>().Where(r => r.Id == currentId).Select(r => r.ParentId).FirstOrDefaultAsync();
-            currentId = res;
+            breadcrumbs.Insert(0, new { parent.Id, parent.Name });
+            currentId = parent.ParentId;
         }
 
         var result = new { Resource = resource, Breadcrumbs = breadcrumbs };
@@ -490,8 +496,14 @@ public class SqlOSFgaDashboardMiddleware
 
         var ancestorIds = new List<string> { resourceId };
         var currentId = resource.ParentId;
-        while (!string.IsNullOrEmpty(currentId))
+        var visited = new HashSet<string>(StringComparer.Ordinal) { resourceId };
+        for (var depth = 0; !string.IsNullOrEmpty(currentId) && depth <= MaxAncestorTraversalDepth; depth++)
         {
+            if (!visited.Add(currentId))
+            {
+                break;
+            }
+
             ancestorIds.Add(currentId);
             var parentId = await dbContext.Set<SqlOSFgaResource>().Where(r => r.Id == currentId).Select(r => r.ParentId).FirstOrDefaultAsync();
             currentId = parentId;

--- a/src/SqlOS/Fga/Extensions/SqlOSFgaConvenienceExtensions.cs
+++ b/src/SqlOS/Fga/Extensions/SqlOSFgaConvenienceExtensions.cs
@@ -35,11 +35,10 @@ public static class SqlOSFgaConvenienceExtensions
         string parentId,
         string name,
         string resourceTypeId,
-        string? id = null,
-        int maxHierarchyDepth = DefaultMaxResourceHierarchyDepth)
+        string? id = null)
     {
         var resourceId = id ?? Guid.NewGuid().ToString();
-        EnsureParentChainDoesNotCreateCycle(context, resourceId, parentId, maxHierarchyDepth);
+        EnsureParentChainDoesNotCreateCycle(context, resourceId, parentId);
         var resource = new SqlOSFgaResource
         {
             Id = resourceId,
@@ -54,15 +53,13 @@ public static class SqlOSFgaConvenienceExtensions
     private static void EnsureParentChainDoesNotCreateCycle(
         ISqlOSFgaDbContext context,
         string resourceId,
-        string parentId,
-        int maxHierarchyDepth)
+        string parentId)
     {
         if (string.Equals(resourceId, parentId, StringComparison.Ordinal))
         {
             throw new InvalidOperationException("FGA resource parent cannot be the resource itself.");
         }
 
-        var maxDepth = Math.Max(1, maxHierarchyDepth);
         var visited = new HashSet<string>(StringComparer.Ordinal) { resourceId };
         string? currentId = parentId;
         var depth = 0;
@@ -74,9 +71,9 @@ public static class SqlOSFgaConvenienceExtensions
                 throw new InvalidOperationException("FGA resource hierarchy contains a cycle.");
             }
 
-            if (depth > maxDepth)
+            if (depth > DefaultMaxResourceHierarchyDepth)
             {
-                throw new InvalidOperationException($"FGA resource hierarchy exceeds the maximum depth of {maxDepth}.");
+                throw new InvalidOperationException($"FGA resource hierarchy exceeds the maximum depth of {DefaultMaxResourceHierarchyDepth}.");
             }
 
             var parent = context.Set<SqlOSFgaResource>()

--- a/src/SqlOS/Fga/Extensions/SqlOSFgaConvenienceExtensions.cs
+++ b/src/SqlOS/Fga/Extensions/SqlOSFgaConvenienceExtensions.cs
@@ -11,6 +11,8 @@ namespace SqlOS.Fga.Extensions;
 /// </summary>
 public static class SqlOSFgaConvenienceExtensions
 {
+    private const int DefaultMaxResourceHierarchyDepth = 10;
+
     /// <summary>
     /// Creates a <see cref="SqlOSFgaResource"/> and adds it to the context (not yet saved).
     /// Returns the generated resource ID so you can assign it to your domain entity.
@@ -33,9 +35,11 @@ public static class SqlOSFgaConvenienceExtensions
         string parentId,
         string name,
         string resourceTypeId,
-        string? id = null)
+        string? id = null,
+        int maxHierarchyDepth = DefaultMaxResourceHierarchyDepth)
     {
         var resourceId = id ?? Guid.NewGuid().ToString();
+        EnsureParentChainDoesNotCreateCycle(context, resourceId, parentId, maxHierarchyDepth);
         var resource = new SqlOSFgaResource
         {
             Id = resourceId,
@@ -45,6 +49,44 @@ public static class SqlOSFgaConvenienceExtensions
         };
         context.Set<SqlOSFgaResource>().Add(resource);
         return resourceId;
+    }
+
+    private static void EnsureParentChainDoesNotCreateCycle(
+        ISqlOSFgaDbContext context,
+        string resourceId,
+        string parentId,
+        int maxHierarchyDepth)
+    {
+        if (string.Equals(resourceId, parentId, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("FGA resource parent cannot be the resource itself.");
+        }
+
+        var maxDepth = Math.Max(1, maxHierarchyDepth);
+        var visited = new HashSet<string>(StringComparer.Ordinal) { resourceId };
+        string? currentId = parentId;
+        var depth = 0;
+
+        while (!string.IsNullOrWhiteSpace(currentId))
+        {
+            if (!visited.Add(currentId))
+            {
+                throw new InvalidOperationException("FGA resource hierarchy contains a cycle.");
+            }
+
+            if (depth > maxDepth)
+            {
+                throw new InvalidOperationException($"FGA resource hierarchy exceeds the maximum depth of {maxDepth}.");
+            }
+
+            var parent = context.Set<SqlOSFgaResource>()
+                .AsNoTracking()
+                .Where(r => r.Id == currentId)
+                .Select(r => new { r.ParentId })
+                .FirstOrDefault();
+            currentId = parent?.ParentId;
+            depth++;
+        }
     }
 
     /// <summary>

--- a/src/SqlOS/Fga/Schema/004_Indexes.sql
+++ b/src/SqlOS/Fga/Schema/004_Indexes.sql
@@ -1,0 +1,50 @@
+-- SqlOSFga Schema v4: Query-composable authorization indexes
+-- These indexes support the TVF plan used for resource ancestry walks and grant lookups.
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.indexes
+    WHERE name = 'IX_{Resources}_ParentId'
+      AND object_id = OBJECT_ID('{Schema}.{Resources}')
+)
+BEGIN
+    CREATE NONCLUSTERED INDEX [IX_{Resources}_ParentId]
+    ON [{Schema}].[{Resources}]([ParentId]);
+END
+GO
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.indexes
+    WHERE name = 'IX_{RolePermissions}_PermissionId_RoleId'
+      AND object_id = OBJECT_ID('{Schema}.{RolePermissions}')
+)
+BEGIN
+    CREATE NONCLUSTERED INDEX [IX_{RolePermissions}_PermissionId_RoleId]
+    ON [{Schema}].[{RolePermissions}]([PermissionId], [RoleId]);
+END
+GO
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.indexes
+    WHERE name = 'IX_{Grants}_ResourceId_SubjectId'
+      AND object_id = OBJECT_ID('{Schema}.{Grants}')
+)
+BEGIN
+    CREATE NONCLUSTERED INDEX [IX_{Grants}_ResourceId_SubjectId]
+    ON [{Schema}].[{Grants}]([ResourceId], [SubjectId])
+    INCLUDE ([RoleId], [EffectiveFrom], [EffectiveTo]);
+END
+GO
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.indexes
+    WHERE name = 'IX_{Grants}_SubjectId'
+      AND object_id = OBJECT_ID('{Schema}.{Grants}')
+)
+BEGIN
+    CREATE NONCLUSTERED INDEX [IX_{Grants}_SubjectId]
+    ON [{Schema}].[{Grants}]([SubjectId]);
+END
+GO
+
+UPDATE [{Schema}].[SqlOSFgaSchema] SET [Version] = 4 WHERE [Version] < 4;
+GO

--- a/src/SqlOS/Fga/Services/SqlOSFgaAuthService.cs
+++ b/src/SqlOS/Fga/Services/SqlOSFgaAuthService.cs
@@ -408,10 +408,12 @@ public class SqlOSFgaAuthService : ISqlOSFgaAuthService
         var entityParam = Expression.Parameter(typeof(T), "entity");
         var resourceIdProp = Expression.Property(entityParam, nameof(IHasResourceId.ResourceId));
         var contextExpr = Expression.Constant(_context, contextType);
+        var filterParameters = new AuthorizationFilterParameters(subjectIdsStr, permissionId);
+        var filterParametersExpr = Expression.Constant(filterParameters);
         var tvfCall = Expression.Call(contextExpr, tvfMethod,
             resourceIdProp,
-            Expression.Constant(subjectIdsStr),
-            Expression.Constant(permissionId));
+            Expression.Field(filterParametersExpr, nameof(AuthorizationFilterParameters.SubjectIds)),
+            Expression.Field(filterParametersExpr, nameof(AuthorizationFilterParameters.PermissionId)));
 
         var anyMethod = typeof(Queryable).GetMethods()
             .First(m => m.Name == "Any" && m.GetParameters().Length == 1)
@@ -492,13 +494,27 @@ public class SqlOSFgaAuthService : ISqlOSFgaAuthService
     {
         var ancestors = new List<SqlOSFgaResource>();
         string? currentId = resourceId;
+        var visited = new HashSet<string>(StringComparer.Ordinal);
+        var depth = 0;
+        var maxDepth = Math.Max(1, _options.MaxResourceHierarchyDepth);
 
         while (currentId != null)
         {
+            if (!visited.Add(currentId))
+            {
+                throw new InvalidOperationException("FGA resource hierarchy contains a cycle.");
+            }
+
+            if (depth > maxDepth)
+            {
+                throw new InvalidOperationException($"FGA resource hierarchy exceeds the configured maximum depth of {maxDepth}.");
+            }
+
             var resource = await _context.Set<SqlOSFgaResource>().FirstOrDefaultAsync(r => r.Id == currentId);
             if (resource == null) break;
             ancestors.Add(resource);
             currentId = resource.ParentId;
+            depth++;
         }
 
         return ancestors;
@@ -514,5 +530,17 @@ public class SqlOSFgaAuthService : ISqlOSFgaAuthService
                        (g.EffectiveFrom == null || g.EffectiveFrom <= now) &&
                        (g.EffectiveTo == null || g.EffectiveTo >= now))
             .ToListAsync();
+    }
+
+    private sealed class AuthorizationFilterParameters
+    {
+        public AuthorizationFilterParameters(string subjectIds, string permissionId)
+        {
+            SubjectIds = subjectIds;
+            PermissionId = permissionId;
+        }
+
+        public readonly string SubjectIds;
+        public readonly string PermissionId;
     }
 }

--- a/src/SqlOS/Fga/Services/SqlOSFgaFunctionInitializer.cs
+++ b/src/SqlOS/Fga/Services/SqlOSFgaFunctionInitializer.cs
@@ -33,6 +33,7 @@ public class SqlOSFgaFunctionInitializer
     {
         var schema = _options.Schema;
         var tables = _options.TableNames;
+        var maxDepth = Math.Max(1, _options.MaxResourceHierarchyDepth);
 
         var dropFunctionSql = $"DROP FUNCTION IF EXISTS [{schema}].fn_IsResourceAccessible";
 
@@ -53,10 +54,11 @@ RETURN
 
         UNION ALL
 
-        SELECT r.Id, r.ParentId, a.Depth + 1
-        FROM [{schema}].[{tables.Resources}] r
-        INNER JOIN ancestors a ON r.Id = a.ParentId
-    )
+	        SELECT r.Id, r.ParentId, a.Depth + 1
+	        FROM [{schema}].[{tables.Resources}] r
+	        INNER JOIN ancestors a ON r.Id = a.ParentId
+	        WHERE a.Depth < {maxDepth}
+	    )
     SELECT TOP 1 a.Id
     FROM ancestors a
     INNER JOIN [{schema}].[{tables.Grants}] g ON a.Id = g.ResourceId

--- a/tests/SqlOS.IntegrationTests/AuthServiceIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/AuthServiceIntegrationTests.cs
@@ -114,7 +114,7 @@ public sealed class AuthServiceIntegrationTests
         try
         {
             // Find the family ID from the original token.
-            var crypto = new SqlOSCryptoService(verifyCtx, Microsoft.Extensions.Options.Options.Create(AspireFixture.Options));
+            var crypto = new SqlOSCryptoService(verifyCtx, Microsoft.Extensions.Options.Options.Create(AspireFixture.Options), AspireFixture.DataProtectionProvider);
             var originalHash = crypto.HashToken(refreshToken);
             var original = await verifyCtx.Set<SqlOS.AuthServer.Models.SqlOSRefreshToken>()
                 .FirstAsync(x => x.TokenHash == originalHash);
@@ -152,7 +152,7 @@ public sealed class AuthServiceIntegrationTests
     {
         var ctx = BuildIsolatedContext();
         var options = Microsoft.Extensions.Options.Options.Create(AspireFixture.Options);
-        var crypto = new SqlOSCryptoService(ctx, options);
+        var crypto = new SqlOSCryptoService(ctx, options, AspireFixture.DataProtectionProvider);
         var admin = new SqlOSAdminService(ctx, options, crypto);
         var emailSender = new TestAuthEmailSender();
         var settings = new SqlOSSettingsService(ctx, options, emailSender);
@@ -248,7 +248,7 @@ public sealed class AuthServiceIntegrationTests
     private static SqlOSAuthService BuildAuthService()
     {
         var options = Options.Create(AspireFixture.Options);
-        var crypto = new SqlOSCryptoService(AspireFixture.SharedContext, options);
+        var crypto = new SqlOSCryptoService(AspireFixture.SharedContext, options, AspireFixture.DataProtectionProvider);
         var admin = new SqlOSAdminService(AspireFixture.SharedContext, options, crypto);
         var emailSender = new TestAuthEmailSender();
         var settings = new SqlOSSettingsService(AspireFixture.SharedContext, options, emailSender);
@@ -259,7 +259,7 @@ public sealed class AuthServiceIntegrationTests
     private static SqlOSAdminService BuildAdminService()
     {
         var options = Options.Create(AspireFixture.Options);
-        var crypto = new SqlOSCryptoService(AspireFixture.SharedContext, options);
+        var crypto = new SqlOSCryptoService(AspireFixture.SharedContext, options, AspireFixture.DataProtectionProvider);
         return new SqlOSAdminService(AspireFixture.SharedContext, options, crypto);
     }
 }

--- a/tests/SqlOS.IntegrationTests/Fga/SqlOSFgaFunctionInitializerIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/Fga/SqlOSFgaFunctionInitializerIntegrationTests.cs
@@ -1,3 +1,5 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -22,5 +24,47 @@ public class SqlOSFgaFunctionInitializerIntegrationTests : FgaIntegrationTestBas
         // Should not throw when run multiple times
         await initializer.EnsureFunctionsExistAsync();
         await initializer.EnsureFunctionsExistAsync();
+    }
+
+    [TestMethod]
+    public async Task EnsureFunctionsExist_AddsConfiguredDepthGuard()
+    {
+        var loggerFactory = LoggerFactory.Create(b => b.AddConsole());
+        var initializer = new SqlOSFgaFunctionInitializer(
+            Context,
+            Options.Create(new SqlOSFgaOptions { MaxResourceHierarchyDepth = 3 }),
+            loggerFactory.CreateLogger<SqlOSFgaFunctionInitializer>());
+
+        try
+        {
+            await initializer.EnsureFunctionsExistAsync();
+
+            var definition = await GetFunctionDefinitionAsync();
+            definition.Should().Contain("WHERE a.Depth < 3");
+        }
+        finally
+        {
+            var defaultInitializer = new SqlOSFgaFunctionInitializer(
+                Context,
+                Options.Create(new SqlOSFgaOptions()),
+                loggerFactory.CreateLogger<SqlOSFgaFunctionInitializer>());
+            await defaultInitializer.EnsureFunctionsExistAsync();
+        }
+    }
+
+    private static async Task<string> GetFunctionDefinitionAsync()
+    {
+        var connection = Context.Database.GetDbConnection();
+        await connection.OpenAsync();
+        try
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "SELECT OBJECT_DEFINITION(OBJECT_ID('[dbo].[fn_IsResourceAccessible]'))";
+            return (await cmd.ExecuteScalarAsync())?.ToString() ?? string.Empty;
+        }
+        finally
+        {
+            await connection.CloseAsync();
+        }
     }
 }

--- a/tests/SqlOS.IntegrationTests/Fga/SqlOSFgaSchemaInitializerIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/Fga/SqlOSFgaSchemaInitializerIntegrationTests.cs
@@ -77,6 +77,23 @@ public class SqlOSFgaSchemaInitializerIntegrationTests : FgaIntegrationTestBase
     }
 
     [TestMethod]
+    public async Task EnsureSchema_V4Migration_AddsAuthorizationIndexes()
+    {
+        var loggerFactory = LoggerFactory.Create(b => b.AddConsole());
+        var initializer = new SqlOSFgaSchemaInitializer(
+            Context,
+            Options.Create(new SqlOSFgaOptions()),
+            loggerFactory.CreateLogger<SqlOSFgaSchemaInitializer>());
+
+        await initializer.EnsureSchemaAsync();
+
+        Assert.IsTrue(await IndexExistsAsync("SqlOSFgaResources", "IX_SqlOSFgaResources_ParentId"));
+        Assert.IsTrue(await IndexExistsAsync("SqlOSFgaRolePermissions", "IX_SqlOSFgaRolePermissions_PermissionId_RoleId"));
+        Assert.IsTrue(await IndexExistsAsync("SqlOSFgaGrants", "IX_SqlOSFgaGrants_ResourceId_SubjectId"));
+        Assert.IsTrue(await IndexExistsAsync("SqlOSFgaGrants", "IX_SqlOSFgaGrants_SubjectId"));
+    }
+
+    [TestMethod]
     public async Task EnsureSchema_SetsCorrectVersion()
     {
         var loggerFactory = LoggerFactory.Create(b => b.AddConsole());
@@ -88,7 +105,7 @@ public class SqlOSFgaSchemaInitializerIntegrationTests : FgaIntegrationTestBase
         await initializer.EnsureSchemaAsync();
 
         var version = await GetSchemaVersionAsync();
-        Assert.IsTrue(version >= 3, $"Schema version should be at least 3, was {version}");
+        Assert.IsTrue(version >= 4, $"Schema version should be at least 4, was {version}");
     }
 
     private async Task<bool> TableExistsAsync(string tableName)
@@ -122,6 +139,31 @@ public class SqlOSFgaSchemaInitializerIntegrationTests : FgaIntegrationTestBase
                 WHERE t.name = @tableName AND c.name = @columnName AND t.schema_id = SCHEMA_ID('dbo')";
             cmd.Parameters.Add(new SqlParameter("@tableName", tableName));
             cmd.Parameters.Add(new SqlParameter("@columnName", columnName));
+            var result = await cmd.ExecuteScalarAsync();
+            return Convert.ToInt32(result) > 0;
+        }
+        finally
+        {
+            await connection.CloseAsync();
+        }
+    }
+
+    private async Task<bool> IndexExistsAsync(string tableName, string indexName)
+    {
+        var connection = Context.Database.GetDbConnection();
+        await connection.OpenAsync();
+        try
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = @"
+                SELECT COUNT(*)
+                FROM sys.indexes i
+                INNER JOIN sys.tables t ON i.object_id = t.object_id
+                WHERE t.name = @tableName
+                  AND i.name = @indexName
+                  AND t.schema_id = SCHEMA_ID('dbo')";
+            cmd.Parameters.Add(new SqlParameter("@tableName", tableName));
+            cmd.Parameters.Add(new SqlParameter("@indexName", indexName));
             var result = await cmd.ExecuteScalarAsync();
             return Convert.ToInt32(result) > 0;
         }

--- a/tests/SqlOS.IntegrationTests/Infrastructure/AspireFixture.cs
+++ b/tests/SqlOS.IntegrationTests/Infrastructure/AspireFixture.cs
@@ -1,5 +1,6 @@
 using Aspire.Hosting;
 using Aspire.Hosting.Testing;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -21,6 +22,7 @@ public static class AspireFixture
     public static TestSqlOSDbContext SharedContext { get; private set; } = null!;
     public static SqlOSAuthServerOptions Options { get; private set; } = new();
     public static SqlOSFgaOptions FgaOptions { get; private set; } = new();
+    public static IDataProtectionProvider DataProtectionProvider { get; } = new EphemeralDataProtectionProvider();
 
     [AssemblyInitialize]
     public static async Task InitializeAsync(TestContext context)
@@ -73,7 +75,7 @@ public static class AspireFixture
         await fgaSeedService.SeedCoreAsync();
         await FgaTestDataSeeder.SeedAsync(SharedContext);
 
-        var crypto = new SqlOSCryptoService(SharedContext, Microsoft.Extensions.Options.Options.Create(Options));
+        var crypto = new SqlOSCryptoService(SharedContext, Microsoft.Extensions.Options.Options.Create(Options), DataProtectionProvider);
         var admin = new SqlOSAdminService(SharedContext, Microsoft.Extensions.Options.Options.Create(Options), crypto);
         await crypto.EnsureActiveSigningKeyAsync();
         await admin.UpsertSeededClientsAsync();

--- a/tests/SqlOS.IntegrationTests/OidcAuthIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/OidcAuthIntegrationTests.cs
@@ -1,6 +1,5 @@
 using System.Security.Cryptography;
 using FluentAssertions;
-using Microsoft.AspNetCore.DataProtection;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -21,7 +20,7 @@ public sealed class OidcAuthIntegrationTests
         await ResetOidcStateAsync();
 
         var options = Options.Create(AspireFixture.Options);
-        var crypto = new SqlOSCryptoService(AspireFixture.SharedContext, options, new EphemeralDataProtectionProvider());
+        var crypto = new SqlOSCryptoService(AspireFixture.SharedContext, options, AspireFixture.DataProtectionProvider);
         var admin = new SqlOSAdminService(AspireFixture.SharedContext, options, crypto);
         const string customLogo = "data:image/svg+xml;charset=utf-8,%3Csvg%20viewBox%3D%220%200%2024%2024%22%3E%3C%2Fsvg%3E";
 
@@ -84,7 +83,7 @@ public sealed class OidcAuthIntegrationTests
         await ResetOidcStateAsync();
 
         var options = Options.Create(AspireFixture.Options);
-        var crypto = new SqlOSCryptoService(AspireFixture.SharedContext, options, new EphemeralDataProtectionProvider());
+        var crypto = new SqlOSCryptoService(AspireFixture.SharedContext, options, AspireFixture.DataProtectionProvider);
         var admin = new SqlOSAdminService(AspireFixture.SharedContext, options, crypto);
         var emailSender = new TestAuthEmailSender();
         var settings = new SqlOSSettingsService(AspireFixture.SharedContext, options, emailSender);
@@ -156,7 +155,7 @@ public sealed class OidcAuthIntegrationTests
         await ResetOidcStateAsync();
 
         var options = Options.Create(AspireFixture.Options);
-        var crypto = new SqlOSCryptoService(AspireFixture.SharedContext, options, new EphemeralDataProtectionProvider());
+        var crypto = new SqlOSCryptoService(AspireFixture.SharedContext, options, AspireFixture.DataProtectionProvider);
         var admin = new SqlOSAdminService(AspireFixture.SharedContext, options, crypto);
         var emailSender = new TestAuthEmailSender();
         var settings = new SqlOSSettingsService(AspireFixture.SharedContext, options, emailSender);
@@ -217,7 +216,7 @@ public sealed class OidcAuthIntegrationTests
         await ResetOidcStateAsync();
 
         var options = Options.Create(AspireFixture.Options);
-        var crypto = new SqlOSCryptoService(AspireFixture.SharedContext, options, new EphemeralDataProtectionProvider());
+        var crypto = new SqlOSCryptoService(AspireFixture.SharedContext, options, AspireFixture.DataProtectionProvider);
         var admin = new SqlOSAdminService(AspireFixture.SharedContext, options, crypto);
         var oidc = new SqlOSOidcAuthService(AspireFixture.SharedContext, admin, crypto, new FakeOidcProviderHttpClientFactory(), NullLogger<SqlOSOidcAuthService>.Instance);
         await EnsureClientAsync(admin, "example-web-apple");

--- a/tests/SqlOS.IntegrationTests/SamlServiceIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/SamlServiceIntegrationTests.cs
@@ -1,6 +1,7 @@
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Security.Cryptography.Xml;
+using System.Security;
 using System.Text;
 using System.IO.Compression;
 using System.Xml;
@@ -24,7 +25,7 @@ public sealed class SamlServiceIntegrationTests
     public async Task SignedSamlResponse_ProducesExchangeableAuthCode()
     {
         var options = Options.Create(AspireFixture.Options);
-        var crypto = new SqlOSCryptoService(AspireFixture.SharedContext, options);
+        var crypto = new SqlOSCryptoService(AspireFixture.SharedContext, options, AspireFixture.DataProtectionProvider);
         var admin = new SqlOSAdminService(AspireFixture.SharedContext, options, crypto);
         var saml = new SqlOSSamlService(AspireFixture.SharedContext, options, admin, crypto);
         var emailSender = new TestAuthEmailSender();
@@ -54,12 +55,9 @@ public sealed class SamlServiceIntegrationTests
             "first_name",
             "last_name"));
 
-        var authUrl = await saml.CreateAuthorizationUrlAsync(new SqlOSAuthorizationUrlRequest(connection.Id, client.ClientId, "https://client.example.local/callback"));
-        var requestToken = QueryHelpers.ParseQuery(new Uri($"https://localhost{authUrl}").Query)["requestToken"].ToString();
-        requestToken.Should().NotBeNull();
-
-        var samlResponse = BuildSignedSamlResponse(cert, "urn:test:idp", "user@example.com", "Saml", "User");
-        var redirectUrl = await saml.HandleAcsAsync(connection.Id, samlResponse, requestToken!, default);
+        var flow = await StartSamlRequestAsync(saml, connection.Id, client.ClientId);
+        var samlResponse = BuildSignedSamlResponse(cert, "urn:test:idp", "user@example.com", "Saml", "User", flow);
+        var redirectUrl = await saml.HandleAcsAsync(connection.Id, samlResponse, flow.RelayState, default);
         redirectUrl.Should().StartWith("https://client.example.local/callback?code=");
 
         var code = QueryHelpers.ParseQuery(new Uri(redirectUrl).Query)["code"].ToString();
@@ -74,7 +72,7 @@ public sealed class SamlServiceIntegrationTests
     public async Task PkceSamlAuthorizationFlow_CanExchangeCode()
     {
         var options = Options.Create(AspireFixture.Options);
-        var crypto = new SqlOSCryptoService(AspireFixture.SharedContext, options);
+        var crypto = new SqlOSCryptoService(AspireFixture.SharedContext, options, AspireFixture.DataProtectionProvider);
         var admin = new SqlOSAdminService(AspireFixture.SharedContext, options, crypto);
         var emailSender = new TestAuthEmailSender();
         var settings = new SqlOSSettingsService(AspireFixture.SharedContext, options, emailSender);
@@ -118,11 +116,11 @@ public sealed class SamlServiceIntegrationTests
             "S256"));
 
         start.AuthorizationUrl.Should().Contain("SAMLRequest=");
-        var relayState = QueryHelpers.ParseQuery(new Uri(start.AuthorizationUrl).Query)["RelayState"].ToString();
-        relayState.Should().NotBeNullOrWhiteSpace();
+        var flow = ParseSamlFlow(start.AuthorizationUrl);
+        flow.RelayState.Should().NotBeNullOrWhiteSpace();
 
-        var samlResponse = BuildSignedSamlResponse(certificate, "urn:pkce:idp", $"user@{domain}", "Pkce", "User");
-        var redirectUrl = await saml.HandleAcsAsync(connection.Id, samlResponse, relayState!, default);
+        var samlResponse = BuildSignedSamlResponse(certificate, "urn:pkce:idp", $"user@{domain}", "Pkce", "User", flow);
+        var redirectUrl = await saml.HandleAcsAsync(connection.Id, samlResponse, flow.RelayState, default);
         redirectUrl.Should().Contain("state=");
 
         var query = QueryHelpers.ParseQuery(new Uri(redirectUrl).Query);
@@ -141,7 +139,7 @@ public sealed class SamlServiceIntegrationTests
     public async Task SignedSamlResponse_WithExistingEmail_ReusesUserWhenAutoProvisioning()
     {
         var options = Options.Create(AspireFixture.Options);
-        var crypto = new SqlOSCryptoService(AspireFixture.SharedContext, options);
+        var crypto = new SqlOSCryptoService(AspireFixture.SharedContext, options, AspireFixture.DataProtectionProvider);
         var admin = new SqlOSAdminService(AspireFixture.SharedContext, options, crypto);
         var saml = new SqlOSSamlService(AspireFixture.SharedContext, options, admin, crypto);
 
@@ -169,12 +167,9 @@ public sealed class SamlServiceIntegrationTests
             "first_name",
             "last_name"));
 
-        var authUrl = await saml.CreateAuthorizationUrlAsync(new SqlOSAuthorizationUrlRequest(connection.Id, client.ClientId, "https://client.example.local/callback"));
-        var requestToken = QueryHelpers.ParseQuery(new Uri($"https://localhost{authUrl}").Query)["requestToken"].ToString();
-        requestToken.Should().NotBeNull();
-
-        var samlResponse = BuildSignedSamlResponse(certificate, "urn:existing:idp", email, "Existing", "User");
-        var redirectUrl = await saml.HandleAcsAsync(connection.Id, samlResponse, requestToken!, default);
+        var flow = await StartSamlRequestAsync(saml, connection.Id, client.ClientId);
+        var samlResponse = BuildSignedSamlResponse(certificate, "urn:existing:idp", email, "Existing", "User", flow);
+        var redirectUrl = await saml.HandleAcsAsync(connection.Id, samlResponse, flow.RelayState, default);
         redirectUrl.Should().StartWith("https://client.example.local/callback?code=");
 
         var normalizedEmail = SqlOSAdminService.NormalizeEmail(email);
@@ -227,9 +222,9 @@ public sealed class SamlServiceIntegrationTests
             "first_name",
             "last_name"));
 
-        var requestToken = await CreateRequestTokenAsync(saml, connection.Id, client.ClientId);
-        var samlResponse = BuildSignedSamlResponse(certificate, "urn:existing-member:idp", email, "Existing", "Member");
-        var redirectUrl = await saml.HandleAcsAsync(connection.Id, samlResponse, requestToken, default);
+        var flow = await StartSamlRequestAsync(saml, connection.Id, client.ClientId);
+        var samlResponse = BuildSignedSamlResponse(certificate, "urn:existing-member:idp", email, "Existing", "Member", flow);
+        var redirectUrl = await saml.HandleAcsAsync(connection.Id, samlResponse, flow.RelayState, default);
 
         redirectUrl.Should().StartWith("https://client.example.local/callback?code=");
         var normalizedEmail = SqlOSAdminService.NormalizeEmail(email);
@@ -267,9 +262,9 @@ public sealed class SamlServiceIntegrationTests
             "first_name",
             "last_name"));
 
-        var requestToken = await CreateRequestTokenAsync(saml, connection.Id, client.ClientId);
-        var samlResponse = BuildSignedSamlResponse(certificate, "urn:existing-nonmember:idp", email, "Existing", "Nonmember");
-        var action = async () => await saml.HandleAcsAsync(connection.Id, samlResponse, requestToken, default);
+        var flow = await StartSamlRequestAsync(saml, connection.Id, client.ClientId);
+        var samlResponse = BuildSignedSamlResponse(certificate, "urn:existing-nonmember:idp", email, "Existing", "Nonmember", flow);
+        var action = async () => await saml.HandleAcsAsync(connection.Id, samlResponse, flow.RelayState, default);
 
         await action.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("No user could be resolved from the SAML assertion.");
@@ -302,9 +297,9 @@ public sealed class SamlServiceIntegrationTests
             "first_name",
             "last_name"));
 
-        var requestToken = await CreateRequestTokenAsync(saml, connection.Id, client.ClientId);
-        var samlResponse = BuildSignedSamlResponse(certificate, "urn:missing-jit-off:idp", email, "Missing", "User");
-        var action = async () => await saml.HandleAcsAsync(connection.Id, samlResponse, requestToken, default);
+        var flow = await StartSamlRequestAsync(saml, connection.Id, client.ClientId);
+        var samlResponse = BuildSignedSamlResponse(certificate, "urn:missing-jit-off:idp", email, "Missing", "User", flow);
+        var action = async () => await saml.HandleAcsAsync(connection.Id, samlResponse, flow.RelayState, default);
 
         await action.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("No user could be resolved from the SAML assertion.");
@@ -317,7 +312,7 @@ public sealed class SamlServiceIntegrationTests
     public async Task AuthorizationUrl_UsesRedirectBindingDeflateEncoding()
     {
         var options = Options.Create(AspireFixture.Options);
-        var crypto = new SqlOSCryptoService(AspireFixture.SharedContext, options);
+        var crypto = new SqlOSCryptoService(AspireFixture.SharedContext, options, AspireFixture.DataProtectionProvider);
         var admin = new SqlOSAdminService(AspireFixture.SharedContext, options, crypto);
         var saml = new SqlOSSamlService(AspireFixture.SharedContext, options, admin, crypto);
 
@@ -361,10 +356,218 @@ public sealed class SamlServiceIntegrationTests
         xml.Should().Contain(connection.SingleSignOnUrl);
     }
 
+    [TestMethod]
+    public async Task SignedSamlResponse_WithExtraUnsignedAssertion_IsRejected()
+    {
+        var (_, admin, saml) = CreateSamlServices();
+        var org = await admin.CreateOrganizationAsync(new SqlOSCreateOrganizationRequest($"Wrapping {Guid.NewGuid():N}", null));
+        var client = await CreateSamlClientAsync(admin, "wrapping");
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest("CN=SqlOSWrappingSamlIdP", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        var certificate = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(30));
+        var connection = await admin.CreateSsoConnectionAsync(new SqlOSCreateSsoConnectionRequest(
+            org.Id,
+            "Wrapping SSO",
+            "urn:wrapping:idp",
+            "https://idp.example.test/sso",
+            certificate.ExportCertificatePem(),
+            true,
+            false,
+            "email",
+            "first_name",
+            "last_name"));
+
+        var flow = await StartSamlRequestAsync(saml, connection.Id, client.ClientId);
+        var samlResponse = BuildSignedSamlResponse(
+            certificate,
+            "urn:wrapping:idp",
+            "legitimate@example.com",
+            "Legitimate",
+            "User",
+            flow,
+            signAssertion: true,
+            addExtraUnsignedAssertion: true);
+        var action = async () => await saml.HandleAcsAsync(connection.Id, samlResponse, flow.RelayState, default);
+
+        await action.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("SAML response must contain exactly one assertion.");
+    }
+
+    [TestMethod]
+    public async Task SignedSamlResponse_WithWrongAudience_IsRejected()
+    {
+        var (_, admin, saml) = CreateSamlServices();
+        var org = await admin.CreateOrganizationAsync(new SqlOSCreateOrganizationRequest($"Audience {Guid.NewGuid():N}", null));
+        var client = await CreateSamlClientAsync(admin, "audience");
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest("CN=SqlOSAudienceSamlIdP", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        var certificate = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(30));
+        var connection = await admin.CreateSsoConnectionAsync(new SqlOSCreateSsoConnectionRequest(
+            org.Id,
+            "Audience SSO",
+            "urn:audience:idp",
+            "https://idp.example.test/sso",
+            certificate.ExportCertificatePem(),
+            true,
+            false,
+            "email",
+            "first_name",
+            "last_name"));
+
+        var flow = await StartSamlRequestAsync(saml, connection.Id, client.ClientId);
+        var samlResponse = BuildSignedSamlResponse(certificate, "urn:audience:idp", "user@example.com", "Audience", "User", flow, audience: "urn:wrong:audience");
+        var action = async () => await saml.HandleAcsAsync(connection.Id, samlResponse, flow.RelayState, default);
+
+        await action.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("SAML assertion audience mismatch.");
+    }
+
+    [TestMethod]
+    public async Task SignedSamlResponse_WithWrongInResponseTo_IsRejected()
+    {
+        var (_, admin, saml) = CreateSamlServices();
+        var org = await admin.CreateOrganizationAsync(new SqlOSCreateOrganizationRequest($"InResponseTo {Guid.NewGuid():N}", null));
+        var client = await CreateSamlClientAsync(admin, "inresponse");
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest("CN=SqlOSInResponseSamlIdP", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        var certificate = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(30));
+        var connection = await admin.CreateSsoConnectionAsync(new SqlOSCreateSsoConnectionRequest(
+            org.Id,
+            "InResponseTo SSO",
+            "urn:inresponse:idp",
+            "https://idp.example.test/sso",
+            certificate.ExportCertificatePem(),
+            true,
+            false,
+            "email",
+            "first_name",
+            "last_name"));
+
+        var flow = await StartSamlRequestAsync(saml, connection.Id, client.ClientId);
+        var samlResponse = BuildSignedSamlResponse(certificate, "urn:inresponse:idp", "user@example.com", "Response", "User", flow, inResponseTo: "_wrong");
+        var action = async () => await saml.HandleAcsAsync(connection.Id, samlResponse, flow.RelayState, default);
+
+        await action.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("SAML response InResponseTo mismatch.");
+    }
+
+    [TestMethod]
+    public async Task SignedSamlResponse_WithExpiredAssertion_IsRejected()
+    {
+        var (_, admin, saml) = CreateSamlServices();
+        var org = await admin.CreateOrganizationAsync(new SqlOSCreateOrganizationRequest($"Expired {Guid.NewGuid():N}", null));
+        var client = await CreateSamlClientAsync(admin, "expired");
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest("CN=SqlOSExpiredSamlIdP", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        var certificate = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(30));
+        var connection = await admin.CreateSsoConnectionAsync(new SqlOSCreateSsoConnectionRequest(
+            org.Id,
+            "Expired SSO",
+            "urn:expired:idp",
+            "https://idp.example.test/sso",
+            certificate.ExportCertificatePem(),
+            true,
+            false,
+            "email",
+            "first_name",
+            "last_name"));
+
+        var flow = await StartSamlRequestAsync(saml, connection.Id, client.ClientId);
+        var samlResponse = BuildSignedSamlResponse(
+            certificate,
+            "urn:expired:idp",
+            "user@example.com",
+            "Expired",
+            "User",
+            flow,
+            notBefore: DateTime.UtcNow.AddMinutes(-20),
+            notOnOrAfter: DateTime.UtcNow.AddMinutes(-10));
+        var action = async () => await saml.HandleAcsAsync(connection.Id, samlResponse, flow.RelayState, default);
+
+        await action.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("SAML assertion has expired.");
+    }
+
+    [TestMethod]
+    public async Task SignedSamlResponse_WithSha1Signature_IsRejected()
+    {
+        var (_, admin, saml) = CreateSamlServices();
+        var org = await admin.CreateOrganizationAsync(new SqlOSCreateOrganizationRequest($"Sha1 {Guid.NewGuid():N}", null));
+        var client = await CreateSamlClientAsync(admin, "sha1");
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest("CN=SqlOSSha1SamlIdP", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        var certificate = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(30));
+        var connection = await admin.CreateSsoConnectionAsync(new SqlOSCreateSsoConnectionRequest(
+            org.Id,
+            "Sha1 SSO",
+            "urn:sha1:idp",
+            "https://idp.example.test/sso",
+            certificate.ExportCertificatePem(),
+            true,
+            false,
+            "email",
+            "first_name",
+            "last_name"));
+
+        var flow = await StartSamlRequestAsync(saml, connection.Id, client.ClientId);
+        var samlResponse = BuildSignedSamlResponse(
+            certificate,
+            "urn:sha1:idp",
+            "user@example.com",
+            "Sha",
+            "One",
+            flow,
+            mutateAfterSigning: (document, _) =>
+            {
+                var signatureMethod = document.GetElementsByTagName("SignatureMethod", SignedXml.XmlDsigNamespaceUrl).OfType<XmlElement>().Single();
+                signatureMethod.SetAttribute("Algorithm", SignedXml.XmlDsigRSASHA1Url);
+            });
+        var action = async () => await saml.HandleAcsAsync(connection.Id, samlResponse, flow.RelayState, default);
+
+        await action.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("SAML signature algorithm is not allowed.");
+    }
+
+    [TestMethod]
+    public async Task SamlResponse_WithDtd_IsRejectedBeforeXmlEntityResolution()
+    {
+        var (_, admin, saml) = CreateSamlServices();
+        var org = await admin.CreateOrganizationAsync(new SqlOSCreateOrganizationRequest($"Dtd {Guid.NewGuid():N}", null));
+        var client = await CreateSamlClientAsync(admin, "dtd");
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest("CN=SqlOSDtdSamlIdP", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        var certificate = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(30));
+        var connection = await admin.CreateSsoConnectionAsync(new SqlOSCreateSsoConnectionRequest(
+            org.Id,
+            "Dtd SSO",
+            "urn:dtd:idp",
+            "https://idp.example.test/sso",
+            certificate.ExportCertificatePem(),
+            true,
+            false,
+            "email",
+            "first_name",
+            "last_name"));
+
+        var flow = await StartSamlRequestAsync(saml, connection.Id, client.ClientId);
+        var xml = """
+        <!DOCTYPE samlp:Response [
+          <!ENTITY xxe SYSTEM "file:///etc/passwd">
+        ]>
+        <samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_dtd" Version="2.0">
+          <saml:Issuer>&xxe;</saml:Issuer>
+        </samlp:Response>
+        """;
+        var samlResponse = Convert.ToBase64String(Encoding.UTF8.GetBytes(xml));
+        var action = async () => await saml.HandleAcsAsync(connection.Id, samlResponse, flow.RelayState, default);
+
+        await action.Should().ThrowAsync<XmlException>();
+    }
+
     private static (SqlOSCryptoService Crypto, SqlOSAdminService Admin, SqlOSSamlService Saml) CreateSamlServices()
     {
         var options = Options.Create(AspireFixture.Options);
-        var crypto = new SqlOSCryptoService(AspireFixture.SharedContext, options);
+        var crypto = new SqlOSCryptoService(AspireFixture.SharedContext, options, AspireFixture.DataProtectionProvider);
         var admin = new SqlOSAdminService(AspireFixture.SharedContext, options, crypto);
         var saml = new SqlOSSamlService(AspireFixture.SharedContext, options, admin, crypto);
         return (crypto, admin, saml);
@@ -377,13 +580,19 @@ public sealed class SamlServiceIntegrationTests
             "sqlos-tests",
             new List<string> { "https://client.example.local/callback" }));
 
-    private static async Task<string> CreateRequestTokenAsync(SqlOSSamlService saml, string connectionId, string clientId)
+    private static async Task<SamlFlow> StartSamlRequestAsync(SqlOSSamlService saml, string connectionId, string clientId)
     {
         var authUrl = await saml.CreateAuthorizationUrlAsync(new SqlOSAuthorizationUrlRequest(
             connectionId,
             clientId,
             "https://client.example.local/callback"));
-        return QueryHelpers.ParseQuery(new Uri($"https://localhost{authUrl}").Query)["requestToken"].ToString();
+        var requestToken = QueryHelpers.ParseQuery(new Uri($"https://localhost{authUrl}").Query)["requestToken"].ToString();
+        requestToken.Should().NotBeNullOrWhiteSpace();
+
+        var loginUrl = await saml.BuildIdentityProviderRedirectAsync(connectionId, requestToken!);
+        var flow = ParseSamlFlow(loginUrl);
+        flow.RelayState.Should().Be(requestToken);
+        return flow;
     }
 
     private static async Task MarkEmailVerifiedAsync(string userId)
@@ -399,24 +608,51 @@ public sealed class SamlServiceIntegrationTests
         string issuer,
         string email,
         string firstName,
-        string lastName)
+        string lastName,
+        SamlFlow flow,
+        bool signAssertion = false,
+        bool includeConditions = true,
+        bool addExtraUnsignedAssertion = false,
+        string? audience = null,
+        string? recipient = null,
+        string? inResponseTo = null,
+        DateTime? notBefore = null,
+        DateTime? notOnOrAfter = null,
+        Action<XmlDocument, XmlElement, XmlElement>? mutateBeforeSigning = null,
+        Action<XmlDocument, XmlElement>? mutateAfterSigning = null)
     {
         var responseId = $"_{Guid.NewGuid():N}";
         var assertionId = $"_{Guid.NewGuid():N}";
         var issueInstant = DateTime.UtcNow.ToString("o");
+        var effectiveAudience = audience ?? AspireFixture.Options.Issuer;
+        var effectiveRecipient = recipient ?? flow.AssertionConsumerServiceUrl;
+        var effectiveInResponseTo = inResponseTo ?? flow.RequestId;
+        var effectiveNotBefore = (notBefore ?? DateTime.UtcNow.AddMinutes(-1)).ToString("o");
+        var effectiveNotOnOrAfter = (notOnOrAfter ?? DateTime.UtcNow.AddMinutes(5)).ToString("o");
+        var conditionsXml = includeConditions
+            ? $"""
+                <saml:Conditions NotBefore="{effectiveNotBefore}" NotOnOrAfter="{effectiveNotOnOrAfter}">
+                  <saml:AudienceRestriction><saml:Audience>{SecurityElement.Escape(effectiveAudience)}</saml:Audience></saml:AudienceRestriction>
+                </saml:Conditions>
+            """
+            : string.Empty;
         var xml = $"""
-        <samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="{responseId}" Version="2.0" IssueInstant="{issueInstant}">
-          <saml:Issuer>{issuer}</saml:Issuer>
+        <samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="{responseId}" Version="2.0" IssueInstant="{issueInstant}" Destination="{effectiveRecipient}" InResponseTo="{effectiveInResponseTo}">
+          <saml:Issuer>{SecurityElement.Escape(issuer)}</saml:Issuer>
           <samlp:Status><samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success" /></samlp:Status>
           <saml:Assertion ID="{assertionId}" Version="2.0" IssueInstant="{issueInstant}">
-            <saml:Issuer>{issuer}</saml:Issuer>
+            <saml:Issuer>{SecurityElement.Escape(issuer)}</saml:Issuer>
             <saml:Subject>
-              <saml:NameID>{email}</saml:NameID>
+              <saml:NameID>{SecurityElement.Escape(email)}</saml:NameID>
+              <saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+                <saml:SubjectConfirmationData InResponseTo="{effectiveInResponseTo}" Recipient="{effectiveRecipient}" NotOnOrAfter="{effectiveNotOnOrAfter}" />
+              </saml:SubjectConfirmation>
             </saml:Subject>
+            {conditionsXml}
             <saml:AttributeStatement>
-              <saml:Attribute Name="email"><saml:AttributeValue>{email}</saml:AttributeValue></saml:Attribute>
-              <saml:Attribute Name="first_name"><saml:AttributeValue>{firstName}</saml:AttributeValue></saml:Attribute>
-              <saml:Attribute Name="last_name"><saml:AttributeValue>{lastName}</saml:AttributeValue></saml:Attribute>
+              <saml:Attribute Name="email"><saml:AttributeValue>{SecurityElement.Escape(email)}</saml:AttributeValue></saml:Attribute>
+              <saml:Attribute Name="first_name"><saml:AttributeValue>{SecurityElement.Escape(firstName)}</saml:AttributeValue></saml:Attribute>
+              <saml:Attribute Name="last_name"><saml:AttributeValue>{SecurityElement.Escape(lastName)}</saml:AttributeValue></saml:Attribute>
             </saml:AttributeStatement>
           </saml:Assertion>
         </samlp:Response>
@@ -425,23 +661,60 @@ public sealed class SamlServiceIntegrationTests
         var xmlDoc = new XmlDocument { PreserveWhitespace = true };
         xmlDoc.LoadXml(xml);
         var responseElement = xmlDoc.DocumentElement!;
+        var assertionElement = (XmlElement)responseElement.GetElementsByTagName("Assertion", "urn:oasis:names:tc:SAML:2.0:assertion")[0]!;
+        if (addExtraUnsignedAssertion)
+        {
+            var extraAssertion = xmlDoc.CreateElement("saml", "Assertion", "urn:oasis:names:tc:SAML:2.0:assertion");
+            extraAssertion.SetAttribute("ID", $"_{Guid.NewGuid():N}");
+            extraAssertion.SetAttribute("Version", "2.0");
+            extraAssertion.SetAttribute("IssueInstant", issueInstant);
+            extraAssertion.InnerXml = $"""
+              <saml:Issuer xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">{SecurityElement.Escape(issuer)}</saml:Issuer>
+              <saml:Subject xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
+                <saml:NameID>attacker@example.com</saml:NameID>
+              </saml:Subject>
+            """;
+            responseElement.InsertBefore(extraAssertion, assertionElement);
+        }
+
+        mutateBeforeSigning?.Invoke(xmlDoc, responseElement, assertionElement);
         var privateKey = certificate.GetRSAPrivateKey()
             ?? throw new InvalidOperationException("Test certificate does not contain an RSA private key.");
-        var signedXml = new SignedXml(responseElement)
+        var signedElement = signAssertion ? assertionElement : responseElement;
+        var signedXml = new SignedXml(signedElement)
         {
             SigningKey = privateKey
         };
         signedXml.SignedInfo!.CanonicalizationMethod = SignedXml.XmlDsigExcC14NTransformUrl;
         signedXml.SignedInfo.SignatureMethod = SignedXml.XmlDsigRSASHA256Url;
-        var reference = new Reference { Uri = $"#{responseId}" };
+        var reference = new Reference { Uri = $"#{signedElement.GetAttribute("ID")}", DigestMethod = SignedXml.XmlDsigSHA256Url };
         reference.AddTransform(new XmlDsigEnvelopedSignatureTransform());
         reference.AddTransform(new XmlDsigExcC14NTransform());
         signedXml.AddReference(reference);
         signedXml.KeyInfo = new KeyInfo();
         signedXml.KeyInfo.AddClause(new KeyInfoX509Data(certificate));
         signedXml.ComputeSignature();
-        responseElement.InsertAfter(xmlDoc.ImportNode(signedXml.GetXml(), true), responseElement.FirstChild);
+        signedElement.InsertAfter(xmlDoc.ImportNode(signedXml.GetXml(), true), signedElement.FirstChild);
+        mutateAfterSigning?.Invoke(xmlDoc, responseElement);
         return Convert.ToBase64String(Encoding.UTF8.GetBytes(xmlDoc.OuterXml));
+    }
+
+    private static SamlFlow ParseSamlFlow(string loginUrl)
+    {
+        var query = QueryHelpers.ParseQuery(new Uri(loginUrl).Query);
+        var relayState = query["RelayState"].ToString();
+        var samlRequest = query["SAMLRequest"].ToString();
+        relayState.Should().NotBeNullOrWhiteSpace();
+        samlRequest.Should().NotBeNullOrWhiteSpace();
+
+        var xml = InflateSamlRequest(samlRequest!);
+        var xmlDoc = new XmlDocument { XmlResolver = null };
+        xmlDoc.LoadXml(xml);
+        var root = xmlDoc.DocumentElement!;
+        return new SamlFlow(
+            relayState!,
+            root.GetAttribute("ID"),
+            root.GetAttribute("AssertionConsumerServiceURL"));
     }
 
     private static string InflateSamlRequest(string samlRequest)
@@ -452,4 +725,6 @@ public sealed class SamlServiceIntegrationTests
         using var reader = new StreamReader(inflater, Encoding.UTF8);
         return reader.ReadToEnd();
     }
+
+    private sealed record SamlFlow(string RelayState, string RequestId, string AssertionConsumerServiceUrl);
 }

--- a/tests/SqlOS.Tests/Fga/SqlOSFgaSubjectServiceTests.cs
+++ b/tests/SqlOS.Tests/Fga/SqlOSFgaSubjectServiceTests.cs
@@ -1,6 +1,9 @@
+using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SqlOS.Fga.Configuration;
 using SqlOS.Fga.Extensions;
 using SqlOS.Fga.Interfaces;
 using SqlOS.Fga.Models;
@@ -56,6 +59,47 @@ public class SqlOSFgaSubjectServiceTests
     public void Cleanup()
     {
         _context.Dispose();
+    }
+
+    [TestMethod]
+    public void CreateResource_WhenParentIsSelf_Throws()
+    {
+        Assert.ThrowsException<InvalidOperationException>(() =>
+            _context.CreateResource("res_self", "Self", "root", id: "res_self"));
+    }
+
+    [TestMethod]
+    public void CreateResource_WhenExistingParentChainHasCycle_Throws()
+    {
+        _context.Set<SqlOSFgaResource>().AddRange(
+            new SqlOSFgaResource { Id = "res_a", ParentId = "res_b", Name = "A", ResourceTypeId = "root" },
+            new SqlOSFgaResource { Id = "res_b", ParentId = "res_a", Name = "B", ResourceTypeId = "root" });
+        _context.SaveChanges();
+
+        Assert.ThrowsException<InvalidOperationException>(() =>
+            _context.CreateResource("res_a", "Child", "root", id: "res_child"));
+    }
+
+    [TestMethod]
+    public async Task GetAuthorizationFilterAsync_UsesCapturedParametersInsteadOfLiteralConstants()
+    {
+        _context.Set<SqlOSFgaPermission>().Add(new SqlOSFgaPermission
+        {
+            Id = "perm_read",
+            Key = "READ",
+            Name = "Read"
+        });
+        _context.SaveChanges();
+        var authService = new SqlOSFgaAuthService(
+            _context,
+            Options.Create(new SqlOSFgaOptions()),
+            NullLogger<SqlOSFgaAuthService>.Instance);
+
+        var filter = await authService.GetAuthorizationFilterAsync<TestProtectedEntity>("subj_user", "READ");
+        var constants = ConstantCollector.Collect(filter);
+
+        Assert.IsFalse(constants.Contains("subj_user"));
+        Assert.IsFalse(constants.Contains("perm_read"));
     }
 
     [TestMethod]
@@ -208,5 +252,28 @@ public class SqlOSFgaSubjectServiceTests
         var groups = await _service.GetGroupsForSubjectAsync(agent.SubjectId);
         Assert.AreEqual(1, groups.Count);
         Assert.AreEqual(group.Id, groups[0].Id);
+    }
+
+    private sealed class TestProtectedEntity : IHasResourceId
+    {
+        public string ResourceId { get; set; } = string.Empty;
+    }
+
+    private sealed class ConstantCollector : ExpressionVisitor
+    {
+        private readonly List<object?> _values = new();
+
+        public static List<object?> Collect(Expression expression)
+        {
+            var collector = new ConstantCollector();
+            collector.Visit(expression);
+            return collector._values;
+        }
+
+        protected override Expression VisitConstant(ConstantExpression node)
+        {
+            _values.Add(node.Value);
+            return base.VisitConstant(node);
+        }
     }
 }

--- a/tests/SqlOS.Tests/SqlOSCryptoServiceTests.cs
+++ b/tests/SqlOS.Tests/SqlOSCryptoServiceTests.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SqlOS.AuthServer.Configuration;
+using SqlOS.AuthServer.Models;
 using SqlOS.AuthServer.Services;
 using SqlOS.Tests.Infrastructure;
 
@@ -34,6 +35,85 @@ public sealed class SqlOSCryptoServiceTests
         var second = await service.EnsureActiveSigningKeyAsync();
 
         second.Id.Should().Be(first.Id);
+    }
+
+    [TestMethod]
+    public async Task EnsureActiveSigningKey_WithDataProtection_StoresProtectedPrivateKey()
+    {
+        using var context = CreateContext();
+        var service = new SqlOSCryptoService(
+            context,
+            Options.Create(new SqlOSAuthServerOptions()),
+            new EphemeralDataProtectionProvider());
+
+        var key = await service.EnsureActiveSigningKeyAsync();
+
+        key.PrivateKeyPem.Should().StartWith("dp:");
+        key.PrivateKeyPem.Should().NotContain("BEGIN PRIVATE KEY");
+        service.UnprotectSecret(key.PrivateKeyPem).Should().Contain("BEGIN PRIVATE KEY");
+    }
+
+    [TestMethod]
+    public async Task EnsureActiveSigningKey_WithDataProtection_ProtectsLegacyPlaintextPrivateKey()
+    {
+        using var context = CreateContext();
+        var plaintextService = new SqlOSCryptoService(context, Options.Create(new SqlOSAuthServerOptions()));
+        var legacyKey = await plaintextService.EnsureActiveSigningKeyAsync();
+        legacyKey.PrivateKeyPem.Should().Contain("BEGIN PRIVATE KEY");
+
+        var protectedService = new SqlOSCryptoService(
+            context,
+            Options.Create(new SqlOSAuthServerOptions()),
+            new EphemeralDataProtectionProvider());
+
+        var upgradedKey = await protectedService.EnsureActiveSigningKeyAsync();
+
+        upgradedKey.Id.Should().Be(legacyKey.Id);
+        upgradedKey.PrivateKeyPem.Should().StartWith("dp:");
+        protectedService.UnprotectSecret(upgradedKey.PrivateKeyPem).Should().Contain("BEGIN PRIVATE KEY");
+    }
+
+    [TestMethod]
+    public async Task CreateAccessToken_WithProtectedSigningKey_Succeeds()
+    {
+        using var context = CreateContext();
+        var service = new SqlOSCryptoService(
+            context,
+            Options.Create(new SqlOSAuthServerOptions()),
+            new EphemeralDataProtectionProvider());
+        await service.EnsureActiveSigningKeyAsync();
+
+        var user = new SqlOSUser
+        {
+            Id = "usr_test",
+            DisplayName = "Test User",
+            DefaultEmail = "test@example.com",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+        var session = new SqlOSSession
+        {
+            Id = "ses_test",
+            UserId = user.Id,
+            AuthenticationMethod = "password",
+            CreatedAt = DateTime.UtcNow,
+            LastSeenAt = DateTime.UtcNow,
+            IdleExpiresAt = DateTime.UtcNow.AddHours(1),
+            AbsoluteExpiresAt = DateTime.UtcNow.AddHours(1)
+        };
+        var client = new SqlOSClientApplication
+        {
+            Id = "cli_test",
+            ClientId = "test-client",
+            Name = "Test Client",
+            Audience = "test-api",
+            CreatedAt = DateTime.UtcNow
+        };
+
+        var token = await service.CreateAccessTokenAsync(user, session, client, "org_test");
+
+        token.Should().NotBeNullOrWhiteSpace();
+        context.Set<SqlOSSigningKey>().Single().PrivateKeyPem.Should().StartWith("dp:");
     }
 
     [TestMethod]

--- a/web/content/docs/authserver/overview.mdx
+++ b/web/content/docs/authserver/overview.mdx
@@ -83,6 +83,12 @@ Open `/sqlos/admin/auth/`. Manage orgs, users, memberships, clients, OIDC, SSO, 
 | `SqlOSOidcAuthService` | Google, Microsoft, Apple, and custom OIDC |
 | `SqlOSSettingsService` | Session lifetimes and security configuration |
 
+## Signing keys and protected secrets
+
+SqlOS stores JWT signing keys in your application database. Private signing key PEMs are protected with `SqlOSCryptoService.ProtectSecret` when ASP.NET Data Protection is available, and legacy plaintext rows are upgraded the next time the active key is loaded.
+
+Production deployments should configure a durable Data Protection key ring outside the application database. If Data Protection keys are lost, existing protected signing keys and other protected secrets cannot be unprotected.
+
 ## Hosted and headless
 
 <Accordion>


### PR DESCRIPTION
Closes #95

## Summary
- Bind SAML claim consumption to the signed Response/Assertion reference, reject wrapping-style multi-assertion responses, pin XML signature/digest algorithms and transforms, and validate assertion conditions, audience, recipient, and request correlation.
- Protect JWT signing private keys with ASP.NET Core Data Protection when available, migrate legacy plaintext active keys opportunistically, and document the durable key-ring requirement.
- Add FGA authorization indexes, bound hierarchy recursion, detect cycles during resource creation/traversal, and parameterize authorization filter inputs.

## Validation
- dotnet test SqlOS.sln
- dotnet build tests/SqlOS.IntegrationTests/SqlOS.IntegrationTests.csproj
- npm ci (web)
- npm run build (web)
- npm run lint (web)

## Notes
- `dotnet test SqlOS.sln` reports that `examples/SqlOS.Example.Tests` has no discovered tests, but the command exits successfully and the unit/integration projects pass.