### PR TITLE
Enforce signing key lifecycle invariants

### DIFF
--- a/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerModelConfiguration.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerModelConfiguration.cs
@@ -394,9 +394,19 @@ public static class SqlOSAuthServerModelConfiguration
 
         modelBuilder.Entity<SqlOSSigningKey>(entity =>
         {
-            entity.ToTable("SqlOSSigningKeys", schema, t => t.ExcludeFromMigrations());
+            entity.ToTable("SqlOSSigningKeys", schema, t =>
+            {
+                t.ExcludeFromMigrations();
+                t.HasCheckConstraint(
+                    "CK_SqlOSSigningKeys_Lifecycle",
+                    "(([IsActive] = CONVERT(bit, 1) AND [RetiredAt] IS NULL) OR ([IsActive] = CONVERT(bit, 0) AND [RetiredAt] IS NOT NULL))");
+            });
             entity.HasKey(x => x.Id);
             entity.HasIndex(x => x.Kid).IsUnique();
+            entity.HasIndex(x => x.IsActive)
+                .IsUnique()
+                .HasDatabaseName("UX_SqlOSSigningKeys_Active")
+                .HasFilter("[IsActive] = 1");
             entity.Property(x => x.Kid).HasMaxLength(120);
             entity.Property(x => x.Algorithm).HasMaxLength(20);
         });

--- a/src/SqlOS/AuthServer/Extensions/EndpointRouteBuilderExtensions.cs
+++ b/src/SqlOS/AuthServer/Extensions/EndpointRouteBuilderExtensions.cs
@@ -4447,6 +4447,7 @@ public static class EndpointRouteBuilderExtensions
 
             var keys = await cryptoService.ListSigningKeysAsync(cancellationToken);
             var rotationSettings = await settingsService.GetKeyRotationSettingsAsync(cancellationToken);
+            var diagnostics = await cryptoService.GetSigningKeyDiagnosticsAsync(rotationSettings.GraceWindow, cancellationToken);
             var activeKey = keys.FirstOrDefault(k => k.IsActive);
 
             return Results.Ok(new
@@ -4463,6 +4464,7 @@ public static class EndpointRouteBuilderExtensions
                 }),
                 rotationIntervalDays = rotationSettings.RotationInterval.TotalDays,
                 graceWindowDays = rotationSettings.GraceWindow.TotalDays,
+                diagnostics,
                 nextRotationDue = activeKey != null
                     ? activeKey.ActivatedAt.Add(rotationSettings.RotationInterval)
                     : (DateTime?)null

--- a/src/SqlOS/AuthServer/Schema/026_SigningKeyLifecycleInvariants.sql
+++ b/src/SqlOS/AuthServer/Schema/026_SigningKeyLifecycleInvariants.sql
@@ -1,0 +1,62 @@
+IF OBJECT_ID('[{Schema}].[SqlOSSigningKeys]', 'U') IS NOT NULL
+BEGIN
+    DECLARE @SigningKeyInvariantNow DATETIME2 = SYSUTCDATETIME();
+
+    ;WITH RankedActiveKeys AS (
+        SELECT
+            [Id],
+            ROW_NUMBER() OVER (ORDER BY [ActivatedAt] DESC, [Id] DESC) AS [Rank]
+        FROM [{Schema}].[SqlOSSigningKeys]
+        WHERE [IsActive] = 1
+    )
+    UPDATE [SigningKeys]
+    SET
+        [IsActive] = 0,
+        [RetiredAt] = COALESCE([SigningKeys].[RetiredAt], @SigningKeyInvariantNow)
+    FROM [{Schema}].[SqlOSSigningKeys] AS [SigningKeys]
+    INNER JOIN [RankedActiveKeys] AS [Ranked]
+        ON [Ranked].[Id] = [SigningKeys].[Id]
+    WHERE [Ranked].[Rank] > 1;
+
+    UPDATE [{Schema}].[SqlOSSigningKeys]
+    SET [RetiredAt] = NULL
+    WHERE [IsActive] = 1
+      AND [RetiredAt] IS NOT NULL;
+
+    UPDATE [{Schema}].[SqlOSSigningKeys]
+    SET [RetiredAt] = COALESCE([ActivatedAt], @SigningKeyInvariantNow)
+    WHERE [IsActive] = 0
+      AND [RetiredAt] IS NULL;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM sys.indexes
+        WHERE [name] = 'UX_SqlOSSigningKeys_Active'
+          AND [object_id] = OBJECT_ID('[{Schema}].[SqlOSSigningKeys]')
+    )
+    BEGIN
+        CREATE UNIQUE INDEX [UX_SqlOSSigningKeys_Active]
+            ON [{Schema}].[SqlOSSigningKeys] ([IsActive])
+            WHERE [IsActive] = 1;
+    END
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM sys.check_constraints
+        WHERE [name] = 'CK_SqlOSSigningKeys_Lifecycle'
+          AND [parent_object_id] = OBJECT_ID('[{Schema}].[SqlOSSigningKeys]')
+    )
+    BEGIN
+        ALTER TABLE [{Schema}].[SqlOSSigningKeys]
+            ADD CONSTRAINT [CK_SqlOSSigningKeys_Lifecycle]
+            CHECK (
+                ([IsActive] = CONVERT(bit, 1) AND [RetiredAt] IS NULL)
+                OR ([IsActive] = CONVERT(bit, 0) AND [RetiredAt] IS NOT NULL)
+            );
+    END
+END
+
+IF EXISTS (SELECT * FROM [{Schema}].[SqlOSSchema])
+    UPDATE [{Schema}].[SqlOSSchema] SET [Version] = 26;
+ELSE
+    INSERT INTO [{Schema}].[SqlOSSchema] ([Version]) VALUES (26);

