### PR TITLE
Fix signing key recovery across instance replacement

### DIFF
--- a/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerOptions.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerOptions.cs
@@ -33,6 +33,14 @@ public class SqlOSAuthServerOptions
     public bool RequireVerifiedEmailForPasswordLogin { get; set; }
     public bool EnableLocalPasswordAuth { get; set; } = true;
     public bool EnableSaml { get; set; } = true;
+    /// <summary>
+    /// Protects SqlOS JWT signing private keys with ASP.NET Core Data Protection before storing
+    /// them in the application database. Enable this only when the host application's Data
+    /// Protection key ring is persisted and shared by every application instance and revision;
+    /// container-local key rings make protected signing keys unreadable after replacement or
+    /// scale-out and can prevent token issuance.
+    /// </summary>
+    public bool ProtectSigningKeysWithDataProtection { get; set; }
     public int DefaultSigningKeyRotationIntervalDays { get; set; } = 90;
     public int DefaultSigningKeyGraceWindowDays { get; set; } = 7;
     public int DefaultSigningKeyRetiredCleanupDays { get; set; } = 30;

--- a/src/SqlOS/AuthServer/Services/SqlOSCryptoService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSCryptoService.cs
@@ -192,7 +192,7 @@ public sealed class SqlOSCryptoService
             Id = GenerateId("key"),
             Kid = GenerateOpaqueToken(16),
             PublicKeyPem = rsa.ExportRSAPublicKeyPem(),
-            PrivateKeyPem = ProtectSecret(rsa.ExportPkcs8PrivateKeyPem()),
+            PrivateKeyPem = ProtectSigningPrivateKey(rsa.ExportPkcs8PrivateKeyPem()),
             ActivatedAt = DateTime.UtcNow,
             IsActive = true
         };
@@ -227,7 +227,7 @@ public sealed class SqlOSCryptoService
             Id = GenerateId("key"),
             Kid = GenerateOpaqueToken(16),
             PublicKeyPem = rsa.ExportRSAPublicKeyPem(),
-            PrivateKeyPem = ProtectSecret(rsa.ExportPkcs8PrivateKeyPem()),
+            PrivateKeyPem = ProtectSigningPrivateKey(rsa.ExportPkcs8PrivateKeyPem()),
             ActivatedAt = now,
             IsActive = true
         };
@@ -271,9 +271,10 @@ public sealed class SqlOSCryptoService
         CancellationToken cancellationToken = default)
     {
         var key = await EnsureActiveSigningKeyAsync(cancellationToken);
+        var signingMaterial = await GetSigningMaterialAsync(key, cancellationToken);
         using var rsa = RSA.Create();
-        rsa.ImportFromPem(UnprotectSecret(key.PrivateKeyPem));
-        var signingKey = new RsaSecurityKey(rsa.ExportParameters(true)) { KeyId = key.Kid };
+        rsa.ImportFromPem(signingMaterial.PrivateKeyPem);
+        var signingKey = new RsaSecurityKey(rsa.ExportParameters(true)) { KeyId = signingMaterial.Key.Kid };
 
         var now = DateTime.UtcNow;
         var claims = new List<Claim>
@@ -310,6 +311,51 @@ public sealed class SqlOSCryptoService
             signingCredentials: new SigningCredentials(signingKey, SecurityAlgorithms.RsaSha256));
 
         return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+
