### PR TITLE
Simplify SqlOS application setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,38 +60,39 @@ Full walkthrough: **[sqlos.dev/docs/getting-started](https://sqlos.dev/docs/gett
    dotnet add package SqlOS
    ```
 
-2. **Use SQL Server for your EF `DbContext`**  
+2. **Use SQL Server for your EF `DbContext`**
    SqlOS uses the same database as your context. Point EF at SQL Server like any other app.
 
-3. **Wire your `DbContext`**  
-   Add the two SqlOS interfaces. Add the FGA `IsResourceAccessible` query. Call `UseSqlOS` in `OnModelCreating`:
+3. **Create your `DbContext`**
+   Derive from `SqlOSDbContext<TContext>` to add the SqlOS auth server model, FGA model, and FGA TVF mapping:
 
    ```csharp
-   public sealed class AppDbContext : DbContext, ISqlOSAuthServerDbContext, ISqlOSFgaDbContext
+   public sealed class AppDbContext(DbContextOptions<AppDbContext> options)
+       : SqlOSDbContext<AppDbContext>(options)
    {
-       public IQueryable<SqlOSFgaAccessibleResource> IsResourceAccessible(
-           string subjectId,
-           string permissionKey)
-           => FromExpression(() => IsResourceAccessible(subjectId, permissionKey));
+       public DbSet<Project> Projects => Set<Project>();
 
-       protected override void OnModelCreating(ModelBuilder modelBuilder)
+       protected override void OnApplicationModelCreating(ModelBuilder modelBuilder)
        {
-           base.OnModelCreating(modelBuilder);
-           modelBuilder.UseSqlOS(GetType());
+           modelBuilder.Entity<Project>();
        }
    }
    ```
 
+   The low-level `ISqlOSAuthServerDbContext`, `ISqlOSFgaDbContext`, and `modelBuilder.UseSqlOS(...)` path remains available when you need custom model control.
+
 4. **Register SqlOS on the host**
 
    ```csharp
-   builder.AddSqlOS<AppDbContext>(options =>
-   {
-       options.AuthServer.SeedOwnedWebApp(
-           "todo-web",
-           "Todo Web App",
-           "https://app.example.com/auth/callback");
-   });
+   builder.AddSqlOS<AppDbContext>(
+       db => db.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")),
+       options =>
+       {
+           options.AuthServer.SeedOwnedWebApp(
+               "todo-web",
+               "Todo Web App",
+               "https://app.example.com/auth/callback");
+       });
    ```
 
 5. **Map routes after `Build()`**
@@ -100,6 +101,8 @@ Full walkthrough: **[sqlos.dev/docs/getting-started](https://sqlos.dev/docs/gett
    var app = builder.Build();
    app.MapSqlOS();
    ```
+
+   Protect APIs with `RequireSqlOSAccessToken(audience)`, then use `http.SqlOSUserId()`, `fga.Allows(...)`, `db.AddSqlOSResource(...)`, and `db.GrantSqlOSRole(...)` in normal endpoint code.
 
 On startup, SqlOS updates its own schema. Default URLs: admin at `/sqlos`, OAuth at `/sqlos/auth`. Change the prefix with `DashboardBasePath` if you need to.
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Full walkthrough: **[sqlos.dev/docs/getting-started](https://sqlos.dev/docs/gett
    app.MapSqlOS();
    ```
 
-   Protect APIs with `RequireSqlOSAccessToken(audience)`, then use `http.SqlOSUserId()`, `fga.Allows(...)`, `db.AddSqlOSResource(...)`, and `db.GrantSqlOSRole(...)` in normal endpoint code.
+   Protect APIs with `RequireSqlOSAccessToken(audience)`, then use `http.SqlOSUserId()`, `fga.Allows(...)`, `db.EnsureSqlOSUserSubjectAsync(...)`, `db.EnsureSqlOSResourceAsync(...)`, and `db.EnsureSqlOSRoleGrantAsync(...)` in normal endpoint code.
 
 On startup, SqlOS updates its own schema. Default URLs: admin at `/sqlos`, OAuth at `/sqlos/auth`. Change the prefix with `DashboardBasePath` if you need to.
 

--- a/examples/SqlOS.Example.Api/Data/ExampleAppDbContext.cs
+++ b/examples/SqlOS.Example.Api/Data/ExampleAppDbContext.cs
@@ -1,14 +1,11 @@
 using Microsoft.EntityFrameworkCore;
-using SqlOS.AuthServer.Interfaces;
+using SqlOS;
 using SqlOS.Example.Api.FgaRetail.Models;
 using SqlOS.Example.Api.Models;
-using SqlOS.Extensions;
-using SqlOS.Fga.Interfaces;
-using SqlOS.Fga.Models;
 
 namespace SqlOS.Example.Api.Data;
 
-public sealed class ExampleAppDbContext : DbContext, ISqlOSAuthServerDbContext, ISqlOSFgaDbContext
+public sealed class ExampleAppDbContext : SqlOSDbContext<ExampleAppDbContext>
 {
     public ExampleAppDbContext(DbContextOptions<ExampleAppDbContext> options) : base(options)
     {
@@ -20,17 +17,8 @@ public sealed class ExampleAppDbContext : DbContext, ISqlOSAuthServerDbContext, 
     public DbSet<InventoryItem> InventoryItems => Set<InventoryItem>();
     public DbSet<ExampleUserProfile> ExampleUserProfiles => Set<ExampleUserProfile>();
 
-    public IQueryable<SqlOSFgaAccessibleResource> IsResourceAccessible(
-        string resourceId,
-        string subjectIds,
-        string permissionId)
-        => FromExpression(() => IsResourceAccessible(resourceId, subjectIds, permissionId));
-
-    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    protected override void OnApplicationModelCreating(ModelBuilder modelBuilder)
     {
-        base.OnModelCreating(modelBuilder);
-        modelBuilder.UseSqlOS(Database.IsRelational() ? GetType() : null);
-
         modelBuilder.Entity<Workspace>(entity =>
         {
             entity.HasKey(x => x.Id);

--- a/examples/SqlOS.Example.Api/Program.cs
+++ b/examples/SqlOS.Example.Api/Program.cs
@@ -28,252 +28,251 @@ var connectionString =
 if (string.IsNullOrWhiteSpace(connectionString))
     throw new InvalidOperationException("Connection string 'DefaultConnection' was not configured.");
 
-builder.Services.AddDbContext<ExampleAppDbContext>(options =>
-    options.UseSqlServer(connectionString));
-
-builder.AddSqlOS<ExampleAppDbContext>(options =>
-{
-    options.DashboardBasePath = "/sqlos";
-    var exampleClientId = builder.Configuration["ExampleFrontend:ClientId"] ?? "example-web";
-    var exampleCallbackUrl = builder.Configuration["ExampleFrontend:CallbackUrl"] ?? "http://localhost:3000/auth/callback";
-    var emailConnectionString = builder.Configuration["SqlOS:Email:AzureCommunicationServicesConnectionString"]
-        ?? builder.Configuration["SqlOS:EmailOtp:AzureCommunicationServicesConnectionString"]
-        ?? builder.Configuration["AZURE_EMAIL_CONNECTION_STRING"];
-    var emailFromAddress = builder.Configuration["SqlOS:Email:FromAddress"]
-        ?? builder.Configuration["SqlOS:EmailOtp:FromAddress"]
-        ?? builder.Configuration["AZURE_EMAIL_SENDER_ADDRESS"];
-    var enablePhoneOtp = builder.Configuration.GetValue<bool>("SqlOS:PhoneOtp:Enabled");
-    var twilioAccountSid = builder.Configuration["SqlOS:PhoneOtp:TwilioAccountSid"]
-        ?? builder.Configuration["TWILIO_ACCOUNT_SID"];
-    var twilioAuthToken = builder.Configuration["SqlOS:PhoneOtp:TwilioAuthToken"]
-        ?? builder.Configuration["TWILIO_AUTH_TOKEN"];
-    var twilioVerifyServiceSid = builder.Configuration["SqlOS:PhoneOtp:TwilioVerifyServiceSid"]
-        ?? builder.Configuration["TWILIO_VERIFY_SERVICE_SID"];
-    var phoneOtpDefaultRegion = builder.Configuration["SqlOS:PhoneOtp:DefaultRegion"]
-        ?? builder.Configuration["TWILIO_DEFAULT_REGION"];
-
-    // "Continue with Microsoft" social login. Secrets are never committed: the AppHost forwards
-    // them as environment variables (SqlOS__Oidc__Microsoft__*) when configured for the developer.
-    var microsoftOidcClientId = builder.Configuration["SqlOS:Oidc:Microsoft:ClientId"];
-    var microsoftOidcClientSecret = builder.Configuration["SqlOS:Oidc:Microsoft:ClientSecret"];
-    var microsoftOidcTenant = builder.Configuration["SqlOS:Oidc:Microsoft:Tenant"];
-
-    if (Enum.TryParse<SqlOSDashboardAuthMode>(builder.Configuration["SqlOS:Dashboard:AuthMode"], ignoreCase: true, out var authMode))
+builder.AddSqlOS<ExampleAppDbContext>(
+    (DbContextOptionsBuilder db) => db.UseSqlServer(connectionString),
+    options =>
     {
-        options.Dashboard.AuthMode = authMode;
-    }
+        options.DashboardBasePath = "/sqlos";
+        var exampleClientId = builder.Configuration["ExampleFrontend:ClientId"] ?? "example-web";
+        var exampleCallbackUrl = builder.Configuration["ExampleFrontend:CallbackUrl"] ?? "http://localhost:3000/auth/callback";
+        var emailConnectionString = builder.Configuration["SqlOS:Email:AzureCommunicationServicesConnectionString"]
+            ?? builder.Configuration["SqlOS:EmailOtp:AzureCommunicationServicesConnectionString"]
+            ?? builder.Configuration["AZURE_EMAIL_CONNECTION_STRING"];
+        var emailFromAddress = builder.Configuration["SqlOS:Email:FromAddress"]
+            ?? builder.Configuration["SqlOS:EmailOtp:FromAddress"]
+            ?? builder.Configuration["AZURE_EMAIL_SENDER_ADDRESS"];
+        var enablePhoneOtp = builder.Configuration.GetValue<bool>("SqlOS:PhoneOtp:Enabled");
+        var twilioAccountSid = builder.Configuration["SqlOS:PhoneOtp:TwilioAccountSid"]
+            ?? builder.Configuration["TWILIO_ACCOUNT_SID"];
+        var twilioAuthToken = builder.Configuration["SqlOS:PhoneOtp:TwilioAuthToken"]
+            ?? builder.Configuration["TWILIO_AUTH_TOKEN"];
+        var twilioVerifyServiceSid = builder.Configuration["SqlOS:PhoneOtp:TwilioVerifyServiceSid"]
+            ?? builder.Configuration["TWILIO_VERIFY_SERVICE_SID"];
+        var phoneOtpDefaultRegion = builder.Configuration["SqlOS:PhoneOtp:DefaultRegion"]
+            ?? builder.Configuration["TWILIO_DEFAULT_REGION"];
 
-    var dashboardPassword = builder.Configuration["SqlOS:Dashboard:Password"];
-    if (!string.IsNullOrWhiteSpace(dashboardPassword))
-    {
-        options.Dashboard.Password = dashboardPassword;
-    }
+        // "Continue with Microsoft" social login. Secrets are never committed: the AppHost forwards
+        // them as environment variables (SqlOS__Oidc__Microsoft__*) when configured for the developer.
+        var microsoftOidcClientId = builder.Configuration["SqlOS:Oidc:Microsoft:ClientId"];
+        var microsoftOidcClientSecret = builder.Configuration["SqlOS:Oidc:Microsoft:ClientSecret"];
+        var microsoftOidcTenant = builder.Configuration["SqlOS:Oidc:Microsoft:Tenant"];
 
-    var sessionMinutes = builder.Configuration.GetValue<int?>("SqlOS:Dashboard:SessionLifetimeMinutes");
-    if (sessionMinutes is > 0)
-    {
-        options.Dashboard.SessionLifetime = TimeSpan.FromMinutes(sessionMinutes.Value);
-    }
-
-    var auth = options.AuthServer;
-    auth.Issuer = builder.Configuration["SqlOS:Issuer"] ?? "https://localhost/sqlos/auth";
-    auth.DefaultSigningKeyRotationIntervalDays = 90;
-    auth.DefaultSigningKeyGraceWindowDays = 7;
-    options.ConfigureEmail(email =>
-    {
-        email.AzureCommunicationServicesConnectionString = emailConnectionString;
-        email.FromAddress = emailFromAddress;
-    });
-    auth.ConfigureEmailOtp(emailOtp =>
-    {
-        emailOtp.AzureCommunicationServicesConnectionString = emailConnectionString;
-        emailOtp.FromAddress = emailFromAddress;
-        emailOtp.ApplicationName = "SqlOS Example";
-    });
-    auth.ConfigurePhoneOtp(phone =>
-    {
-        phone.Enabled = enablePhoneOtp;
-        phone.TwilioAccountSid = twilioAccountSid;
-        phone.TwilioAuthToken = twilioAuthToken;
-        phone.TwilioVerifyServiceSid = twilioVerifyServiceSid;
-        if (!string.IsNullOrWhiteSpace(phoneOtpDefaultRegion))
+        if (Enum.TryParse<SqlOSDashboardAuthMode>(builder.Configuration["SqlOS:Dashboard:AuthMode"], ignoreCase: true, out var authMode))
         {
-            phone.DefaultRegion = phoneOtpDefaultRegion;
+            options.Dashboard.AuthMode = authMode;
         }
-    });
-    auth.ConfigureMfa(mfa =>
-    {
-        mfa.Enabled = true;
-        mfa.AllowUserSelfEnrollmentByDefault = true;
-        mfa.RecoveryCodesEnabledByDefault = true;
-        mfa.Totp.Issuer = "SqlOS Example";
-    });
 
-    var headlessFrontendUrl = builder.Configuration["SqlOS:HeadlessFrontendUrl"]
-        ?? builder.Configuration["ExampleFrontend:Origin"]
-        ?? "http://localhost:3000";
-    var enableHeadlessAuthPage = builder.Configuration.GetValue<bool?>("SqlOS:EnableHeadlessAuthPage") ?? true;
-
-    auth.SeedAuthPage(page =>
-    {
-        page.PageTitle = "Sign in";
-        page.PageSubtitle = "Use the hosted SqlOS auth page to sign in to the example application.";
-        page.PrimaryColor = "#2563eb";
-        page.AccentColor = "#0f172a";
-        page.BackgroundColor = "#f8fafc";
-        page.Layout = "split";
-        page.EnablePasswordSignup = true;
-        page.EnabledCredentialTypes = enablePhoneOtp
-            ? ["password", "email_otp", "phone_otp"]
-            : ["password", "email_otp"];
-    });
-    auth.SeedAuthEmails(email =>
-    {
-        email.ApplicationName = "SqlOS Example";
-        email.PrimaryColor = "#2563eb";
-        email.AccentColor = "#0f172a";
-        email.BackgroundColor = "#f8fafc";
-    });
-    auth.SeedBrowserClient(
-        exampleClientId,
-        "Example Web Client",
-        exampleCallbackUrl,
-        "https://client.example.local/callback",
-        "sqlos-expo://auth-callback");
-    auth.SeedBrowserClient(
-        "example-angular",
-        "Example Angular Client",
-        "http://localhost:4200/auth/callback");
-    auth.SeedBrowserClient(
-        "example-expo",
-        "Example Expo Client",
-        "sqlos-expo://auth-callback");
-
-    // Seed the Microsoft social connection only when credentials are supplied so a fresh checkout
-    // without Azure configured still boots cleanly (the button simply does not appear).
-    if (!string.IsNullOrWhiteSpace(microsoftOidcClientId) && !string.IsNullOrWhiteSpace(microsoftOidcClientSecret))
-    {
-        var oidcCallbackOrigin = builder.Configuration["SqlOS:Oidc:CallbackBaseUrl"]
-            ?? (Uri.TryCreate(auth.Issuer, UriKind.Absolute, out var issuerUri)
-                ? issuerUri.GetLeftPart(UriPartial.Authority)
-                : "http://localhost:5062");
-        var microsoftCallbackUri = $"{oidcCallbackOrigin.TrimEnd('/')}/api/v1/auth/oidc/callback/{{connectionId}}";
-
-        auth.SeedMicrosoftConnection(
-            microsoftOidcClientId,
-            microsoftOidcClientSecret,
-            microsoftOidcTenant,
-            microsoftCallbackUri);
-    }
-
-    if (enableHeadlessAuthPage)
-    {
-        auth.UseHeadlessAuthPage(headless =>
+        var dashboardPassword = builder.Configuration["SqlOS:Dashboard:Password"];
+        if (!string.IsNullOrWhiteSpace(dashboardPassword))
         {
-            headless.BuildUiUrl = ctx =>
-            {
-                var origin = ctx.HttpContext.Items["HeadlessFrontendOrigin"] as string
-                    ?? headlessFrontendUrl;
-                var query = new Dictionary<string, string?>
-                {
-                    ["request"] = ctx.RequestId,
-                    ["view"] = ctx.View,
-                    ["error"] = ctx.Error,
-                    ["email"] = ctx.Email,
-                    ["pendingToken"] = ctx.PendingToken,
-                    ["displayName"] = ctx.DisplayName,
-                };
-                return QueryHelpers.AddQueryString(
-                    $"{origin.TrimEnd('/')}/auth/authorize", query);
-            };
+            options.Dashboard.Password = dashboardPassword;
+        }
 
-            headless.OnHeadlessSignupAsync = async (ctx, cancellationToken) =>
-            {
-                var logger = ctx.HttpContext.RequestServices
-                    .GetRequiredService<ILoggerFactory>()
-                    .CreateLogger("HeadlessSignup");
-                var dbContext = ctx.HttpContext.RequestServices.GetRequiredService<ExampleAppDbContext>();
+        var sessionMinutes = builder.Configuration.GetValue<int?>("SqlOS:Dashboard:SessionLifetimeMinutes");
+        if (sessionMinutes is > 0)
+        {
+            options.Dashboard.SessionLifetime = TimeSpan.FromMinutes(sessionMinutes.Value);
+        }
 
-                var firstName = ctx.CustomFields?["firstName"]?.GetValue<string>();
-                var lastName = ctx.CustomFields?["lastName"]?.GetValue<string>();
-                var referralSource = ctx.CustomFields?["referralSource"]?.GetValue<string>()?.Trim();
-
-                if (string.IsNullOrWhiteSpace(referralSource))
-                {
-                    throw new SqlOSHeadlessValidationException(
-                        "Tell us how you heard about SqlOS.",
-                        new Dictionary<string, string>(StringComparer.Ordinal)
-                        {
-                            ["referralSource"] = "Select a referral source to complete signup."
-                        });
-                }
-
-                var profile = await dbContext.ExampleUserProfiles
-                    .FirstOrDefaultAsync(x => x.SqlOSUserId == ctx.User.Id, cancellationToken);
-
-                if (profile == null)
-                {
-                    profile = new ExampleUserProfile
-                    {
-                        SqlOSUserId = ctx.User.Id,
-                        CreatedAt = DateTime.UtcNow
-                    };
-                    dbContext.ExampleUserProfiles.Add(profile);
-                }
-
-                profile.DefaultEmail = ctx.User.DefaultEmail ?? string.Empty;
-                profile.DisplayName = ctx.User.DisplayName ?? ctx.User.DefaultEmail ?? "Example User";
-                profile.OrganizationId = ctx.Organization?.Id;
-                profile.OrganizationName = ctx.Organization?.Name;
-                profile.ReferralSource = referralSource!;
-                profile.UpdatedAt = DateTime.UtcNow;
-
-                await dbContext.SaveChangesAsync(cancellationToken);
-
-                logger.LogInformation(
-                    "Headless signup completed: {Email}, Org={OrgName}, FirstName={First}, LastName={Last}, Referral={Referral}",
-                    ctx.User.DefaultEmail,
-                    ctx.Organization?.Name,
-                    firstName,
-                    lastName,
-                    referralSource);
-            };
+        var auth = options.AuthServer;
+        auth.Issuer = builder.Configuration["SqlOS:Issuer"] ?? "https://localhost/sqlos/auth";
+        auth.DefaultSigningKeyRotationIntervalDays = 90;
+        auth.DefaultSigningKeyGraceWindowDays = 7;
+        options.ConfigureEmail(email =>
+        {
+            email.AzureCommunicationServicesConnectionString = emailConnectionString;
+            email.FromAddress = emailFromAddress;
         });
-    }
+        auth.ConfigureEmailOtp(emailOtp =>
+        {
+            emailOtp.AzureCommunicationServicesConnectionString = emailConnectionString;
+            emailOtp.FromAddress = emailFromAddress;
+            emailOtp.ApplicationName = "SqlOS Example";
+        });
+        auth.ConfigurePhoneOtp(phone =>
+        {
+            phone.Enabled = enablePhoneOtp;
+            phone.TwilioAccountSid = twilioAccountSid;
+            phone.TwilioAuthToken = twilioAuthToken;
+            phone.TwilioVerifyServiceSid = twilioVerifyServiceSid;
+            if (!string.IsNullOrWhiteSpace(phoneOtpDefaultRegion))
+            {
+                phone.DefaultRegion = phoneOtpDefaultRegion;
+            }
+        });
+        auth.ConfigureMfa(mfa =>
+        {
+            mfa.Enabled = true;
+            mfa.AllowUserSelfEnrollmentByDefault = true;
+            mfa.RecoveryCodesEnabledByDefault = true;
+            mfa.Totp.Issuer = "SqlOS Example";
+        });
 
-    options.Fga.Seed(seed =>
-    {
-        seed.ResourceType(
-            ExampleFgaService.OrganizationResourceTypeId,
-            "Organization",
-            "Organization root for example workspace access.");
-        seed.ResourceType(
-            ExampleFgaService.WorkspaceResourceTypeId,
-            "Workspace",
-            "Workspace resources in the example application.");
-        seed.Permission(
-            "perm_workspace_view",
-            ExampleFgaService.WorkspaceViewPermission,
-            "View workspaces",
-            ExampleFgaService.WorkspaceResourceTypeId);
-        seed.Permission(
-            "perm_workspace_manage",
-            ExampleFgaService.WorkspaceManagePermission,
-            "Manage workspaces",
-            ExampleFgaService.WorkspaceResourceTypeId);
-        seed.Role(
-            "role_org_member",
-            ExampleFgaService.OrgMemberRole,
-            "Organization Member");
-        seed.Role(
-            "role_org_admin",
-            ExampleFgaService.OrgAdminRole,
-            "Organization Admin");
-        seed.RolePermission(ExampleFgaService.OrgMemberRole, ExampleFgaService.WorkspaceViewPermission);
-        seed.RolePermission(ExampleFgaService.OrgAdminRole, ExampleFgaService.WorkspaceViewPermission);
-        seed.RolePermission(ExampleFgaService.OrgAdminRole, ExampleFgaService.WorkspaceManagePermission);
+        var headlessFrontendUrl = builder.Configuration["SqlOS:HeadlessFrontendUrl"]
+            ?? builder.Configuration["ExampleFrontend:Origin"]
+            ?? "http://localhost:3000";
+        var enableHeadlessAuthPage = builder.Configuration.GetValue<bool?>("SqlOS:EnableHeadlessAuthPage") ?? true;
+
+        auth.SeedAuthPage(page =>
+        {
+            page.PageTitle = "Sign in";
+            page.PageSubtitle = "Use the hosted SqlOS auth page to sign in to the example application.";
+            page.PrimaryColor = "#2563eb";
+            page.AccentColor = "#0f172a";
+            page.BackgroundColor = "#f8fafc";
+            page.Layout = "split";
+            page.EnablePasswordSignup = true;
+            page.EnabledCredentialTypes = enablePhoneOtp
+                ? ["password", "email_otp", "phone_otp"]
+                : ["password", "email_otp"];
+        });
+        auth.SeedAuthEmails(email =>
+        {
+            email.ApplicationName = "SqlOS Example";
+            email.PrimaryColor = "#2563eb";
+            email.AccentColor = "#0f172a";
+            email.BackgroundColor = "#f8fafc";
+        });
+        auth.SeedBrowserClient(
+            exampleClientId,
+            "Example Web Client",
+            exampleCallbackUrl,
+            "https://client.example.local/callback",
+            "sqlos-expo://auth-callback");
+        auth.SeedBrowserClient(
+            "example-angular",
+            "Example Angular Client",
+            "http://localhost:4200/auth/callback");
+        auth.SeedBrowserClient(
+            "example-expo",
+            "Example Expo Client",
+            "sqlos-expo://auth-callback");
+
+        // Seed the Microsoft social connection only when credentials are supplied so a fresh checkout
+        // without Azure configured still boots cleanly (the button simply does not appear).
+        if (!string.IsNullOrWhiteSpace(microsoftOidcClientId) && !string.IsNullOrWhiteSpace(microsoftOidcClientSecret))
+        {
+            var oidcCallbackOrigin = builder.Configuration["SqlOS:Oidc:CallbackBaseUrl"]
+                ?? (Uri.TryCreate(auth.Issuer, UriKind.Absolute, out var issuerUri)
+                    ? issuerUri.GetLeftPart(UriPartial.Authority)
+                    : "http://localhost:5062");
+            var microsoftCallbackUri = $"{oidcCallbackOrigin.TrimEnd('/')}/api/v1/auth/oidc/callback/{{connectionId}}";
+
+            auth.SeedMicrosoftConnection(
+                microsoftOidcClientId,
+                microsoftOidcClientSecret,
+                microsoftOidcTenant,
+                microsoftCallbackUri);
+        }
+
+        if (enableHeadlessAuthPage)
+        {
+            auth.UseHeadlessAuthPage(headless =>
+            {
+                headless.BuildUiUrl = ctx =>
+                {
+                    var origin = ctx.HttpContext.Items["HeadlessFrontendOrigin"] as string
+                        ?? headlessFrontendUrl;
+                    var query = new Dictionary<string, string?>
+                    {
+                        ["request"] = ctx.RequestId,
+                        ["view"] = ctx.View,
+                        ["error"] = ctx.Error,
+                        ["email"] = ctx.Email,
+                        ["pendingToken"] = ctx.PendingToken,
+                        ["displayName"] = ctx.DisplayName,
+                    };
+                    return QueryHelpers.AddQueryString(
+                        $"{origin.TrimEnd('/')}/auth/authorize", query);
+                };
+
+                headless.OnHeadlessSignupAsync = async (ctx, cancellationToken) =>
+                {
+                    var logger = ctx.HttpContext.RequestServices
+                        .GetRequiredService<ILoggerFactory>()
+                        .CreateLogger("HeadlessSignup");
+                    var dbContext = ctx.HttpContext.RequestServices.GetRequiredService<ExampleAppDbContext>();
+
+                    var firstName = ctx.CustomFields?["firstName"]?.GetValue<string>();
+                    var lastName = ctx.CustomFields?["lastName"]?.GetValue<string>();
+                    var referralSource = ctx.CustomFields?["referralSource"]?.GetValue<string>()?.Trim();
+
+                    if (string.IsNullOrWhiteSpace(referralSource))
+                    {
+                        throw new SqlOSHeadlessValidationException(
+                            "Tell us how you heard about SqlOS.",
+                            new Dictionary<string, string>(StringComparer.Ordinal)
+                            {
+                                ["referralSource"] = "Select a referral source to complete signup."
+                            });
+                    }
+
+                    var profile = await dbContext.ExampleUserProfiles
+                        .FirstOrDefaultAsync(x => x.SqlOSUserId == ctx.User.Id, cancellationToken);
+
+                    if (profile == null)
+                    {
+                        profile = new ExampleUserProfile
+                        {
+                            SqlOSUserId = ctx.User.Id,
+                            CreatedAt = DateTime.UtcNow
+                        };
+                        dbContext.ExampleUserProfiles.Add(profile);
+                    }
+
+                    profile.DefaultEmail = ctx.User.DefaultEmail ?? string.Empty;
+                    profile.DisplayName = ctx.User.DisplayName ?? ctx.User.DefaultEmail ?? "Example User";
+                    profile.OrganizationId = ctx.Organization?.Id;
+                    profile.OrganizationName = ctx.Organization?.Name;
+                    profile.ReferralSource = referralSource!;
+                    profile.UpdatedAt = DateTime.UtcNow;
+
+                    await dbContext.SaveChangesAsync(cancellationToken);
+
+                    logger.LogInformation(
+                        "Headless signup completed: {Email}, Org={OrgName}, FirstName={First}, LastName={Last}, Referral={Referral}",
+                        ctx.User.DefaultEmail,
+                        ctx.Organization?.Name,
+                        firstName,
+                        lastName,
+                        referralSource);
+                };
+            });
+        }
+
+        options.Fga.Seed(seed =>
+        {
+            seed.ResourceType(
+                ExampleFgaService.OrganizationResourceTypeId,
+                "Organization",
+                "Organization root for example workspace access.");
+            seed.ResourceType(
+                ExampleFgaService.WorkspaceResourceTypeId,
+                "Workspace",
+                "Workspace resources in the example application.");
+            seed.Permission(
+                "perm_workspace_view",
+                ExampleFgaService.WorkspaceViewPermission,
+                "View workspaces",
+                ExampleFgaService.WorkspaceResourceTypeId);
+            seed.Permission(
+                "perm_workspace_manage",
+                ExampleFgaService.WorkspaceManagePermission,
+                "Manage workspaces",
+                ExampleFgaService.WorkspaceResourceTypeId);
+            seed.Role(
+                "role_org_member",
+                ExampleFgaService.OrgMemberRole,
+                "Organization Member");
+            seed.Role(
+                "role_org_admin",
+                ExampleFgaService.OrgAdminRole,
+                "Organization Admin");
+            seed.RolePermission(ExampleFgaService.OrgMemberRole, ExampleFgaService.WorkspaceViewPermission);
+            seed.RolePermission(ExampleFgaService.OrgAdminRole, ExampleFgaService.WorkspaceViewPermission);
+            seed.RolePermission(ExampleFgaService.OrgAdminRole, ExampleFgaService.WorkspaceManagePermission);
+        });
     });
-});
 
 builder.Services.AddScoped<ExampleFgaService>();
 builder.Services.AddScoped<RetailSeedService>();

--- a/examples/SqlOS.Todo.Api/Data/TodoSampleDbContext.cs
+++ b/examples/SqlOS.Todo.Api/Data/TodoSampleDbContext.cs
@@ -1,28 +1,16 @@
 using Microsoft.EntityFrameworkCore;
-using SqlOS.AuthServer.Interfaces;
-using SqlOS.Fga.Interfaces;
-using SqlOS.Fga.Models;
-using SqlOS.Extensions;
+using SqlOS;
 using SqlOS.Todo.Api.Models;
 
 namespace SqlOS.Todo.Api.Data;
 
 public sealed class TodoSampleDbContext(DbContextOptions<TodoSampleDbContext> options)
-    : DbContext(options), ISqlOSAuthServerDbContext, ISqlOSFgaDbContext
+    : SqlOSDbContext<TodoSampleDbContext>(options)
 {
     public DbSet<TodoItem> TodoItems => Set<TodoItem>();
 
-    public IQueryable<SqlOSFgaAccessibleResource> IsResourceAccessible(
-        string resourceId,
-        string subjectIds,
-        string permissionId)
-        => FromExpression(() => IsResourceAccessible(resourceId, subjectIds, permissionId));
-
-    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    protected override void OnApplicationModelCreating(ModelBuilder modelBuilder)
     {
-        base.OnModelCreating(modelBuilder);
-        modelBuilder.UseSqlOS(Database.IsRelational() ? GetType() : null);
-
         modelBuilder.Entity<TodoItem>(entity =>
         {
             entity.HasKey(x => x.Id);

--- a/examples/SqlOS.Todo.Api/Program.cs
+++ b/examples/SqlOS.Todo.Api/Program.cs
@@ -29,7 +29,6 @@ if (string.IsNullOrWhiteSpace(connectionString))
     throw new InvalidOperationException("Connection string 'DefaultConnection' was not configured.");
 }
 
-builder.Services.AddDbContext<TodoSampleDbContext>(options => options.UseSqlServer(connectionString));
 builder.Services.AddScoped<TodoFgaService>();
 builder.Services.Configure<JsonOptions>(options =>
 {
@@ -90,202 +89,204 @@ builder.Services.AddCors(options =>
     });
 });
 
-builder.AddSqlOS<TodoSampleDbContext>(options =>
-{
-    options.DashboardBasePath = "/sqlos";
-    var emailConnectionString = builder.Configuration["SqlOS:Email:AzureCommunicationServicesConnectionString"]
-        ?? builder.Configuration["SqlOS:EmailOtp:AzureCommunicationServicesConnectionString"]
-        ?? builder.Configuration["AZURE_EMAIL_CONNECTION_STRING"];
-    var emailFromAddress = builder.Configuration["SqlOS:Email:FromAddress"]
-        ?? builder.Configuration["SqlOS:EmailOtp:FromAddress"]
-        ?? builder.Configuration["AZURE_EMAIL_SENDER_ADDRESS"];
-    var twilioAccountSid = builder.Configuration["SqlOS:PhoneOtp:TwilioAccountSid"]
-        ?? builder.Configuration["TWILIO_ACCOUNT_SID"];
-    var twilioAuthToken = builder.Configuration["SqlOS:PhoneOtp:TwilioAuthToken"]
-        ?? builder.Configuration["TWILIO_AUTH_TOKEN"];
-    var twilioVerifyServiceSid = builder.Configuration["SqlOS:PhoneOtp:TwilioVerifyServiceSid"]
-        ?? builder.Configuration["TWILIO_VERIFY_SERVICE_SID"];
-    var phoneOtpDefaultRegion = builder.Configuration["SqlOS:PhoneOtp:DefaultRegion"]
-        ?? builder.Configuration["TWILIO_DEFAULT_REGION"];
-    var enabledCredentialTypes = new List<string>();
-    if (sampleConfig.EnableEmailOtp)
+builder.AddSqlOS<TodoSampleDbContext>(
+    db => db.UseSqlServer(connectionString),
+    options =>
     {
-        enabledCredentialTypes.Add("email_otp");
-    }
-    if (enablePhoneOtp)
-    {
-        enabledCredentialTypes.Add("phone_otp");
-    }
-    if (enabledCredentialTypes.Count == 0)
-    {
-        enabledCredentialTypes.Add("password");
-    }
-    var passwordAuthEnabled = enabledCredentialTypes.Contains("password", StringComparer.OrdinalIgnoreCase);
-
-    var auth = options.AuthServer;
-    auth.Issuer = builder.Configuration["SqlOS:Issuer"] ?? $"{publicOrigin}/sqlos/auth";
-    auth.PublicOrigin = publicOrigin;
-    auth.DefaultAudience = sampleConfig.Resource;
-    auth.EnableLocalPasswordAuth = passwordAuthEnabled;
-    options.ConfigureEmail(email =>
-    {
-        email.AzureCommunicationServicesConnectionString = emailConnectionString;
-        email.FromAddress = emailFromAddress;
-    });
-    auth.ConfigureEmailOtp(email =>
-    {
-        email.AzureCommunicationServicesConnectionString = emailConnectionString;
-        email.FromAddress = emailFromAddress;
-        email.ApplicationName = "SqlOS Todo";
-    });
-    auth.ConfigurePhoneOtp(phone =>
-    {
-        phone.Enabled = enablePhoneOtp;
-        phone.TwilioAccountSid = twilioAccountSid;
-        phone.TwilioAuthToken = twilioAuthToken;
-        phone.TwilioVerifyServiceSid = twilioVerifyServiceSid;
-        if (!string.IsNullOrWhiteSpace(phoneOtpDefaultRegion))
+        options.DashboardBasePath = "/sqlos";
+        var emailConnectionString = builder.Configuration["SqlOS:Email:AzureCommunicationServicesConnectionString"]
+            ?? builder.Configuration["SqlOS:EmailOtp:AzureCommunicationServicesConnectionString"]
+            ?? builder.Configuration["AZURE_EMAIL_CONNECTION_STRING"];
+        var emailFromAddress = builder.Configuration["SqlOS:Email:FromAddress"]
+            ?? builder.Configuration["SqlOS:EmailOtp:FromAddress"]
+            ?? builder.Configuration["AZURE_EMAIL_SENDER_ADDRESS"];
+        var twilioAccountSid = builder.Configuration["SqlOS:PhoneOtp:TwilioAccountSid"]
+            ?? builder.Configuration["TWILIO_ACCOUNT_SID"];
+        var twilioAuthToken = builder.Configuration["SqlOS:PhoneOtp:TwilioAuthToken"]
+            ?? builder.Configuration["TWILIO_AUTH_TOKEN"];
+        var twilioVerifyServiceSid = builder.Configuration["SqlOS:PhoneOtp:TwilioVerifyServiceSid"]
+            ?? builder.Configuration["TWILIO_VERIFY_SERVICE_SID"];
+        var phoneOtpDefaultRegion = builder.Configuration["SqlOS:PhoneOtp:DefaultRegion"]
+            ?? builder.Configuration["TWILIO_DEFAULT_REGION"];
+        var enabledCredentialTypes = new List<string>();
+        if (sampleConfig.EnableEmailOtp)
         {
-            phone.DefaultRegion = phoneOtpDefaultRegion;
+            enabledCredentialTypes.Add("email_otp");
         }
-    });
-
-    auth.SeedAuthPage(page =>
-    {
-        page.PageTitle = sampleConfig.EnableEmailOtp || enablePhoneOtp ? "Check your code. Ship the Todo app." : "Ship the Todo app first.";
-        page.PageSubtitle = sampleConfig.EnableEmailOtp || enablePhoneOtp
-            ? "Use passwordless email or SMS codes for sign in and sign up, then land back in the hosted-first Todo sample."
-            : "Start with hosted auth, then graduate to headless and public-client onboarding when you need it.";
-        page.PrimaryColor = "#0f172a";
-        page.AccentColor = "#2563eb";
-        page.BackgroundColor = "#f8fafc";
-        page.Layout = "split";
-        page.EnablePasswordSignup = passwordAuthEnabled;
-        page.EnabledCredentialTypes = enabledCredentialTypes;
-    });
-
-    auth.SeedAuthEmails(email =>
-    {
-        email.ApplicationName = "SqlOS Todo";
-        email.PrimaryColor = "#0f172a";
-        email.AccentColor = "#2563eb";
-        email.BackgroundColor = "#f8fafc";
-    });
-
-    auth.SeedClient(client =>
-    {
-        client.ClientId = sampleConfig.HostedClientId;
-        client.Name = sampleConfig.HostedClientName;
-        client.Description = "Hosted-first web client for the SqlOS Todo sample.";
-        client.Audience = sampleConfig.Resource;
-        client.RedirectUris = [hostedCallbackUrl];
-        client.AllowedScopes = sampleConfig.AllowedScopes;
-        client.ClientType = "public_pkce";
-        client.RequirePkce = true;
-        client.IsFirstParty = true;
-    });
-
-    auth.SeedClient(client =>
-    {
-        client.ClientId = sampleConfig.LocalClientId;
-        client.Name = "Todo Local";
-        client.Description = "Local preregistered client for localhost MCP development against the Todo sample.";
-        client.Audience = sampleConfig.Resource;
-        client.RedirectUris = [localClientRedirectUri];
-        client.AllowedScopes = sampleConfig.AllowedScopes;
-        client.ClientType = "public_pkce";
-        client.RequirePkce = true;
-        client.IsFirstParty = false;
-    });
-
-    auth.SeedClient(client =>
-    {
-        client.ClientId = sampleConfig.EmcyClientId;
-        client.Name = "Todo Emcy MCP";
-        client.Description = "Local downstream client for the Emcy-hosted MCP Todo demo.";
-        client.Audience = sampleConfig.Resource;
-        client.RedirectUris = [emcyClientRedirectUri];
-        client.AllowedScopes = sampleConfig.AllowedScopes;
-        client.ClientType = "public_pkce";
-        client.RequirePkce = true;
-        client.IsFirstParty = false;
-    });
-
-    auth.SeedCliClient(
-        sampleConfig.CliClientId,
-        sampleConfig.CliClientName,
-        sampleConfig.Resource,
-        sampleConfig.AllowedScopes.ToArray());
-
-    options.Fga.Seed(seed =>
-    {
-        seed.ResourceType(
-            TodoFgaService.TenantResourceTypeId,
-            "Tenant",
-            "Per-user tenant root for the Todo sample.");
-        seed.ResourceType(
-            TodoFgaService.TodoResourceTypeId,
-            "Todo",
-            "Individual todo items in the Todo sample.");
-        seed.Permission(
-            "perm_tenant_create_todo",
-            TodoFgaService.TenantCreateTodoPermission,
-            "Create todos",
-            TodoFgaService.TenantResourceTypeId);
-        seed.Permission(
-            "perm_todo_read",
-            TodoFgaService.TodoReadPermission,
-            "Read todos",
-            TodoFgaService.TodoResourceTypeId);
-        seed.Permission(
-            "perm_todo_write",
-            TodoFgaService.TodoWritePermission,
-            "Write todos",
-            TodoFgaService.TodoResourceTypeId);
-        seed.Role(
-            "role_tenant_owner",
-            TodoFgaService.TenantOwnerRole,
-            "Tenant Owner",
-            "Single-user owner role for the Todo sample.");
-        seed.RolePermission(TodoFgaService.TenantOwnerRole, TodoFgaService.TenantCreateTodoPermission);
-        seed.RolePermission(TodoFgaService.TenantOwnerRole, TodoFgaService.TodoReadPermission);
-        seed.RolePermission(TodoFgaService.TenantOwnerRole, TodoFgaService.TodoWritePermission);
-    });
-
-    auth.EnablePortableMcpClients(registration =>
-    {
-        foreach (var host in cimdTrustedHosts)
+        if (enablePhoneOtp)
         {
-            registration.Cimd.TrustedHosts.Add(host);
+            enabledCredentialTypes.Add("phone_otp");
         }
-    });
-
-    if (sampleConfig.EnableDcr)
-    {
-        auth.ClientRegistration.Dcr.Enabled = true;
-        auth.ClientRegistration.Dcr.AllowHttpsRedirectUris = true;
-        auth.ClientRegistration.Dcr.AllowLoopbackRedirectUris = true;
-    }
-
-    if (sampleConfig.EnableHeadless)
-    {
-        auth.UseHeadlessAuthPage(headless =>
+        if (enabledCredentialTypes.Count == 0)
         {
-            headless.BuildUiUrl = ctx => QueryHelpers.AddQueryString(
-                $"{publicOrigin}{sampleConfig.HeadlessUiPath}",
-                new Dictionary<string, string?>
-                {
-                    ["request"] = ctx.RequestId,
-                    ["view"] = ctx.View,
-                    ["error"] = ctx.Error,
-                    ["email"] = ctx.Email,
-                    ["pendingToken"] = ctx.PendingToken,
-                    ["displayName"] = ctx.DisplayName,
-                    ["ui_context"] = ctx.UiContext?.ToJsonString()
-                });
+            enabledCredentialTypes.Add("password");
+        }
+        var passwordAuthEnabled = enabledCredentialTypes.Contains("password", StringComparer.OrdinalIgnoreCase);
+
+        var auth = options.AuthServer;
+        auth.Issuer = builder.Configuration["SqlOS:Issuer"] ?? $"{publicOrigin}/sqlos/auth";
+        auth.PublicOrigin = publicOrigin;
+        auth.DefaultAudience = sampleConfig.Resource;
+        auth.EnableLocalPasswordAuth = passwordAuthEnabled;
+        options.ConfigureEmail(email =>
+        {
+            email.AzureCommunicationServicesConnectionString = emailConnectionString;
+            email.FromAddress = emailFromAddress;
         });
-    }
-});
+        auth.ConfigureEmailOtp(email =>
+        {
+            email.AzureCommunicationServicesConnectionString = emailConnectionString;
+            email.FromAddress = emailFromAddress;
+            email.ApplicationName = "SqlOS Todo";
+        });
+        auth.ConfigurePhoneOtp(phone =>
+        {
+            phone.Enabled = enablePhoneOtp;
+            phone.TwilioAccountSid = twilioAccountSid;
+            phone.TwilioAuthToken = twilioAuthToken;
+            phone.TwilioVerifyServiceSid = twilioVerifyServiceSid;
+            if (!string.IsNullOrWhiteSpace(phoneOtpDefaultRegion))
+            {
+                phone.DefaultRegion = phoneOtpDefaultRegion;
+            }
+        });
+
+        auth.SeedAuthPage(page =>
+        {
+            page.PageTitle = sampleConfig.EnableEmailOtp || enablePhoneOtp ? "Check your code. Ship the Todo app." : "Ship the Todo app first.";
+            page.PageSubtitle = sampleConfig.EnableEmailOtp || enablePhoneOtp
+                ? "Use passwordless email or SMS codes for sign in and sign up, then land back in the hosted-first Todo sample."
+                : "Start with hosted auth, then graduate to headless and public-client onboarding when you need it.";
+            page.PrimaryColor = "#0f172a";
+            page.AccentColor = "#2563eb";
+            page.BackgroundColor = "#f8fafc";
+            page.Layout = "split";
+            page.EnablePasswordSignup = passwordAuthEnabled;
+            page.EnabledCredentialTypes = enabledCredentialTypes;
+        });
+
+        auth.SeedAuthEmails(email =>
+        {
+            email.ApplicationName = "SqlOS Todo";
+            email.PrimaryColor = "#0f172a";
+            email.AccentColor = "#2563eb";
+            email.BackgroundColor = "#f8fafc";
+        });
+
+        auth.SeedClient(client =>
+        {
+            client.ClientId = sampleConfig.HostedClientId;
+            client.Name = sampleConfig.HostedClientName;
+            client.Description = "Hosted-first web client for the SqlOS Todo sample.";
+            client.Audience = sampleConfig.Resource;
+            client.RedirectUris = [hostedCallbackUrl];
+            client.AllowedScopes = sampleConfig.AllowedScopes;
+            client.ClientType = "public_pkce";
+            client.RequirePkce = true;
+            client.IsFirstParty = true;
+        });
+
+        auth.SeedClient(client =>
+        {
+            client.ClientId = sampleConfig.LocalClientId;
+            client.Name = "Todo Local";
+            client.Description = "Local preregistered client for localhost MCP development against the Todo sample.";
+            client.Audience = sampleConfig.Resource;
+            client.RedirectUris = [localClientRedirectUri];
+            client.AllowedScopes = sampleConfig.AllowedScopes;
+            client.ClientType = "public_pkce";
+            client.RequirePkce = true;
+            client.IsFirstParty = false;
+        });
+
+        auth.SeedClient(client =>
+        {
+            client.ClientId = sampleConfig.EmcyClientId;
+            client.Name = "Todo Emcy MCP";
+            client.Description = "Local downstream client for the Emcy-hosted MCP Todo demo.";
+            client.Audience = sampleConfig.Resource;
+            client.RedirectUris = [emcyClientRedirectUri];
+            client.AllowedScopes = sampleConfig.AllowedScopes;
+            client.ClientType = "public_pkce";
+            client.RequirePkce = true;
+            client.IsFirstParty = false;
+        });
+
+        auth.SeedCliClient(
+            sampleConfig.CliClientId,
+            sampleConfig.CliClientName,
+            sampleConfig.Resource,
+            sampleConfig.AllowedScopes.ToArray());
+
+        options.Fga.Seed(seed =>
+        {
+            seed.ResourceType(
+                TodoFgaService.TenantResourceTypeId,
+                "Tenant",
+                "Per-user tenant root for the Todo sample.");
+            seed.ResourceType(
+                TodoFgaService.TodoResourceTypeId,
+                "Todo",
+                "Individual todo items in the Todo sample.");
+            seed.Permission(
+                "perm_tenant_create_todo",
+                TodoFgaService.TenantCreateTodoPermission,
+                "Create todos",
+                TodoFgaService.TenantResourceTypeId);
+            seed.Permission(
+                "perm_todo_read",
+                TodoFgaService.TodoReadPermission,
+                "Read todos",
+                TodoFgaService.TodoResourceTypeId);
+            seed.Permission(
+                "perm_todo_write",
+                TodoFgaService.TodoWritePermission,
+                "Write todos",
+                TodoFgaService.TodoResourceTypeId);
+            seed.Role(
+                "role_tenant_owner",
+                TodoFgaService.TenantOwnerRole,
+                "Tenant Owner",
+                "Single-user owner role for the Todo sample.");
+            seed.RolePermission(TodoFgaService.TenantOwnerRole, TodoFgaService.TenantCreateTodoPermission);
+            seed.RolePermission(TodoFgaService.TenantOwnerRole, TodoFgaService.TodoReadPermission);
+            seed.RolePermission(TodoFgaService.TenantOwnerRole, TodoFgaService.TodoWritePermission);
+        });
+
+        auth.EnablePortableMcpClients(registration =>
+        {
+            foreach (var host in cimdTrustedHosts)
+            {
+                registration.Cimd.TrustedHosts.Add(host);
+            }
+        });
+
+        if (sampleConfig.EnableDcr)
+        {
+            auth.ClientRegistration.Dcr.Enabled = true;
+            auth.ClientRegistration.Dcr.AllowHttpsRedirectUris = true;
+            auth.ClientRegistration.Dcr.AllowLoopbackRedirectUris = true;
+        }
+
+        if (sampleConfig.EnableHeadless)
+        {
+            auth.UseHeadlessAuthPage(headless =>
+            {
+                headless.BuildUiUrl = ctx => QueryHelpers.AddQueryString(
+                    $"{publicOrigin}{sampleConfig.HeadlessUiPath}",
+                    new Dictionary<string, string?>
+                    {
+                        ["request"] = ctx.RequestId,
+                        ["view"] = ctx.View,
+                        ["error"] = ctx.Error,
+                        ["email"] = ctx.Email,
+                        ["pendingToken"] = ctx.PendingToken,
+                        ["displayName"] = ctx.DisplayName,
+                        ["ui_context"] = ctx.UiContext?.ToJsonString()
+                    });
+            });
+        }
+    });
 
 var app = builder.Build();
 
@@ -451,11 +452,11 @@ app.MapPost("/api/todos", async (
     }
 
     var todoContext = authResult.Context!;
-    var access = await fgaAuthService.CheckAccessAsync(
+    var allowed = await fgaAuthService.Allows(
         todoContext.SubjectId,
         TodoFgaService.TenantCreateTodoPermission,
         todoContext.TenantResourceId);
-    if (!access.Allowed)
+    if (!allowed)
     {
         return CreatePermissionDenied();
     }
@@ -506,11 +507,11 @@ app.MapPost("/api/todos/{id:guid}/toggle", async (
     }
 
     var todoContext = authResult.Context!;
-    var access = await fgaAuthService.CheckAccessAsync(
+    var allowed = await fgaAuthService.Allows(
         todoContext.SubjectId,
         TodoFgaService.TodoWritePermission,
         item.ResourceId);
-    if (!access.Allowed)
+    if (!allowed)
     {
         return CreatePermissionDenied();
     }
@@ -553,11 +554,11 @@ app.MapDelete("/api/todos/{id:guid}", async (
     }
 
     var todoContext = authResult.Context!;
-    var access = await fgaAuthService.CheckAccessAsync(
+    var allowed = await fgaAuthService.Allows(
         todoContext.SubjectId,
         TodoFgaService.TodoWritePermission,
         item.ResourceId);
-    if (!access.Allowed)
+    if (!allowed)
     {
         return CreatePermissionDenied();
     }

--- a/examples/SqlOS.Todo.Api/Program.cs
+++ b/examples/SqlOS.Todo.Api/Program.cs
@@ -468,7 +468,10 @@ app.MapPost("/api/todos", async (
         Title = request.Title.Trim(),
         CreatedAt = DateTime.UtcNow
     };
-    item.ResourceId = todoFgaService.CreateTodoResource(item, todoContext.TenantResourceId);
+    item.ResourceId = await todoFgaService.CreateTodoResourceAsync(
+        item,
+        todoContext.TenantResourceId,
+        cancellationToken);
 
     dbContext.TodoItems.Add(item);
     await dbContext.SaveChangesAsync(cancellationToken);

--- a/examples/SqlOS.Todo.Api/Services/TodoFgaService.cs
+++ b/examples/SqlOS.Todo.Api/Services/TodoFgaService.cs
@@ -1,7 +1,7 @@
 using System.Security.Claims;
 using Microsoft.EntityFrameworkCore;
 using SqlOS.AuthServer.Contracts;
-using SqlOS.Fga.Extensions;
+using SqlOS.Extensions;
 using SqlOS.Fga.Models;
 using SqlOS.Todo.Api.Data;
 using SqlOS.Todo.Api.Models;
@@ -55,7 +55,7 @@ public sealed class TodoFgaService
     public string CreateTodoResource(TodoItem item, string tenantResourceId)
     {
         var resourceId = GetTodoResourceId(item.Id);
-        _context.CreateResource(tenantResourceId, item.Title, TodoResourceTypeId, resourceId);
+        _context.AddSqlOSResource(resourceId, tenantResourceId, item.Title, TodoResourceTypeId);
         return resourceId;
     }
 

--- a/examples/SqlOS.Todo.Api/Services/TodoFgaService.cs
+++ b/examples/SqlOS.Todo.Api/Services/TodoFgaService.cs
@@ -37,25 +37,48 @@ public sealed class TodoFgaService
         var displayName = GetDisplayName(validated.Principal, subjectId);
         var email = GetClaimValue(validated.Principal, "email");
         var tenantResourceId = GetTenantResourceId(subjectId);
-        var hasChanges = false;
 
-        hasChanges |= await UpsertSubjectAsync(subjectId, displayName, cancellationToken);
-        hasChanges |= await UpsertUserAsync(subjectId, email, cancellationToken);
-        hasChanges |= await UpsertTenantResourceAsync(subjectId, tenantResourceId, displayName, cancellationToken);
-        hasChanges |= await UpsertTenantGrantAsync(subjectId, tenantResourceId, cancellationToken);
+        var user = await _context.EnsureSqlOSUserSubjectAsync(
+            subjectId,
+            displayName,
+            email,
+            externalRef: subjectId,
+            isActive: true,
+            cancellationToken: cancellationToken);
+        user.LastLoginAt = DateTime.UtcNow;
+        user.UpdatedAt = DateTime.UtcNow;
 
-        if (hasChanges)
-        {
-            await _context.SaveChangesAsync(cancellationToken);
-        }
+        await _context.EnsureSqlOSResourceAsync(
+            tenantResourceId,
+            "root",
+            displayName,
+            TenantResourceTypeId,
+            $"Todo tenant for {subjectId}",
+            cancellationToken);
+        await _context.EnsureSqlOSRoleGrantAsync(
+            subjectId,
+            tenantResourceId,
+            TenantOwnerRole,
+            "Todo tenant owner grant.",
+            cancellationToken);
+
+        await _context.SaveChangesAsync(cancellationToken);
 
         return new TodoFgaContext(subjectId, tenantResourceId);
     }
 
-    public string CreateTodoResource(TodoItem item, string tenantResourceId)
+    public async Task<string> CreateTodoResourceAsync(
+        TodoItem item,
+        string tenantResourceId,
+        CancellationToken cancellationToken = default)
     {
         var resourceId = GetTodoResourceId(item.Id);
-        _context.AddSqlOSResource(resourceId, tenantResourceId, item.Title, TodoResourceTypeId);
+        await _context.EnsureSqlOSResourceAsync(
+            resourceId,
+            tenantResourceId,
+            item.Title,
+            TodoResourceTypeId,
+            cancellationToken: cancellationToken);
         return resourceId;
     }
 
@@ -72,200 +95,6 @@ public sealed class TodoFgaService
     public static string GetTenantResourceId(string userId) => $"tenant::{userId}";
 
     public static string GetTodoResourceId(Guid todoId) => $"todo::{todoId:D}";
-
-    private async Task<bool> UpsertSubjectAsync(
-        string subjectId,
-        string displayName,
-        CancellationToken cancellationToken)
-    {
-        var subject = await _context.Set<SqlOSFgaSubject>()
-            .FirstOrDefaultAsync(x => x.Id == subjectId, cancellationToken);
-
-        if (subject == null)
-        {
-            _context.Set<SqlOSFgaSubject>().Add(new SqlOSFgaSubject
-            {
-                Id = subjectId,
-                SubjectTypeId = "user",
-                DisplayName = displayName,
-                ExternalRef = subjectId
-            });
-            return true;
-        }
-
-        var changed = false;
-        if (!string.Equals(subject.SubjectTypeId, "user", StringComparison.Ordinal))
-        {
-            subject.SubjectTypeId = "user";
-            changed = true;
-        }
-
-        if (!string.Equals(subject.DisplayName, displayName, StringComparison.Ordinal))
-        {
-            subject.DisplayName = displayName;
-            changed = true;
-        }
-
-        if (!string.Equals(subject.ExternalRef, subjectId, StringComparison.Ordinal))
-        {
-            subject.ExternalRef = subjectId;
-            changed = true;
-        }
-
-        if (changed)
-        {
-            subject.UpdatedAt = DateTime.UtcNow;
-        }
-
-        return changed;
-    }
-
-    private async Task<bool> UpsertUserAsync(
-        string subjectId,
-        string? email,
-        CancellationToken cancellationToken)
-    {
-        var user = await _context.Set<SqlOSFgaUser>()
-            .FirstOrDefaultAsync(x => x.SubjectId == subjectId, cancellationToken);
-        if (user == null)
-        {
-            _context.Set<SqlOSFgaUser>().Add(new SqlOSFgaUser
-            {
-                Id = $"fgauser::{subjectId}",
-                SubjectId = subjectId,
-                Email = email,
-                IsActive = true,
-                LastLoginAt = DateTime.UtcNow
-            });
-            return true;
-        }
-
-        if (!string.Equals(user.Email, email, StringComparison.Ordinal))
-        {
-            user.Email = email;
-        }
-
-        if (!user.IsActive)
-        {
-            user.IsActive = true;
-        }
-
-        user.LastLoginAt = DateTime.UtcNow;
-        user.UpdatedAt = DateTime.UtcNow;
-        return true;
-    }
-
-    private async Task<bool> UpsertTenantResourceAsync(
-        string subjectId,
-        string tenantResourceId,
-        string displayName,
-        CancellationToken cancellationToken)
-    {
-        var resource = await _context.Set<SqlOSFgaResource>()
-            .FirstOrDefaultAsync(x => x.Id == tenantResourceId, cancellationToken);
-        if (resource == null)
-        {
-            _context.Set<SqlOSFgaResource>().Add(new SqlOSFgaResource
-            {
-                Id = tenantResourceId,
-                ParentId = "root",
-                Name = displayName,
-                Description = $"Todo tenant for {subjectId}",
-                ResourceTypeId = TenantResourceTypeId,
-                IsActive = true
-            });
-            return true;
-        }
-
-        var changed = false;
-        if (!string.Equals(resource.ParentId, "root", StringComparison.Ordinal))
-        {
-            resource.ParentId = "root";
-            changed = true;
-        }
-
-        if (!string.Equals(resource.Name, displayName, StringComparison.Ordinal))
-        {
-            resource.Name = displayName;
-            changed = true;
-        }
-
-        var description = $"Todo tenant for {subjectId}";
-        if (!string.Equals(resource.Description, description, StringComparison.Ordinal))
-        {
-            resource.Description = description;
-            changed = true;
-        }
-
-        if (!string.Equals(resource.ResourceTypeId, TenantResourceTypeId, StringComparison.Ordinal))
-        {
-            resource.ResourceTypeId = TenantResourceTypeId;
-            changed = true;
-        }
-
-        if (!resource.IsActive)
-        {
-            resource.IsActive = true;
-            changed = true;
-        }
-
-        if (changed)
-        {
-            resource.UpdatedAt = DateTime.UtcNow;
-        }
-
-        return changed;
-    }
-
-    private async Task<bool> UpsertTenantGrantAsync(
-        string subjectId,
-        string tenantResourceId,
-        CancellationToken cancellationToken)
-    {
-        var roleId = await _context.Set<SqlOSFgaRole>()
-            .Where(x => x.Key == TenantOwnerRole)
-            .Select(x => x.Id)
-            .FirstOrDefaultAsync(cancellationToken);
-
-        if (string.IsNullOrWhiteSpace(roleId))
-        {
-            throw new InvalidOperationException($"FGA role '{TenantOwnerRole}' was not seeded.");
-        }
-
-        var existingGrants = await _context.Set<SqlOSFgaGrant>()
-            .Where(x => x.SubjectId == subjectId && x.ResourceId == tenantResourceId)
-            .ToListAsync(cancellationToken);
-
-        var changed = false;
-        foreach (var grant in existingGrants.Where(x => x.RoleId != roleId))
-        {
-            _context.Set<SqlOSFgaGrant>().Remove(grant);
-            changed = true;
-        }
-
-        var ownerGrant = existingGrants.FirstOrDefault(x => x.RoleId == roleId);
-        if (ownerGrant == null)
-        {
-            _context.Set<SqlOSFgaGrant>().Add(new SqlOSFgaGrant
-            {
-                Id = $"grant::{subjectId}::{TenantOwnerRole}",
-                SubjectId = subjectId,
-                ResourceId = tenantResourceId,
-                RoleId = roleId,
-                Description = "Todo tenant owner grant."
-            });
-            return true;
-        }
-
-        if (!string.Equals(ownerGrant.Description, "Todo tenant owner grant.", StringComparison.Ordinal))
-        {
-            ownerGrant.Description = "Todo tenant owner grant.";
-            ownerGrant.UpdatedAt = DateTime.UtcNow;
-            changed = true;
-        }
-
-        return changed;
-    }
 
     private static string GetDisplayName(ClaimsPrincipal principal, string subjectId)
     {

--- a/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerOptions.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerOptions.cs
@@ -367,6 +367,13 @@ public class SqlOSAuthServerOptions
                 .ToList();
         });
 
+    public SqlOSAuthServerOptions SeedMcpStackClient(
+        string clientId,
+        string name,
+        string? audience = null,
+        params string[] allowedScopes)
+        => SeedCliClient(clientId, name, audience, allowedScopes);
+
     public SqlOSAuthServerOptions EnablePortableMcpClients(Action<SqlOSClientRegistrationOptions>? configure = null)
     {
         ClientRegistration.Cimd.Enabled = true;

--- a/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerOptions.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerOptions.cs
@@ -367,7 +367,7 @@ public class SqlOSAuthServerOptions
                 .ToList();
         });
 
-    public SqlOSAuthServerOptions SeedMcpStackClient(
+    public SqlOSAuthServerOptions SeedDeviceFlowClient(
         string clientId,
         string name,
         string? audience = null,

--- a/src/SqlOS/Extensions/SqlOSErgonomicsExtensions.cs
+++ b/src/SqlOS/Extensions/SqlOSErgonomicsExtensions.cs
@@ -126,35 +126,14 @@ public static class SqlOSErgonomicsExtensions
         resource.ParentId = normalizedParentId;
         resource.Name = RequireValue(name, nameof(name));
         resource.ResourceTypeId = RequireValue(resourceTypeId, nameof(resourceTypeId));
-        resource.Description = NormalizeOptional(description);
+        if (description != null)
+        {
+            resource.Description = NormalizeOptional(description);
+        }
+
         resource.IsActive = true;
         resource.UpdatedAt = DateTime.UtcNow;
         return resource;
-    }
-
-    public static SqlOSFgaGrant GrantSqlOSRole(
-        this ISqlOSFgaDbContext context,
-        string subjectId,
-        string resourceId,
-        string roleId,
-        string? description = null)
-    {
-        ArgumentNullException.ThrowIfNull(context);
-
-        var normalizedSubjectId = RequireValue(subjectId, nameof(subjectId));
-        var normalizedResourceId = RequireValue(resourceId, nameof(resourceId));
-        var normalizedRoleId = RequireValue(roleId, nameof(roleId));
-
-        var grant = new SqlOSFgaGrant
-        {
-            Id = BuildGrantId(normalizedSubjectId, normalizedResourceId, normalizedRoleId),
-            SubjectId = normalizedSubjectId,
-            ResourceId = normalizedResourceId,
-            RoleId = normalizedRoleId,
-            Description = NormalizeOptional(description)
-        };
-        context.Set<SqlOSFgaGrant>().Add(grant);
-        return grant;
     }
 
     public static async Task<SqlOSFgaGrant> GrantSqlOSRoleAsync(
@@ -222,7 +201,11 @@ public static class SqlOSErgonomicsExtensions
             return grant;
         }
 
-        grant.Description = NormalizeOptional(description);
+        if (description != null)
+        {
+            grant.Description = NormalizeOptional(description);
+        }
+
         grant.UpdatedAt = DateTime.UtcNow;
         return grant;
     }
@@ -234,7 +217,7 @@ public static class SqlOSErgonomicsExtensions
         string? email = null,
         string? organizationId = null,
         string? externalRef = null,
-        bool isActive = true,
+        bool? isActive = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(context);
@@ -259,14 +242,22 @@ public static class SqlOSErgonomicsExtensions
                 Id = BuildTypedSubjectRowId("usr", subject.Id),
                 SubjectId = subject.Id,
                 Email = NormalizeOptional(email),
-                IsActive = isActive
+                IsActive = isActive ?? true
             };
             users.Add(user);
             return user;
         }
 
-        user.Email = NormalizeOptional(email);
-        user.IsActive = isActive;
+        if (email != null)
+        {
+            user.Email = NormalizeOptional(email);
+        }
+
+        if (isActive.HasValue)
+        {
+            user.IsActive = isActive.Value;
+        }
+
         user.UpdatedAt = DateTime.UtcNow;
         return user;
     }
@@ -309,8 +300,16 @@ public static class SqlOSErgonomicsExtensions
             return agent;
         }
 
-        agent.AgentType = NormalizeOptional(agentType);
-        agent.Description = NormalizeOptional(description);
+        if (agentType != null)
+        {
+            agent.AgentType = NormalizeOptional(agentType);
+        }
+
+        if (description != null)
+        {
+            agent.Description = NormalizeOptional(description);
+        }
+
         agent.UpdatedAt = DateTime.UtcNow;
         return agent;
     }
@@ -359,8 +358,16 @@ public static class SqlOSErgonomicsExtensions
 
         account.ClientId = RequireValue(clientId, nameof(clientId));
         account.ClientSecretHash = RequireValue(clientSecretHash, nameof(clientSecretHash));
-        account.Description = NormalizeOptional(description);
-        account.ExpiresAt = expiresAt;
+        if (description != null)
+        {
+            account.Description = NormalizeOptional(description);
+        }
+
+        if (expiresAt.HasValue)
+        {
+            account.ExpiresAt = expiresAt;
+        }
+
         account.UpdatedAt = DateTime.UtcNow;
         return account;
     }
@@ -469,8 +476,16 @@ public static class SqlOSErgonomicsExtensions
         }
 
         subject.DisplayName = RequireValue(displayName, nameof(displayName));
-        subject.OrganizationId = NormalizeOptional(organizationId);
-        subject.ExternalRef = NormalizeOptional(externalRef) ?? normalizedSubjectId;
+        if (organizationId != null)
+        {
+            subject.OrganizationId = NormalizeOptional(organizationId);
+        }
+
+        if (externalRef != null)
+        {
+            subject.ExternalRef = NormalizeOptional(externalRef);
+        }
+
         subject.UpdatedAt = DateTime.UtcNow;
         return subject;
     }

--- a/src/SqlOS/Extensions/SqlOSErgonomicsExtensions.cs
+++ b/src/SqlOS/Extensions/SqlOSErgonomicsExtensions.cs
@@ -108,6 +108,14 @@ public static class SqlOSErgonomicsExtensions
 
         var normalizedResourceId = RequireValue(resourceId, nameof(resourceId));
         var normalizedParentId = NormalizeOptional(parentResourceId);
+        var normalizedResourceTypeId = RequireValue(resourceTypeId, nameof(resourceTypeId));
+        EnsureResourceParentIsNotSelf(normalizedResourceId, normalizedParentId);
+        await FindRequiredResourceTypeAsync(context, normalizedResourceTypeId, cancellationToken);
+        if (normalizedParentId != null)
+        {
+            await FindRequiredResourceAsync(context, normalizedParentId, cancellationToken);
+        }
+
         await EnsureParentChainDoesNotCreateCycleAsync(context, normalizedResourceId, normalizedParentId, cancellationToken);
 
         var resource = await FindResourceAsync(context, normalizedResourceId, cancellationToken);
@@ -117,7 +125,7 @@ public static class SqlOSErgonomicsExtensions
                 normalizedResourceId,
                 normalizedParentId,
                 name,
-                resourceTypeId,
+                normalizedResourceTypeId,
                 description);
             context.Set<SqlOSFgaResource>().Add(resource);
             return resource;
@@ -125,7 +133,7 @@ public static class SqlOSErgonomicsExtensions
 
         resource.ParentId = normalizedParentId;
         resource.Name = RequireValue(name, nameof(name));
-        resource.ResourceTypeId = RequireValue(resourceTypeId, nameof(resourceTypeId));
+        resource.ResourceTypeId = normalizedResourceTypeId;
         if (description != null)
         {
             resource.Description = NormalizeOptional(description);
@@ -522,7 +530,24 @@ public static class SqlOSErgonomicsExtensions
         string resourceId,
         CancellationToken cancellationToken)
         => await FindResourceAsync(context, resourceId, cancellationToken)
-            ?? throw new InvalidOperationException($"FGA resource '{resourceId}' was not found. Provision the resource before granting roles.");
+            ?? throw new InvalidOperationException($"FGA resource '{resourceId}' was not found.");
+
+    private static async Task<SqlOSFgaResourceType?> FindResourceTypeAsync(
+        ISqlOSFgaDbContext context,
+        string resourceTypeId,
+        CancellationToken cancellationToken)
+    {
+        var resourceTypes = context.Set<SqlOSFgaResourceType>();
+        return resourceTypes.Local.FirstOrDefault(x => x.Id == resourceTypeId)
+            ?? await resourceTypes.FirstOrDefaultAsync(x => x.Id == resourceTypeId, cancellationToken);
+    }
+
+    private static async Task<SqlOSFgaResourceType> FindRequiredResourceTypeAsync(
+        ISqlOSFgaDbContext context,
+        string resourceTypeId,
+        CancellationToken cancellationToken)
+        => await FindResourceTypeAsync(context, resourceTypeId, cancellationToken)
+            ?? throw new InvalidOperationException($"FGA resource type '{resourceTypeId}' was not found. Seed or create the resource type before provisioning resources.");
 
     private static async Task<string> ResolveRoleIdAsync(
         ISqlOSFgaDbContext context,

--- a/src/SqlOS/Extensions/SqlOSErgonomicsExtensions.cs
+++ b/src/SqlOS/Extensions/SqlOSErgonomicsExtensions.cs
@@ -24,10 +24,19 @@ public static class SqlOSErgonomicsExtensions
     {
         ArgumentNullException.ThrowIfNull(group);
 
-        var options = SqlOSAccessTokenValidationMiddleware.ValidateOptions(new SqlOSAccessTokenValidationOptions
-        {
-            ExpectedAudience = expectedAudience
-        });
+        return group.RequireSqlOSAccessToken(options => options.ExpectedAudience = expectedAudience);
+    }
+
+    public static RouteGroupBuilder RequireSqlOSAccessToken(
+        this RouteGroupBuilder group,
+        Action<SqlOSAccessTokenValidationOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(group);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        var options = new SqlOSAccessTokenValidationOptions();
+        configure(options);
+        SqlOSAccessTokenValidationMiddleware.ValidateOptions(options);
 
         group.AddEndpointFilter((context, next) =>
             SqlOSAccessTokenEndpointFilter.InvokeAsync(context, next, options));
@@ -77,7 +86,6 @@ public static class SqlOSErgonomicsExtensions
         ArgumentNullException.ThrowIfNull(context);
 
         var resource = CreateResource(
-            context,
             resourceId,
             parentResourceId,
             name,
@@ -100,15 +108,12 @@ public static class SqlOSErgonomicsExtensions
 
         var normalizedResourceId = RequireValue(resourceId, nameof(resourceId));
         var normalizedParentId = NormalizeOptional(parentResourceId);
-        EnsureParentChainDoesNotCreateCycle(context, normalizedResourceId, normalizedParentId);
+        await EnsureParentChainDoesNotCreateCycleAsync(context, normalizedResourceId, normalizedParentId, cancellationToken);
 
-        var resource = await context.Set<SqlOSFgaResource>()
-            .FirstOrDefaultAsync(x => x.Id == normalizedResourceId, cancellationToken);
-
+        var resource = await FindResourceAsync(context, normalizedResourceId, cancellationToken);
         if (resource == null)
         {
             resource = CreateResource(
-                context,
                 normalizedResourceId,
                 normalizedParentId,
                 name,
@@ -131,17 +136,42 @@ public static class SqlOSErgonomicsExtensions
         this ISqlOSFgaDbContext context,
         string subjectId,
         string resourceId,
-        string roleKeyOrId,
-        string? description = null,
-        string subjectTypeId = "user",
-        string? subjectDisplayName = null)
+        string roleId,
+        string? description = null)
     {
         ArgumentNullException.ThrowIfNull(context);
 
         var normalizedSubjectId = RequireValue(subjectId, nameof(subjectId));
         var normalizedResourceId = RequireValue(resourceId, nameof(resourceId));
-        var roleId = ResolveRoleId(context, roleKeyOrId);
-        EnsureSubject(context, normalizedSubjectId, subjectTypeId, subjectDisplayName);
+        var normalizedRoleId = RequireValue(roleId, nameof(roleId));
+
+        var grant = new SqlOSFgaGrant
+        {
+            Id = BuildGrantId(normalizedSubjectId, normalizedResourceId, normalizedRoleId),
+            SubjectId = normalizedSubjectId,
+            ResourceId = normalizedResourceId,
+            RoleId = normalizedRoleId,
+            Description = NormalizeOptional(description)
+        };
+        context.Set<SqlOSFgaGrant>().Add(grant);
+        return grant;
+    }
+
+    public static async Task<SqlOSFgaGrant> GrantSqlOSRoleAsync(
+        this ISqlOSFgaDbContext context,
+        string subjectId,
+        string resourceId,
+        string roleKeyOrId,
+        string? description = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var normalizedSubjectId = RequireValue(subjectId, nameof(subjectId));
+        var normalizedResourceId = RequireValue(resourceId, nameof(resourceId));
+        await FindRequiredSubjectAsync(context, normalizedSubjectId, cancellationToken);
+        await FindRequiredResourceAsync(context, normalizedResourceId, cancellationToken);
+        var roleId = await ResolveRoleIdAsync(context, roleKeyOrId, cancellationToken);
 
         var grant = new SqlOSFgaGrant
         {
@@ -161,23 +191,22 @@ public static class SqlOSErgonomicsExtensions
         string resourceId,
         string roleKeyOrId,
         string? description = null,
-        string subjectTypeId = "user",
-        string? subjectDisplayName = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(context);
 
         var normalizedSubjectId = RequireValue(subjectId, nameof(subjectId));
         var normalizedResourceId = RequireValue(resourceId, nameof(resourceId));
+        await FindRequiredSubjectAsync(context, normalizedSubjectId, cancellationToken);
+        await FindRequiredResourceAsync(context, normalizedResourceId, cancellationToken);
         var roleId = await ResolveRoleIdAsync(context, roleKeyOrId, cancellationToken);
-        await EnsureSubjectAsync(context, normalizedSubjectId, subjectTypeId, subjectDisplayName, cancellationToken);
 
-        var grant = await context.Set<SqlOSFgaGrant>()
-            .FirstOrDefaultAsync(
-                x => x.SubjectId == normalizedSubjectId
-                    && x.ResourceId == normalizedResourceId
-                    && x.RoleId == roleId,
-                cancellationToken);
+        var grant = await FindGrantAsync(
+            context,
+            normalizedSubjectId,
+            normalizedResourceId,
+            roleId,
+            cancellationToken);
 
         if (grant == null)
         {
@@ -198,8 +227,145 @@ public static class SqlOSErgonomicsExtensions
         return grant;
     }
 
+    public static async Task<SqlOSFgaUser> EnsureSqlOSUserSubjectAsync(
+        this ISqlOSFgaDbContext context,
+        string subjectId,
+        string displayName,
+        string? email = null,
+        string? organizationId = null,
+        string? externalRef = null,
+        bool isActive = true,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var subject = await EnsureTypedSubjectAsync(
+            context,
+            subjectId,
+            "user",
+            displayName,
+            organizationId,
+            externalRef,
+            cancellationToken);
+
+        var users = context.Set<SqlOSFgaUser>();
+        var user = users.Local.FirstOrDefault(x => x.SubjectId == subject.Id)
+            ?? await users.FirstOrDefaultAsync(x => x.SubjectId == subject.Id, cancellationToken);
+
+        if (user == null)
+        {
+            user = new SqlOSFgaUser
+            {
+                Id = BuildTypedSubjectRowId("usr", subject.Id),
+                SubjectId = subject.Id,
+                Email = NormalizeOptional(email),
+                IsActive = isActive
+            };
+            users.Add(user);
+            return user;
+        }
+
+        user.Email = NormalizeOptional(email);
+        user.IsActive = isActive;
+        user.UpdatedAt = DateTime.UtcNow;
+        return user;
+    }
+
+    public static async Task<SqlOSFgaAgent> EnsureSqlOSAgentSubjectAsync(
+        this ISqlOSFgaDbContext context,
+        string subjectId,
+        string displayName,
+        string? agentType = null,
+        string? description = null,
+        string? organizationId = null,
+        string? externalRef = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var subject = await EnsureTypedSubjectAsync(
+            context,
+            subjectId,
+            "agent",
+            displayName,
+            organizationId,
+            externalRef,
+            cancellationToken);
+
+        var agents = context.Set<SqlOSFgaAgent>();
+        var agent = agents.Local.FirstOrDefault(x => x.SubjectId == subject.Id)
+            ?? await agents.FirstOrDefaultAsync(x => x.SubjectId == subject.Id, cancellationToken);
+
+        if (agent == null)
+        {
+            agent = new SqlOSFgaAgent
+            {
+                Id = BuildTypedSubjectRowId("agt", subject.Id),
+                SubjectId = subject.Id,
+                AgentType = NormalizeOptional(agentType),
+                Description = NormalizeOptional(description)
+            };
+            agents.Add(agent);
+            return agent;
+        }
+
+        agent.AgentType = NormalizeOptional(agentType);
+        agent.Description = NormalizeOptional(description);
+        agent.UpdatedAt = DateTime.UtcNow;
+        return agent;
+    }
+
+    public static async Task<SqlOSFgaServiceAccount> EnsureSqlOSServiceAccountSubjectAsync(
+        this ISqlOSFgaDbContext context,
+        string subjectId,
+        string displayName,
+        string clientId,
+        string clientSecretHash,
+        string? description = null,
+        DateTime? expiresAt = null,
+        string? organizationId = null,
+        string? externalRef = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var subject = await EnsureTypedSubjectAsync(
+            context,
+            subjectId,
+            "service_account",
+            displayName,
+            organizationId,
+            externalRef,
+            cancellationToken);
+
+        var accounts = context.Set<SqlOSFgaServiceAccount>();
+        var account = accounts.Local.FirstOrDefault(x => x.SubjectId == subject.Id)
+            ?? await accounts.FirstOrDefaultAsync(x => x.SubjectId == subject.Id, cancellationToken);
+
+        if (account == null)
+        {
+            account = new SqlOSFgaServiceAccount
+            {
+                Id = BuildTypedSubjectRowId("sa", subject.Id),
+                SubjectId = subject.Id,
+                ClientId = RequireValue(clientId, nameof(clientId)),
+                ClientSecretHash = RequireValue(clientSecretHash, nameof(clientSecretHash)),
+                Description = NormalizeOptional(description),
+                ExpiresAt = expiresAt
+            };
+            accounts.Add(account);
+            return account;
+        }
+
+        account.ClientId = RequireValue(clientId, nameof(clientId));
+        account.ClientSecretHash = RequireValue(clientSecretHash, nameof(clientSecretHash));
+        account.Description = NormalizeOptional(description);
+        account.ExpiresAt = expiresAt;
+        account.UpdatedAt = DateTime.UtcNow;
+        return account;
+    }
+
     private static SqlOSFgaResource CreateResource(
-        ISqlOSFgaDbContext context,
         string resourceId,
         string? parentResourceId,
         string name,
@@ -208,7 +374,7 @@ public static class SqlOSErgonomicsExtensions
     {
         var normalizedResourceId = RequireValue(resourceId, nameof(resourceId));
         var normalizedParentId = NormalizeOptional(parentResourceId);
-        EnsureParentChainDoesNotCreateCycle(context, normalizedResourceId, normalizedParentId);
+        EnsureResourceParentIsNotSelf(normalizedResourceId, normalizedParentId);
 
         return new SqlOSFgaResource
         {
@@ -221,20 +387,18 @@ public static class SqlOSErgonomicsExtensions
         };
     }
 
-    private static void EnsureParentChainDoesNotCreateCycle(
+    private static async Task EnsureParentChainDoesNotCreateCycleAsync(
         ISqlOSFgaDbContext context,
         string resourceId,
-        string? parentId)
+        string? parentId,
+        CancellationToken cancellationToken)
     {
         if (string.IsNullOrWhiteSpace(parentId))
         {
             return;
         }
 
-        if (string.Equals(resourceId, parentId, StringComparison.Ordinal))
-        {
-            throw new InvalidOperationException("FGA resource parent cannot be the resource itself.");
-        }
+        EnsureResourceParentIsNotSelf(resourceId, parentId);
 
         var visited = new HashSet<string>(StringComparer.Ordinal) { resourceId };
         var currentId = parentId;
@@ -252,24 +416,98 @@ public static class SqlOSErgonomicsExtensions
                 throw new InvalidOperationException($"FGA resource hierarchy exceeds the maximum depth of {DefaultMaxResourceHierarchyDepth}.");
             }
 
-            currentId = context.Set<SqlOSFgaResource>()
-                .AsNoTracking()
-                .Where(r => r.Id == currentId)
-                .Select(r => r.ParentId)
-                .FirstOrDefault();
+            var localParent = context.Set<SqlOSFgaResource>().Local.FirstOrDefault(r => r.Id == currentId);
+            currentId = localParent != null
+                ? localParent.ParentId
+                : await context.Set<SqlOSFgaResource>()
+                    .AsNoTracking()
+                    .Where(r => r.Id == currentId)
+                    .Select(r => r.ParentId)
+                    .FirstOrDefaultAsync(cancellationToken);
             depth++;
         }
     }
 
-    private static string ResolveRoleId(ISqlOSFgaDbContext context, string roleKeyOrId)
+    private static void EnsureResourceParentIsNotSelf(string resourceId, string? parentId)
     {
-        var normalizedRole = RequireValue(roleKeyOrId, nameof(roleKeyOrId));
-        return context.Set<SqlOSFgaRole>()
-            .Where(x => x.Key == normalizedRole || x.Id == normalizedRole)
-            .Select(x => x.Id)
-            .FirstOrDefault()
-            ?? throw new InvalidOperationException($"FGA role '{normalizedRole}' was not found.");
+        if (string.Equals(resourceId, parentId, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("FGA resource parent cannot be the resource itself.");
+        }
     }
+
+    private static async Task<SqlOSFgaSubject> EnsureTypedSubjectAsync(
+        ISqlOSFgaDbContext context,
+        string subjectId,
+        string subjectTypeId,
+        string displayName,
+        string? organizationId,
+        string? externalRef,
+        CancellationToken cancellationToken)
+    {
+        var normalizedSubjectId = RequireValue(subjectId, nameof(subjectId));
+        var normalizedSubjectTypeId = RequireValue(subjectTypeId, nameof(subjectTypeId));
+        var subject = await FindSubjectAsync(context, normalizedSubjectId, cancellationToken);
+
+        if (subject == null)
+        {
+            subject = new SqlOSFgaSubject
+            {
+                Id = normalizedSubjectId,
+                SubjectTypeId = normalizedSubjectTypeId,
+                DisplayName = RequireValue(displayName, nameof(displayName)),
+                OrganizationId = NormalizeOptional(organizationId),
+                ExternalRef = NormalizeOptional(externalRef) ?? normalizedSubjectId
+            };
+            context.Set<SqlOSFgaSubject>().Add(subject);
+            return subject;
+        }
+
+        if (!string.Equals(subject.SubjectTypeId, normalizedSubjectTypeId, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException($"FGA subject '{normalizedSubjectId}' already exists as type '{subject.SubjectTypeId}', not '{normalizedSubjectTypeId}'.");
+        }
+
+        subject.DisplayName = RequireValue(displayName, nameof(displayName));
+        subject.OrganizationId = NormalizeOptional(organizationId);
+        subject.ExternalRef = NormalizeOptional(externalRef) ?? normalizedSubjectId;
+        subject.UpdatedAt = DateTime.UtcNow;
+        return subject;
+    }
+
+    private static async Task<SqlOSFgaSubject?> FindSubjectAsync(
+        ISqlOSFgaDbContext context,
+        string subjectId,
+        CancellationToken cancellationToken)
+    {
+        var subjects = context.Set<SqlOSFgaSubject>();
+        return subjects.Local.FirstOrDefault(x => x.Id == subjectId)
+            ?? await subjects.FirstOrDefaultAsync(x => x.Id == subjectId, cancellationToken);
+    }
+
+    private static async Task<SqlOSFgaSubject> FindRequiredSubjectAsync(
+        ISqlOSFgaDbContext context,
+        string subjectId,
+        CancellationToken cancellationToken)
+        => await FindSubjectAsync(context, subjectId, cancellationToken)
+            ?? throw new InvalidOperationException($"FGA subject '{subjectId}' was not found. Provision the subject explicitly before granting roles.");
+
+    private static async Task<SqlOSFgaResource?> FindResourceAsync(
+        ISqlOSFgaDbContext context,
+        string resourceId,
+        CancellationToken cancellationToken)
+    {
+        var resources = context.Set<SqlOSFgaResource>();
+        return resources.Local.FirstOrDefault(x => x.Id == resourceId)
+            ?? await resources.FirstOrDefaultAsync(x => x.Id == resourceId, cancellationToken);
+    }
+
+    private static async Task<SqlOSFgaResource> FindRequiredResourceAsync(
+        ISqlOSFgaDbContext context,
+        string resourceId,
+        CancellationToken cancellationToken)
+        => await FindResourceAsync(context, resourceId, cancellationToken)
+            ?? throw new InvalidOperationException($"FGA resource '{resourceId}' was not found. Provision the resource before granting roles.");
 
     private static async Task<string> ResolveRoleIdAsync(
         ISqlOSFgaDbContext context,
@@ -277,7 +515,14 @@ public static class SqlOSErgonomicsExtensions
         CancellationToken cancellationToken)
     {
         var normalizedRole = RequireValue(roleKeyOrId, nameof(roleKeyOrId));
-        var roleId = await context.Set<SqlOSFgaRole>()
+        var roles = context.Set<SqlOSFgaRole>();
+        var localRole = roles.Local.FirstOrDefault(x => x.Key == normalizedRole || x.Id == normalizedRole);
+        if (localRole != null)
+        {
+            return localRole.Id;
+        }
+
+        var roleId = await roles
             .Where(x => x.Key == normalizedRole || x.Id == normalizedRole)
             .Select(x => x.Id)
             .FirstOrDefaultAsync(cancellationToken);
@@ -286,53 +531,35 @@ public static class SqlOSErgonomicsExtensions
             ?? throw new InvalidOperationException($"FGA role '{normalizedRole}' was not found.");
     }
 
-    private static void EnsureSubject(
+    private static async Task<SqlOSFgaGrant?> FindGrantAsync(
         ISqlOSFgaDbContext context,
         string subjectId,
-        string subjectTypeId,
-        string? displayName)
-    {
-        var normalizedSubjectId = RequireValue(subjectId, nameof(subjectId));
-        var subject = context.Set<SqlOSFgaSubject>().FirstOrDefault(x => x.Id == normalizedSubjectId);
-        if (subject == null)
-        {
-            context.Set<SqlOSFgaSubject>().Add(new SqlOSFgaSubject
-            {
-                Id = normalizedSubjectId,
-                SubjectTypeId = RequireValue(subjectTypeId, nameof(subjectTypeId)),
-                DisplayName = NormalizeOptional(displayName) ?? normalizedSubjectId,
-                ExternalRef = normalizedSubjectId
-            });
-        }
-    }
-
-    private static async Task EnsureSubjectAsync(
-        ISqlOSFgaDbContext context,
-        string subjectId,
-        string subjectTypeId,
-        string? displayName,
+        string resourceId,
+        string roleId,
         CancellationToken cancellationToken)
     {
-        var normalizedSubjectId = RequireValue(subjectId, nameof(subjectId));
-        var subject = await context.Set<SqlOSFgaSubject>()
-            .FirstOrDefaultAsync(x => x.Id == normalizedSubjectId, cancellationToken);
-
-        if (subject == null)
-        {
-            context.Set<SqlOSFgaSubject>().Add(new SqlOSFgaSubject
-            {
-                Id = normalizedSubjectId,
-                SubjectTypeId = RequireValue(subjectTypeId, nameof(subjectTypeId)),
-                DisplayName = NormalizeOptional(displayName) ?? normalizedSubjectId,
-                ExternalRef = normalizedSubjectId
-            });
-        }
+        var grants = context.Set<SqlOSFgaGrant>();
+        return grants.Local.FirstOrDefault(x =>
+                x.SubjectId == subjectId
+                && x.ResourceId == resourceId
+                && x.RoleId == roleId)
+            ?? await grants.FirstOrDefaultAsync(
+                x => x.SubjectId == subjectId
+                    && x.ResourceId == resourceId
+                    && x.RoleId == roleId,
+                cancellationToken);
     }
 
     private static string BuildGrantId(string subjectId, string resourceId, string roleId)
     {
         var bytes = SHA256.HashData(Encoding.UTF8.GetBytes($"{subjectId}\n{resourceId}\n{roleId}"));
         return $"grant::{Convert.ToHexString(bytes).ToLowerInvariant()[..32]}";
+    }
+
+    private static string BuildTypedSubjectRowId(string prefix, string subjectId)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes($"{prefix}\n{subjectId}"));
+        return $"{prefix}::{Convert.ToHexString(bytes).ToLowerInvariant()[..32]}";
     }
 
     private static string RequireValue(string value, string paramName)
@@ -357,6 +584,11 @@ internal static class SqlOSAccessTokenEndpointFilter
         SqlOSAccessTokenValidationOptions options)
     {
         var httpContext = context.HttpContext;
+        if (options.ShouldValidate is { } shouldValidate && !shouldValidate(httpContext))
+        {
+            return await next(context);
+        }
+
         var authService = httpContext.RequestServices.GetRequiredService<SqlOSAuthService>();
         var authorization = httpContext.Request.Headers.Authorization.ToString();
         if (!authorization.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))

--- a/src/SqlOS/Extensions/SqlOSErgonomicsExtensions.cs
+++ b/src/SqlOS/Extensions/SqlOSErgonomicsExtensions.cs
@@ -1,0 +1,433 @@
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using SqlOS.AuthServer.Configuration;
+using SqlOS.AuthServer.Contracts;
+using SqlOS.AuthServer.Extensions;
+using SqlOS.AuthServer.Services;
+using SqlOS.Fga.Interfaces;
+using SqlOS.Fga.Models;
+
+namespace SqlOS.Extensions;
+
+/// <summary>
+/// Convenience extensions for the common SqlOS application path.
+/// </summary>
+public static class SqlOSErgonomicsExtensions
+{
+    private const int DefaultMaxResourceHierarchyDepth = 10;
+
+    public static RouteGroupBuilder RequireSqlOSAccessToken(this RouteGroupBuilder group, string expectedAudience)
+    {
+        ArgumentNullException.ThrowIfNull(group);
+
+        var options = SqlOSAccessTokenValidationMiddleware.ValidateOptions(new SqlOSAccessTokenValidationOptions
+        {
+            ExpectedAudience = expectedAudience
+        });
+
+        group.AddEndpointFilter((context, next) =>
+            SqlOSAccessTokenEndpointFilter.InvokeAsync(context, next, options));
+
+        return group;
+    }
+
+    public static SqlOSValidatedToken SqlOSToken(this HttpContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        return context.GetSqlOSValidatedToken()
+            ?? throw new InvalidOperationException("No validated SqlOS access token is available. Protect the endpoint with RequireSqlOSAccessToken(...) or UseSqlOSAccessTokenValidation(...).");
+    }
+
+    public static string SqlOSUserId(this HttpContext context)
+    {
+        var token = context.SqlOSToken();
+        if (string.IsNullOrWhiteSpace(token.UserId))
+        {
+            throw new InvalidOperationException("The validated SqlOS access token does not include a user id.");
+        }
+
+        return token.UserId;
+    }
+
+    public static async Task<bool> Allows(
+        this ISqlOSFgaAuthService authService,
+        string subjectId,
+        string permissionKey,
+        string resourceId)
+    {
+        ArgumentNullException.ThrowIfNull(authService);
+
+        var result = await authService.CheckAccessAsync(subjectId, permissionKey, resourceId);
+        return result.Allowed;
+    }
+
+    public static SqlOSFgaResource AddSqlOSResource(
+        this ISqlOSFgaDbContext context,
+        string resourceId,
+        string? parentResourceId,
+        string name,
+        string resourceTypeId,
+        string? description = null)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var resource = CreateResource(
+            context,
+            resourceId,
+            parentResourceId,
+            name,
+            resourceTypeId,
+            description);
+        context.Set<SqlOSFgaResource>().Add(resource);
+        return resource;
+    }
+
+    public static async Task<SqlOSFgaResource> EnsureSqlOSResourceAsync(
+        this ISqlOSFgaDbContext context,
+        string resourceId,
+        string? parentResourceId,
+        string name,
+        string resourceTypeId,
+        string? description = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var normalizedResourceId = RequireValue(resourceId, nameof(resourceId));
+        var normalizedParentId = NormalizeOptional(parentResourceId);
+        EnsureParentChainDoesNotCreateCycle(context, normalizedResourceId, normalizedParentId);
+
+        var resource = await context.Set<SqlOSFgaResource>()
+            .FirstOrDefaultAsync(x => x.Id == normalizedResourceId, cancellationToken);
+
+        if (resource == null)
+        {
+            resource = CreateResource(
+                context,
+                normalizedResourceId,
+                normalizedParentId,
+                name,
+                resourceTypeId,
+                description);
+            context.Set<SqlOSFgaResource>().Add(resource);
+            return resource;
+        }
+
+        resource.ParentId = normalizedParentId;
+        resource.Name = RequireValue(name, nameof(name));
+        resource.ResourceTypeId = RequireValue(resourceTypeId, nameof(resourceTypeId));
+        resource.Description = NormalizeOptional(description);
+        resource.IsActive = true;
+        resource.UpdatedAt = DateTime.UtcNow;
+        return resource;
+    }
+
+    public static SqlOSFgaGrant GrantSqlOSRole(
+        this ISqlOSFgaDbContext context,
+        string subjectId,
+        string resourceId,
+        string roleKeyOrId,
+        string? description = null,
+        string subjectTypeId = "user",
+        string? subjectDisplayName = null)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var normalizedSubjectId = RequireValue(subjectId, nameof(subjectId));
+        var normalizedResourceId = RequireValue(resourceId, nameof(resourceId));
+        var roleId = ResolveRoleId(context, roleKeyOrId);
+        EnsureSubject(context, normalizedSubjectId, subjectTypeId, subjectDisplayName);
+
+        var grant = new SqlOSFgaGrant
+        {
+            Id = BuildGrantId(normalizedSubjectId, normalizedResourceId, roleId),
+            SubjectId = normalizedSubjectId,
+            ResourceId = normalizedResourceId,
+            RoleId = roleId,
+            Description = NormalizeOptional(description)
+        };
+        context.Set<SqlOSFgaGrant>().Add(grant);
+        return grant;
+    }
+
+    public static async Task<SqlOSFgaGrant> EnsureSqlOSRoleGrantAsync(
+        this ISqlOSFgaDbContext context,
+        string subjectId,
+        string resourceId,
+        string roleKeyOrId,
+        string? description = null,
+        string subjectTypeId = "user",
+        string? subjectDisplayName = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var normalizedSubjectId = RequireValue(subjectId, nameof(subjectId));
+        var normalizedResourceId = RequireValue(resourceId, nameof(resourceId));
+        var roleId = await ResolveRoleIdAsync(context, roleKeyOrId, cancellationToken);
+        await EnsureSubjectAsync(context, normalizedSubjectId, subjectTypeId, subjectDisplayName, cancellationToken);
+
+        var grant = await context.Set<SqlOSFgaGrant>()
+            .FirstOrDefaultAsync(
+                x => x.SubjectId == normalizedSubjectId
+                    && x.ResourceId == normalizedResourceId
+                    && x.RoleId == roleId,
+                cancellationToken);
+
+        if (grant == null)
+        {
+            grant = new SqlOSFgaGrant
+            {
+                Id = BuildGrantId(normalizedSubjectId, normalizedResourceId, roleId),
+                SubjectId = normalizedSubjectId,
+                ResourceId = normalizedResourceId,
+                RoleId = roleId,
+                Description = NormalizeOptional(description)
+            };
+            context.Set<SqlOSFgaGrant>().Add(grant);
+            return grant;
+        }
+
+        grant.Description = NormalizeOptional(description);
+        grant.UpdatedAt = DateTime.UtcNow;
+        return grant;
+    }
+
+    private static SqlOSFgaResource CreateResource(
+        ISqlOSFgaDbContext context,
+        string resourceId,
+        string? parentResourceId,
+        string name,
+        string resourceTypeId,
+        string? description)
+    {
+        var normalizedResourceId = RequireValue(resourceId, nameof(resourceId));
+        var normalizedParentId = NormalizeOptional(parentResourceId);
+        EnsureParentChainDoesNotCreateCycle(context, normalizedResourceId, normalizedParentId);
+
+        return new SqlOSFgaResource
+        {
+            Id = normalizedResourceId,
+            ParentId = normalizedParentId,
+            Name = RequireValue(name, nameof(name)),
+            ResourceTypeId = RequireValue(resourceTypeId, nameof(resourceTypeId)),
+            Description = NormalizeOptional(description),
+            IsActive = true
+        };
+    }
+
+    private static void EnsureParentChainDoesNotCreateCycle(
+        ISqlOSFgaDbContext context,
+        string resourceId,
+        string? parentId)
+    {
+        if (string.IsNullOrWhiteSpace(parentId))
+        {
+            return;
+        }
+
+        if (string.Equals(resourceId, parentId, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("FGA resource parent cannot be the resource itself.");
+        }
+
+        var visited = new HashSet<string>(StringComparer.Ordinal) { resourceId };
+        var currentId = parentId;
+        var depth = 0;
+
+        while (!string.IsNullOrWhiteSpace(currentId))
+        {
+            if (!visited.Add(currentId))
+            {
+                throw new InvalidOperationException("FGA resource hierarchy contains a cycle.");
+            }
+
+            if (depth > DefaultMaxResourceHierarchyDepth)
+            {
+                throw new InvalidOperationException($"FGA resource hierarchy exceeds the maximum depth of {DefaultMaxResourceHierarchyDepth}.");
+            }
+
+            currentId = context.Set<SqlOSFgaResource>()
+                .AsNoTracking()
+                .Where(r => r.Id == currentId)
+                .Select(r => r.ParentId)
+                .FirstOrDefault();
+            depth++;
+        }
+    }
+
+    private static string ResolveRoleId(ISqlOSFgaDbContext context, string roleKeyOrId)
+    {
+        var normalizedRole = RequireValue(roleKeyOrId, nameof(roleKeyOrId));
+        return context.Set<SqlOSFgaRole>()
+            .Where(x => x.Key == normalizedRole || x.Id == normalizedRole)
+            .Select(x => x.Id)
+            .FirstOrDefault()
+            ?? throw new InvalidOperationException($"FGA role '{normalizedRole}' was not found.");
+    }
+
+    private static async Task<string> ResolveRoleIdAsync(
+        ISqlOSFgaDbContext context,
+        string roleKeyOrId,
+        CancellationToken cancellationToken)
+    {
+        var normalizedRole = RequireValue(roleKeyOrId, nameof(roleKeyOrId));
+        var roleId = await context.Set<SqlOSFgaRole>()
+            .Where(x => x.Key == normalizedRole || x.Id == normalizedRole)
+            .Select(x => x.Id)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        return roleId
+            ?? throw new InvalidOperationException($"FGA role '{normalizedRole}' was not found.");
+    }
+
+    private static void EnsureSubject(
+        ISqlOSFgaDbContext context,
+        string subjectId,
+        string subjectTypeId,
+        string? displayName)
+    {
+        var normalizedSubjectId = RequireValue(subjectId, nameof(subjectId));
+        var subject = context.Set<SqlOSFgaSubject>().FirstOrDefault(x => x.Id == normalizedSubjectId);
+        if (subject == null)
+        {
+            context.Set<SqlOSFgaSubject>().Add(new SqlOSFgaSubject
+            {
+                Id = normalizedSubjectId,
+                SubjectTypeId = RequireValue(subjectTypeId, nameof(subjectTypeId)),
+                DisplayName = NormalizeOptional(displayName) ?? normalizedSubjectId,
+                ExternalRef = normalizedSubjectId
+            });
+        }
+    }
+
+    private static async Task EnsureSubjectAsync(
+        ISqlOSFgaDbContext context,
+        string subjectId,
+        string subjectTypeId,
+        string? displayName,
+        CancellationToken cancellationToken)
+    {
+        var normalizedSubjectId = RequireValue(subjectId, nameof(subjectId));
+        var subject = await context.Set<SqlOSFgaSubject>()
+            .FirstOrDefaultAsync(x => x.Id == normalizedSubjectId, cancellationToken);
+
+        if (subject == null)
+        {
+            context.Set<SqlOSFgaSubject>().Add(new SqlOSFgaSubject
+            {
+                Id = normalizedSubjectId,
+                SubjectTypeId = RequireValue(subjectTypeId, nameof(subjectTypeId)),
+                DisplayName = NormalizeOptional(displayName) ?? normalizedSubjectId,
+                ExternalRef = normalizedSubjectId
+            });
+        }
+    }
+
+    private static string BuildGrantId(string subjectId, string resourceId, string roleId)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes($"{subjectId}\n{resourceId}\n{roleId}"));
+        return $"grant::{Convert.ToHexString(bytes).ToLowerInvariant()[..32]}";
+    }
+
+    private static string RequireValue(string value, string paramName)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new InvalidOperationException($"{paramName} is required.");
+        }
+
+        return value.Trim();
+    }
+
+    private static string? NormalizeOptional(string? value)
+        => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+}
+
+internal static class SqlOSAccessTokenEndpointFilter
+{
+    public static async ValueTask<object?> InvokeAsync(
+        EndpointFilterInvocationContext context,
+        EndpointFilterDelegate next,
+        SqlOSAccessTokenValidationOptions options)
+    {
+        var httpContext = context.HttpContext;
+        var authService = httpContext.RequestServices.GetRequiredService<SqlOSAuthService>();
+        var authorization = httpContext.Request.Headers.Authorization.ToString();
+        if (!authorization.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+        {
+            return Unauthorized(options, "A bearer access token is required.");
+        }
+
+        var rawToken = authorization["Bearer ".Length..].Trim();
+        if (string.IsNullOrWhiteSpace(rawToken))
+        {
+            return Unauthorized(options, "A bearer access token is required.");
+        }
+
+        var validated = await authService.ValidateAccessTokenAsync(
+            rawToken,
+            options.ExpectedAudience,
+            httpContext.RequestAborted);
+
+        if (validated == null)
+        {
+            return Unauthorized(options, "The bearer access token is invalid, expired, revoked, or was not minted for this resource.");
+        }
+
+        httpContext.User = validated.Principal;
+        httpContext.Items[SqlOSAccessTokenValidationExtensions.ValidatedTokenItemKey] = validated;
+        return await next(context);
+    }
+
+    private static IResult Unauthorized(SqlOSAccessTokenValidationOptions options, string description)
+        => new SqlOSUnauthorizedTokenResult(options, description);
+
+    private sealed class SqlOSUnauthorizedTokenResult : IResult
+    {
+        private readonly SqlOSAccessTokenValidationOptions _options;
+        private readonly string _description;
+
+        public SqlOSUnauthorizedTokenResult(SqlOSAccessTokenValidationOptions options, string description)
+        {
+            _options = options;
+            _description = description;
+        }
+
+        public async Task ExecuteAsync(HttpContext httpContext)
+        {
+            httpContext.Response.StatusCode = StatusCodes.Status401Unauthorized;
+            httpContext.Response.Headers.WWWAuthenticate = BuildChallenge();
+            await httpContext.Response.WriteAsJsonAsync(new
+            {
+                error = "invalid_token",
+                error_description = _description
+            });
+        }
+
+        private string BuildChallenge()
+        {
+            var parts = new List<string>
+            {
+                $"Bearer realm=\"{EscapeHeaderValue(_options.Realm)}\"",
+                "error=\"invalid_token\"",
+                $"error_description=\"{EscapeHeaderValue(_description)}\""
+            };
+
+            if (!string.IsNullOrWhiteSpace(_options.ResourceMetadataUrl))
+            {
+                parts.Add($"resource_metadata=\"{EscapeHeaderValue(_options.ResourceMetadataUrl!)}\"");
+            }
+
+            return string.Join(", ", parts);
+        }
+
+        private static string EscapeHeaderValue(string value)
+            => value.Replace("\\", "\\\\", StringComparison.Ordinal).Replace("\"", "\\\"", StringComparison.Ordinal);
+    }
+}

--- a/src/SqlOS/Extensions/WebApplicationBuilderExtensions.cs
+++ b/src/SqlOS/Extensions/WebApplicationBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using SqlOS.AuthServer.Interfaces;
 using SqlOS.Configuration;
 using SqlOS.Fga.Interfaces;
@@ -16,6 +17,21 @@ public static class WebApplicationBuilderExtensions
         where TContext : DbContext, ISqlOSAuthServerDbContext, ISqlOSFgaDbContext
     {
         builder.Services.AddSqlOS<TContext>(configure);
+        return builder;
+    }
+
+    /// <summary>
+    /// Registers the application's EF Core DbContext and SqlOS (auth server + FGA) in one host call.
+    /// After <see cref="WebApplicationBuilder.Build"/>, call <see cref="WebApplicationExtensions.MapSqlOS"/> once to map OAuth and admin API routes.
+    /// </summary>
+    public static WebApplicationBuilder AddSqlOS<TContext>(
+        this WebApplicationBuilder builder,
+        Action<DbContextOptionsBuilder> configureDbContext,
+        Action<SqlOSOptions>? configureSqlOS = null)
+        where TContext : DbContext, ISqlOSAuthServerDbContext, ISqlOSFgaDbContext
+    {
+        builder.Services.AddDbContext<TContext>(configureDbContext);
+        builder.Services.AddSqlOS<TContext>(configureSqlOS);
         return builder;
     }
 }

--- a/src/SqlOS/Fga/Configuration/SqlOSFgaSeedBuilder.cs
+++ b/src/SqlOS/Fga/Configuration/SqlOSFgaSeedBuilder.cs
@@ -93,6 +93,9 @@ public sealed class SqlOSFgaSeedBuilder
         return this;
     }
 
+    public SqlOSFgaSeedBuilder Permission(string key, string name, string resourceTypeId)
+        => Permission(key, key, name, resourceTypeId);
+
     public SqlOSFgaSeedBuilder Role(string id, string key, string name, string? description = null, bool isVirtual = false)
     {
         var normalizedId = RequireValue(id, nameof(id));
@@ -114,6 +117,13 @@ public sealed class SqlOSFgaSeedBuilder
         _rolesById[role.Id] = role;
         _rolesByKey[role.Key] = role;
         return this;
+    }
+
+    public SqlOSFgaRoleSeedBuilder Role(string key, string name)
+    {
+        var normalizedKey = RequireValue(key, nameof(key));
+        Role(normalizedKey, normalizedKey, name);
+        return new SqlOSFgaRoleSeedBuilder(this, normalizedKey);
     }
 
     public SqlOSFgaSeedBuilder RolePermission(string roleKey, string permissionKey)
@@ -183,4 +193,26 @@ public sealed class SqlOSFgaSeedBuilder
             Description = source.Description,
             IsVirtual = source.IsVirtual
         };
+}
+
+public sealed class SqlOSFgaRoleSeedBuilder
+{
+    private readonly SqlOSFgaSeedBuilder _builder;
+    private readonly string _roleKey;
+
+    internal SqlOSFgaRoleSeedBuilder(SqlOSFgaSeedBuilder builder, string roleKey)
+    {
+        _builder = builder;
+        _roleKey = roleKey;
+    }
+
+    public SqlOSFgaSeedBuilder Can(params string[] permissionKeys)
+    {
+        foreach (var permissionKey in permissionKeys)
+        {
+            _builder.RolePermission(_roleKey, permissionKey);
+        }
+
+        return _builder;
+    }
 }

--- a/src/SqlOS/Properties/AssemblyInfo.cs
+++ b/src/SqlOS/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("SqlOS.Tests")]

--- a/src/SqlOS/SqlOSDbContext.cs
+++ b/src/SqlOS/SqlOSDbContext.cs
@@ -1,0 +1,35 @@
+using Microsoft.EntityFrameworkCore;
+using SqlOS.AuthServer.Interfaces;
+using SqlOS.Extensions;
+using SqlOS.Fga.Interfaces;
+using SqlOS.Fga.Models;
+
+namespace SqlOS;
+
+/// <summary>
+/// Base DbContext for applications that host SqlOS auth server and FGA in the same EF Core model.
+/// </summary>
+public abstract class SqlOSDbContext<TContext>(DbContextOptions<TContext> options)
+    : DbContext(options), ISqlOSAuthServerDbContext, ISqlOSFgaDbContext
+    where TContext : DbContext
+{
+    public IQueryable<SqlOSFgaAccessibleResource> IsResourceAccessible(
+        string resourceId,
+        string subjectIds,
+        string permissionId)
+        => FromExpression(() => IsResourceAccessible(resourceId, subjectIds, permissionId));
+
+    protected sealed override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+        modelBuilder.UseSqlOS(Database.IsRelational() ? typeof(TContext) : null);
+        OnApplicationModelCreating(modelBuilder);
+    }
+
+    /// <summary>
+    /// Configure application-owned EF entities after SqlOS has registered its auth server and FGA model.
+    /// </summary>
+    protected virtual void OnApplicationModelCreating(ModelBuilder modelBuilder)
+    {
+    }
+}

--- a/src/SqlOS/SqlOSDbContext.cs
+++ b/src/SqlOS/SqlOSDbContext.cs
@@ -11,7 +11,7 @@ namespace SqlOS;
 /// </summary>
 public abstract class SqlOSDbContext<TContext>(DbContextOptions<TContext> options)
     : DbContext(options), ISqlOSAuthServerDbContext, ISqlOSFgaDbContext
-    where TContext : DbContext
+    where TContext : SqlOSDbContext<TContext>
 {
     public IQueryable<SqlOSFgaAccessibleResource> IsResourceAccessible(
         string resourceId,

--- a/tests/SqlOS.Tests/SqlOS.Tests.csproj
+++ b/tests/SqlOS.Tests/SqlOS.Tests.csproj
@@ -20,6 +20,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\SqlOS\SqlOS.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/SqlOS.Tests/SqlOSDbContextErgonomicsTests.cs
+++ b/tests/SqlOS.Tests/SqlOSDbContextErgonomicsTests.cs
@@ -1,0 +1,93 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SqlOS.AuthServer.Interfaces;
+using SqlOS.Configuration;
+using SqlOS.Extensions;
+using SqlOS.Fga.Interfaces;
+
+namespace SqlOS.Tests;
+
+[TestClass]
+public sealed class SqlOSDbContextErgonomicsTests
+{
+    [TestMethod]
+    public void SqlOSDbContext_RegistersInheritedTvfOnRelationalContext()
+    {
+        var options = new DbContextOptionsBuilder<EasyModeTestDbContext>()
+            .UseSqlServer("Server=(localdb)\\mssqllocaldb;Database=SqlOS_EasyMode_Test;Trusted_Connection=True;TrustServerCertificate=True")
+            .Options;
+
+        using var context = new EasyModeTestDbContext(options);
+
+        var tvfMethod = typeof(EasyModeTestDbContext).GetMethod(
+            nameof(ISqlOSFgaDbContext.IsResourceAccessible),
+            [typeof(string), typeof(string), typeof(string)]);
+
+        tvfMethod.Should().NotBeNull();
+
+        var dbFunction = context.Model.FindDbFunction(tvfMethod!);
+        dbFunction.Should().NotBeNull();
+        dbFunction!.Name.Should().Be("fn_IsResourceAccessible");
+        dbFunction.Schema.Should().Be("dbo");
+    }
+
+    [TestMethod]
+    public void AddSqlOS_WithDbContextOptions_RegistersDbContextAndSqlOSServices()
+    {
+        var builder = WebApplication.CreateBuilder();
+
+        builder.AddSqlOS<EasyModeTestDbContext>(
+            db => db.UseInMemoryDatabase(Guid.NewGuid().ToString("N")),
+            sqlos => sqlos.Fga.RootResourceId = "easy_mode_root");
+
+        using var app = builder.Build();
+        using var scope = app.Services.CreateScope();
+
+        var context = scope.ServiceProvider.GetRequiredService<EasyModeTestDbContext>();
+
+        context.Database.ProviderName.Should().Be("Microsoft.EntityFrameworkCore.InMemory");
+        scope.ServiceProvider.GetRequiredService<ISqlOSAuthServerDbContext>().Should().BeSameAs(context);
+        scope.ServiceProvider.GetRequiredService<ISqlOSFgaDbContext>().Should().BeSameAs(context);
+        app.Services.GetRequiredService<IOptions<SqlOSOptions>>().Value.Fga.RootResourceId.Should().Be("easy_mode_root");
+    }
+
+    [TestMethod]
+    public void SqlOSDbContext_AllowsDefaultApplicationModelHook()
+    {
+        var options = new DbContextOptionsBuilder<DefaultHookTestDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .Options;
+
+        using var context = new DefaultHookTestDbContext(options);
+
+        context.Model.GetEntityTypes().Should().NotBeEmpty();
+    }
+
+    private sealed class EasyModeTestDbContext(DbContextOptions<EasyModeTestDbContext> options)
+        : SqlOSDbContext<EasyModeTestDbContext>(options)
+    {
+        public DbSet<EasyModeEntity> Entities => Set<EasyModeEntity>();
+
+        protected override void OnApplicationModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<EasyModeEntity>(entity =>
+            {
+                entity.HasKey(x => x.Id);
+                entity.Property(x => x.Name).HasMaxLength(64).IsRequired();
+            });
+        }
+    }
+
+    private sealed class EasyModeEntity
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+
+    private sealed class DefaultHookTestDbContext(DbContextOptions<DefaultHookTestDbContext> options)
+        : SqlOSDbContext<DefaultHookTestDbContext>(options);
+}

--- a/tests/SqlOS.Tests/SqlOSDbContextErgonomicsTests.cs
+++ b/tests/SqlOS.Tests/SqlOSDbContextErgonomicsTests.cs
@@ -67,6 +67,16 @@ public sealed class SqlOSDbContextErgonomicsTests
         context.Model.GetEntityTypes().Should().NotBeEmpty();
     }
 
+    [TestMethod]
+    public void SqlOSDbContext_ConstrainsTypeParameterToDerivedContext()
+    {
+        var typeParameter = typeof(SqlOSDbContext<>).GetGenericArguments().Should().ContainSingle().Subject;
+        var constraint = typeParameter.GetGenericParameterConstraints().Should().ContainSingle().Subject;
+
+        constraint.IsGenericType.Should().BeTrue();
+        constraint.GetGenericTypeDefinition().Should().Be(typeof(SqlOSDbContext<>));
+    }
+
     private sealed class EasyModeTestDbContext(DbContextOptions<EasyModeTestDbContext> options)
         : SqlOSDbContext<EasyModeTestDbContext>(options)
     {

--- a/tests/SqlOS.Tests/SqlOSDbContextErgonomicsTests.cs
+++ b/tests/SqlOS.Tests/SqlOSDbContextErgonomicsTests.cs
@@ -17,13 +17,13 @@ public sealed class SqlOSDbContextErgonomicsTests
     [TestMethod]
     public void SqlOSDbContext_RegistersInheritedTvfOnRelationalContext()
     {
-        var options = new DbContextOptionsBuilder<EasyModeTestDbContext>()
-            .UseSqlServer("Server=(localdb)\\mssqllocaldb;Database=SqlOS_EasyMode_Test;Trusted_Connection=True;TrustServerCertificate=True")
+        var options = new DbContextOptionsBuilder<RecommendedSetupTestDbContext>()
+            .UseSqlServer("Server=(localdb)\\mssqllocaldb;Database=SqlOS_RecommendedSetup_Test;Trusted_Connection=True;TrustServerCertificate=True")
             .Options;
 
-        using var context = new EasyModeTestDbContext(options);
+        using var context = new RecommendedSetupTestDbContext(options);
 
-        var tvfMethod = typeof(EasyModeTestDbContext).GetMethod(
+        var tvfMethod = typeof(RecommendedSetupTestDbContext).GetMethod(
             nameof(ISqlOSFgaDbContext.IsResourceAccessible),
             [typeof(string), typeof(string), typeof(string)]);
 
@@ -40,19 +40,19 @@ public sealed class SqlOSDbContextErgonomicsTests
     {
         var builder = WebApplication.CreateBuilder();
 
-        builder.AddSqlOS<EasyModeTestDbContext>(
+        builder.AddSqlOS<RecommendedSetupTestDbContext>(
             db => db.UseInMemoryDatabase(Guid.NewGuid().ToString("N")),
-            sqlos => sqlos.Fga.RootResourceId = "easy_mode_root");
+            sqlos => sqlos.Fga.RootResourceId = "recommended_setup_root");
 
         using var app = builder.Build();
         using var scope = app.Services.CreateScope();
 
-        var context = scope.ServiceProvider.GetRequiredService<EasyModeTestDbContext>();
+        var context = scope.ServiceProvider.GetRequiredService<RecommendedSetupTestDbContext>();
 
         context.Database.ProviderName.Should().Be("Microsoft.EntityFrameworkCore.InMemory");
         scope.ServiceProvider.GetRequiredService<ISqlOSAuthServerDbContext>().Should().BeSameAs(context);
         scope.ServiceProvider.GetRequiredService<ISqlOSFgaDbContext>().Should().BeSameAs(context);
-        app.Services.GetRequiredService<IOptions<SqlOSOptions>>().Value.Fga.RootResourceId.Should().Be("easy_mode_root");
+        app.Services.GetRequiredService<IOptions<SqlOSOptions>>().Value.Fga.RootResourceId.Should().Be("recommended_setup_root");
     }
 
     [TestMethod]
@@ -77,14 +77,14 @@ public sealed class SqlOSDbContextErgonomicsTests
         constraint.GetGenericTypeDefinition().Should().Be(typeof(SqlOSDbContext<>));
     }
 
-    private sealed class EasyModeTestDbContext(DbContextOptions<EasyModeTestDbContext> options)
-        : SqlOSDbContext<EasyModeTestDbContext>(options)
+    private sealed class RecommendedSetupTestDbContext(DbContextOptions<RecommendedSetupTestDbContext> options)
+        : SqlOSDbContext<RecommendedSetupTestDbContext>(options)
     {
-        public DbSet<EasyModeEntity> Entities => Set<EasyModeEntity>();
+        public DbSet<RecommendedSetupEntity> Entities => Set<RecommendedSetupEntity>();
 
         protected override void OnApplicationModelCreating(ModelBuilder modelBuilder)
         {
-            modelBuilder.Entity<EasyModeEntity>(entity =>
+            modelBuilder.Entity<RecommendedSetupEntity>(entity =>
             {
                 entity.HasKey(x => x.Id);
                 entity.Property(x => x.Name).HasMaxLength(64).IsRequired();
@@ -92,7 +92,7 @@ public sealed class SqlOSDbContextErgonomicsTests
         }
     }
 
-    private sealed class EasyModeEntity
+    private sealed class RecommendedSetupEntity
     {
         public int Id { get; set; }
         public string Name { get; set; } = string.Empty;

--- a/tests/SqlOS.Tests/SqlOSErgonomicsExtensionsTests.cs
+++ b/tests/SqlOS.Tests/SqlOSErgonomicsExtensionsTests.cs
@@ -91,16 +91,13 @@ public sealed class SqlOSErgonomicsExtensionsTests
     }
 
     [TestMethod]
-    public async Task GrantSqlOSRole_DoesNotCreateMissingSubject()
+    public void GrantSqlOSRole_HasNoPublicSyncOverload()
     {
-        using var context = CreateContext();
-        SeedFgaCore(context);
-        await context.SaveChangesAsync();
-
-        context.GrantSqlOSRole("typo_user", "root", "role_owner");
-
-        context.Set<SqlOSFgaSubject>().Local.Should().NotContain(x => x.Id == "typo_user");
-        (await context.Set<SqlOSFgaSubject>().FindAsync("typo_user")).Should().BeNull();
+        typeof(SqlOSErgonomicsExtensions)
+            .GetMethods()
+            .Where(x => x.Name == "GrantSqlOSRole")
+            .Should()
+            .BeEmpty("role grants must validate subject/resource existence and resolve role keys asynchronously");
     }
 
     [TestMethod]
@@ -118,6 +115,89 @@ public sealed class SqlOSErgonomicsExtensionsTests
         var missingResource = async () => await context.EnsureSqlOSRoleGrantAsync("usr_1", "missing_resource", "owner");
         await missingResource.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("*resource 'missing_resource' was not found*");
+    }
+
+    [TestMethod]
+    public async Task EnsureHelpers_PreserveExistingOptionalMetadataWhenArgumentsAreOmitted()
+    {
+        using var context = CreateContext();
+        SeedFgaCore(context);
+        await context.SaveChangesAsync();
+
+        await context.EnsureSqlOSUserSubjectAsync(
+            "usr_1",
+            "User One",
+            "user@example.test",
+            "org_1",
+            "external_1",
+            false);
+        await context.EnsureSqlOSAgentSubjectAsync(
+            "agt_1",
+            "Agent One",
+            "worker",
+            "Initial description",
+            "org_1",
+            "agent_external_1");
+        await context.EnsureSqlOSServiceAccountSubjectAsync(
+            "sa_1",
+            "Service Account One",
+            "client_1",
+            "secret_1",
+            "Initial account",
+            new DateTime(2030, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            "org_1",
+            "sa_external_1");
+        await context.EnsureSqlOSResourceAsync(
+            "workspace_1",
+            "root",
+            "Workspace 1",
+            "workspace",
+            "Initial resource");
+        await context.EnsureSqlOSRoleGrantAsync(
+            "usr_1",
+            "workspace_1",
+            "owner",
+            "Initial grant");
+        await context.SaveChangesAsync();
+
+        await context.EnsureSqlOSUserSubjectAsync("usr_1", "User One Updated");
+        await context.EnsureSqlOSAgentSubjectAsync("agt_1", "Agent One Updated");
+        await context.EnsureSqlOSServiceAccountSubjectAsync("sa_1", "Service Account One Updated", "client_2", "secret_2");
+        await context.EnsureSqlOSResourceAsync("workspace_1", "root", "Workspace 1 Updated", "workspace");
+        await context.EnsureSqlOSRoleGrantAsync("usr_1", "workspace_1", "owner");
+        await context.SaveChangesAsync();
+
+        var subject = await context.Set<SqlOSFgaSubject>().SingleAsync(x => x.Id == "usr_1");
+        subject.DisplayName.Should().Be("User One Updated");
+        subject.OrganizationId.Should().Be("org_1");
+        subject.ExternalRef.Should().Be("external_1");
+
+        var user = await context.Set<SqlOSFgaUser>().SingleAsync(x => x.SubjectId == "usr_1");
+        user.Email.Should().Be("user@example.test");
+        user.IsActive.Should().BeFalse();
+
+        var agentSubject = await context.Set<SqlOSFgaSubject>().SingleAsync(x => x.Id == "agt_1");
+        agentSubject.OrganizationId.Should().Be("org_1");
+        agentSubject.ExternalRef.Should().Be("agent_external_1");
+        var agent = await context.Set<SqlOSFgaAgent>().SingleAsync(x => x.SubjectId == "agt_1");
+        agent.AgentType.Should().Be("worker");
+        agent.Description.Should().Be("Initial description");
+
+        var serviceAccountSubject = await context.Set<SqlOSFgaSubject>().SingleAsync(x => x.Id == "sa_1");
+        serviceAccountSubject.OrganizationId.Should().Be("org_1");
+        serviceAccountSubject.ExternalRef.Should().Be("sa_external_1");
+        var serviceAccount = await context.Set<SqlOSFgaServiceAccount>().SingleAsync(x => x.SubjectId == "sa_1");
+        serviceAccount.ClientId.Should().Be("client_2");
+        serviceAccount.ClientSecretHash.Should().Be("secret_2");
+        serviceAccount.Description.Should().Be("Initial account");
+        serviceAccount.ExpiresAt.Should().Be(new DateTime(2030, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        var resource = await context.Set<SqlOSFgaResource>().SingleAsync(x => x.Id == "workspace_1");
+        resource.Name.Should().Be("Workspace 1 Updated");
+        resource.Description.Should().Be("Initial resource");
+
+        var grant = await context.Set<SqlOSFgaGrant>().SingleAsync(x => x.SubjectId == "usr_1" && x.ResourceId == "workspace_1");
+        grant.Description.Should().Be("Initial grant");
     }
 
     [TestMethod]

--- a/tests/SqlOS.Tests/SqlOSErgonomicsExtensionsTests.cs
+++ b/tests/SqlOS.Tests/SqlOSErgonomicsExtensionsTests.cs
@@ -44,19 +44,32 @@ public sealed class SqlOSErgonomicsExtensionsTests
     }
 
     [TestMethod]
-    public async Task ResourceAndGrantHelpers_AddAndEnsureFgaRowsWithoutManualModelTypes()
+    public async Task SubjectResourceAndGrantHelpers_ProvisionExplicitlyAndGrantExistingRows()
     {
         using var context = CreateContext();
         SeedFgaCore(context);
         await context.SaveChangesAsync();
 
-        var resource = context.AddSqlOSResource("workspace_1", "root", "Workspace 1", "workspace");
-        var grant = context.GrantSqlOSRole("usr_1", "workspace_1", "owner", "Workspace owner");
+        var user = await context.EnsureSqlOSUserSubjectAsync("usr_1", "User One", "user@example.test");
+        var agent = await context.EnsureSqlOSAgentSubjectAsync("agt_1", "Agent One", "worker", "Background worker");
+        var serviceAccount = await context.EnsureSqlOSServiceAccountSubjectAsync(
+            "sa_1",
+            "Service Account One",
+            "client_1",
+            "hashed-secret",
+            "API integration");
+        var resource = await context.EnsureSqlOSResourceAsync("workspace_1", "root", "Workspace 1", "workspace");
+        var grant = await context.GrantSqlOSRoleAsync("usr_1", "workspace_1", "owner", "Workspace owner");
         await context.SaveChangesAsync();
 
+        user.SubjectId.Should().Be("usr_1");
+        agent.SubjectId.Should().Be("agt_1");
+        serviceAccount.SubjectId.Should().Be("sa_1");
         resource.Id.Should().Be("workspace_1");
         grant.RoleId.Should().Be("role_owner");
-        (await context.Set<SqlOSFgaSubject>().FindAsync("usr_1")).Should().NotBeNull();
+        (await context.Set<SqlOSFgaUser>().SingleAsync(x => x.SubjectId == "usr_1")).Email.Should().Be("user@example.test");
+        (await context.Set<SqlOSFgaAgent>().SingleAsync(x => x.SubjectId == "agt_1")).AgentType.Should().Be("worker");
+        (await context.Set<SqlOSFgaServiceAccount>().SingleAsync(x => x.SubjectId == "sa_1")).ClientId.Should().Be("client_1");
 
         var ensuredResource = await context.EnsureSqlOSResourceAsync(
             "workspace_1",
@@ -75,6 +88,36 @@ public sealed class SqlOSErgonomicsExtensionsTests
         ensuredResource.Description.Should().Be("Updated");
         ensuredGrant.Description.Should().Be("Updated owner grant");
         context.Set<SqlOSFgaGrant>().Count(x => x.SubjectId == "usr_1" && x.ResourceId == "workspace_1").Should().Be(1);
+    }
+
+    [TestMethod]
+    public async Task GrantSqlOSRole_DoesNotCreateMissingSubject()
+    {
+        using var context = CreateContext();
+        SeedFgaCore(context);
+        await context.SaveChangesAsync();
+
+        context.GrantSqlOSRole("typo_user", "root", "role_owner");
+
+        context.Set<SqlOSFgaSubject>().Local.Should().NotContain(x => x.Id == "typo_user");
+        (await context.Set<SqlOSFgaSubject>().FindAsync("typo_user")).Should().BeNull();
+    }
+
+    [TestMethod]
+    public async Task EnsureSqlOSRoleGrantAsync_RequiresExistingSubjectAndResource()
+    {
+        using var context = CreateContext();
+        SeedFgaCore(context);
+        await context.SaveChangesAsync();
+
+        var missingSubject = async () => await context.EnsureSqlOSRoleGrantAsync("missing_user", "root", "owner");
+        await missingSubject.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*subject 'missing_user' was not found*");
+
+        await context.EnsureSqlOSUserSubjectAsync("usr_1", "User One");
+        var missingResource = async () => await context.EnsureSqlOSRoleGrantAsync("usr_1", "missing_resource", "owner");
+        await missingResource.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*resource 'missing_resource' was not found*");
     }
 
     [TestMethod]
@@ -100,15 +143,15 @@ public sealed class SqlOSErgonomicsExtensionsTests
     }
 
     [TestMethod]
-    public void SeedMcpStackClient_CreatesDeviceFlowPublicClient()
+    public void SeedDeviceFlowClient_CreatesDeviceFlowPublicClient()
     {
         var options = new SqlOSAuthServerOptions();
 
-        options.SeedMcpStackClient("checklist-mcpstack", "MCP Stack", "https://api.example.test", "READ", "WRITE");
+        options.SeedDeviceFlowClient("checklist-cli", "Checklist CLI", "https://api.example.test", "READ", "WRITE");
 
         var client = options.ClientSeeds.Should().ContainSingle().Subject;
-        client.ClientId.Should().Be("checklist-mcpstack");
-        client.Name.Should().Be("MCP Stack");
+        client.ClientId.Should().Be("checklist-cli");
+        client.Name.Should().Be("Checklist CLI");
         client.Audience.Should().Be("https://api.example.test");
         client.ClientType.Should().Be("public_cli");
         client.RequirePkce.Should().BeTrue();
@@ -126,7 +169,10 @@ public sealed class SqlOSErgonomicsExtensionsTests
 
     private static void SeedFgaCore(TestSqlOSInMemoryDbContext context)
     {
-        context.Set<SqlOSFgaSubjectType>().Add(new SqlOSFgaSubjectType { Id = "user", Name = "User" });
+        context.Set<SqlOSFgaSubjectType>().AddRange(
+            new SqlOSFgaSubjectType { Id = "user", Name = "User" },
+            new SqlOSFgaSubjectType { Id = "agent", Name = "Agent" },
+            new SqlOSFgaSubjectType { Id = "service_account", Name = "Service Account" });
         context.Set<SqlOSFgaResourceType>().AddRange(
             new SqlOSFgaResourceType { Id = "root", Name = "Root" },
             new SqlOSFgaResourceType { Id = "workspace", Name = "Workspace" });

--- a/tests/SqlOS.Tests/SqlOSErgonomicsExtensionsTests.cs
+++ b/tests/SqlOS.Tests/SqlOSErgonomicsExtensionsTests.cs
@@ -118,6 +118,73 @@ public sealed class SqlOSErgonomicsExtensionsTests
     }
 
     [TestMethod]
+    public async Task EnsureSqlOSResourceAsync_RequiresExistingParentResource()
+    {
+        using var context = CreateContext();
+        SeedFgaCore(context);
+        await context.SaveChangesAsync();
+
+        var missingParent = async () => await context.EnsureSqlOSResourceAsync(
+            "workspace_1",
+            "missing_parent",
+            "Workspace 1",
+            "workspace");
+
+        await missingParent.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*resource 'missing_parent' was not found*");
+        context.Set<SqlOSFgaResource>().Local.Should().NotContain(x => x.Id == "workspace_1");
+    }
+
+    [TestMethod]
+    public async Task EnsureSqlOSResourceAsync_RequiresExistingResourceType()
+    {
+        using var context = CreateContext();
+        SeedFgaCore(context);
+        await context.SaveChangesAsync();
+
+        var missingResourceType = async () => await context.EnsureSqlOSResourceAsync(
+            "workspace_1",
+            "root",
+            "Workspace 1",
+            "workpsace");
+
+        await missingResourceType.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*resource type 'workpsace' was not found*");
+        context.Set<SqlOSFgaResource>().Local.Should().NotContain(x => x.Id == "workspace_1");
+    }
+
+    [TestMethod]
+    public async Task EnsureSqlOSResourceAsync_ValidatesParentAndResourceTypeWhenUpdating()
+    {
+        using var context = CreateContext();
+        SeedFgaCore(context);
+        await context.SaveChangesAsync();
+
+        await context.EnsureSqlOSResourceAsync("workspace_1", "root", "Workspace 1", "workspace");
+        await context.SaveChangesAsync();
+
+        var missingParent = async () => await context.EnsureSqlOSResourceAsync(
+            "workspace_1",
+            "missing_parent",
+            "Workspace 1",
+            "workspace");
+        await missingParent.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*resource 'missing_parent' was not found*");
+
+        var missingResourceType = async () => await context.EnsureSqlOSResourceAsync(
+            "workspace_1",
+            "root",
+            "Workspace 1",
+            "workpsace");
+        await missingResourceType.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*resource type 'workpsace' was not found*");
+
+        var resource = await context.Set<SqlOSFgaResource>().SingleAsync(x => x.Id == "workspace_1");
+        resource.ParentId.Should().Be("root");
+        resource.ResourceTypeId.Should().Be("workspace");
+    }
+
+    [TestMethod]
     public async Task EnsureHelpers_PreserveExistingOptionalMetadataWhenArgumentsAreOmitted()
     {
         using var context = CreateContext();

--- a/tests/SqlOS.Tests/SqlOSErgonomicsExtensionsTests.cs
+++ b/tests/SqlOS.Tests/SqlOSErgonomicsExtensionsTests.cs
@@ -1,0 +1,162 @@
+using System.Linq.Expressions;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SqlOS.AuthServer.Configuration;
+using SqlOS.AuthServer.Extensions;
+using SqlOS.Extensions;
+using SqlOS.Fga.Configuration;
+using SqlOS.Fga.Interfaces;
+using SqlOS.Fga.Models;
+using SqlOS.Tests.Infrastructure;
+
+namespace SqlOS.Tests;
+
+[TestClass]
+public sealed class SqlOSErgonomicsExtensionsTests
+{
+    [TestMethod]
+    public void SqlOSToken_AndSqlOSUserId_ReadValidatedToken()
+    {
+        var httpContext = new DefaultHttpContext();
+        var token = new SqlOS.AuthServer.Contracts.SqlOSValidatedToken(
+            new System.Security.Claims.ClaimsPrincipal(),
+            "sess_1",
+            "usr_1",
+            "org_1",
+            "client_1",
+            "api");
+        httpContext.Items[SqlOSAccessTokenValidationExtensions.ValidatedTokenItemKey] = token;
+
+        httpContext.SqlOSToken().Should().BeSameAs(token);
+        httpContext.SqlOSUserId().Should().Be("usr_1");
+    }
+
+    [TestMethod]
+    public async Task Allows_ReturnsCheckAccessDecision()
+    {
+        var allowed = await new FakeFgaAuthService(true).Allows("usr_1", "READ", "res_1");
+        var denied = await new FakeFgaAuthService(false).Allows("usr_1", "READ", "res_1");
+
+        allowed.Should().BeTrue();
+        denied.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public async Task ResourceAndGrantHelpers_AddAndEnsureFgaRowsWithoutManualModelTypes()
+    {
+        using var context = CreateContext();
+        SeedFgaCore(context);
+        await context.SaveChangesAsync();
+
+        var resource = context.AddSqlOSResource("workspace_1", "root", "Workspace 1", "workspace");
+        var grant = context.GrantSqlOSRole("usr_1", "workspace_1", "owner", "Workspace owner");
+        await context.SaveChangesAsync();
+
+        resource.Id.Should().Be("workspace_1");
+        grant.RoleId.Should().Be("role_owner");
+        (await context.Set<SqlOSFgaSubject>().FindAsync("usr_1")).Should().NotBeNull();
+
+        var ensuredResource = await context.EnsureSqlOSResourceAsync(
+            "workspace_1",
+            "root",
+            "Workspace One",
+            "workspace",
+            "Updated");
+        var ensuredGrant = await context.EnsureSqlOSRoleGrantAsync(
+            "usr_1",
+            "workspace_1",
+            "owner",
+            "Updated owner grant");
+        await context.SaveChangesAsync();
+
+        ensuredResource.Name.Should().Be("Workspace One");
+        ensuredResource.Description.Should().Be("Updated");
+        ensuredGrant.Description.Should().Be("Updated owner grant");
+        context.Set<SqlOSFgaGrant>().Count(x => x.SubjectId == "usr_1" && x.ResourceId == "workspace_1").Should().Be(1);
+    }
+
+    [TestMethod]
+    public void FgaSeedDsl_CreatesPermissionsRolesAndRolePermissions()
+    {
+        var seed = new SqlOSFgaSeedBuilder();
+
+        seed.ResourceType("workspace", "Workspace");
+        seed.Permission("CHECKLIST_READ", "Read", "workspace");
+        seed.Permission("CHECKLIST_WRITE", "Write", "workspace");
+        seed.Role("owner", "Owner").Can("CHECKLIST_READ", "CHECKLIST_WRITE");
+
+        var data = seed.Build();
+
+        data.Permissions.Should().ContainSingle(x =>
+            x.Id == "CHECKLIST_READ"
+            && x.Key == "CHECKLIST_READ"
+            && x.Name == "Read"
+            && x.ResourceTypeId == "workspace");
+        data.Roles.Should().ContainSingle(x => x.Id == "owner" && x.Key == "owner" && x.Name == "Owner");
+        var rolePermissions = data.RolePermissions.Should().ContainSingle(x => x.RoleKey == "owner").Subject;
+        rolePermissions.PermissionKeys.Should().Equal("CHECKLIST_READ", "CHECKLIST_WRITE");
+    }
+
+    [TestMethod]
+    public void SeedMcpStackClient_CreatesDeviceFlowPublicClient()
+    {
+        var options = new SqlOSAuthServerOptions();
+
+        options.SeedMcpStackClient("checklist-mcpstack", "MCP Stack", "https://api.example.test", "READ", "WRITE");
+
+        var client = options.ClientSeeds.Should().ContainSingle().Subject;
+        client.ClientId.Should().Be("checklist-mcpstack");
+        client.Name.Should().Be("MCP Stack");
+        client.Audience.Should().Be("https://api.example.test");
+        client.ClientType.Should().Be("public_cli");
+        client.RequirePkce.Should().BeTrue();
+        client.AllowDeviceAuthorization.Should().BeTrue();
+        client.AllowedScopes.Should().Equal("READ", "WRITE");
+    }
+
+    private static TestSqlOSInMemoryDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<TestSqlOSInMemoryDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .Options;
+        return new TestSqlOSInMemoryDbContext(options);
+    }
+
+    private static void SeedFgaCore(TestSqlOSInMemoryDbContext context)
+    {
+        context.Set<SqlOSFgaSubjectType>().Add(new SqlOSFgaSubjectType { Id = "user", Name = "User" });
+        context.Set<SqlOSFgaResourceType>().AddRange(
+            new SqlOSFgaResourceType { Id = "root", Name = "Root" },
+            new SqlOSFgaResourceType { Id = "workspace", Name = "Workspace" });
+        context.Set<SqlOSFgaResource>().Add(new SqlOSFgaResource
+        {
+            Id = "root",
+            Name = "Root",
+            ResourceTypeId = "root"
+        });
+        context.Set<SqlOSFgaRole>().Add(new SqlOSFgaRole
+        {
+            Id = "role_owner",
+            Key = "owner",
+            Name = "Owner"
+        });
+    }
+
+    private sealed class FakeFgaAuthService(bool allowed) : ISqlOSFgaAuthService
+    {
+        public Task<SqlOSFgaAccessCheckResult> CheckAccessAsync(string subjectId, string permissionKey, string resourceId)
+            => Task.FromResult(new SqlOSFgaAccessCheckResult { Allowed = allowed });
+
+        public Task<bool> HasCapabilityAsync(string subjectId, string permissionKey)
+            => Task.FromResult(allowed);
+
+        public Task<SqlOSFgaResourceAccessTrace> TraceResourceAccessAsync(string subjectId, string resourceId, string permissionKey)
+            => throw new NotImplementedException();
+
+        public Task<Expression<Func<T, bool>>> GetAuthorizationFilterAsync<T>(string subjectId, string permissionKey)
+            where T : IHasResourceId
+            => throw new NotImplementedException();
+    }
+}

--- a/tests/SqlOS.Tests/SqlOSResourceBindingTests.cs
+++ b/tests/SqlOS.Tests/SqlOSResourceBindingTests.cs
@@ -11,6 +11,7 @@ using SqlOS.AuthServer.Contracts;
 using SqlOS.AuthServer.Extensions;
 using SqlOS.AuthServer.Models;
 using SqlOS.AuthServer.Services;
+using SqlOS.Extensions;
 using SqlOS.Tests.Infrastructure;
 
 namespace SqlOS.Tests;
@@ -110,6 +111,81 @@ public sealed class SqlOSResourceBindingTests
 
         nextCalled.Should().BeFalse();
         httpContext.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+        httpContext.GetSqlOSValidatedToken().Should().BeNull();
+    }
+
+    [TestMethod]
+    public async Task RequireSqlOSAccessToken_Filter_StoresValidatedTokenAndUser()
+    {
+        using var context = CreateContext();
+        var (options, _, auth) = CreateAuthHarness(context);
+        var user = await SeedUserAsync(context);
+        var client = await SeedClientAsync(context, options.Value, "filter-client", "https://client.example.test/callback", "https://api-a.example.test");
+
+        var tokens = await auth.CreateSessionTokensForUserAsync(
+            user,
+            client,
+            null,
+            "password",
+            "test-agent",
+            "127.0.0.1");
+
+        var httpContext = new DefaultHttpContext
+        {
+            RequestServices = new ServiceCollection()
+                .AddSingleton(auth)
+                .BuildServiceProvider()
+        };
+        httpContext.Request.Headers.Authorization = $"Bearer {tokens.AccessToken}";
+        var invocationContext = new TestEndpointFilterInvocationContext(httpContext);
+        var optionsValue = SqlOSAccessTokenValidationMiddleware.ValidateOptions(new SqlOSAccessTokenValidationOptions
+        {
+            ExpectedAudience = "https://api-a.example.test"
+        });
+
+        var nextCalled = false;
+        var result = await SqlOSAccessTokenEndpointFilter.InvokeAsync(
+            invocationContext,
+            ctx =>
+            {
+                nextCalled = true;
+                ctx.HttpContext.SqlOSUserId().Should().Be(user.Id);
+                return ValueTask.FromResult<object?>("ok");
+            },
+            optionsValue);
+
+        nextCalled.Should().BeTrue();
+        result.Should().Be("ok");
+        httpContext.GetSqlOSValidatedToken().Should().NotBeNull();
+    }
+
+    [TestMethod]
+    public async Task RequireSqlOSAccessToken_Filter_RejectsMissingBearerToken()
+    {
+        using var context = CreateContext();
+        var (_, _, auth) = CreateAuthHarness(context);
+        var httpContext = new DefaultHttpContext
+        {
+            RequestServices = new ServiceCollection()
+                .AddSingleton(auth)
+                .BuildServiceProvider()
+        };
+        var invocationContext = new TestEndpointFilterInvocationContext(httpContext);
+        var optionsValue = SqlOSAccessTokenValidationMiddleware.ValidateOptions(new SqlOSAccessTokenValidationOptions
+        {
+            ExpectedAudience = "https://api-a.example.test"
+        });
+
+        var result = await SqlOSAccessTokenEndpointFilter.InvokeAsync(
+            invocationContext,
+            _ => ValueTask.FromResult<object?>("should-not-run"),
+            optionsValue);
+
+        var unauthorized = result.Should().BeAssignableTo<IResult>().Subject;
+        await unauthorized.ExecuteAsync(httpContext);
+
+        httpContext.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+        httpContext.Response.Headers.WWWAuthenticate.ToString().Should().Contain("invalid_token");
         httpContext.GetSqlOSValidatedToken().Should().BeNull();
     }
 
@@ -472,5 +548,15 @@ public sealed class SqlOSResourceBindingTests
         }
 
         return false;
+    }
+
+    private sealed class TestEndpointFilterInvocationContext(HttpContext httpContext) : EndpointFilterInvocationContext
+    {
+        public override HttpContext HttpContext { get; } = httpContext;
+
+        public override IList<object?> Arguments { get; } = [];
+
+        public override T GetArgument<T>(int index)
+            => (T)Arguments[index]!;
     }
 }

--- a/tests/SqlOS.Tests/SqlOSResourceBindingTests.cs
+++ b/tests/SqlOS.Tests/SqlOSResourceBindingTests.cs
@@ -160,6 +160,32 @@ public sealed class SqlOSResourceBindingTests
     }
 
     [TestMethod]
+    public async Task RequireSqlOSAccessToken_Filter_SkipsWhenPredicateReturnsFalse()
+    {
+        var httpContext = new DefaultHttpContext();
+        var invocationContext = new TestEndpointFilterInvocationContext(httpContext);
+        var optionsValue = SqlOSAccessTokenValidationMiddleware.ValidateOptions(new SqlOSAccessTokenValidationOptions
+        {
+            ExpectedAudience = "https://api-a.example.test",
+            ShouldValidate = _ => false
+        });
+
+        var nextCalled = false;
+        var result = await SqlOSAccessTokenEndpointFilter.InvokeAsync(
+            invocationContext,
+            _ =>
+            {
+                nextCalled = true;
+                return ValueTask.FromResult<object?>("skipped");
+            },
+            optionsValue);
+
+        nextCalled.Should().BeTrue();
+        result.Should().Be("skipped");
+        httpContext.GetSqlOSValidatedToken().Should().BeNull();
+    }
+
+    [TestMethod]
     public async Task RequireSqlOSAccessToken_Filter_RejectsMissingBearerToken()
     {
         using var context = CreateContext();
@@ -173,7 +199,9 @@ public sealed class SqlOSResourceBindingTests
         var invocationContext = new TestEndpointFilterInvocationContext(httpContext);
         var optionsValue = SqlOSAccessTokenValidationMiddleware.ValidateOptions(new SqlOSAccessTokenValidationOptions
         {
-            ExpectedAudience = "https://api-a.example.test"
+            ExpectedAudience = "https://api-a.example.test",
+            Realm = "Example API",
+            ResourceMetadataUrl = "https://api-a.example.test/.well-known/oauth-protected-resource"
         });
 
         var result = await SqlOSAccessTokenEndpointFilter.InvokeAsync(
@@ -185,8 +213,26 @@ public sealed class SqlOSResourceBindingTests
         await unauthorized.ExecuteAsync(httpContext);
 
         httpContext.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+        httpContext.Response.Headers.WWWAuthenticate.ToString().Should().Contain("realm=\"Example API\"");
         httpContext.Response.Headers.WWWAuthenticate.ToString().Should().Contain("invalid_token");
+        httpContext.Response.Headers.WWWAuthenticate.ToString().Should().Contain("resource_metadata=\"https://api-a.example.test/.well-known/oauth-protected-resource\"");
         httpContext.GetSqlOSValidatedToken().Should().BeNull();
+    }
+
+    [TestMethod]
+    public void RequireSqlOSAccessToken_OptionsOverload_AcceptsResourceMetadata()
+    {
+        var app = WebApplication.CreateBuilder().Build();
+        var group = app.MapGroup("/api");
+
+        var result = group.RequireSqlOSAccessToken(options =>
+        {
+            options.ExpectedAudience = "https://api-a.example.test";
+            options.Realm = "Example API";
+            options.ResourceMetadataUrl = "https://api-a.example.test/.well-known/oauth-protected-resource";
+        });
+
+        result.Should().BeSameAs(group);
     }
 
     [TestMethod]

--- a/web/content/blog/authorized-list-queries-ef-core-sqlos.mdx
+++ b/web/content/blog/authorized-list-queries-ef-core-sqlos.mdx
@@ -175,9 +175,10 @@ var item = new TodoItem
     CreatedAt = DateTime.UtcNow
 };
 
-item.ResourceId = todoFgaService.CreateTodoResource(
+item.ResourceId = await todoFgaService.CreateTodoResourceAsync(
     item,
-    todoContext.TenantResourceId);
+    todoContext.TenantResourceId,
+    cancellationToken);
 
 dbContext.TodoItems.Add(item);
 await dbContext.SaveChangesAsync(cancellationToken);
@@ -186,15 +187,19 @@ await dbContext.SaveChangesAsync(cancellationToken);
 The helper creates `todo::{todoId}` under the tenant resource:
 
 ```csharp
-public string CreateTodoResource(TodoItem item, string tenantResourceId)
+public async Task<string> CreateTodoResourceAsync(
+    TodoItem item,
+    string tenantResourceId,
+    CancellationToken cancellationToken = default)
 {
     var resourceId = GetTodoResourceId(item.Id);
 
-    _context.CreateResource(
+    await _context.EnsureSqlOSResourceAsync(
+        resourceId,
         tenantResourceId,
         item.Title,
         TodoResourceTypeId,
-        resourceId);
+        cancellationToken: cancellationToken);
 
     return resourceId;
 }

--- a/web/content/docs/getting-started.mdx
+++ b/web/content/docs/getting-started.mdx
@@ -28,7 +28,7 @@ You'll learn how to install SqlOS, wire a minimal host, run the Todo sample, and
     Add `SqlOS` to your ASP.NET app.
   </Step>
   <Step title="Register on your DbContext">
-    Implement the SqlOS interfaces and call `AddSqlOS` during host setup.
+    Derive from `SqlOSDbContext<TContext>` and call `AddSqlOS` during host setup.
   </Step>
   <Step title="Map routes and verify">
     Call `MapSqlOS()`, start the app, and open the admin dashboard.
@@ -140,7 +140,11 @@ For API routes that accept SqlOS access tokens, protect a route group and read t
 
 ```csharp
 var api = app.MapGroup("/api")
-    .RequireSqlOSAccessToken("https://localhost:5001/api");
+    .RequireSqlOSAccessToken(options =>
+    {
+        options.ExpectedAudience = "https://localhost:5001/api";
+        options.ResourceMetadataUrl = "https://localhost:5001/.well-known/oauth-protected-resource";
+    });
 
 api.MapGet("/me", (HttpContext http) =>
 {

--- a/web/content/docs/getting-started.mdx
+++ b/web/content/docs/getting-started.mdx
@@ -47,22 +47,25 @@ A complete minimal `Program.cs` for an owned web app with hosted auth:
 
 ```csharp
 using Microsoft.EntityFrameworkCore;
+using SqlOS;
 using SqlOS.Extensions;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddDbContext<AppDbContext>(options =>
-    options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
+var connectionString = builder.Configuration.GetConnectionString("DefaultConnection")
+    ?? throw new InvalidOperationException("Connection string 'DefaultConnection' was not configured.");
 
-builder.AddSqlOS<AppDbContext>(options =>
-{
-    options.AuthServer.Issuer = "https://localhost:5001/sqlos/auth";
-    options.AuthServer.PublicOrigin = "https://localhost:5001";
-    options.AuthServer.SeedOwnedWebApp(
-        "web",
-        "My Application",
-        "https://localhost:5001/auth/callback");
-});
+builder.AddSqlOS<AppDbContext>(
+    db => db.UseSqlServer(connectionString),
+    options =>
+    {
+        options.AuthServer.Issuer = "https://localhost:5001/sqlos/auth";
+        options.AuthServer.PublicOrigin = "https://localhost:5001";
+        options.AuthServer.SeedOwnedWebApp(
+            "web",
+            "My Application",
+            "https://localhost:5001/auth/callback");
+    });
 
 var app = builder.Build();
 app.MapSqlOS();
@@ -71,28 +74,22 @@ app.Run();
 
 ## Set up your DbContext
 
-Your context implements the SqlOS interfaces. This sample includes both auth and FGA:
+Derive from `SqlOSDbContext<TContext>` to include the SqlOS auth server model, FGA model, and FGA TVF mapping. Add application entities in `OnApplicationModelCreating`:
 
 ```csharp
-public sealed class AppDbContext : DbContext,
-    ISqlOSAuthServerDbContext,
-    ISqlOSFgaDbContext
+public sealed class AppDbContext(DbContextOptions<AppDbContext> options)
+    : SqlOSDbContext<AppDbContext>(options)
 {
     public DbSet<Project> Projects => Set<Project>();
 
-    public IQueryable<SqlOSFgaAccessibleResource> IsResourceAccessible(
-        string subjectId,
-        string permissionKey)
-        => FromExpression(() =>
-            IsResourceAccessible(subjectId, permissionKey));
-
-    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    protected override void OnApplicationModelCreating(ModelBuilder modelBuilder)
     {
-        base.OnModelCreating(modelBuilder);
-        modelBuilder.UseSqlOS(GetType());
+        modelBuilder.Entity<Project>();
     }
 }
 ```
+
+If you need full EF model control, the lower-level path is still available: implement `ISqlOSAuthServerDbContext` and `ISqlOSFgaDbContext`, expose `IsResourceAccessible`, and call `modelBuilder.UseSqlOS(...)` yourself.
 
 `appsettings.json` needs a SQL Server connection string and optional dashboard password:
 
@@ -128,15 +125,32 @@ This gives you:
 
 ## Seed a client
 
-Register your frontend as an OAuth client so users can sign in immediately:
+Register your frontend as an OAuth client so users can sign in immediately. Put this inside the `options => { ... }` callback passed to `builder.AddSqlOS`:
 
 ```csharp
-builder.AddSqlOS<AppDbContext>(options =>
+options.AuthServer.SeedOwnedWebApp(
+    "my-app",
+    "My Application",
+    "http://localhost:3000/auth/callback");
+```
+
+## Protect an API
+
+For API routes that accept SqlOS access tokens, protect a route group and read the validated token from `HttpContext`:
+
+```csharp
+var api = app.MapGroup("/api")
+    .RequireSqlOSAccessToken("https://localhost:5001/api");
+
+api.MapGet("/me", (HttpContext http) =>
 {
-    options.AuthServer.SeedOwnedWebApp(
-        "my-app",
-        "My Application",
-        "http://localhost:3000/auth/callback");
+    var token = http.SqlOSToken();
+    return Results.Ok(new
+    {
+        userId = http.SqlOSUserId(),
+        token.ClientId,
+        token.Audience
+    });
 });
 ```
 

--- a/web/content/docs/guides/configuration.mdx
+++ b/web/content/docs/guides/configuration.mdx
@@ -12,33 +12,35 @@ section: guides
   actionLabel="Getting Started"
 />
 
-You'll learn the three integration points: host registration, EF model registration, and route mapping.
+You'll learn the easy-mode integration points: host registration, DbContext inheritance, and route mapping.
 
 ## Wire SqlOS in three places
 
-1. **Host registration** — `builder.AddSqlOS<AppDbContext>(...)`
-2. **EF model** — `modelBuilder.UseSqlOS(GetType())` in `OnModelCreating`
+1. **Host registration** — `builder.AddSqlOS<AppDbContext>(db => db.UseSqlServer(...), options => ...)`
+2. **EF model** — derive from `SqlOSDbContext<AppDbContext>` and put app entities in `OnApplicationModelCreating`
 3. **Routes** — `app.MapSqlOS()` after `Build()`
 
 ## Minimal owned-app setup
 
 ```csharp
-builder.AddSqlOS<AppDbContext>(options =>
-{
-    options.AuthServer.Issuer = "https://app.example.com/sqlos/auth";
-    options.AuthServer.PublicOrigin = "https://app.example.com";
-
-    options.AuthServer.SeedAuthPage(page =>
+builder.AddSqlOS<AppDbContext>(
+    db => db.UseSqlServer(connectionString),
+    options =>
     {
-        page.PageTitle = "Sign in";
-        page.PageSubtitle = "Secure your owned app first.";
-    });
+        options.AuthServer.Issuer = "https://app.example.com/sqlos/auth";
+        options.AuthServer.PublicOrigin = "https://app.example.com";
 
-    options.AuthServer.SeedOwnedWebApp(
-        "web",
-        "Main Web App",
-        "https://app.example.com/auth/callback");
-});
+        options.AuthServer.SeedAuthPage(page =>
+        {
+            page.PageTitle = "Sign in";
+            page.PageSubtitle = "Secure your owned app first.";
+        });
+
+        options.AuthServer.SeedOwnedWebApp(
+            "web",
+            "Main Web App",
+            "https://app.example.com/auth/callback");
+    });
 ```
 
 ## FGA seeding
@@ -49,11 +51,41 @@ Keep auth and FGA seeding in the same `AddSqlOS` call:
 options.Fga.Seed(seed =>
 {
     seed.ResourceType("workspace", "Workspace");
-    seed.Permission("perm_workspace_view", "workspace.view", "View workspace", "workspace");
-    seed.Role("role_workspace_admin", "workspace_admin", "Workspace Admin");
-    seed.RolePermission("workspace_admin", "workspace.view");
+    seed.Permission("workspace.read", "Read workspace", "workspace");
+    seed.Permission("workspace.write", "Write workspace", "workspace");
+    seed.Role("workspace_admin", "Workspace Admin").Can("workspace.read", "workspace.write");
 });
 ```
+
+Use the explicit-ID overloads when you need stable IDs that differ from public permission or role keys.
+
+## Protected API helpers
+
+Protect a route group with SqlOS access-token validation, then use the validated token and FGA helpers in endpoints:
+
+```csharp
+var api = app.MapGroup("/api")
+    .RequireSqlOSAccessToken("https://api.example.com");
+
+api.MapPost("/workspaces", async (
+    CreateWorkspace request,
+    AppDbContext db,
+    ISqlOSFgaAuthService fga,
+    HttpContext http) =>
+{
+    var userId = http.SqlOSUserId();
+    var workspace = new Workspace(request.Name);
+
+    db.Workspaces.Add(workspace);
+    db.AddSqlOSResource(workspace.ResourceId, "root", workspace.Name, "workspace");
+    db.GrantSqlOSRole(userId, workspace.ResourceId, "workspace_admin");
+
+    await db.SaveChangesAsync();
+    return Results.Created($"/api/workspaces/{workspace.Id}", workspace);
+});
+```
+
+For idempotent provisioning paths, use `EnsureSqlOSResourceAsync(...)` and `EnsureSqlOSRoleGrantAsync(...)`.
 
 ## Client onboarding modes
 
@@ -68,6 +100,13 @@ options.AuthServer.EnablePortableMcpClients(registration =>
 {
     registration.Cimd.TrustedHosts.Add("clients.example.com");
 });
+
+options.AuthServer.SeedMcpStackClient(
+    "myapp-mcpstack",
+    "MCP Stack",
+    "https://api.example.com",
+    "workspace.read",
+    "workspace.write");
 ```
 
 ## Email OTP and invitations

--- a/web/content/docs/guides/configuration.mdx
+++ b/web/content/docs/guides/configuration.mdx
@@ -65,7 +65,11 @@ Protect a route group with SqlOS access-token validation, then use the validated
 
 ```csharp
 var api = app.MapGroup("/api")
-    .RequireSqlOSAccessToken("https://api.example.com");
+    .RequireSqlOSAccessToken(options =>
+    {
+        options.ExpectedAudience = "https://api.example.com";
+        options.ResourceMetadataUrl = "https://api.example.com/.well-known/oauth-protected-resource";
+    });
 
 api.MapPost("/workspaces", async (
     CreateWorkspace request,
@@ -77,15 +81,16 @@ api.MapPost("/workspaces", async (
     var workspace = new Workspace(request.Name);
 
     db.Workspaces.Add(workspace);
-    db.AddSqlOSResource(workspace.ResourceId, "root", workspace.Name, "workspace");
-    db.GrantSqlOSRole(userId, workspace.ResourceId, "workspace_admin");
+    await db.EnsureSqlOSUserSubjectAsync(userId, userId);
+    await db.EnsureSqlOSResourceAsync(workspace.ResourceId, "root", workspace.Name, "workspace");
+    await db.EnsureSqlOSRoleGrantAsync(userId, workspace.ResourceId, "workspace_admin");
 
     await db.SaveChangesAsync();
     return Results.Created($"/api/workspaces/{workspace.Id}", workspace);
 });
 ```
 
-For idempotent provisioning paths, use `EnsureSqlOSResourceAsync(...)` and `EnsureSqlOSRoleGrantAsync(...)`.
+Grant helpers never create subjects implicitly. Provision users, agents, or service accounts explicitly with `EnsureSqlOSUserSubjectAsync(...)`, `EnsureSqlOSAgentSubjectAsync(...)`, or `EnsureSqlOSServiceAccountSubjectAsync(...)` before granting roles.
 
 ## Client onboarding modes
 
@@ -101,9 +106,9 @@ options.AuthServer.EnablePortableMcpClients(registration =>
     registration.Cimd.TrustedHosts.Add("clients.example.com");
 });
 
-options.AuthServer.SeedMcpStackClient(
-    "myapp-mcpstack",
-    "MCP Stack",
+options.AuthServer.SeedDeviceFlowClient(
+    "myapp-cli",
+    "CLI",
     "https://api.example.com",
     "workspace.read",
     "workspace.write");

--- a/web/content/docs/guides/configuration.mdx
+++ b/web/content/docs/guides/configuration.mdx
@@ -12,7 +12,7 @@ section: guides
   actionLabel="Getting Started"
 />
 
-You'll learn the easy-mode integration points: host registration, DbContext inheritance, and route mapping.
+You'll learn the recommended SqlOS SDK setup: host registration, DbContext inheritance, and route mapping.
 
 ## Wire SqlOS in three places
 


### PR DESCRIPTION
## Summary
- Add `SqlOSDbContext<TContext>` as the recommended DbContext base class so app contexts do not need to copy SqlOS interfaces, TVF methods, or `UseSqlOS(...)` wiring.
- Add `WebApplicationBuilder.AddSqlOS<TContext>(db => ..., sqlos => ...)` so host setup can register EF and SqlOS together.
- Add SDK helpers for protected route groups, validated token access, FGA access checks, explicit subject provisioning, idempotent resource provisioning, and role grants.
- Update examples and docs to show the recommended setup while keeping the lower-level EF hooks available for advanced model control.
- Update the Todo sample to use the SDK provisioning helpers for user subjects, tenant resources, todo resources, and role grants.

## Validation
- `./scripts/build.sh`
- `./scripts/unit-tests.sh`
- `ASPIRE_ALLOW_UNSECURED_TRANSPORT=true ./scripts/integration-tests.sh`
- `./scripts/docs-check.sh`
- `./scripts/merge-coverage.sh && GITHUB_BASE_REF=main ./scripts/pr-coverage-check.sh`
- `git diff --check`