--- a/src/SqlOS/AuthServer/Services/SqlOSCryptoService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSCryptoService.cs
@@ -197,15 +197,28 @@ public sealed class SqlOSCryptoService
             IsActive = true
         };
         _context.Set<SqlOSSigningKey>().Add(activeKey);
-        await _context.SaveChangesAsync(cancellationToken);
-        return activeKey;
+        try
+        {
+            await _context.SaveChangesAsync(cancellationToken);
+            return activeKey;
+        }
+        catch (DbUpdateException)
+        {
+            var concurrentActiveKey = await TryResolveConcurrentActiveSigningKeyAsync(cancellationToken);
+            if (concurrentActiveKey != null)
+            {
+                return concurrentActiveKey;
+            }
+
+            throw;
+        }
     }
 
     public async Task<List<SqlOSSigningKey>> GetValidationSigningKeysAsync(TimeSpan? graceWindow = null, CancellationToken cancellationToken = default)
     {
         var cutoff = DateTime.UtcNow.Add(-(graceWindow ?? TimeSpan.FromDays(7)));
         return await _context.Set<SqlOSSigningKey>()
-            .Where(x => x.IsActive || x.RetiredAt == null || x.RetiredAt >= cutoff)
+            .Where(x => x.IsActive || (x.RetiredAt != null && x.RetiredAt >= cutoff))
             .ToListAsync(cancellationToken);
     }
 
@@ -232,8 +245,21 @@ public sealed class SqlOSCryptoService
             IsActive = true
         };
         _context.Set<SqlOSSigningKey>().Add(newKey);
-        await _context.SaveChangesAsync(cancellationToken);
-        return newKey;
+        try
+        {
+            await _context.SaveChangesAsync(cancellationToken);
+            return newKey;
+        }
+        catch (DbUpdateException)
+        {
+            var concurrentActiveKey = await TryResolveConcurrentActiveSigningKeyAsync(cancellationToken);
+            if (concurrentActiveKey != null)
+            {
+                return concurrentActiveKey;
+            }
+
+            throw;
+        }
     }
 
     public async Task<bool> ShouldRotateSigningKeyAsync(TimeSpan rotationInterval, CancellationToken cancellationToken = default)
@@ -262,6 +288,62 @@ public sealed class SqlOSCryptoService
         => await _context.Set<SqlOSSigningKey>()
             .OrderByDescending(x => x.ActivatedAt)
             .ToListAsync(cancellationToken);