+    private async Task<(SqlOSSigningKey Key, string PrivateKeyPem)> GetSigningMaterialAsync(
+        SqlOSSigningKey key,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return (key, UnprotectSecret(key.PrivateKeyPem));
+        }
+        catch (InvalidOperationException) when (key.PrivateKeyPem.StartsWith("dp:", StringComparison.Ordinal))
+        {
+            var replacement = await ReplaceUnreadableActiveSigningKeyAsync(key, cancellationToken);
+            return (replacement, UnprotectSecret(replacement.PrivateKeyPem));
+        }
+    }
+
+    private async Task<SqlOSSigningKey> ReplaceUnreadableActiveSigningKeyAsync(
+        SqlOSSigningKey unreadableKey,
+        CancellationToken cancellationToken)
+    {
+        var activeKey = await _context.Set<SqlOSSigningKey>()
+            .FirstOrDefaultAsync(x => x.Id == unreadableKey.Id && x.IsActive, cancellationToken);
+        if (activeKey == null)
+        {
+            return await EnsureActiveSigningKeyAsync(cancellationToken);
+        }
+
+        var now = DateTime.UtcNow;
+        activeKey.IsActive = false;
+        activeKey.RetiredAt = now;
+
+        using var rsa = RSA.Create(2048);
+        var replacement = new SqlOSSigningKey
+        {
+            Id = GenerateId("key"),
+            Kid = GenerateOpaqueToken(16),
+            PublicKeyPem = rsa.ExportRSAPublicKeyPem(),
+            PrivateKeyPem = ProtectSigningPrivateKey(rsa.ExportPkcs8PrivateKeyPem()),
+            ActivatedAt = now,
+            IsActive = true
+        };
+        _context.Set<SqlOSSigningKey>().Add(replacement);
+        await _context.SaveChangesAsync(cancellationToken);
+        return replacement;
     }
 
     public async Task<SqlOSValidatedToken?> ValidateAccessTokenAsync(
@@ -431,12 +477,14 @@ public sealed class SqlOSCryptoService
 
     private async Task ProtectSigningKeyAtRestIfNeededAsync(SqlOSSigningKey key, CancellationToken cancellationToken)
     {
-        if (string.IsNullOrWhiteSpace(key.PrivateKeyPem) || key.PrivateKeyPem.StartsWith("dp:", StringComparison.Ordinal))
+        if (!_options.ProtectSigningKeysWithDataProtection
+            || string.IsNullOrWhiteSpace(key.PrivateKeyPem)
+            || key.PrivateKeyPem.StartsWith("dp:", StringComparison.Ordinal))
         {
             return;
         }
 
-        var protectedPrivateKey = ProtectSecret(key.PrivateKeyPem);
+        var protectedPrivateKey = ProtectSigningPrivateKey(key.PrivateKeyPem);
         if (string.Equals(protectedPrivateKey, key.PrivateKeyPem, StringComparison.Ordinal))
         {
             return;
@@ -445,4 +493,9 @@ public sealed class SqlOSCryptoService
         key.PrivateKeyPem = protectedPrivateKey;
         await _context.SaveChangesAsync(cancellationToken);
     }
+
+    private string ProtectSigningPrivateKey(string privateKeyPem)
+        => _options.ProtectSigningKeysWithDataProtection
+            ? ProtectSecret(privateKeyPem)
+            : privateKeyPem;
 }

--- a/src/SqlOS/SqlOS.csproj
+++ b/src/SqlOS/SqlOS.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>SqlOS</PackageId>
-    <Version>3.14.3</Version>
+    <Version>3.14.4</Version>
     <Authors>Ross Slaney</Authors>
     <Description>Embedded auth server and fine-grained authorization runtime for .NET + SQL Server + EF Core.</Description>
     <PackageTags>authentication;authorization;fga;saml;jwt;sessions;efcore;sqlserver</PackageTags>

--- a/tests/SqlOS.IntegrationTests/AuthServerSigningKeyResilienceIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/AuthServerSigningKeyResilienceIntegrationTests.cs
@@ -1,0 +1,299 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SqlOS.AuthServer.Configuration;
+using SqlOS.AuthServer.Contracts;
+using SqlOS.AuthServer.Models;
+using SqlOS.AuthServer.Services;
+using SqlOS.IntegrationTests.Infrastructure;
+
+namespace SqlOS.IntegrationTests;
+
+[TestClass]
+public sealed class AuthServerSigningKeyResilienceIntegrationTests
+{
+    [TestMethod]
+    public async Task AuthorizationCodeExchange_WithUnreadablePersistedSigningKey_RotatesAndIssuesTokens()
+    {
+        TestSqlOSDbContext? setupContext = null;
+        string? connectionString = null;
+
+        try
+        {
+            setupContext = await AspireFixture.CreateIsolatedAuthContextAsync("SqlOSKeyResilience");
+            connectionString = setupContext.Database.GetConnectionString();
+            connectionString.Should().NotBeNullOrWhiteSpace();
+
+            var clientId = $"key-resilience-{Guid.NewGuid():N}"[..30];
+            var redirectUri = $"https://client.example.test/{clientId}/callback";
+            var setupOptions = CreateOptions(clientId, redirectUri, protectSigningKeys: true);
+            var setupStack = BuildStack(
+                setupContext,
+                setupOptions,
+                new EphemeralDataProtectionProvider());
+
+            await setupStack.Admin.UpsertSeededClientsAsync();
+            var protectedKey = await setupStack.Crypto.EnsureActiveSigningKeyAsync();
+            protectedKey.PrivateKeyPem.Should().StartWith("dp:");
+
+            var user = await setupStack.Admin.CreateUserAsync(new SqlOSCreateUserRequest(
+                "Key Resilience User",
+                $"key-resilience-{Guid.NewGuid():N}@example.com",
+                "P@ssword123!"));
+            var organization = await setupStack.Admin.CreateOrganizationAsync(
+                new SqlOSCreateOrganizationRequest($"Key Resilience {Guid.NewGuid():N}", null));
+            await setupStack.Admin.CreateMembershipAsync(
+                organization.Id,
+                new SqlOSCreateMembershipRequest(user.Id, "owner"));
+
+            var codeVerifier = setupStack.Crypto.GenerateOpaqueToken();
+            var authorizationRequest = await setupStack.AuthorizationServer.CreateAuthorizationRequestAsync(
+                new SqlOSAuthorizeRequestInput(
+                    "code",
+                    clientId,
+                    redirectUri,
+                    "key-resilience-state",
+                    "openid profile email offline_access",
+                    setupStack.Crypto.CreatePkceCodeChallenge(codeVerifier),
+                    "S256",
+                    null,
+                    user.DefaultEmail,
+                    null,
+                    null,
+                    "hosted",
+                    null));
+
+            var redirect = await setupStack.AuthorizationServer.IssueAuthorizationRedirectAsync(
+                authorizationRequest,
+                user,
+                organization.Id,
+                "email_otp",
+                CreateHttpContext());
+            var code = QueryHelpers.ParseQuery(new Uri(redirect).Query)["code"].ToString();
+            code.Should().NotBeNullOrWhiteSpace();
+
+            await setupContext.DisposeAsync();
+            setupContext = null;
+
+            await using var replacementContext = CreateContext(connectionString!);
+            var replacementStack = BuildStack(
+                replacementContext,
+                CreateOptions(clientId, redirectUri, protectSigningKeys: false),
+                new EphemeralDataProtectionProvider());
+
+            var tokenResult = await replacementStack.AuthorizationServer.ExchangeAuthorizationCodeAsync(
+                new SqlOSTokenRequest(
+                    "authorization_code",
+                    code,
+                    redirectUri,
+                    clientId,
+                    codeVerifier,
+                    null,
+                    null),
+                CreateHttpContext());
+
+            tokenResult.Tokens.AccessToken.Should().NotBeNullOrWhiteSpace();
+            tokenResult.Tokens.RefreshToken.Should().NotBeNullOrWhiteSpace();
+            tokenResult.Tokens.OrganizationId.Should().Be(organization.Id);
+
+            var retiredKey = await replacementContext.Set<SqlOSSigningKey>()
+                .SingleAsync(x => x.Id == protectedKey.Id);
+            retiredKey.IsActive.Should().BeFalse();
+            retiredKey.RetiredAt.Should().NotBeNull();
+
+            var activeKey = await replacementContext.Set<SqlOSSigningKey>()
+                .SingleAsync(x => x.IsActive);
+            activeKey.Id.Should().NotBe(protectedKey.Id);
+            activeKey.PrivateKeyPem.Should().Contain("BEGIN PRIVATE KEY");
+            activeKey.PrivateKeyPem.Should().NotStartWith("dp:");
+        }
+        finally
+        {
+            if (setupContext != null)
+            {
+                await setupContext.DisposeAsync();
+            }
+
+            if (!string.IsNullOrWhiteSpace(connectionString))
+            {
+                await using var cleanupContext = CreateContext(connectionString);
+                await cleanupContext.Database.EnsureDeletedAsync();
+            }
+        }
+    }
+
+    [TestMethod]
+    public async Task AuthorizationCodeExchange_DefaultSigningKeyStorage_SurvivesReplacementInstance()
+    {
+        TestSqlOSDbContext? setupContext = null;
+        string? connectionString = null;
+
+        try
+        {
+            setupContext = await AspireFixture.CreateIsolatedAuthContextAsync("SqlOSDefaultKey");
+            connectionString = setupContext.Database.GetConnectionString();
+            connectionString.Should().NotBeNullOrWhiteSpace();
+
+            var clientId = $"default-key-{Guid.NewGuid():N}"[..30];
+            var redirectUri = $"https://client.example.test/{clientId}/callback";
+            var options = CreateOptions(clientId, redirectUri, protectSigningKeys: false);
+            var setupStack = BuildStack(
+                setupContext,
+                options,
+                new EphemeralDataProtectionProvider());
+
+            await setupStack.Admin.UpsertSeededClientsAsync();
+            var signingKey = await setupStack.Crypto.EnsureActiveSigningKeyAsync();
+            signingKey.PrivateKeyPem.Should().Contain("BEGIN PRIVATE KEY");
+            signingKey.PrivateKeyPem.Should().NotStartWith("dp:");
+
+            var user = await setupStack.Admin.CreateUserAsync(new SqlOSCreateUserRequest(
+                "Default Key User",
+                $"default-key-{Guid.NewGuid():N}@example.com",
+                "P@ssword123!"));
+            var organization = await setupStack.Admin.CreateOrganizationAsync(
+                new SqlOSCreateOrganizationRequest($"Default Key {Guid.NewGuid():N}", null));
+            await setupStack.Admin.CreateMembershipAsync(
+                organization.Id,
+                new SqlOSCreateMembershipRequest(user.Id, "member"));
+
+            var codeVerifier = setupStack.Crypto.GenerateOpaqueToken();
+            var authorizationRequest = await setupStack.AuthorizationServer.CreateAuthorizationRequestAsync(
+                new SqlOSAuthorizeRequestInput(
+                    "code",
+                    clientId,
+                    redirectUri,
+                    "default-key-state",
+                    "openid profile email offline_access",
+                    setupStack.Crypto.CreatePkceCodeChallenge(codeVerifier),
+                    "S256",
+                    null,
+                    user.DefaultEmail,
+                    null,
+                    null,
+                    "hosted",
+                    null));
+
+            var redirect = await setupStack.AuthorizationServer.IssueAuthorizationRedirectAsync(
+                authorizationRequest,
+                user,
+                organization.Id,
+                "password",
+                CreateHttpContext());
+            var code = QueryHelpers.ParseQuery(new Uri(redirect).Query)["code"].ToString();
+            code.Should().NotBeNullOrWhiteSpace();
+
+            await setupContext.DisposeAsync();
+            setupContext = null;
+
+            await using var replacementContext = CreateContext(connectionString!);
+            var replacementStack = BuildStack(
+                replacementContext,
+                CreateOptions(clientId, redirectUri, protectSigningKeys: false),
+                new EphemeralDataProtectionProvider());
+
+            var tokenResult = await replacementStack.AuthorizationServer.ExchangeAuthorizationCodeAsync(
+                new SqlOSTokenRequest(
+                    "authorization_code",
+                    code,
+                    redirectUri,
+                    clientId,
+                    codeVerifier,
+                    null,
+                    null),
+                CreateHttpContext());
+
+            tokenResult.Tokens.AccessToken.Should().NotBeNullOrWhiteSpace();
+            tokenResult.Tokens.RefreshToken.Should().NotBeNullOrWhiteSpace();
+
+            var activeKeys = await replacementContext.Set<SqlOSSigningKey>()
+                .Where(x => x.IsActive)
+                .ToListAsync();
+            activeKeys.Should().ContainSingle();
+            activeKeys[0].Id.Should().Be(signingKey.Id);
+        }
+        finally
+        {
+            if (setupContext != null)
+            {
+                await setupContext.DisposeAsync();
+            }
+
+            if (!string.IsNullOrWhiteSpace(connectionString))
+            {
+                await using var cleanupContext = CreateContext(connectionString);
+                await cleanupContext.Database.EnsureDeletedAsync();
+            }
+        }
+    }
+
+    private static SqlOSAuthServerOptions CreateOptions(
+        string clientId,
+        string redirectUri,
+        bool protectSigningKeys)
+    {
+        var options = new SqlOSAuthServerOptions
+        {
+            Issuer = AspireFixture.Options.Issuer,
+            BasePath = AspireFixture.Options.BasePath,
+            ProtectSigningKeysWithDataProtection = protectSigningKeys
+        };
+        options.SeedBrowserClient(clientId, $"Key Resilience Client {clientId}", redirectUri);
+        options.SeedAuthPage(page =>
+        {
+            page.EnabledCredentialTypes = ["password", "email_otp"];
+            page.EnablePasswordSignup = true;
+        });
+        return options;
+    }
+
+    private static ServiceStack BuildStack(
+        TestSqlOSDbContext context,
+        SqlOSAuthServerOptions optionsValue,
+        IDataProtectionProvider dataProtectionProvider)
+    {
+        var options = Options.Create(optionsValue);
+        var crypto = new SqlOSCryptoService(context, options, dataProtectionProvider);
+        var admin = new SqlOSAdminService(context, options, crypto);
+        var emailSender = new TestAuthEmailSender { IsConfigured = true };
+        var settings = new SqlOSSettingsService(context, options, emailSender);
+        var emailOtp = new SqlOSEmailOtpService(context, admin, crypto, settings, emailSender, options);
+        var auth = new SqlOSAuthService(context, options, admin, crypto, settings, emailOtp);
+        var authPageSession = new SqlOSAuthPageSessionService(context, crypto, settings);
+        var authorizationServer = new SqlOSAuthorizationServerService(
+            context,
+            admin,
+            auth,
+            crypto,
+            settings,
+            authPageSession,
+            options);
+        return new ServiceStack(crypto, admin, authorizationServer);
+    }
+
+    private static TestSqlOSDbContext CreateContext(string connectionString)
+    {
+        var dbOptions = new DbContextOptionsBuilder<TestSqlOSDbContext>()
+            .UseSqlServer(connectionString)
+            .Options;
+        return new TestSqlOSDbContext(dbOptions);
+    }
+
+    private static DefaultHttpContext CreateHttpContext()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Scheme = "https";
+        context.Request.Host = new HostString("auth.example.test");
+        context.Request.Headers.UserAgent = "SqlOS signing-key resilience integration test";
+        return context;
+    }
+
+    private sealed record ServiceStack(
+        SqlOSCryptoService Crypto,
+        SqlOSAdminService Admin,
+        SqlOSAuthorizationServerService AuthorizationServer);
+}

