### PR TITLE
Add GitHub OIDC setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Think **WorkOS / AuthKit**, but **self-hosted** and **your database**.
 - **Resource Indicators** — bind `resource` end to end and mint audience-aware access tokens
 - **Organizations & Users** — multi-tenant user management with memberships and roles
 - **Password Credentials** — secure local authentication with session management
-- **Social Login** — Google, Microsoft, Apple, and any custom OIDC provider
+- **Social Login** — Google, Microsoft, GitHub, Apple, and any custom OIDC provider
 - **SAML SSO** — enterprise single sign-on with home realm discovery by verified or operator-managed email domain
 - **Delegated SSO Portal** — one-organization setup links for customer IT admins, with provider guides, DNS TXT domain verification, metadata import, and a headless setup state machine
 - **Sessions & Refresh Tokens** — full lifecycle management with revocation
@@ -312,7 +312,7 @@ examples/SqlOS.Example.AppHost           # Aspire orchestration
 - [Dynamic Client Registration](web/content/docs/authserver/dynamic-client-registration.mdx) — compatibility-mode runtime registration
 - [MCP Resource Indicators and Audience](web/content/docs/authserver/mcp-resource-indicators-and-audience.mdx) — resource-bound tokens and audience validation
 - [OIDC Auth](web/content/docs/authserver/oidc-auth.mdx) — OpenID Connect provider support