+
+    public async Task<SqlOSSigningKeyDiagnostics> GetSigningKeyDiagnosticsAsync(
+        TimeSpan graceWindow,
+        CancellationToken cancellationToken = default)
+    {
+        var now = DateTime.UtcNow;
+        var cutoff = now.Subtract(graceWindow);
+        var keys = await _context.Set<SqlOSSigningKey>()
+            .AsNoTracking()
+            .OrderByDescending(x => x.ActivatedAt)
+            .ToListAsync(cancellationToken);
+
+        var issues = new List<SqlOSSigningKeyDiagnosticIssue>();
+        var activeKeys = keys.Where(static key => key.IsActive).ToList();
+        if (activeKeys.Count == 0)
+        {
+            issues.Add(new SqlOSSigningKeyDiagnosticIssue(
+                "no_active_signing_key",
+                "critical",
+                "No active signing key exists."));
+        }
+        else if (activeKeys.Count > 1)
+        {
+            issues.Add(new SqlOSSigningKeyDiagnosticIssue(
+                "multiple_active_signing_keys",
+                "critical",
+                "More than one active signing key exists."));
+        }
+
+        foreach (var key in activeKeys.Where(static key => key.RetiredAt != null))
+        {
+            issues.Add(new SqlOSSigningKeyDiagnosticIssue(
+                "active_key_has_retired_at",
+                "error",
+                "An active signing key has a RetiredAt timestamp.",
+                key.Id,
+                key.Kid));
+        }
+
+        foreach (var key in keys.Where(static key => !key.IsActive && key.RetiredAt == null))
+        {
+            issues.Add(new SqlOSSigningKeyDiagnosticIssue(
+                "inactive_key_missing_retired_at",
+                "error",
+                "An inactive signing key is missing RetiredAt.",
+                key.Id,
+                key.Kid));
+        }
+
+        return new SqlOSSigningKeyDiagnostics(
+            keys.Count,
+            activeKeys.Count,
+            keys.Count(key => key.IsActive || (key.RetiredAt != null && key.RetiredAt >= cutoff)),
+            keys.Count(key => !key.IsActive && key.RetiredAt == null),
+            issues);
+    }
 
     public async Task<string> CreateAccessTokenAsync(
         SqlOSUser user,
@@ -354,8 +436,21 @@ public sealed class SqlOSCryptoService
             IsActive = true
         };
         _context.Set<SqlOSSigningKey>().Add(replacement);
-        await _context.SaveChangesAsync(cancellationToken);
-        return replacement;
+        try
+        {
+            await _context.SaveChangesAsync(cancellationToken);
+            return replacement;
+        }
+        catch (DbUpdateException)
+        {
+            var concurrentActiveKey = await TryResolveConcurrentActiveSigningKeyAsync(cancellationToken);
+            if (concurrentActiveKey != null)
+            {
+                return concurrentActiveKey;
+            }
+
+            throw;
+        }
     }
 
     public async Task<SqlOSValidatedToken?> ValidateAccessTokenAsync(
@@ -475,6 +570,24 @@ public sealed class SqlOSCryptoService
         return new RsaSecurityKey(parameters) { KeyId = key.Kid };
     }
 
+    private async Task<SqlOSSigningKey?> TryResolveConcurrentActiveSigningKeyAsync(CancellationToken cancellationToken)
+    {
+        if (_context is DbContext dbContext)
+        {
+            foreach (var entry in dbContext.ChangeTracker.Entries<SqlOSSigningKey>())
+            {
+                if (entry.State is EntityState.Added or EntityState.Modified)
+                {
+                    entry.State = EntityState.Detached;
+                }
+            }
+        }
+
+        return await _context.Set<SqlOSSigningKey>()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(x => x.IsActive, cancellationToken);
+    }
+
     private async Task ProtectSigningKeyAtRestIfNeededAsync(SqlOSSigningKey key, CancellationToken cancellationToken)
     {
         if (!_options.ProtectSigningKeysWithDataProtection
@@ -499,3 +612,17 @@ public sealed class SqlOSCryptoService
             ? ProtectSecret(privateKeyPem)
             : privateKeyPem;
 }
+
+public sealed record SqlOSSigningKeyDiagnostics(
+    int TotalKeyCount,
+    int ActiveKeyCount,
+    int ValidationKeyCount,
+    int InactiveMissingRetiredAtCount,
+    IReadOnlyList<SqlOSSigningKeyDiagnosticIssue> Issues);
+
+public sealed record SqlOSSigningKeyDiagnosticIssue(
+    string Code,
+    string Severity,
+    string Message,
+    string? KeyId = null,
+    string? Kid = null);

--- a/tests/SqlOS.IntegrationTests/AuthServerSigningKeyResilienceIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/AuthServerSigningKeyResilienceIntegrationTests.cs
@@ -231,6 +231,74 @@ public sealed class AuthServerSigningKeyResilienceIntegrationTests
         }
     }
 