--- a/tests/SqlOS.IntegrationTests/Infrastructure/AspireFixture.cs
+++ b/tests/SqlOS.IntegrationTests/Infrastructure/AspireFixture.cs
@@ -1,6 +1,7 @@
 using Aspire.Hosting;
 using Aspire.Hosting.Testing;
 using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -81,6 +82,42 @@ public static class AspireFixture
         await admin.UpsertSeededClientsAsync();
 
         context.WriteLine($"SqlOS integration DB initialized: {databaseName}");
+    }
+
+    public static async Task<TestSqlOSDbContext> CreateIsolatedAuthContextAsync(
+        string databasePrefix = "SqlOSCase",
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(SqlConnectionString))
+        {
+            throw new InvalidOperationException("AspireFixture has not been initialized.");
+        }
+
+        var safePrefix = new string(databasePrefix.Where(char.IsLetterOrDigit).ToArray());
+        if (string.IsNullOrWhiteSpace(safePrefix))
+        {
+            safePrefix = "SqlOSCase";
+        }
+
+        safePrefix = safePrefix.Length > 24 ? safePrefix[..24] : safePrefix;
+        var builder = new SqlConnectionStringBuilder(SqlConnectionString)
+        {
+            InitialCatalog = $"{safePrefix}_{Guid.NewGuid():N}"
+        };
+
+        var dbOptions = new DbContextOptionsBuilder<TestSqlOSDbContext>()
+            .UseSqlServer(builder.ConnectionString)
+            .Options;
+        var context = new TestSqlOSDbContext(dbOptions);
+        await context.Database.EnsureCreatedAsync(cancellationToken);
+
+        var schemaInitializer = new SqlOSSchemaInitializer(
+            context,
+            Microsoft.Extensions.Options.Options.Create(Options),
+            LoggerFactory.Create(b => b.AddConsole()).CreateLogger<SqlOSSchemaInitializer>());
+        await schemaInitializer.EnsureSchemaAsync(cancellationToken);
+
+        return context;
     }
 
     [AssemblyCleanup]

