### PR TITLE
Repair application assignment schema migration

### DIFF
--- a/src/SqlOS/AuthServer/Schema/024_RepairApplicationAssignments.sql
+++ b/src/SqlOS/AuthServer/Schema/024_RepairApplicationAssignments.sql
@@ -1,0 +1,117 @@
+IF OBJECT_ID('{Schema}.SqlOSClientApplications', 'U') IS NOT NULL
+   AND COL_LENGTH('{Schema}.SqlOSClientApplications', 'AccessMode') IS NULL
+BEGIN
+    ALTER TABLE [{Schema}].[SqlOSClientApplications]
+    ADD [AccessMode] NVARCHAR(40) NOT NULL
+        CONSTRAINT [DF_SqlOSClientApplications_AccessMode] DEFAULT 'all_organizations';
+END
+
+GO
+
+IF OBJECT_ID('{Schema}.SqlOSSessions', 'U') IS NOT NULL
+   AND COL_LENGTH('{Schema}.SqlOSSessions', 'OrganizationId') IS NULL
+BEGIN
+    ALTER TABLE [{Schema}].[SqlOSSessions]
+    ADD [OrganizationId] NVARCHAR(64) NULL;
+END
+
+GO
+
+IF OBJECT_ID('{Schema}.SqlOSSessions', 'U') IS NOT NULL
+   AND OBJECT_ID('{Schema}.SqlOSOrganizations', 'U') IS NOT NULL
+   AND COL_LENGTH('{Schema}.SqlOSSessions', 'OrganizationId') IS NOT NULL
+   AND NOT EXISTS (
+       SELECT 1
+       FROM sys.foreign_keys
+       WHERE name = 'FK_SqlOSSessions_Organizations'
+         AND parent_object_id = OBJECT_ID('{Schema}.SqlOSSessions')
+   )
+BEGIN
+    ALTER TABLE [{Schema}].[SqlOSSessions]
+    ADD CONSTRAINT [FK_SqlOSSessions_Organizations]
+    FOREIGN KEY ([OrganizationId]) REFERENCES [{Schema}].[SqlOSOrganizations]([Id]);
+END
+
+GO
+
+IF OBJECT_ID('{Schema}.SqlOSApplicationAssignments', 'U') IS NULL
+   AND OBJECT_ID('{Schema}.SqlOSClientApplications', 'U') IS NOT NULL
+   AND OBJECT_ID('{Schema}.SqlOSOrganizations', 'U') IS NOT NULL
+BEGIN
+    CREATE TABLE [{Schema}].[SqlOSApplicationAssignments]
+    (
+        [Id] NVARCHAR(64) NOT NULL,
+        [ClientApplicationId] NVARCHAR(64) NOT NULL,
+        [OrganizationId] NVARCHAR(64) NULL,
+        [PrincipalType] NVARCHAR(40) NOT NULL,
+        [PrincipalId] NVARCHAR(128) NULL,
+        [RoleKey] NVARCHAR(80) NULL,
+        [Access] NVARCHAR(20) NOT NULL,
+        [Reason] NVARCHAR(500) NULL,
+        [CreatedAt] DATETIME2 NOT NULL,
+        [CreatedByActorType] NVARCHAR(80) NULL,
+        [CreatedByActorId] NVARCHAR(128) NULL,
+        [RevokedAt] DATETIME2 NULL,
+        [RevokedByActorType] NVARCHAR(80) NULL,
+        [RevokedByActorId] NVARCHAR(128) NULL,
+        CONSTRAINT [PK_SqlOSApplicationAssignments] PRIMARY KEY ([Id]),
+        CONSTRAINT [FK_SqlOSApplicationAssignments_ClientApplication] FOREIGN KEY ([ClientApplicationId]) REFERENCES [{Schema}].[SqlOSClientApplications]([Id]),
+        CONSTRAINT [FK_SqlOSApplicationAssignments_Organization] FOREIGN KEY ([OrganizationId]) REFERENCES [{Schema}].[SqlOSOrganizations]([Id])
+    );
+END
+
+GO
+
+IF OBJECT_ID('{Schema}.SqlOSClientApplications', 'U') IS NOT NULL
+   AND COL_LENGTH('{Schema}.SqlOSClientApplications', 'AccessMode') IS NOT NULL
+   AND NOT EXISTS (
+       SELECT 1
+       FROM sys.indexes
+       WHERE name = 'IX_SqlOSClientApplications_AccessMode'
+         AND object_id = OBJECT_ID('{Schema}.SqlOSClientApplications')
+   )
+BEGIN
+    CREATE INDEX [IX_SqlOSClientApplications_AccessMode]
+    ON [{Schema}].[SqlOSClientApplications]([AccessMode]);
+END
+
+IF OBJECT_ID('{Schema}.SqlOSApplicationAssignments', 'U') IS NOT NULL
+   AND NOT EXISTS (
+       SELECT 1
+       FROM sys.indexes
+       WHERE name = 'IX_SqlOSApplicationAssignments_Target'
+         AND object_id = OBJECT_ID('{Schema}.SqlOSApplicationAssignments')
+   )
+BEGIN
+    CREATE INDEX [IX_SqlOSApplicationAssignments_Target]
+    ON [{Schema}].[SqlOSApplicationAssignments]([ClientApplicationId], [PrincipalType], [PrincipalId], [OrganizationId], [RoleKey], [RevokedAt]);
+END
+
+IF OBJECT_ID('{Schema}.SqlOSApplicationAssignments', 'U') IS NOT NULL
+   AND NOT EXISTS (
+       SELECT 1
+       FROM sys.indexes
+       WHERE name = 'IX_SqlOSApplicationAssignments_ClientApplicationId_RevokedAt'
+         AND object_id = OBJECT_ID('{Schema}.SqlOSApplicationAssignments')
+   )
+BEGIN
+    CREATE INDEX [IX_SqlOSApplicationAssignments_ClientApplicationId_RevokedAt]
+    ON [{Schema}].[SqlOSApplicationAssignments]([ClientApplicationId], [RevokedAt]);
+END
+
+IF OBJECT_ID('{Schema}.SqlOSApplicationAssignments', 'U') IS NOT NULL
+   AND NOT EXISTS (
+       SELECT 1
+       FROM sys.indexes
+       WHERE name = 'IX_SqlOSApplicationAssignments_OrganizationId_RevokedAt'
+         AND object_id = OBJECT_ID('{Schema}.SqlOSApplicationAssignments')
+   )
+BEGIN
+    CREATE INDEX [IX_SqlOSApplicationAssignments_OrganizationId_RevokedAt]
+    ON [{Schema}].[SqlOSApplicationAssignments]([OrganizationId], [RevokedAt]);
+END
+
+GO
+
+DELETE FROM [{Schema}].[SqlOSSchema];
+INSERT INTO [{Schema}].[SqlOSSchema] ([Version]) VALUES (24);