+    [TestMethod]
+    public async Task RotateSigningKeyAsync_WithConcurrentCalls_PreservesLifecycleInvariants()
+    {
+        TestSqlOSDbContext? setupContext = null;
+        string? connectionString = null;
+
+        try
+        {
+            setupContext = await AspireFixture.CreateIsolatedAuthContextAsync("SqlOSKeyRace");
+            connectionString = setupContext.Database.GetConnectionString();
+            connectionString.Should().NotBeNullOrWhiteSpace();
+
+            var setupCrypto = new SqlOSCryptoService(
+                setupContext,
+                Options.Create(AspireFixture.Options),
+                new EphemeralDataProtectionProvider());
+            await setupCrypto.EnsureActiveSigningKeyAsync();
+
+            await setupContext.DisposeAsync();
+            setupContext = null;
+
+            var start = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var rotateTasks = Enumerable.Range(0, 8)
+                .Select(async _ =>
+                {
+                    await start.Task;
+                    await using var context = CreateContext(connectionString!);
+                    var crypto = new SqlOSCryptoService(
+                        context,
+                        Options.Create(AspireFixture.Options),
+                        new EphemeralDataProtectionProvider());
+                    return await crypto.RotateSigningKeyAsync();
+                })
+                .ToArray();
+
+            start.SetResult();
+            var rotatedKeys = await Task.WhenAll(rotateTasks);
+            rotatedKeys.Should().OnlyContain(static key => key.IsActive);
+
+            await using var verificationContext = CreateContext(connectionString!);
+            var keys = await verificationContext.Set<SqlOSSigningKey>()
+                .OrderByDescending(x => x.ActivatedAt)
+                .ToListAsync();
+            keys.Should().ContainSingle(static key => key.IsActive);
+            keys.Where(static key => !key.IsActive).Should().OnlyContain(static key => key.RetiredAt != null);
+
+            var diagnostics = await new SqlOSCryptoService(
+                    verificationContext,
+                    Options.Create(AspireFixture.Options),
+                    new EphemeralDataProtectionProvider())
+                .GetSigningKeyDiagnosticsAsync(TimeSpan.FromDays(7));
+            diagnostics.Issues.Should().BeEmpty();
+        }
+        finally
+        {
+            if (setupContext != null)
+            {
+                await setupContext.DisposeAsync();
+            }
+
+            if (!string.IsNullOrWhiteSpace(connectionString))
+            {
+                await using var cleanupContext = CreateContext(connectionString);
+                await cleanupContext.Database.EnsureDeletedAsync();
+            }
+        }
+    }
+
     private static SqlOSAuthServerOptions CreateOptions(
         string clientId,
         string redirectUri,

--- a/tests/SqlOS.IntegrationTests/SchemaInitializerIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/SchemaInitializerIntegrationTests.cs
@@ -45,6 +45,9 @@ public sealed class SchemaInitializerIntegrationTests
         {
             Assert.IsTrue(await TableExistsAsync(table), $"Table {table} should exist.");
         }
+
+        Assert.IsTrue(await IndexExistsAsync(AspireFixture.SharedContext, "SqlOSSigningKeys", "UX_SqlOSSigningKeys_Active"));
+        Assert.IsTrue(await CheckConstraintExistsAsync(AspireFixture.SharedContext, "SqlOSSigningKeys", "CK_SqlOSSigningKeys_Lifecycle"));
     }
 
     [TestMethod]
@@ -148,7 +151,43 @@ public sealed class SchemaInitializerIntegrationTests
             Assert.IsTrue(await IndexExistsAsync(context, "SqlOSAuditEvents", "IX_SqlOSAuditEvents_Action_OccurredAt"));
             Assert.IsTrue(await IndexExistsAsync(context, "SqlOSAuditEvents", "UX_SqlOSAuditEvents_IdempotencyKeyHash"));
             Assert.AreEqual("user.login", await ScalarStringAsync(context, "SELECT TOP 1 [Action] FROM [dbo].[SqlOSAuditEvents]"));