--- a/tests/SqlOS.Tests/SqlOSCryptoServiceTests.cs
+++ b/tests/SqlOS.Tests/SqlOSCryptoServiceTests.cs
@@ -38,12 +38,27 @@ public sealed class SqlOSCryptoServiceTests
     }
 
     [TestMethod]
-    public async Task EnsureActiveSigningKey_WithDataProtection_StoresProtectedPrivateKey()
+    public async Task EnsureActiveSigningKey_WithDefaultOptions_DoesNotProtectSigningKeyEvenWhenDataProtectionExists()
     {
         using var context = CreateContext();
         var service = new SqlOSCryptoService(
             context,
             Options.Create(new SqlOSAuthServerOptions()),
+            new EphemeralDataProtectionProvider());
+
+        var key = await service.EnsureActiveSigningKeyAsync();
+
+        key.PrivateKeyPem.Should().Contain("BEGIN PRIVATE KEY");
+        key.PrivateKeyPem.Should().NotStartWith("dp:");
+    }
+
+    [TestMethod]
+    public async Task EnsureActiveSigningKey_WithSigningKeyDataProtection_StoresProtectedPrivateKey()
+    {
+        using var context = CreateContext();
+        var service = new SqlOSCryptoService(
+            context,
+            SigningKeyProtectedOptions(),
             new EphemeralDataProtectionProvider());
 
         var key = await service.EnsureActiveSigningKeyAsync();
@@ -54,7 +69,7 @@ public sealed class SqlOSCryptoServiceTests
     }
 
     [TestMethod]