--- a/src/SqlOS/SqlOS.csproj
+++ b/src/SqlOS/SqlOS.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>SqlOS</PackageId>
-    <Version>3.14.2</Version>
+    <Version>3.14.3</Version>
     <Authors>Ross Slaney</Authors>
     <Description>Embedded auth server and fine-grained authorization runtime for .NET + SQL Server + EF Core.</Description>
     <PackageTags>authentication;authorization;fga;saml;jwt;sessions;efcore;sqlserver</PackageTags>

--- a/tests/SqlOS.IntegrationTests/SchemaInitializerIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/SchemaInitializerIntegrationTests.cs
@@ -148,7 +148,46 @@ public sealed class SchemaInitializerIntegrationTests
             Assert.IsTrue(await IndexExistsAsync(context, "SqlOSAuditEvents", "IX_SqlOSAuditEvents_Action_OccurredAt"));
             Assert.IsTrue(await IndexExistsAsync(context, "SqlOSAuditEvents", "UX_SqlOSAuditEvents_IdempotencyKeyHash"));
             Assert.AreEqual("user.login", await ScalarStringAsync(context, "SELECT TOP 1 [Action] FROM [dbo].[SqlOSAuditEvents]"));
-            Assert.AreEqual(23, await ScalarIntAsync(context, "SELECT TOP 1 [Version] FROM [dbo].[SqlOSSchema]"));
+            Assert.AreEqual(24, await ScalarIntAsync(context, "SELECT TOP 1 [Version] FROM [dbo].[SqlOSSchema]"));
+        }
+        finally
+        {
+            await DropDatabaseAsync(databaseName);
+        }
+    }
+
+    [TestMethod]
+    public async Task EnsureSchema_RepairsVersion23MissingApplicationAssignmentsSchema()
+    {
+        var databaseName = $"SqlOSRepair_{Guid.NewGuid():N}"[..30];
+        var databaseConnectionString = BuildDatabaseConnectionString(databaseName);
+        await CreateDatabaseAsync(databaseName);
+
+        try
+        {
+            var dbOptions = new DbContextOptionsBuilder<TestSqlOSDbContext>()
+                .UseSqlServer(databaseConnectionString)
+                .Options;
+
+            await using var context = new TestSqlOSDbContext(dbOptions);
+            await SeedVersion23WithoutApplicationAssignmentsSchemaAsync(context);
+
+            var initializer = new SqlOSSchemaInitializer(
+                context,
+                Options.Create(AspireFixture.Options),
+                LoggerFactory.Create(b => b.AddConsole()).CreateLogger<SqlOSSchemaInitializer>());
+
+            await initializer.EnsureSchemaAsync();
+
+            Assert.IsTrue(await ColumnExistsAsync(context, "SqlOSClientApplications", "AccessMode"));
+            Assert.IsTrue(await ColumnExistsAsync(context, "SqlOSSessions", "OrganizationId"));
+            Assert.IsTrue(await TableExistsAsync(context, "SqlOSApplicationAssignments"));
+            Assert.IsTrue(await ForeignKeyExistsAsync(context, "SqlOSSessions", "FK_SqlOSSessions_Organizations"));
+            Assert.IsTrue(await IndexExistsAsync(context, "SqlOSClientApplications", "IX_SqlOSClientApplications_AccessMode"));
+            Assert.IsTrue(await IndexExistsAsync(context, "SqlOSApplicationAssignments", "IX_SqlOSApplicationAssignments_Target"));
+            Assert.IsTrue(await IndexExistsAsync(context, "SqlOSApplicationAssignments", "IX_SqlOSApplicationAssignments_ClientApplicationId_RevokedAt"));
+            Assert.IsTrue(await IndexExistsAsync(context, "SqlOSApplicationAssignments", "IX_SqlOSApplicationAssignments_OrganizationId_RevokedAt"));
+            Assert.AreEqual(24, await ScalarIntAsync(context, "SELECT TOP 1 [Version] FROM [dbo].[SqlOSSchema]"));
         }
         finally
         {
@@ -157,14 +196,43 @@ public sealed class SchemaInitializerIntegrationTests
     }
 
     private static async Task<bool> TableExistsAsync(string tableName)
+        => await TableExistsAsync(AspireFixture.SharedContext, tableName);
+
+    private static async Task<bool> TableExistsAsync(DbContext context, string tableName)
     {
-        var connection = AspireFixture.SharedContext.Database.GetDbConnection();
+        var connection = context.Database.GetDbConnection();
         await connection.OpenAsync();
         try
         {
             using var cmd = connection.CreateCommand();
             cmd.CommandText = "SELECT COUNT(*) FROM sys.tables WHERE name = @name AND schema_id = SCHEMA_ID('dbo')";
             cmd.Parameters.Add(new SqlParameter("@name", tableName));
+            var result = await cmd.ExecuteScalarAsync();
+            return Convert.ToInt32(result) > 0;
+        }
+        finally
+        {
+            await connection.CloseAsync();
+        }
+    }
+
+    private static async Task<bool> ForeignKeyExistsAsync(DbContext context, string tableName, string foreignKeyName)
+    {
+        var connection = context.Database.GetDbConnection();
+        await connection.OpenAsync();
+        try
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = """
+                SELECT COUNT(*)
+                FROM sys.foreign_keys fk
+                INNER JOIN sys.tables t ON fk.parent_object_id = t.object_id
+                WHERE t.name = @tableName
+                  AND fk.name = @foreignKeyName
+                  AND t.schema_id = SCHEMA_ID('dbo')
+                """;
+            cmd.Parameters.Add(new SqlParameter("@tableName", tableName));
+            cmd.Parameters.Add(new SqlParameter("@foreignKeyName", foreignKeyName));
             var result = await cmd.ExecuteScalarAsync();
             return Convert.ToInt32(result) > 0;
         }
@@ -259,6 +327,26 @@ public sealed class SchemaInitializerIntegrationTests
                 'user.login',
                 'user',
                 SYSUTCDATETIME()
+            );
+            """);
+    }
+
+    private static async Task SeedVersion23WithoutApplicationAssignmentsSchemaAsync(DbContext context)
+    {
+        await context.Database.ExecuteSqlRawAsync("""
+            CREATE TABLE [dbo].[SqlOSSchema] ([Version] INT NOT NULL);
+            INSERT INTO [dbo].[SqlOSSchema] ([Version]) VALUES (23);
+
+            CREATE TABLE [dbo].[SqlOSOrganizations] (
+                [Id] NVARCHAR(64) NOT NULL PRIMARY KEY
+            );
+
+            CREATE TABLE [dbo].[SqlOSClientApplications] (
+                [Id] NVARCHAR(64) NOT NULL PRIMARY KEY
+            );
+
+            CREATE TABLE [dbo].[SqlOSSessions] (
+                [Id] NVARCHAR(64) NOT NULL PRIMARY KEY
             );
             """);
     }


### PR DESCRIPTION
## Summary
- add migration 024 to repair databases marked current but missing application assignment schema from migration 017
- bump SqlOS package version to 3.14.3
- add regression coverage for version 23 databases missing AccessMode/application assignment schema

## Tests
- dotnet test tests/SqlOS.IntegrationTests/SqlOS.IntegrationTests.csproj --filter "FullyQualifiedName~SchemaInitializerIntegrationTests"
- dotnet test tests/SqlOS.Tests/SqlOS.Tests.csproj
- dotnet pack src/SqlOS/SqlOS.csproj --configuration Release --no-restore