-            Assert.AreEqual(24, await ScalarIntAsync(context, "SELECT TOP 1 [Version] FROM [dbo].[SqlOSSchema]"));
+            Assert.AreEqual(26, await ScalarIntAsync(context, "SELECT TOP 1 [Version] FROM [dbo].[SqlOSSchema]"));
+        }
+        finally
+        {
+            await DropDatabaseAsync(databaseName);
+        }
+    }
+
+    [TestMethod]
+    public async Task EnsureSchema_RepairsSigningKeyLifecycleInvariants()
+    {
+        var databaseName = $"SqlOSKeys_{Guid.NewGuid():N}"[..30];
+        var databaseConnectionString = BuildDatabaseConnectionString(databaseName);
+        await CreateDatabaseAsync(databaseName);
+
+        try
+        {
+            var dbOptions = new DbContextOptionsBuilder<TestSqlOSDbContext>()
+                .UseSqlServer(databaseConnectionString)
+                .Options;
+
+            await using var context = new TestSqlOSDbContext(dbOptions);
+            await SeedVersion25InvalidSigningKeyLifecycleAsync(context);
+
+            var initializer = new SqlOSSchemaInitializer(
+                context,
+                Options.Create(AspireFixture.Options),
+                LoggerFactory.Create(b => b.AddConsole()).CreateLogger<SqlOSSchemaInitializer>());
+
+            await initializer.EnsureSchemaAsync();
+
+            Assert.IsTrue(await IndexExistsAsync(context, "SqlOSSigningKeys", "UX_SqlOSSigningKeys_Active"));
+            Assert.IsTrue(await CheckConstraintExistsAsync(context, "SqlOSSigningKeys", "CK_SqlOSSigningKeys_Lifecycle"));
+            Assert.AreEqual(1, await ScalarIntAsync(context, "SELECT COUNT(*) FROM [dbo].[SqlOSSigningKeys] WHERE [IsActive] = 1"));
+            Assert.AreEqual(0, await ScalarIntAsync(context, "SELECT COUNT(*) FROM [dbo].[SqlOSSigningKeys] WHERE [IsActive] = 0 AND [RetiredAt] IS NULL"));
+            Assert.AreEqual(0, await ScalarIntAsync(context, "SELECT COUNT(*) FROM [dbo].[SqlOSSigningKeys] WHERE [IsActive] = 1 AND [RetiredAt] IS NOT NULL"));
+            Assert.AreEqual(26, await ScalarIntAsync(context, "SELECT TOP 1 [Version] FROM [dbo].[SqlOSSchema]"));
         }
         finally
         {
@@ -187,7 +226,7 @@ public sealed class SchemaInitializerIntegrationTests
             Assert.IsTrue(await IndexExistsAsync(context, "SqlOSApplicationAssignments", "IX_SqlOSApplicationAssignments_Target"));
             Assert.IsTrue(await IndexExistsAsync(context, "SqlOSApplicationAssignments", "IX_SqlOSApplicationAssignments_ClientApplicationId_RevokedAt"));
             Assert.IsTrue(await IndexExistsAsync(context, "SqlOSApplicationAssignments", "IX_SqlOSApplicationAssignments_OrganizationId_RevokedAt"));
-            Assert.AreEqual(24, await ScalarIntAsync(context, "SELECT TOP 1 [Version] FROM [dbo].[SqlOSSchema]"));
+            Assert.AreEqual(26, await ScalarIntAsync(context, "SELECT TOP 1 [Version] FROM [dbo].[SqlOSSchema]"));
         }
         finally
         {
@@ -297,6 +336,32 @@ public sealed class SchemaInitializerIntegrationTests
         }
     }
 