-    public async Task EnsureActiveSigningKey_WithDataProtection_ProtectsLegacyPlaintextPrivateKey()
+    public async Task EnsureActiveSigningKey_WithSigningKeyDataProtection_ProtectsLegacyPlaintextPrivateKey()
     {
         using var context = CreateContext();
         var plaintextService = new SqlOSCryptoService(context, Options.Create(new SqlOSAuthServerOptions()));
@@ -63,7 +78,7 @@ public sealed class SqlOSCryptoServiceTests
 
         var protectedService = new SqlOSCryptoService(
             context,
-            Options.Create(new SqlOSAuthServerOptions()),
+            SigningKeyProtectedOptions(),
             new EphemeralDataProtectionProvider());
 
         var upgradedKey = await protectedService.EnsureActiveSigningKeyAsync();
@@ -79,7 +94,7 @@ public sealed class SqlOSCryptoServiceTests
         using var context = CreateContext();
         var service = new SqlOSCryptoService(
             context,
-            Options.Create(new SqlOSAuthServerOptions()),
+            SigningKeyProtectedOptions(),
             new EphemeralDataProtectionProvider());
         await service.EnsureActiveSigningKeyAsync();
 
@@ -117,6 +132,35 @@ public sealed class SqlOSCryptoServiceTests
     }
 
     [TestMethod]