-- [Google OIDC](https://sqlos.dev/docs/authserver/google-oidc) · [Microsoft OIDC](https://sqlos.dev/docs/authserver/microsoft-oidc) · [Apple OIDC](https://sqlos.dev/docs/authserver/apple-oidc) · [Custom OIDC](https://sqlos.dev/docs/authserver/custom-oidc)
+- [Google OIDC](https://sqlos.dev/docs/authserver/google-oidc) · [Microsoft OIDC](https://sqlos.dev/docs/authserver/microsoft-oidc) · [GitHub OIDC](https://sqlos.dev/docs/authserver/github-oidc) · [Apple OIDC](https://sqlos.dev/docs/authserver/apple-oidc) · [Custom OIDC](https://sqlos.dev/docs/authserver/custom-oidc)
 - [Guides](https://sqlos.dev/docs/guides/index) — task-oriented walkthroughs
 - [Entra SSO Testing](docs/ENTRA_SSO.md) — SAML SSO with Microsoft Entra
 - [Example App](docs/EXAMPLE_APP.md) — running the demo stack

--- a/docs/EXAMPLE_APP.md
+++ b/docs/EXAMPLE_APP.md
@@ -7,7 +7,7 @@ Use it when you want to explore:
 - local password login
 - hosted and headless auth UI
 - optional SMS OTP through Twilio Verify
-- Google, Microsoft, Apple, and custom OIDC login
+- Google, Microsoft, GitHub, Apple, and custom OIDC/social login
 - org membership
 - organization email invitations
 - SAML SSO initiation and callback flow
@@ -82,6 +82,7 @@ For OIDC setup, use:
 - [OIDC auth guide](../web/content/docs/authserver/oidc-auth.mdx)
 - [Google OIDC](GOOGLE_OIDC.md)
 - [Microsoft OIDC](MICROSOFT_OIDC.md)
+- [GitHub OIDC](GITHUB_OIDC.md)
 - [Apple OIDC](APPLE_OIDC.md)
 - [Custom OIDC](CUSTOM_OIDC.md)
 

--- a/docs/GITHUB_OIDC.md
+++ b/docs/GITHUB_OIDC.md
@@ -1,0 +1,5 @@
+# GitHub OIDC
+
+Moved to **https://sqlos.dev/docs/authserver/github-oidc**
+
+See also: [GitHub sign-in guide](https://sqlos.dev/docs/guides/github-oidc)

--- a/web/content/docs/authserver/apple-oidc.mdx
+++ b/web/content/docs/authserver/apple-oidc.mdx
@@ -12,7 +12,7 @@ Sign in with Apple requires an Apple Developer account and works on web only.
 1. In [Apple Developer Portal](https://developer.apple.com/account/resources/identifiers/list/serviceId), register a Services ID
 2. Enable **Sign in with Apple** and configure:
    - **Domain**: your app domain
-   - **Return URL**: `http://localhost:5062/api/v1/auth/oidc/callback/{connectionId}`
+   - **Return URL**: `http://localhost:5062/sqlos/auth/oidc/callback`
 3. Create a key for Sign in with Apple
 4. Create the OIDC connection in SqlOS:
 

--- a/web/content/docs/authserver/github-oidc.mdx
+++ b/web/content/docs/authserver/github-oidc.mdx
@@ -1,0 +1,146 @@
+---
+title: "GitHub OIDC"
+description: "Configure GitHub OAuth social login for SqlOS AuthServer."
+order: 18
+section: authserver
+---
+
+<Banner
+  eyebrow="Provider"
+  title="Sign in with GitHub"
+  href="/docs/guides/github-oidc"
+  actionLabel="GitHub setup guide"
+/>
+
+Use this page when you need the exact GitHub provider settings for the SqlOS AuthServer dashboard, admin API, or startup seed.
+
+<Callout type="info" title="GitHub is OAuth profile mode">
+  The built-in GitHub provider is managed from the same SqlOS Social Login/OIDC screen as Google, Microsoft, Apple, and custom OIDC providers. GitHub does not use OIDC discovery or ID tokens in SqlOS; SqlOS exchanges the OAuth code and then calls GitHub profile and email APIs.
+</Callout>
+
+## Redirect URI
+
+Register the SqlOS provider callback URL as the GitHub OAuth App **Authorization callback URL**.
+
+Default production form:
+
+```text
+https://your-app.example.com/sqlos/auth/oidc/callback
+```
+
+Default local form:
+
+```text
+http://localhost:5062/sqlos/auth/oidc/callback
+```
+
+If `AuthServer.BasePath` is customized, use:
+
+```text
+{AuthServer.PublicOrigin}{AuthServer.BasePath}/oidc/callback
+```
+
+The dashboard at **`/sqlos/admin/auth/oidc`** shows the exact callback URI for the current host and base path.
+
+## GitHub OAuth App setup
+
+1. Open [GitHub OAuth Apps](https://github.com/settings/developers).
+2. Create a new OAuth App.
+3. Set the homepage URL for your app.
+4. Set **Authorization callback URL** to the SqlOS provider callback URI.
+5. Copy the **Client ID**.
+6. Generate and copy a **Client secret**.
+
+GitHub OAuth Apps have a single authorization callback URL. Create separate OAuth Apps for local, staging, and production when each environment has a different callback URL.
+
+## SqlOS dashboard setup
+
+1. Open **`/sqlos/admin/auth/oidc`**.
+2. Create a connection:
+   - Provider: **GitHub**
+   - Display name: `GitHub`
+   - Client ID: GitHub OAuth App client ID
+   - Client secret: GitHub OAuth App client secret
+   - Allowed callback URI: the prefilled SqlOS provider callback URI
+3. Save the connection.
+4. Enable the connection.
+
+Default scopes when left empty: `read:user`, `user:email`.
+
+## Code-first setup
+
+Seed the connection from `AddSqlOS` when you want fresh databases and preview environments to come up with GitHub login already configured:
+
+```csharp
+var publicOrigin = builder.Configuration["SqlOS:PublicOrigin"]!;
+
+builder.AddSqlOS<AppDbContext>(options =>
+{
+    options.AuthServer.PublicOrigin = publicOrigin;
+
+    options.AuthServer.SeedGitHubConnection(
+        clientId: builder.Configuration["SqlOS:Oidc:GitHub:ClientId"]!,
+        clientSecret: builder.Configuration["SqlOS:Oidc:GitHub:ClientSecret"]!,
+        $"{publicOrigin}/sqlos/auth/oidc/callback");
+});
+```
+
+`SeedGitHubConnection` creates a `SqlOSOidcConnection` with:
+
+| Field | Value |
+| --- | --- |
+| Provider type | `GitHub` |
+| Display name | `GitHub` |
+| Protocol | `OAuthProfile` |
+| Authorization endpoint | `https://github.com/login/oauth/authorize` |
+| Token endpoint | `https://github.com/login/oauth/access_token` |
+| Profile endpoints | `https://api.github.com/user` and `https://api.github.com/user/emails` |
+| Default scopes | `read:user`, `user:email` |
+| Client auth method | `ClientSecretPost` |
+
+## Admin API setup
+
+```bash
+curl -X POST http://localhost:5062/sqlos/admin/auth/api/oidc-connections \
+  -H "Content-Type: application/json" \
+  -d '{
+    "providerType": "github",
+    "displayName": "GitHub",
+    "clientId": "YOUR_GITHUB_CLIENT_ID",
+    "clientSecret": "YOUR_GITHUB_CLIENT_SECRET",
+    "allowedCallbackUris": [
+      "http://localhost:5062/sqlos/auth/oidc/callback"
+    ]
+  }'
+```
+
+Enable the connection:
+
+```bash
+curl -X POST http://localhost:5062/sqlos/admin/auth/api/oidc-connections/{id}/enable
+```
+
+## Runtime behavior
+
+- SqlOS sends users to GitHub with `scope=read:user user:email`.
+- GitHub redirects back to `/sqlos/auth/oidc/callback`.
+- SqlOS exchanges the code for a GitHub OAuth access token.
+- SqlOS calls `/user` for the stable numeric GitHub user id and display profile.
+- SqlOS calls `/user/emails` and requires a verified primary email address.
+- SqlOS links future sign-ins by the GitHub user id and then completes the normal SqlOS login flow.
+
+## Common failures
+
+| Error | Fix |
+| --- | --- |
+| GitHub says the callback URL is incorrect | Register the exact callback URI shown in the SqlOS dashboard. |
+| `GitHub did not return a verified primary email address.` | Ask the user to verify a primary email address in GitHub. |
+| GitHub button is missing | Enable the connection and confirm `/sqlos/auth/oidc/providers` returns the GitHub provider. |
+| Callback uses the wrong host | Set `AuthServer.PublicOrigin` to the public origin of the deployed app. |
+
+## Next steps
+
+- [Add GitHub sign-in](/docs/guides/github-oidc)
+- [OIDC Social Login](/docs/authserver/oidc-auth)
+- [Google OIDC](/docs/authserver/google-oidc)
+- [Microsoft OIDC](/docs/authserver/microsoft-oidc)

--- a/web/content/docs/authserver/google-oidc.mdx
+++ b/web/content/docs/authserver/google-oidc.mdx
@@ -16,19 +16,19 @@ You'll learn how to register redirect URIs in Google Cloud and create the connec
 
 ## Redirect URI
 
-The callback path is connection-specific:
+The default hosted provider callback path is:
 
 ```text
-https://your-app.example.com/sqlos/admin/auth/api/oidc/callback/{connectionId}
+https://your-app.example.com/sqlos/auth/oidc/callback
 ```
 
-For local development with the example API:
+For local development with the default SqlOS base path:
 
 ```text
-http://localhost:5062/api/v1/auth/oidc/callback/{connectionId}
+http://localhost:5062/sqlos/auth/oidc/callback
 ```
 
-Create the OIDC connection in SqlOS first, then copy the final callback URI (with `connectionId`) into Google Cloud.
+Create the OIDC connection in SqlOS first, then copy the dashboard callback URI into Google Cloud.
 
 ## Google Cloud setup
 
@@ -45,7 +45,7 @@ Create the OIDC connection in SqlOS first, then copy the final callback URI (wit
    - Provider: **Google**
    - Display name: shown on the login button
    - Client ID and client secret from Google
-3. Save, then update Google’s redirect URIs with the exact callback shown for that connection id.
+3. Save, then update Google's redirect URIs with the exact callback shown by the dashboard.
 4. **Enable** the connection.
 
 Default scopes when left empty: `openid`, `email`, `profile`.

--- a/web/content/docs/authserver/microsoft-oidc.mdx
+++ b/web/content/docs/authserver/microsoft-oidc.mdx
@@ -11,7 +11,7 @@ section: authserver
 2. Under **Authentication > Web**, add the redirect URI:
 
 ```
-http://localhost:5062/api/v1/auth/oidc/callback/{connectionId}
+http://localhost:5062/sqlos/auth/oidc/callback
 ```
 
 3. Under **Certificates & secrets**, create a client secret
@@ -43,9 +43,9 @@ options.AuthServer.SeedMicrosoftConnection(
     clientId: builder.Configuration["SqlOS:Oidc:Microsoft:ClientId"]!,
     clientSecret: builder.Configuration["SqlOS:Oidc:Microsoft:ClientSecret"]!,
     tenant: "common",
-    "http://localhost:5062/api/v1/auth/oidc/callback/{connectionId}");
+    "http://localhost:5062/sqlos/auth/oidc/callback");
 ```
 
-See [Google and Microsoft sign-in](/docs/guides/social-oidc#seed-from-startup) for seeding behavior and the general `SeedOidcConnection` form.
+See [Social sign-in](/docs/guides/social-oidc#seed-from-startup) for seeding behavior and the general `SeedOidcConnection` form.
 
 See [OIDC Social Login](/docs/authserver/oidc-auth) for the complete auth flow.

--- a/web/content/docs/authserver/oidc-auth.mdx
+++ b/web/content/docs/authserver/oidc-auth.mdx
@@ -1,11 +1,11 @@
 ---
 title: "OIDC Social Login"
-description: "Configure Google, Microsoft, Apple, and custom OIDC providers."
+description: "Configure Google, Microsoft, Apple, GitHub, and custom social providers."
 order: 14
 section: authserver
 ---
 
-SqlOS supports social login via OpenID Connect. Users click a provider button, authenticate with the provider, and are linked or created in SqlOS.
+SqlOS supports social login via OpenID Connect providers and GitHub OAuth. Users click a provider button, authenticate with the provider, and are linked or created in SqlOS.
 
 ## Supported providers
 
@@ -14,6 +14,7 @@ SqlOS supports social login via OpenID Connect. Users click a provider button, a
 | Google | `google` | Standard OAuth 2.0 |
 | Microsoft | `microsoft` | Entra ID (Azure AD) |
 | Apple | `apple` | Web only, requires Apple Developer account |
+| GitHub | `github` | OAuth profile/email lookup through GitHub's user APIs |
 | Custom | any | Any OIDC-compliant provider via discovery or manual config |
 
 ## Setup
@@ -37,13 +38,15 @@ curl -X POST http://localhost:5062/sqlos/admin/auth/api/oidc-connections \
 
 ### 2. Configure the callback URI
 
-Each connection gets a unique callback URI:
+SqlOS owns the provider callback URI:
 
 ```
-http://localhost:5062/api/v1/auth/oidc/callback/{connectionId}
+http://localhost:5062/sqlos/auth/oidc/callback
 ```
 
-Add this URI to your provider's allowed redirect URIs.
+Add the exact dashboard-provided URI to your provider's allowed redirect URIs.
+
+If you build a custom headless callback with `SqlOSOidcAuthService`, register your app-owned callback route instead. The example API uses `/api/v1/auth/oidc/callback/{connectionId}` so the callback can complete the handoff before returning to the frontend.
 
 ### 3. Enable the connection
 
@@ -119,7 +122,7 @@ window.location.href = authorizationUrl;
 ### Google
 
 1. Create an OAuth 2.0 Client ID in [Google Cloud Console](https://console.cloud.google.com/apis/credentials)
-2. Set the callback URI to `http://localhost:5062/api/v1/auth/oidc/callback/{connectionId}`
+2. Set the callback URI to `http://localhost:5062/sqlos/auth/oidc/callback`
 3. Create the connection with `providerType: "google"`, your client ID and secret
 
 ### Microsoft
@@ -133,6 +136,15 @@ window.location.href = authorizationUrl;
 1. Register in [Apple Developer Portal](https://developer.apple.com/account/resources/identifiers/list/serviceId)
 2. Enable "Sign in with Apple" and configure the callback domain
 3. Create the connection with `providerType: "apple"`, your service ID and key
+
+### GitHub
+
+1. Create an OAuth App in [GitHub Developer settings](https://github.com/settings/developers)
+2. Set the Authorization callback URL to the SqlOS callback URI
+3. Create the connection with `providerType: "github"`, your GitHub client ID and secret
+4. Keep default scopes so SqlOS can request `read:user` and `user:email`
+
+See [GitHub OIDC](/docs/authserver/github-oidc) for dashboard, API, and code-first setup.
 
 ### Custom OIDC
 

--- a/web/content/docs/authserver/overview.mdx
+++ b/web/content/docs/authserver/overview.mdx
@@ -31,7 +31,7 @@ AuthServer is SqlOS's identity piece. Users, orgs, sessions, tokens, OIDC, and S
   <Card title="Users" description="Email/password, email OTP, SSO-provisioned, or OIDC-linked identities." />
   <Card title="Sessions" description="JWT access tokens, refresh token rotation, and replay detection." />
   <Card title="MFA and recovery codes" description="Optional self-enrollment, tenant-required TOTP, and recovery-code challenges." />
-  <Card title="OIDC" description="Google, Microsoft, Apple, and custom providers." />
+  <Card title="OIDC" description="Google, Microsoft, GitHub, Apple, and custom providers." />
   <Card title="SAML SSO" description="Enterprise SSO with provisioning and hosted flows." />
   <Card title="Invitations" description="Email-bound organization invites with hosted, headless, and SDK acceptance." />
   <Card title="CLI OAuth" description="Device Authorization Grant for terminal apps and remote sessions." />
@@ -80,7 +80,7 @@ Open `/sqlos/admin/auth/`. Manage orgs, users, memberships, clients, OIDC, SSO, 
 | `SqlOSCryptoService` | Token generation, PKCE, password hashing, JWKS |
 | `SqlOSHomeRealmDiscoveryService` | Route users to password or SSO by email domain |
 | `SqlOSSsoAuthorizationService` | SAML SSO authorization and code exchange |
-| `SqlOSOidcAuthService` | Google, Microsoft, Apple, and custom OIDC |
+| `SqlOSOidcAuthService` | Google, Microsoft, GitHub, Apple, and custom social login |
 | `SqlOSSettingsService` | Session lifetimes and security configuration |
 
 ## Signing keys and protected secrets

--- a/web/content/docs/authserver/users-and-credentials.mdx
+++ b/web/content/docs/authserver/users-and-credentials.mdx
@@ -38,7 +38,7 @@ curl -X POST http://localhost:5062/sqlos/admin/auth/api/users \
 | --- | --- | --- |
 | Local | Dashboard, SDK, Email OTP signup, or invitation signup | Optional |
 | SSO-provisioned | SAML login with auto-provisioning | No |
-| OIDC-linked | Google, Microsoft, Apple, or custom OIDC login | No |
+| OIDC-linked | Google, Microsoft, GitHub, Apple, or custom social login | No |
 
 Users without a password can sign in through Email OTP, SSO, or OIDC. You can add a password later through the dashboard or SDK when local password auth is enabled.
 

--- a/web/content/docs/guides/github-oidc.mdx
+++ b/web/content/docs/guides/github-oidc.mdx
@@ -1,0 +1,135 @@
+---
+title: "Add GitHub sign-in"
+description: "Create a GitHub OAuth App and enable GitHub social login from the SqlOS dashboard or startup code."
+order: 3
+section: guides
+---
+
+<Banner
+  eyebrow="Guide"
+  title="Ship Continue with GitHub"
+  href="/docs/authserver/github-oidc"
+  actionLabel="GitHub provider reference"
+/>
+
+You'll learn how to create the GitHub OAuth App, register the SqlOS callback URL, and enable the provider from either the dashboard or code.
+
+<Callout type="info" title="Prerequisites">
+  - A SqlOS app with `app.MapSqlOS()` mapped
+  - A registered SqlOS OAuth client for your app
+  - Admin access to `/sqlos/admin/auth/`
+  - Permission to create a GitHub OAuth App for your account or organization
+</Callout>
+
+## Goal
+
+Users see **Continue with GitHub** on the hosted AuthPage or your headless login UI. After GitHub redirects back to SqlOS, SqlOS resolves the user's GitHub profile, requires a verified primary email address, and completes the normal SqlOS login flow.
+
+<Callout type="info" title="Protocol note">
+  SqlOS shows GitHub beside the OIDC providers because it uses the same social login connection, dashboard, hosted AuthPage, and headless API surface. GitHub login itself is OAuth 2.0 with profile and email API lookups, not an OIDC ID-token flow.
+</Callout>
+
+## 1. Create the GitHub OAuth App
+
+1. Open GitHub **Settings > Developer settings > OAuth Apps** or the same page in your GitHub organization settings.
+2. Create a **New OAuth App**.
+3. Set **Application name** and **Homepage URL** for your app.
+4. Set **Authorization callback URL** to the SqlOS provider callback URL.
+
+For the default SqlOS mount path, the provider callback URL is:
+
+```text
+https://your-app.example.com/sqlos/auth/oidc/callback
+```
+
+For local development with the default SqlOS base path:
+
+```text
+http://localhost:5062/sqlos/auth/oidc/callback
+```
+
+If you changed `DashboardBasePath` or `AuthServer.BasePath`, use:
+
+```text
+{AuthServer.PublicOrigin}{AuthServer.BasePath}/oidc/callback
+```
+
+<Callout type="tip" title="Copy from SqlOS">
+  The dashboard shows the exact callback URI for the current app origin and base path. Use the dashboard value as the source of truth when setting up GitHub.
+</Callout>
+
+5. Register the app and copy the GitHub **Client ID**.
+6. Generate a **Client secret** and store it in configuration, user secrets, or your secret manager.
+
+## 2. Enable GitHub from the dashboard
+
+1. Open **`/sqlos/admin/auth/oidc`** in your running app.
+2. Create a social provider connection:
+   - Provider: **GitHub**
+   - Display name: `GitHub`
+   - Client ID: the GitHub OAuth App client ID
+   - Client secret: the GitHub OAuth App client secret
+   - Allowed callback URI: keep the prefilled SqlOS callback URL
+3. Leave scopes empty unless you need to override the defaults. SqlOS requests `read:user` and `user:email`.
+4. Save the connection.
+5. Enable the connection.
+
+GitHub OAuth Apps allow one authorization callback URL. Use separate GitHub OAuth Apps for local, staging, and production when those environments have different callback URLs.
+
+## 3. Seed GitHub from code
+
+For repeatable environments, seed the GitHub connection at startup instead of creating it by hand in the dashboard:
+
+```csharp
+var publicOrigin = builder.Configuration["SqlOS:PublicOrigin"]
+    ?? "https://your-app.example.com";
+
+builder.AddSqlOS<AppDbContext>(options =>
+{
+    options.AuthServer.PublicOrigin = publicOrigin;
+
+    options.AuthServer.SeedGitHubConnection(
+        clientId: builder.Configuration["SqlOS:Oidc:GitHub:ClientId"]!,
+        clientSecret: builder.Configuration["SqlOS:Oidc:GitHub:ClientSecret"]!,
+        $"{publicOrigin}/sqlos/auth/oidc/callback");
+});
+```
+
+Store the secret outside source control:
+
+```bash
+dotnet user-secrets set "SqlOS:Oidc:GitHub:ClientId" "YOUR_GITHUB_CLIENT_ID"
+dotnet user-secrets set "SqlOS:Oidc:GitHub:ClientSecret" "YOUR_GITHUB_CLIENT_SECRET"
+dotnet user-secrets set "SqlOS:PublicOrigin" "https://localhost:5001"
+```
+
+<Callout type="info" title="Seeding behavior">
+  - Startup seeds are reconciled on every boot and matched by provider type.
+  - Client ID, callbacks, scopes, and endpoints stay in sync with code.
+  - Client secret is updated only when the seed supplies one.
+  - A manual dashboard disable survives restarts, so operators can pause GitHub login without changing code.
+</Callout>
+
+## 4. Test the flow
+
+1. Open your app's hosted authorization URL or `/sqlos/auth/login`.
+2. Choose **Continue with GitHub**.
+3. Complete GitHub authorization.
+4. Confirm the user returns to your app with a SqlOS session and tokens.
+5. Check **`/sqlos/admin/auth/users`** and **`/sqlos/admin/auth/sessions`** to confirm the user and session were created.
+
+## Common failures
+
+| Error | Fix |
+| --- | --- |
+| `redirect_uri_mismatch` or GitHub callback error | The GitHub OAuth App callback must exactly match the SqlOS provider callback URL. |
+| Login fails after GitHub authorization | Confirm the user has a verified primary email address in GitHub. |
+| Provider button does not appear | Enable the GitHub connection and check that it appears in `/sqlos/auth/oidc/providers`. |
+| Works locally but not in production | Set `AuthServer.PublicOrigin` to the public origin and register that production callback URL in GitHub. |
+
+## Next steps
+
+- [GitHub provider reference](/docs/authserver/github-oidc)
+- [OIDC Social Login](/docs/authserver/oidc-auth)
+- [Home realm discovery](/docs/authserver/home-realm-discovery)
+- [Troubleshooting](/docs/guides/troubleshooting)

--- a/web/content/docs/guides/index.mdx
+++ b/web/content/docs/guides/index.mdx
@@ -19,7 +19,8 @@ You'll learn which guide to pick for your next integration task.
 <CardGrid cols={2}>
   <Card title="Password login" description="Add hosted password auth to an existing ASP.NET app." href="/docs/guides/password-login" />
   <Card title="Authenticator MFA" description="Enable TOTP, recovery codes, and tenant-required MFA." href="/docs/guides/mfa-totp" />
-  <Card title="Google & Microsoft sign-in" description="Configure social OIDC from the dashboard." href="/docs/guides/social-oidc" />
+  <Card title="Social sign-in" description="Configure Google, Microsoft, GitHub, Apple, or custom login." href="/docs/guides/social-oidc" />
+  <Card title="GitHub sign-in" description="Create the GitHub OAuth App and enable the SqlOS provider." href="/docs/guides/github-oidc" />
   <Card title="SAML SSO for an org" description="Enterprise SSO with Entra or any SAML IdP." href="/docs/guides/saml-sso" />
   <Card title="Model FGA" description="Design a multi-tenant resource hierarchy." href="/docs/guides/model-fga" />
   <Card title="Filter EF queries" description="Authorization as a LINQ WHERE clause." href="/docs/guides/ef-query-filters" />

--- a/web/content/docs/guides/password-login.mdx
+++ b/web/content/docs/guides/password-login.mdx
@@ -62,5 +62,6 @@ app.MapSqlOS();
 ## Next steps
 
 - [Email OTP](/docs/authserver/email-otp) for passwordless sign-in
-- [Google & Microsoft sign-in](/docs/guides/social-oidc)
+- [Social sign-in](/docs/guides/social-oidc)
+- [GitHub sign-in](/docs/guides/github-oidc)
 - [Headless auth](/docs/authserver/headless-auth) for a custom SPA UI

--- a/web/content/docs/guides/social-oidc.mdx
+++ b/web/content/docs/guides/social-oidc.mdx
@@ -1,18 +1,18 @@
 ---
-title: "Google and Microsoft sign-in"
-description: "Configure social OIDC providers from the SqlOS dashboard."
+title: "Social sign-in"
+description: "Configure Google, Microsoft, GitHub, Apple, and custom social providers from the SqlOS dashboard."
 order: 2
 section: guides
 ---
 
 <Banner
   eyebrow="Guide"
-  title="Add Google or Microsoft social login"
-  href="/docs/authserver/google-oidc"
-  actionLabel="Google OIDC reference"
+  title="Add social login"
+  href="/docs/authserver/github-oidc"
+  actionLabel="GitHub provider reference"
 />
 
-You'll learn how to register redirect URIs, create an OIDC connection in SqlOS, and test the hosted login flow.
+You'll learn how to register redirect URIs, create a social provider connection in SqlOS, and test the hosted login flow.
 
 <Callout type="info" title="Prerequisites">
   - SqlOS running with [password login](/docs/guides/password-login) or another primary flow
@@ -21,7 +21,7 @@ You'll learn how to register redirect URIs, create an OIDC connection in SqlOS, 
 
 ## Goal
 
-Users click **Continue with Google** or **Continue with Microsoft** on the hosted AuthPage.
+Users click provider buttons such as **Continue with Google**, **Continue with Microsoft**, or **Continue with GitHub** on the hosted AuthPage.
 
 ## Google
 
@@ -42,6 +42,16 @@ See [Google OIDC](/docs/authserver/google-oidc) for curl-based setup and failure
 
 See [Microsoft OIDC](/docs/authserver/microsoft-oidc).
 
+## GitHub
+
+1. Create a GitHub OAuth App in [GitHub Developer settings](https://github.com/settings/developers).
+2. Open **`/sqlos/admin/auth/oidc`** in your running app.
+3. Create a connection with provider **GitHub**, your GitHub OAuth App client ID, and client secret.
+4. Copy the **provider callback URI** SqlOS shows and set it as the GitHub OAuth App **Authorization callback URL**.
+5. Enable the connection.
+
+SqlOS requests `read:user` and `user:email` by default so it can load the GitHub profile and verified primary email address. See [GitHub OIDC](/docs/authserver/github-oidc) for dashboard, API, and code-first setup.
+
 ## Seed from startup
 
 Instead of clicking through the dashboard, you can seed a connection from code so it exists on a fresh database. This is consistent with `SeedAuthPage`, `SeedAuthEmails`, and client seeding: the bootstrapper reconciles the connection on startup, matched by provider type (and display name for custom providers).
@@ -56,14 +66,19 @@ builder.AddSqlOS<AppDbContext>(options =>
         clientId: builder.Configuration["SqlOS:Oidc:Microsoft:ClientId"]!,
         clientSecret: builder.Configuration["SqlOS:Oidc:Microsoft:ClientSecret"]!,
         tenant: "common",
-        // {connectionId} is replaced with the generated connection id at seed time.
-        "https://your-app.example.com/api/v1/auth/oidc/callback/{connectionId}");
+        "https://your-app.example.com/sqlos/auth/oidc/callback");
 
     // "Continue with Google".
     auth.SeedGoogleConnection(
         clientId: builder.Configuration["SqlOS:Oidc:Google:ClientId"]!,
         clientSecret: builder.Configuration["SqlOS:Oidc:Google:ClientSecret"]!,
-        "https://your-app.example.com/api/v1/auth/oidc/callback/{connectionId}");
+        "https://your-app.example.com/sqlos/auth/oidc/callback");
+
+    // "Continue with GitHub". GitHub uses OAuth profile/email lookup through the same social provider surface.
+    auth.SeedGitHubConnection(
+        clientId: builder.Configuration["SqlOS:Oidc:GitHub:ClientId"]!,
+        clientSecret: builder.Configuration["SqlOS:Oidc:GitHub:ClientSecret"]!,
+        "https://your-app.example.com/sqlos/auth/oidc/callback");
 });
 ```
 
@@ -77,7 +92,7 @@ auth.SeedOidcConnection(oidc =>
     oidc.ClientId = builder.Configuration["SqlOS:Oidc:Acme:ClientId"]!;
     oidc.ClientSecret = builder.Configuration["SqlOS:Oidc:Acme:ClientSecret"];
     oidc.DiscoveryUrl = "https://id.acme.com/.well-known/openid-configuration";
-    oidc.AllowedCallbackUris = ["https://your-app.example.com/api/v1/auth/oidc/callback/{connectionId}"];
+    oidc.AllowedCallbackUris = ["https://your-app.example.com/sqlos/auth/oidc/callback"];
 });
 ```
 
@@ -85,7 +100,7 @@ auth.SeedOidcConnection(oidc =>
   - Seeds are reconciled on every startup. Client id, callbacks, scopes, and endpoints are kept in sync with your code.
   - A client secret is only overwritten when the seed supplies one, so configuration without a secret never clears a stored credential.
   - Enable/disable is owner-managed once the connection exists: a manual disable from the dashboard survives restarts.
-  - Add the same SqlOS-owned callback URI to the provider (Entra, Google, etc.). The connection id is shown in the dashboard after the first boot.
+  - Add the same SqlOS-owned callback URI to the provider (Entra, Google, GitHub, etc.). The dashboard shows the callback after the first boot.
 </Callout>
 
 ## Test
@@ -102,4 +117,5 @@ auth.SeedOidcConnection(oidc =>
 
 - [SAML SSO for an org](/docs/guides/saml-sso)
 - [OIDC overview](/docs/authserver/oidc-auth)
+- [GitHub provider reference](/docs/authserver/github-oidc)
 - [Troubleshooting](/docs/guides/troubleshooting)

--- a/web/content/docs/reference/authserver-api.mdx
+++ b/web/content/docs/reference/authserver-api.mdx
@@ -24,7 +24,7 @@ Complete reference for every public method in the AuthServer module.
 | MFA / TOTP | `SqlOSAuthService` MFA methods and `SqlOSSettingsService` MFA policy methods |
 | Token validation | `ValidateAccessTokenAsync` |
 | Admin CRUD | `SqlOSAdminService` |
-| OIDC social | `SqlOSOidcAuthService` |
+| OIDC social | `SqlOSOidcAuthService` — Google, Microsoft, GitHub, Apple, and custom providers |
 | SAML SSO | `SqlOSSsoAuthorizationService` |
 
 ## SqlOSAuthService
@@ -907,7 +907,7 @@ await adminService.ImportSsoMetadataAsync(
 
 ### CreateOidcConnectionAsync
 
-Register an OIDC social login provider (Google, Microsoft, Apple, or custom).
+Register an OIDC/social login provider (Google, Microsoft, GitHub, Apple, or custom).
 
 ```csharp
 var conn = await adminService.CreateOidcConnectionAsync(
@@ -931,7 +931,7 @@ var conn = await adminService.CreateOidcConnectionAsync(
 
 | Name | Type | Description |
 |------|------|-------------|
-| `request.ProviderType` | `SqlOSOidcProviderType` | `Google`, `Microsoft`, `Apple`, or `Custom`. |
+| `request.ProviderType` | `SqlOSOidcProviderType` | `Google`, `Microsoft`, `GitHub`, `Apple`, or `Custom`. |
 | `request.DisplayName` | `string` | Display name for the provider. |
 | `request.ClientId` | `string` | OAuth client ID from the provider. |
 | `request.ClientSecret` | `string?` | OAuth client secret. |
@@ -944,6 +944,31 @@ var conn = await adminService.CreateOidcConnectionAsync(
 **Returns**
 
 `Task<SqlOSOidcConnection>` — the created connection.
+
+---
+
+### SeedGitHubConnection
+
+Seed a GitHub social login connection from startup code. Use this for repeatable local, preview, and production environments where the dashboard should already show GitHub after the first boot.
+
+```csharp
+options.AuthServer.SeedGitHubConnection(
+    clientId: builder.Configuration["SqlOS:Oidc:GitHub:ClientId"]!,
+    clientSecret: builder.Configuration["SqlOS:Oidc:GitHub:ClientSecret"]!,
+    "https://your-app.example.com/sqlos/auth/oidc/callback");
+```
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `clientId` | `string` | GitHub OAuth App client ID. |
+| `clientSecret` | `string` | GitHub OAuth App client secret. |
+| `allowedCallbackUris` | `params string[]` | SqlOS provider callback URIs to allow. Default base path form is `{AuthServer.PublicOrigin}/sqlos/auth/oidc/callback`. |
+
+The seeded connection uses provider type `GitHub`, display name `GitHub`, protocol `OAuthProfile`, default scopes `read:user` and `user:email`, and the built-in GitHub authorization/token/profile endpoints.
+
+See [GitHub OIDC](/docs/authserver/github-oidc).
 
 ---
 
@@ -1181,7 +1206,7 @@ var tokens = await ssoService.ExchangeCodeAsync(
 
 ## SqlOSOidcAuthService
 
-OIDC (social login) authorization flow — Google, Microsoft, Apple, or custom providers.
+OIDC/social login authorization flow — Google, Microsoft, GitHub, Apple, or custom providers.
 
 ---
 
@@ -1242,7 +1267,7 @@ return Results.Redirect(result.AuthorizationUrl);
 |-------|------|-------------|
 | `AuthorizationUrl` | `string` | Provider URL to redirect to. |
 | `ConnectionId` | `string` | The OIDC connection used. |
-| `ProviderType` | `SqlOSOidcProviderType` | `Google`, `Microsoft`, `Apple`, or `Custom`. |
+| `ProviderType` | `SqlOSOidcProviderType` | `Google`, `Microsoft`, `GitHub`, `Apple`, or `Custom`. |
 | `DisplayName` | `string` | Provider display name. |
 
 ---


### PR DESCRIPTION
## Summary
- add a dedicated GitHub sign-in guide covering GitHub OAuth App setup, dashboard setup, code-first seeding, testing, and failure modes
- add an AuthServer GitHub provider reference with dashboard, admin API, and runtime behavior details
- update OIDC/social docs, guide index, README, and example docs so GitHub is discoverable alongside Google, Microsoft, Apple, and custom providers

## Validation
- scripts/docs-check.sh
- scripts/build.sh
- scripts/unit-tests.sh
- scripts/integration-tests.sh
- Browser smoke test: /docs/guides/github-oidc, /docs/authserver/github-oidc, /docs/guides/index