+    private static async Task<bool> CheckConstraintExistsAsync(DbContext context, string tableName, string constraintName)
+    {
+        var connection = context.Database.GetDbConnection();
+        await connection.OpenAsync();
+        try
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = """
+                SELECT COUNT(*)
+                FROM sys.check_constraints ck
+                INNER JOIN sys.tables t ON ck.parent_object_id = t.object_id
+                WHERE t.name = @tableName
+                  AND ck.name = @constraintName
+                  AND t.schema_id = SCHEMA_ID('dbo')
+                """;
+            cmd.Parameters.Add(new SqlParameter("@tableName", tableName));
+            cmd.Parameters.Add(new SqlParameter("@constraintName", constraintName));
+            var result = await cmd.ExecuteScalarAsync();
+            return Convert.ToInt32(result) > 0;
+        }
+        finally
+        {
+            await connection.CloseAsync();
+        }
+    }
+
     private static async Task SeedVersion22AuditEventsSchemaAsync(DbContext context)
     {
         await context.Database.ExecuteSqlRawAsync("""
@@ -348,6 +413,33 @@ public sealed class SchemaInitializerIntegrationTests
             CREATE TABLE [dbo].[SqlOSSessions] (
                 [Id] NVARCHAR(64) NOT NULL PRIMARY KEY
             );
+            """);
+    }
+
+    private static async Task SeedVersion25InvalidSigningKeyLifecycleAsync(DbContext context)
+    {
+        await context.Database.ExecuteSqlRawAsync("""
+            CREATE TABLE [dbo].[SqlOSSchema] ([Version] INT NOT NULL);
+            INSERT INTO [dbo].[SqlOSSchema] ([Version]) VALUES (25);
+
+            CREATE TABLE [dbo].[SqlOSSigningKeys] (
+                [Id] NVARCHAR(64) NOT NULL PRIMARY KEY,
+                [Kid] NVARCHAR(120) NOT NULL UNIQUE,
+                [Algorithm] NVARCHAR(20) NOT NULL,
+                [PublicKeyPem] NVARCHAR(MAX) NOT NULL,
+                [PrivateKeyPem] NVARCHAR(MAX) NOT NULL,
+                [IsActive] BIT NOT NULL,
+                [ActivatedAt] DATETIME2 NOT NULL,
+                [RetiredAt] DATETIME2 NULL
+            );
+
+            INSERT INTO [dbo].[SqlOSSigningKeys] (
+                [Id], [Kid], [Algorithm], [PublicKeyPem], [PrivateKeyPem], [IsActive], [ActivatedAt], [RetiredAt]
+            )
+            VALUES
+                ('key_active_old', 'kid_active_old', 'RS256', 'public', 'private', 1, DATEADD(day, -10, SYSUTCDATETIME()), NULL),
+                ('key_active_new', 'kid_active_new', 'RS256', 'public', 'private', 1, SYSUTCDATETIME(), SYSUTCDATETIME()),
+                ('key_inactive_unretired', 'kid_inactive_unretired', 'RS256', 'public', 'private', 0, DATEADD(day, -5, SYSUTCDATETIME()), NULL);
             """);
     }
 

--- a/tests/SqlOS.Tests/SqlOSCryptoServiceTests.cs
+++ b/tests/SqlOS.Tests/SqlOSCryptoServiceTests.cs
@@ -38,6 +38,62 @@ public sealed class SqlOSCryptoServiceTests
     }
 
     [TestMethod]