+    public async Task CreateAccessToken_WithUnreadableProtectedSigningKey_RotatesAndSucceeds()
+    {
+        using var context = CreateContext();
+        var originalProvider = new EphemeralDataProtectionProvider();
+        var originalService = new SqlOSCryptoService(context, SigningKeyProtectedOptions(), originalProvider);
+        var originalKey = await originalService.EnsureActiveSigningKeyAsync();
+        originalKey.PrivateKeyPem.Should().StartWith("dp:");
+
+        var replacementProvider = new EphemeralDataProtectionProvider();
+        var recoveryService = new SqlOSCryptoService(
+            context,
+            Options.Create(new SqlOSAuthServerOptions()),
+            replacementProvider);
+
+        var token = await recoveryService.CreateAccessTokenAsync(
+            CreateUser(),
+            CreateSession(),
+            CreateClient(),
+            "org_test");
+
+        token.Should().NotBeNullOrWhiteSpace();
+        originalKey.IsActive.Should().BeFalse();
+        originalKey.RetiredAt.Should().NotBeNull();
+        var activeKey = context.Set<SqlOSSigningKey>().Single(x => x.IsActive);
+        activeKey.Id.Should().NotBe(originalKey.Id);
+        activeKey.PrivateKeyPem.Should().Contain("BEGIN PRIVATE KEY");
+    }
+
+    [TestMethod]
     public void ProtectSecret_UnprotectSecret_RoundTrips()
     {
         using var context = CreateContext();
@@ -136,4 +180,39 @@ public sealed class SqlOSCryptoServiceTests
             .Options;
         return new TestSqlOSInMemoryDbContext(options);
     }
+
+    private static IOptions<SqlOSAuthServerOptions> SigningKeyProtectedOptions()
+        => Options.Create(new SqlOSAuthServerOptions { ProtectSigningKeysWithDataProtection = true });
+
+    private static SqlOSUser CreateUser()
+        => new()
+        {
+            Id = "usr_test",
+            DisplayName = "Test User",
+            DefaultEmail = "test@example.com",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+
+    private static SqlOSSession CreateSession()
+        => new()
+        {
+            Id = "ses_test",
+            UserId = "usr_test",
+            AuthenticationMethod = "password",
+            CreatedAt = DateTime.UtcNow,
+            LastSeenAt = DateTime.UtcNow,
+            IdleExpiresAt = DateTime.UtcNow.AddHours(1),
+            AbsoluteExpiresAt = DateTime.UtcNow.AddHours(1)
+        };
+
+    private static SqlOSClientApplication CreateClient()
+        => new()
+        {
+            Id = "cli_test",
+            ClientId = "test-client",
+            Name = "Test Client",
+            Audience = "test-api",
+            CreatedAt = DateTime.UtcNow
+        };
 }

--- a/web/content/docs/guides/testing.mdx
+++ b/web/content/docs/guides/testing.mdx
@@ -39,6 +39,7 @@ Integration tests use Aspire and SQL Server containers for:
 
 - Auth and FGA schema bootstrap
 - OAuth, OTP, and invitation flows
+- AuthServer resilience across app instance replacement, including persisted signing keys and full PKCE token exchange
 - Client registration and resource indicators
 - FGA checks and EF query composition
 - Example and Todo sample end-to-end paths
@@ -48,6 +49,7 @@ Integration tests use Aspire and SQL Server containers for:
 ```bash
 dotnet test tests/SqlOS.Tests/SqlOS.Tests.csproj --filter SqlOSInvitationServiceTests
 dotnet test tests/SqlOS.Tests/SqlOS.Tests.csproj --filter RequestEmailOtpSignupAsync
+dotnet test tests/SqlOS.IntegrationTests/SqlOS.IntegrationTests.csproj --filter AuthServerSigningKeyResilienceIntegrationTests
 ```
 
 Coverage settings live in `tests/coverlet.runsettings`.


### PR DESCRIPTION
## Summary
- Make ASP.NET Core Data Protection for persisted JWT signing private keys explicit opt-in with `ProtectSigningKeysWithDataProtection`.
- Keep generic `ProtectSecret` behavior unchanged for other SqlOS secrets.
- Recover token issuance when an existing `dp:` active signing key cannot be unprotected by retiring it and creating a fresh active signing key.
- Add unit and Aspire SQL integration regressions for app instance/key-ring replacement during PKCE authorization-code exchange.
- Bump SqlOS package version to 3.14.4.

## Production evidence
- `mcpstack-prod-api` logged Data Protection keys stored under `/root/.aspnet/DataProtection-Keys`, which is container-local in the observed Container Apps revision.
- The user-facing callback error came from `/sqlos/auth/token` returning `invalid_grant` with the SqlOS unprotect failure message during code exchange.

## Validation
- `dotnet test tests/SqlOS.Tests/SqlOS.Tests.csproj --filter FullyQualifiedName~SqlOSCryptoServiceTests`
- `dotnet test tests/SqlOS.IntegrationTests/SqlOS.IntegrationTests.csproj --filter FullyQualifiedName~AuthServerSigningKeyResilienceIntegrationTests`
- `dotnet build SqlOS.sln --configuration Release`
- `./scripts/unit-tests.sh`
- `./scripts/integration-tests.sh`
- `./scripts/docs-check.sh`

## Notes
- Playwright is not currently configured as a first-class repo test harness. This PR adds the regression at the library boundary that failed production: persisted SQL state, separate app instances/Data Protection providers, and full PKCE token exchange.