+    public async Task GetValidationSigningKeysAsync_ExcludesInactiveKeysWithoutRetiredAt()
+    {
+        using var context = CreateContext();
+        var now = DateTime.UtcNow;
+        context.Set<SqlOSSigningKey>().AddRange(
+            CreateStoredSigningKey("key_active", isActive: true, activatedAt: now.AddDays(-1), retiredAt: null),
+            CreateStoredSigningKey("key_recently_retired", isActive: false, activatedAt: now.AddDays(-3), retiredAt: now.AddDays(-1)),
+            CreateStoredSigningKey("key_inactive_unretired", isActive: false, activatedAt: now.AddDays(-3), retiredAt: null),
+            CreateStoredSigningKey("key_expired_retired", isActive: false, activatedAt: now.AddDays(-20), retiredAt: now.AddDays(-10)));
+        await context.SaveChangesAsync();
+        var service = new SqlOSCryptoService(context, Options.Create(new SqlOSAuthServerOptions()));
+
+        var keys = await service.GetValidationSigningKeysAsync(TimeSpan.FromDays(7));
+
+        keys.Select(static key => key.Id).Should().BeEquivalentTo("key_active", "key_recently_retired");
+    }
+
+    [TestMethod]
+    public async Task GetSigningKeyDiagnosticsAsync_FlagsInvalidLifecycleRows()
+    {
+        using var context = CreateContext();
+        var now = DateTime.UtcNow;
+        context.Set<SqlOSSigningKey>().AddRange(
+            CreateStoredSigningKey("key_active_1", isActive: true, activatedAt: now.AddDays(-1), retiredAt: null),
+            CreateStoredSigningKey("key_active_2", isActive: true, activatedAt: now, retiredAt: now),
+            CreateStoredSigningKey("key_inactive_unretired", isActive: false, activatedAt: now.AddDays(-2), retiredAt: null));
+        await context.SaveChangesAsync();
+        var service = new SqlOSCryptoService(context, Options.Create(new SqlOSAuthServerOptions()));
+
+        var diagnostics = await service.GetSigningKeyDiagnosticsAsync(TimeSpan.FromDays(7));
+
+        diagnostics.ActiveKeyCount.Should().Be(2);
+        diagnostics.InactiveMissingRetiredAtCount.Should().Be(1);
+        diagnostics.Issues.Select(static issue => issue.Code).Should().Contain([
+            "multiple_active_signing_keys",
+            "active_key_has_retired_at",
+            "inactive_key_missing_retired_at"
+        ]);
+    }
+
+    [TestMethod]
+    public async Task RotateSigningKeyAsync_LeavesExactlyOneActiveKeyAndRetiredInactiveKeys()
+    {
+        using var context = CreateContext();
+        var service = new SqlOSCryptoService(context, Options.Create(new SqlOSAuthServerOptions()));
+
+        var original = await service.EnsureActiveSigningKeyAsync();
+        var rotated = await service.RotateSigningKeyAsync();
+
+        rotated.Id.Should().NotBe(original.Id);
+        var keys = await context.Set<SqlOSSigningKey>().ToListAsync();
+        keys.Should().ContainSingle(static key => key.IsActive);
+        keys.Where(static key => !key.IsActive).Should().OnlyContain(static key => key.RetiredAt != null);
+    }
+
+    [TestMethod]
     public async Task EnsureActiveSigningKey_WithDefaultOptions_DoesNotProtectSigningKeyEvenWhenDataProtectionExists()
     {
         using var context = CreateContext();
@@ -158,6 +214,10 @@ public sealed class SqlOSCryptoServiceTests
         var activeKey = context.Set<SqlOSSigningKey>().Single(x => x.IsActive);
         activeKey.Id.Should().NotBe(originalKey.Id);
         activeKey.PrivateKeyPem.Should().Contain("BEGIN PRIVATE KEY");
+        context.Set<SqlOSSigningKey>()
+            .Where(static key => !key.IsActive)
+            .Should()
+            .OnlyContain(static key => key.RetiredAt != null);
     }
 
     [TestMethod]
@@ -183,6 +243,23 @@ public sealed class SqlOSCryptoServiceTests
 
     private static IOptions<SqlOSAuthServerOptions> SigningKeyProtectedOptions()
         => Options.Create(new SqlOSAuthServerOptions { ProtectSigningKeysWithDataProtection = true });
+
+    private static SqlOSSigningKey CreateStoredSigningKey(
+        string id,
+        bool isActive,
+        DateTime activatedAt,
+        DateTime? retiredAt)
+        => new()
+        {
+            Id = id,
+            Kid = $"{id}_kid",
+            Algorithm = "RS256",
+            PublicKeyPem = "public",
+            PrivateKeyPem = "private",
+            IsActive = isActive,
+            ActivatedAt = activatedAt,
+            RetiredAt = retiredAt
+        };
 
     private static SqlOSUser CreateUser()
         => new()


### PR DESCRIPTION
## Summary
- exclude inactive unretired signing keys from JWT validation
- add signing-key lifecycle diagnostics to the admin signing-keys response
- add schema repair plus active-key unique and lifecycle check constraints
- make rotation/unreadable-key replacement tolerate concurrent active-key races and return the winning active key

Closes #104

## Validation
- dotnet test tests/SqlOS.Tests/SqlOS.Tests.csproj
- dotnet test tests/SqlOS.IntegrationTests/SqlOS.IntegrationTests.csproj --filter "FullyQualifiedName~SchemaInitializerIntegrationTests|FullyQualifiedName~AuthServerSigningKeyResilienceIntegrationTests"
- scripts/build.sh
- scripts/unit-tests.sh
- scripts/integration-tests.sh
- scripts/docs-check.sh

## Note
- Uses schema migration 026 so it can follow the separately opened issue #102 migration 025.