### PR TITLE
Add entity-backed SqlOS resource ergonomics

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Full walkthrough: **[sqlos.dev/docs/getting-started](https://sqlos.dev/docs/gett
    app.MapSqlOS();
    ```
 
-   Protect APIs with `RequireSqlOSAccessToken(audience)`, then use `http.SqlOSUserId()` and `fga.Allows(...)` in endpoint code. For protected rows, implement `ISqlOSResourceEntity`; `SqlOSDbContext<TContext>` syncs the backing FGA resources when EF saves changes. Provision users, agents, or service accounts explicitly with `ProvisionUserSubjectAsync(...)`, `ProvisionAgentSubjectAsync(...)`, or `ProvisionServiceAccountSubjectAsync(...)`, then grant roles with `GrantRoleAsync(...)`. Use manual resource helpers such as `ProvisionResourceWithIdAsync(...)` for non-entity resources, such as tenant roots.
+   For APIs that accept SqlOS access tokens, `RequireSqlOSAccessToken(audience)` validates the token and populates `HttpContext.User`; your app still chooses how to resolve its current subject. Pass explicit `subjectId`, `resourceId`, role, and permission values into FGA APIs. For protected rows, implement `ISqlOSResourceEntity`; `SqlOSDbContext<TContext>` syncs the backing FGA resources when EF saves changes. Provision users, agents, or service accounts explicitly with `ProvisionUserSubjectAsync(...)`, `ProvisionAgentSubjectAsync(...)`, or `ProvisionServiceAccountSubjectAsync(...)`, then grant roles with `GrantRoleAsync(...)`. Use manual resource helpers such as `ProvisionResourceWithIdAsync(...)` for non-entity resources, such as tenant roots.
 
 On startup, SqlOS updates its own schema. Default URLs: admin at `/sqlos`, OAuth at `/sqlos/auth`. Change the prefix with `DashboardBasePath` if you need to.
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Full walkthrough: **[sqlos.dev/docs/getting-started](https://sqlos.dev/docs/gett
    app.MapSqlOS();
    ```
 
-   Protect APIs with `RequireSqlOSAccessToken(audience)`, then use `http.SqlOSUserId()` and `fga.Allows(...)` in endpoint code. For protected rows, implement `ISqlOSResourceEntity`; `SqlOSDbContext<TContext>` syncs the backing FGA resources when EF saves changes. Provision users, agents, or service accounts explicitly with the `EnsureSqlOS*SubjectAsync(...)` helpers, then grant roles with `GrantRoleAsync(...)`. Use manual resource helpers such as `ProvisionResourceWithIdAsync(...)` for non-entity resources, such as tenant roots.
+   Protect APIs with `RequireSqlOSAccessToken(audience)`, then use `http.SqlOSUserId()` and `fga.Allows(...)` in endpoint code. For protected rows, implement `ISqlOSResourceEntity`; `SqlOSDbContext<TContext>` syncs the backing FGA resources when EF saves changes. Provision users, agents, or service accounts explicitly with `ProvisionUserSubjectAsync(...)`, `ProvisionAgentSubjectAsync(...)`, or `ProvisionServiceAccountSubjectAsync(...)`, then grant roles with `GrantRoleAsync(...)`. Use manual resource helpers such as `ProvisionResourceWithIdAsync(...)` for non-entity resources, such as tenant roots.
 
 On startup, SqlOS updates its own schema. Default URLs: admin at `/sqlos`, OAuth at `/sqlos/auth`. Change the prefix with `DashboardBasePath` if you need to.
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Full walkthrough: **[sqlos.dev/docs/getting-started](https://sqlos.dev/docs/gett
    app.MapSqlOS();
    ```
 
-   Protect APIs with `RequireSqlOSAccessToken(audience)`, then use `http.SqlOSUserId()`, `fga.Allows(...)`, `db.EnsureSqlOSUserSubjectAsync(...)`, `db.EnsureSqlOSResourceAsync(...)`, and `db.EnsureSqlOSRoleGrantAsync(...)` in normal endpoint code.
+   Protect APIs with `RequireSqlOSAccessToken(audience)`, then use `http.SqlOSUserId()` and `fga.Allows(...)` in endpoint code. For protected rows, implement `ISqlOSResourceEntity`; `SqlOSDbContext<TContext>` syncs the backing FGA resources when EF saves changes. Provision users, agents, or service accounts explicitly with the `EnsureSqlOS*SubjectAsync(...)` helpers, then grant roles with `GrantRoleAsync(...)`. Use manual resource helpers such as `ProvisionResourceWithIdAsync(...)` for non-entity resources, such as tenant roots.
 
 On startup, SqlOS updates its own schema. Default URLs: admin at `/sqlos`, OAuth at `/sqlos/auth`. Change the prefix with `DashboardBasePath` if you need to.
 

--- a/examples/SqlOS.Example.Api/Data/ExampleAppDbContext.cs
+++ b/examples/SqlOS.Example.Api/Data/ExampleAppDbContext.cs
@@ -27,6 +27,11 @@ public sealed class ExampleAppDbContext : SqlOSDbContext<ExampleAppDbContext>
             entity.Property(x => x.ResourceId).HasMaxLength(100).IsRequired();
             entity.HasIndex(x => x.OrganizationId);
             entity.HasIndex(x => x.ResourceId);
+            entity.Ignore(x => x.ResourceTypeId);
+            entity.Ignore(x => x.ResourceName);
+            entity.Ignore(x => x.ParentResourceId);
+            entity.Ignore(x => x.ResourceDescription);
+            entity.Ignore(x => x.ResourceIsActive);
         });
 
         modelBuilder.Entity<Chain>(entity =>

--- a/examples/SqlOS.Example.Api/Endpoints/ExampleEndpoints.cs
+++ b/examples/SqlOS.Example.Api/Endpoints/ExampleEndpoints.cs
@@ -5,7 +5,6 @@ using SqlOS.AuthServer.Services;
 using SqlOS.Example.Api.Data;
 using SqlOS.Example.Api.Models;
 using SqlOS.Example.Api.Services;
-using SqlOS.Fga.Extensions;
 using SqlOS.Fga.Interfaces;
 
 namespace SqlOS.Example.Api.Endpoints;

--- a/examples/SqlOS.Example.Api/Endpoints/ExampleEndpoints.cs
+++ b/examples/SqlOS.Example.Api/Endpoints/ExampleEndpoints.cs
@@ -182,6 +182,12 @@ public static class ExampleEndpoints
                 return Results.BadRequest(new { error = "Token must include sub and org_id to create workspaces." });
             }
 
+            var workspaceName = request.Name?.Trim();
+            if (string.IsNullOrWhiteSpace(workspaceName))
+            {
+                return Results.BadRequest(new { error = "Workspace name is required." });
+            }
+
             await fgaService.EnsureUserAccessAsync(subjectId, organizationId, cancellationToken);
             var organizationResourceId = ExampleFgaService.GetOrganizationResourceId(organizationId);
             var access = await authService.CheckAccessAsync(subjectId, ExampleFgaService.WorkspaceManagePermission, organizationResourceId);
@@ -196,7 +202,7 @@ public static class ExampleEndpoints
                 Id = workspaceId,
                 OrganizationId = organizationId,
                 ResourceId = ExampleFgaService.GetWorkspaceResourceId(workspaceId),
-                Name = request.Name,
+                Name = workspaceName,
                 CreatedAt = DateTime.UtcNow
             };
 

--- a/examples/SqlOS.Example.Api/Endpoints/ExampleEndpoints.cs
+++ b/examples/SqlOS.Example.Api/Endpoints/ExampleEndpoints.cs
@@ -190,14 +190,15 @@ public static class ExampleEndpoints
                 return Results.Json(new { error = "Permission denied" }, statusCode: 403);
             }
 
+            var workspaceId = $"wrk_{Guid.NewGuid():N}"[..28];
             var workspace = new Workspace
             {
-                Id = $"wrk_{Guid.NewGuid():N}"[..28],
+                Id = workspaceId,
                 OrganizationId = organizationId,
+                ResourceId = ExampleFgaService.GetWorkspaceResourceId(workspaceId),
                 Name = request.Name,
                 CreatedAt = DateTime.UtcNow
             };
-            workspace.ResourceId = fgaService.CreateWorkspaceResource(workspace);
 
             context.Workspaces.Add(workspace);
             await context.SaveChangesAsync(cancellationToken);

--- a/examples/SqlOS.Example.Api/FgaRetail/Data/RetailDbContext.cs
+++ b/examples/SqlOS.Example.Api/FgaRetail/Data/RetailDbContext.cs
@@ -6,6 +6,11 @@ using SqlOS.Fga.Models;
 
 namespace SqlOS.Example.Api.FgaRetail.Data;
 
+/// <summary>
+/// Lower-level/manual FGA sample context. The recommended application path is
+/// <c>SqlOSDbContext&lt;TContext&gt;</c> plus <c>ISqlOSResourceEntity</c>; this
+/// retail sample intentionally keeps manual resource lifecycle code visible.
+/// </summary>
 public class RetailDbContext : DbContext, ISqlOSFgaDbContext
 {
     public RetailDbContext(DbContextOptions<RetailDbContext> options) : base(options) { }

--- a/examples/SqlOS.Example.Api/FgaRetail/Endpoints/ChainEndpoints.cs
+++ b/examples/SqlOS.Example.Api/FgaRetail/Endpoints/ChainEndpoints.cs
@@ -89,6 +89,8 @@ public static class ChainEndpoints
             var access = await authService.CheckAccessAsync(subjectId, RetailPermissionKeys.ChainEdit, "retail_root");
             if (!access.Allowed) return Results.Json(new { error = "Permission denied" }, statusCode: 403);
 
+            // Retail is the lower-level/manual FGA sample. Recommended app entities use
+            // ISqlOSResourceEntity and let SqlOSDbContext sync resources on SaveChanges.
             var resourceId = context.CreateResource("retail_root", request.Name, RetailResourceTypeIds.Chain);
 
             var chain = new Chain

--- a/examples/SqlOS.Example.Api/FgaRetail/Endpoints/ChainEndpoints.cs
+++ b/examples/SqlOS.Example.Api/FgaRetail/Endpoints/ChainEndpoints.cs
@@ -1,7 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using SqlOS.AuditLogs;
 using SqlOS.Example.Api.Data;
-using SqlOS.Example.Api.FgaRetail.Middleware;
 using SqlOS.Example.Api.FgaRetail.Dtos;
 using SqlOS.Example.Api.FgaRetail.Models;
 using SqlOS.Example.Api.FgaRetail.Seeding;
@@ -28,7 +27,7 @@ public static class ChainEndpoints
             string? sortBy = null,
             string? sortDir = null) =>
         {
-            var subjectId = http.GetSubjectId();
+            var subjectId = RetailSubjectResolver.ResolveSubjectId(http);
 
             var spec = PagedSpec.For<Chain>(c => c.Id)
                 .RequirePermission(RetailPermissionKeys.ChainView)
@@ -58,7 +57,7 @@ public static class ChainEndpoints
             ISqlOSFgaAuthService authService,
             HttpContext http) =>
         {
-            var subjectId = http.GetSubjectId();
+            var subjectId = RetailSubjectResolver.ResolveSubjectId(http);
 
             return await authService.AuthorizedDetailAsync(
                 context.Chains.Include(c => c.Locations),
@@ -84,7 +83,7 @@ public static class ChainEndpoints
             RetailAuditService audit,
             HttpContext http) =>
         {
-            var subjectId = http.GetSubjectId();
+            var subjectId = RetailSubjectResolver.ResolveSubjectId(http);
 
             var access = await authService.CheckAccessAsync(subjectId, RetailPermissionKeys.ChainEdit, "retail_root");
             if (!access.Allowed) return Results.Json(new { error = "Permission denied" }, statusCode: 403);
@@ -137,7 +136,7 @@ public static class ChainEndpoints
             RetailAuditService audit,
             HttpContext http) =>
         {
-            var subjectId = http.GetSubjectId();
+            var subjectId = RetailSubjectResolver.ResolveSubjectId(http);
 
             var chain = await context.Chains.FirstOrDefaultAsync(c => c.Id == id);
             if (chain is null) return Results.NotFound();
@@ -185,7 +184,7 @@ public static class ChainEndpoints
             RetailAuditService audit,
             HttpContext http) =>
         {
-            var subjectId = http.GetSubjectId();
+            var subjectId = RetailSubjectResolver.ResolveSubjectId(http);
 
             var chain = await context.Chains.FirstOrDefaultAsync(c => c.Id == id);
             if (chain is null) return Results.NotFound();

--- a/examples/SqlOS.Example.Api/FgaRetail/Endpoints/InventoryEndpoints.cs
+++ b/examples/SqlOS.Example.Api/FgaRetail/Endpoints/InventoryEndpoints.cs
@@ -93,6 +93,8 @@ public static class InventoryEndpoints
             var access = await authService.CheckAccessAsync(subjectId, RetailPermissionKeys.InventoryEdit, location.ResourceId);
             if (!access.Allowed) return Results.Json(new { error = "Permission denied" }, statusCode: 403);
 
+            // Retail is the lower-level/manual FGA sample. Recommended app entities use
+            // ISqlOSResourceEntity and let SqlOSDbContext sync resources on SaveChanges.
             var resourceId = context.CreateResource(location.ResourceId, request.Name, RetailResourceTypeIds.InventoryItem);
 
             var item = new InventoryItem

--- a/examples/SqlOS.Example.Api/FgaRetail/Endpoints/InventoryEndpoints.cs
+++ b/examples/SqlOS.Example.Api/FgaRetail/Endpoints/InventoryEndpoints.cs
@@ -2,7 +2,6 @@ using Microsoft.EntityFrameworkCore;
 using SqlOS.AuditLogs;
 using SqlOS.Example.Api.Data;
 using SqlOS.Example.Api.FgaRetail.Dtos;
-using SqlOS.Example.Api.FgaRetail.Middleware;
 using SqlOS.Example.Api.FgaRetail.Models;
 using SqlOS.Example.Api.FgaRetail.Seeding;
 using SqlOS.Example.Api.FgaRetail.Services;
@@ -29,7 +28,7 @@ public static class InventoryEndpoints
             string? sortBy = null,
             string? sortDir = null) =>
         {
-            var subjectId = http.GetSubjectId();
+            var subjectId = RetailSubjectResolver.ResolveSubjectId(http);
             var descending = string.Equals(sortDir, "desc", StringComparison.OrdinalIgnoreCase);
             var spec = new GetInventoryItemsSpecification(pageSize, search, locationId, sortBy, descending) { Cursor = cursor };
             var result = await executor.ExecuteAsync(
@@ -55,7 +54,7 @@ public static class InventoryEndpoints
             ISqlOSFgaAuthService authService,
             HttpContext http) =>
         {
-            var subjectId = http.GetSubjectId();
+            var subjectId = RetailSubjectResolver.ResolveSubjectId(http);
 
             return await authService.AuthorizedDetailAsync(
                 context.InventoryItems.Include(i => i.Location),
@@ -85,7 +84,7 @@ public static class InventoryEndpoints
             RetailAuditService audit,
             HttpContext http) =>
         {
-            var subjectId = http.GetSubjectId();
+            var subjectId = RetailSubjectResolver.ResolveSubjectId(http);
 
             var location = await context.Locations.FirstOrDefaultAsync(l => l.Id == locationId);
             if (location is null) return Results.NotFound();
@@ -154,7 +153,7 @@ public static class InventoryEndpoints
             RetailAuditService audit,
             HttpContext http) =>
         {
-            var subjectId = http.GetSubjectId();
+            var subjectId = RetailSubjectResolver.ResolveSubjectId(http);
 
             var item = await context.InventoryItems.Include(i => i.Location).FirstOrDefaultAsync(i => i.Id == id);
             if (item is null) return Results.NotFound();
@@ -215,7 +214,7 @@ public static class InventoryEndpoints
             RetailAuditService audit,
             HttpContext http) =>
         {
-            var subjectId = http.GetSubjectId();
+            var subjectId = RetailSubjectResolver.ResolveSubjectId(http);
 
             var item = await context.InventoryItems.Include(i => i.Location).FirstOrDefaultAsync(i => i.Id == id);
             if (item is null) return Results.NotFound();

--- a/examples/SqlOS.Example.Api/FgaRetail/Endpoints/LocationEndpoints.cs
+++ b/examples/SqlOS.Example.Api/FgaRetail/Endpoints/LocationEndpoints.cs
@@ -119,6 +119,8 @@ public static class LocationEndpoints
             var access = await authService.CheckAccessAsync(subjectId, RetailPermissionKeys.LocationEdit, chain.ResourceId);
             if (!access.Allowed) return Results.Json(new { error = "Permission denied" }, statusCode: 403);
 
+            // Retail is the lower-level/manual FGA sample. Recommended app entities use
+            // ISqlOSResourceEntity and let SqlOSDbContext sync resources on SaveChanges.
             var resourceId = context.CreateResource(chain.ResourceId, request.Name, RetailResourceTypeIds.Location);
 
             var location = new Location

--- a/examples/SqlOS.Example.Api/FgaRetail/Endpoints/LocationEndpoints.cs
+++ b/examples/SqlOS.Example.Api/FgaRetail/Endpoints/LocationEndpoints.cs
@@ -2,7 +2,6 @@ using Microsoft.EntityFrameworkCore;
 using SqlOS.AuditLogs;
 using SqlOS.Example.Api.Data;
 using SqlOS.Example.Api.FgaRetail.Dtos;
-using SqlOS.Example.Api.FgaRetail.Middleware;
 using SqlOS.Example.Api.FgaRetail.Models;
 using SqlOS.Example.Api.FgaRetail.Seeding;
 using SqlOS.Example.Api.FgaRetail.Services;
@@ -26,7 +25,7 @@ public static class LocationEndpoints
             string? search = null,
             string? cursor = null) =>
         {
-            var subjectId = http.GetSubjectId();
+            var subjectId = RetailSubjectResolver.ResolveSubjectId(http);
             var spec = new GetLocationsSpecification(pageSize, search) { Cursor = cursor };
             var result = await executor.ExecuteAsync(
                 context.Locations, spec, subjectId,
@@ -54,7 +53,7 @@ public static class LocationEndpoints
             string? search = null,
             string? cursor = null) =>
         {
-            var subjectId = http.GetSubjectId();
+            var subjectId = RetailSubjectResolver.ResolveSubjectId(http);
             var spec = new GetLocationsSpecification(pageSize, search, chainId) { Cursor = cursor };
             var result = await executor.ExecuteAsync(
                 context.Locations, spec, subjectId,
@@ -79,7 +78,7 @@ public static class LocationEndpoints
             ISqlOSFgaAuthService authService,
             HttpContext http) =>
         {
-            var subjectId = http.GetSubjectId();
+            var subjectId = RetailSubjectResolver.ResolveSubjectId(http);
 
             return await authService.AuthorizedDetailAsync(
                 context.Locations.Include(l => l.Chain).Include(l => l.InventoryItems),
@@ -111,7 +110,7 @@ public static class LocationEndpoints
             RetailAuditService audit,
             HttpContext http) =>
         {
-            var subjectId = http.GetSubjectId();
+            var subjectId = RetailSubjectResolver.ResolveSubjectId(http);
 
             var chain = await context.Chains.FirstOrDefaultAsync(c => c.Id == chainId);
             if (chain is null) return Results.NotFound();
@@ -183,7 +182,7 @@ public static class LocationEndpoints
             RetailAuditService audit,
             HttpContext http) =>
         {
-            var subjectId = http.GetSubjectId();
+            var subjectId = RetailSubjectResolver.ResolveSubjectId(http);
 
             var location = await context.Locations.Include(l => l.Chain).FirstOrDefaultAsync(l => l.Id == id);
             if (location is null) return Results.NotFound();
@@ -244,7 +243,7 @@ public static class LocationEndpoints
             RetailAuditService audit,
             HttpContext http) =>
         {
-            var subjectId = http.GetSubjectId();
+            var subjectId = RetailSubjectResolver.ResolveSubjectId(http);
 
             var location = await context.Locations.Include(l => l.Chain).FirstOrDefaultAsync(l => l.Id == id);
             if (location is null) return Results.NotFound();

--- a/examples/SqlOS.Example.Api/FgaRetail/Services/RetailAuditService.cs
+++ b/examples/SqlOS.Example.Api/FgaRetail/Services/RetailAuditService.cs
@@ -1,7 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using SqlOS.AuditLogs;
 using SqlOS.Example.Api.Data;
-using SqlOS.Example.Api.FgaRetail.Middleware;
 using SqlOS.Fga.Models;
 
 namespace SqlOS.Example.Api.FgaRetail.Services;
@@ -25,7 +24,7 @@ public sealed class RetailAuditService
         IReadOnlyDictionary<string, object?>? metadata = null,
         CancellationToken cancellationToken = default)
     {
-        var subjectId = http.GetSubjectId();
+        var subjectId = RetailSubjectResolver.ResolveSubjectId(http);
         var profile = await context.ExampleUserProfiles
             .AsNoTracking()
             .FirstOrDefaultAsync(x => x.SqlOSUserId == subjectId, cancellationToken);

--- a/examples/SqlOS.Example.Api/FgaRetail/Services/RetailSubjectResolver.cs
+++ b/examples/SqlOS.Example.Api/FgaRetail/Services/RetailSubjectResolver.cs
@@ -1,18 +1,20 @@
 using System.IdentityModel.Tokens.Jwt;
 
-namespace SqlOS.Example.Api.FgaRetail.Middleware;
+namespace SqlOS.Example.Api.FgaRetail.Services;
 
-public static class SubjectIdExtensions
+public static class RetailSubjectResolver
 {
-    public static string GetSubjectId(this HttpContext context)
+    public static string ResolveSubjectId(HttpContext http)
     {
+        ArgumentNullException.ThrowIfNull(http);
+
         // JWT bearer token (AuthServer users)
-        var sub = context.User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value;
+        var sub = http.User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value;
         if (!string.IsNullOrWhiteSpace(sub))
             return sub;
 
         // API key or agent token (resolved by middleware)
-        if (context.Items.TryGetValue("SubjectId", out var subjectId)
+        if (http.Items.TryGetValue("SubjectId", out var subjectId)
             && subjectId is string id
             && !string.IsNullOrWhiteSpace(id))
             return id;

--- a/examples/SqlOS.Example.Api/Models/Workspace.cs
+++ b/examples/SqlOS.Example.Api/Models/Workspace.cs
@@ -2,11 +2,17 @@ using SqlOS.Fga.Interfaces;
 
 namespace SqlOS.Example.Api.Models;
 
-public sealed class Workspace : IHasResourceId
+public sealed class Workspace : ISqlOSResourceEntity
 {
     public string Id { get; set; } = string.Empty;
     public string ResourceId { get; set; } = string.Empty;
     public string OrganizationId { get; set; } = string.Empty;
     public string Name { get; set; } = string.Empty;
     public DateTime CreatedAt { get; set; }
+
+    public string ResourceTypeId => "workspace";
+    public string ResourceName => Name;
+    public string ParentResourceId => $"org::{OrganizationId}";
+    public string? ResourceDescription => null;
+    public bool ResourceIsActive => true;
 }

--- a/examples/SqlOS.Example.Api/Services/ExampleFgaService.cs
+++ b/examples/SqlOS.Example.Api/Services/ExampleFgaService.cs
@@ -1,9 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using SqlOS.AuthServer.Models;
 using SqlOS.Example.Api.Data;
-using SqlOS.Example.Api.Models;
-using SqlOS.Fga.Extensions;
-using SqlOS.Fga.Models;
+using SqlOS.Extensions;
 
 namespace SqlOS.Example.Api.Services;
 
@@ -32,95 +30,38 @@ public sealed class ExampleFgaService
         var membership = await _context.Set<SqlOSMembership>()
             .FirstAsync(x => x.UserId == userId && x.OrganizationId == organizationId && x.IsActive, cancellationToken);
 
-        await EnsureSubjectAsync(user, organizationId, cancellationToken);
-        await EnsureOrganizationResourceAsync(organization, cancellationToken);
-        await EnsureMembershipGrantAsync(userId, organizationId, membership.Role, cancellationToken);
-    }
-
-    public string CreateWorkspaceResource(Workspace workspace)
-    {
-        var resourceId = GetWorkspaceResourceId(workspace.Id);
-        _context.CreateResource(
-            GetOrganizationResourceId(workspace.OrganizationId),
-            workspace.Name,
-            WorkspaceResourceTypeId,
-            resourceId);
-        return resourceId;
+        await ProvisionSubjectAsync(user, organizationId, cancellationToken);
+        await ProvisionOrganizationResourceAsync(organization, cancellationToken);
+        await SyncMembershipGrantAsync(userId, organizationId, membership.Role, cancellationToken);
+        await _context.SaveChangesAsync(cancellationToken);
     }
 
     public static string GetOrganizationResourceId(string organizationId) => $"org::{organizationId}";
 
     public static string GetWorkspaceResourceId(string workspaceId) => $"wrk::{workspaceId}";
 
-    private async Task EnsureSubjectAsync(SqlOSUser user, string organizationId, CancellationToken cancellationToken)
+    private async Task ProvisionSubjectAsync(SqlOSUser user, string organizationId, CancellationToken cancellationToken)
     {
-        var subject = await _context.Set<SqlOSFgaSubject>()
-            .FirstOrDefaultAsync(x => x.Id == user.Id, cancellationToken);
-        if (subject == null)
-        {
-            _context.Set<SqlOSFgaSubject>().Add(new SqlOSFgaSubject
-            {
-                Id = user.Id,
-                SubjectTypeId = "user",
-                DisplayName = user.DisplayName,
-                OrganizationId = organizationId,
-                ExternalRef = user.Id
-            });
-        }
-        else
-        {
-            subject.DisplayName = user.DisplayName;
-            subject.OrganizationId = organizationId;
-            subject.ExternalRef = user.Id;
-        }
-
-        var fgaUser = await _context.Set<SqlOSFgaUser>()
-            .FirstOrDefaultAsync(x => x.SubjectId == user.Id, cancellationToken);
-        if (fgaUser == null)
-        {
-            _context.Set<SqlOSFgaUser>().Add(new SqlOSFgaUser
-            {
-                Id = BuildEntityId("fgausr", user.Id),
-                SubjectId = user.Id,
-                Email = user.DefaultEmail,
-                IsActive = user.IsActive
-            });
-        }
-        else
-        {
-            fgaUser.Email = user.DefaultEmail;
-            fgaUser.IsActive = user.IsActive;
-        }
-
-        await _context.SaveChangesAsync(cancellationToken);
+        await _context.ProvisionUserSubjectAsync(
+            user.Id,
+            user.DisplayName,
+            user.DefaultEmail,
+            organizationId,
+            externalRef: user.Id,
+            isActive: user.IsActive,
+            cancellationToken: cancellationToken);
     }
 
-    private async Task EnsureOrganizationResourceAsync(SqlOSOrganization organization, CancellationToken cancellationToken)
-    {
-        var resourceId = GetOrganizationResourceId(organization.Id);
-        var existing = await _context.Set<SqlOSFgaResource>()
-            .FirstOrDefaultAsync(x => x.Id == resourceId, cancellationToken);
-        if (existing == null)
-        {
-            _context.Set<SqlOSFgaResource>().Add(new SqlOSFgaResource
-            {
-                Id = resourceId,
-                ParentId = "root",
-                Name = organization.Name,
-                ResourceTypeId = OrganizationResourceTypeId,
-                IsActive = organization.IsActive
-            });
-        }
-        else
-        {
-            existing.Name = organization.Name;
-            existing.IsActive = organization.IsActive;
-        }
+    private async Task ProvisionOrganizationResourceAsync(SqlOSOrganization organization, CancellationToken cancellationToken)
+        => await _context.ProvisionResourceWithIdAsync(
+            GetOrganizationResourceId(organization.Id),
+            OrganizationResourceTypeId,
+            organization.Name,
+            "root",
+            isActive: organization.IsActive,
+            cancellationToken: cancellationToken);
 
-        await _context.SaveChangesAsync(cancellationToken);
-    }
-
-    private async Task EnsureMembershipGrantAsync(
+    private async Task SyncMembershipGrantAsync(
         string userId,
         string organizationId,
         string role,
@@ -128,46 +69,16 @@ public sealed class ExampleFgaService
     {
         var resourceId = GetOrganizationResourceId(organizationId);
         var roleKey = IsElevatedRole(role) ? OrgAdminRole : OrgMemberRole;
-        var roleEntity = await _context.Set<SqlOSFgaRole>()
-            .FirstAsync(x => x.Key == roleKey, cancellationToken);
 
-        var existingGrants = await _context.Set<SqlOSFgaGrant>()
-            .Where(x => x.SubjectId == userId && x.ResourceId == resourceId)
-            .ToListAsync(cancellationToken);
-
-        foreach (var grant in existingGrants.Where(x => x.RoleId != roleEntity.Id))
-        {
-            _context.Set<SqlOSFgaGrant>().Remove(grant);
-        }
-
-        if (!existingGrants.Any(x => x.RoleId == roleEntity.Id))
-        {
-            _context.Set<SqlOSFgaGrant>().Add(new SqlOSFgaGrant
-            {
-                Id = BuildEntityId("grant", $"{userId}_{organizationId}_{roleKey}"),
-                SubjectId = userId,
-                ResourceId = resourceId,
-                RoleId = roleEntity.Id,
-                Description = "Synced from auth membership."
-            });
-        }
-
-        await _context.SaveChangesAsync(cancellationToken);
+        await _context.RevokeRoleAsync(
+            userId,
+            resourceId,
+            roleKey == OrgAdminRole ? OrgMemberRole : OrgAdminRole,
+            cancellationToken);
+        await _context.GrantRoleAsync(userId, resourceId, roleKey, cancellationToken);
     }
 
     private static bool IsElevatedRole(string role)
         => role.Equals("admin", StringComparison.OrdinalIgnoreCase)
            || role.Equals("owner", StringComparison.OrdinalIgnoreCase);
-
-    private static string BuildEntityId(string prefix, string source)
-    {
-        var sanitized = new string(source.Where(char.IsLetterOrDigit).ToArray()).ToLowerInvariant();
-        if (string.IsNullOrWhiteSpace(sanitized))
-        {
-            sanitized = Guid.NewGuid().ToString("N");
-        }
-
-        var value = $"{prefix}_{sanitized}";
-        return value.Length <= 30 ? value : value[..30];
-    }
 }

--- a/examples/SqlOS.Example.Api/Services/ExampleFgaService.cs
+++ b/examples/SqlOS.Example.Api/Services/ExampleFgaService.cs
@@ -21,18 +21,18 @@ public sealed class ExampleFgaService
         _context = context;
     }
 
-    public async Task EnsureUserAccessAsync(string userId, string organizationId, CancellationToken cancellationToken = default)
+    public async Task EnsureUserAccessAsync(string subjectId, string organizationId, CancellationToken cancellationToken = default)
     {
         var user = await _context.Set<SqlOSUser>()
-            .FirstAsync(x => x.Id == userId, cancellationToken);
+            .FirstAsync(x => x.Id == subjectId, cancellationToken);
         var organization = await _context.Set<SqlOSOrganization>()
             .FirstAsync(x => x.Id == organizationId, cancellationToken);
         var membership = await _context.Set<SqlOSMembership>()
-            .FirstAsync(x => x.UserId == userId && x.OrganizationId == organizationId && x.IsActive, cancellationToken);
+            .FirstAsync(x => x.UserId == subjectId && x.OrganizationId == organizationId && x.IsActive, cancellationToken);
 
         await ProvisionSubjectAsync(user, organizationId, cancellationToken);
         await ProvisionOrganizationResourceAsync(organization, cancellationToken);
-        await SyncMembershipGrantAsync(userId, organizationId, membership.Role, cancellationToken);
+        await SyncMembershipGrantAsync(subjectId, organizationId, membership.Role, cancellationToken);
         await _context.SaveChangesAsync(cancellationToken);
     }
 
@@ -62,7 +62,7 @@ public sealed class ExampleFgaService
             cancellationToken: cancellationToken);
 
     private async Task SyncMembershipGrantAsync(
-        string userId,
+        string subjectId,
         string organizationId,
         string role,
         CancellationToken cancellationToken)
@@ -71,11 +71,11 @@ public sealed class ExampleFgaService
         var roleKey = IsElevatedRole(role) ? OrgAdminRole : OrgMemberRole;
 
         await _context.RevokeRoleAsync(
-            userId,
+            subjectId,
             resourceId,
             roleKey == OrgAdminRole ? OrgMemberRole : OrgAdminRole,
             cancellationToken);
-        await _context.GrantRoleAsync(userId, resourceId, roleKey, cancellationToken);
+        await _context.GrantRoleAsync(subjectId, resourceId, roleKey, cancellationToken);
     }
 
     private static bool IsElevatedRole(string role)

--- a/examples/SqlOS.Todo.Api/Data/TodoSampleDbContext.cs
+++ b/examples/SqlOS.Todo.Api/Data/TodoSampleDbContext.cs
@@ -20,6 +20,11 @@ public sealed class TodoSampleDbContext(DbContextOptions<TodoSampleDbContext> op
             entity.HasIndex(x => x.ResourceId).IsUnique();
             entity.HasIndex(x => x.SqlOSUserId);
             entity.HasIndex(x => new { x.SqlOSUserId, x.IsCompleted });
+            entity.Ignore(x => x.ResourceTypeId);
+            entity.Ignore(x => x.ResourceName);
+            entity.Ignore(x => x.ParentResourceId);
+            entity.Ignore(x => x.ResourceDescription);
+            entity.Ignore(x => x.ResourceIsActive);
         });
     }
 }

--- a/examples/SqlOS.Todo.Api/Data/TodoSampleDbContext.cs
+++ b/examples/SqlOS.Todo.Api/Data/TodoSampleDbContext.cs
@@ -15,11 +15,11 @@ public sealed class TodoSampleDbContext(DbContextOptions<TodoSampleDbContext> op
         {
             entity.HasKey(x => x.Id);
             entity.Property(x => x.ResourceId).HasMaxLength(450).IsRequired();
-            entity.Property(x => x.SqlOSUserId).HasMaxLength(64).IsRequired();
+            entity.Property(x => x.OwnerSubjectId).HasMaxLength(64).IsRequired();
             entity.Property(x => x.Title).HasMaxLength(200).IsRequired();
             entity.HasIndex(x => x.ResourceId).IsUnique();
-            entity.HasIndex(x => x.SqlOSUserId);
-            entity.HasIndex(x => new { x.SqlOSUserId, x.IsCompleted });
+            entity.HasIndex(x => x.OwnerSubjectId);
+            entity.HasIndex(x => new { x.OwnerSubjectId, x.IsCompleted });
             entity.Ignore(x => x.ResourceTypeId);
             entity.Ignore(x => x.ResourceName);
             entity.Ignore(x => x.ParentResourceId);

--- a/examples/SqlOS.Todo.Api/Models/TodoItem.cs
+++ b/examples/SqlOS.Todo.Api/Models/TodoItem.cs
@@ -7,7 +7,7 @@ public sealed class TodoItem : ISqlOSResourceEntity
 {
     public Guid Id { get; set; }
     public string ResourceId { get; set; } = string.Empty;
-    public string SqlOSUserId { get; set; } = string.Empty;
+    public string OwnerSubjectId { get; set; } = string.Empty;
     public string Title { get; set; } = string.Empty;
     public bool IsCompleted { get; set; }
     public DateTime CreatedAt { get; set; }
@@ -15,9 +15,9 @@ public sealed class TodoItem : ISqlOSResourceEntity
 
     public string ResourceTypeId => TodoFgaService.TodoResourceTypeId;
     public string ResourceName => Title;
-    public string? ParentResourceId => string.IsNullOrWhiteSpace(SqlOSUserId)
+    public string? ParentResourceId => string.IsNullOrWhiteSpace(OwnerSubjectId)
         ? null
-        : TodoFgaService.GetTenantResourceId(SqlOSUserId);
+        : TodoFgaService.GetTenantResourceId(OwnerSubjectId);
     public string? ResourceDescription => null;
     public bool ResourceIsActive => true;
 }

--- a/examples/SqlOS.Todo.Api/Models/TodoItem.cs
+++ b/examples/SqlOS.Todo.Api/Models/TodoItem.cs
@@ -1,8 +1,9 @@
 using SqlOS.Fga.Interfaces;
+using SqlOS.Todo.Api.Services;
 
 namespace SqlOS.Todo.Api.Models;
 
-public sealed class TodoItem : IHasResourceId
+public sealed class TodoItem : ISqlOSResourceEntity
 {
     public Guid Id { get; set; }
     public string ResourceId { get; set; } = string.Empty;
@@ -11,4 +12,12 @@ public sealed class TodoItem : IHasResourceId
     public bool IsCompleted { get; set; }
     public DateTime CreatedAt { get; set; }
     public DateTime? CompletedAt { get; set; }
+
+    public string ResourceTypeId => TodoFgaService.TodoResourceTypeId;
+    public string ResourceName => Title;
+    public string? ParentResourceId => string.IsNullOrWhiteSpace(SqlOSUserId)
+        ? null
+        : TodoFgaService.GetTenantResourceId(SqlOSUserId);
+    public string? ResourceDescription => null;
+    public bool ResourceIsActive => true;
 }

--- a/examples/SqlOS.Todo.Api/Program.cs
+++ b/examples/SqlOS.Todo.Api/Program.cs
@@ -1,3 +1,5 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
 using System.Text.Json;
 using Microsoft.AspNetCore.Http.Json;
 using Microsoft.AspNetCore.WebUtilities;
@@ -424,7 +426,7 @@ app.MapGet("/api/todos", async (
     {
         resource = sampleOptions.Value.Resource,
         audience = todoContext.ValidatedToken.Audience,
-        userId = todoContext.ValidatedToken.UserId,
+        subjectId = todoContext.SubjectId,
         organizationId = todoContext.ValidatedToken.OrganizationId,
         items
     });
@@ -585,7 +587,7 @@ app.MapGet("/api/me", async (
     var todoContext = authResult.Context!;
     return Results.Ok(new
     {
-        todoContext.ValidatedToken.UserId,
+        todoContext.SubjectId,
         todoContext.ValidatedToken.OrganizationId,
         todoContext.ValidatedToken.ClientId,
         audience = todoContext.ValidatedToken.Audience,
@@ -638,12 +640,22 @@ static async Task<TodoRequestAuthResult> RequireTodoContextAsync(
         return TodoRequestAuthResult.Failure(CreateTodoChallenge(httpContext, sampleOptions));
     }
 
-    if (string.IsNullOrWhiteSpace(validated.UserId))
+    httpContext.User = validated.Principal;
+
+    var subjectId = httpContext.User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value;
+    if (string.IsNullOrWhiteSpace(subjectId))
     {
-        return TodoRequestAuthResult.Failure(Results.BadRequest(new { error = "Token must include a user subject." }));
+        return TodoRequestAuthResult.Failure(Results.Unauthorized());
     }
 
-    var fgaContext = await todoFgaService.EnsureUserTenantAccessAsync(validated, cancellationToken);
+    var displayName = GetDisplayName(httpContext.User, subjectId);
+    var email = GetClaimValue(httpContext.User, "email");
+    var fgaContext = await todoFgaService.EnsureUserTenantAccessAsync(
+        subjectId,
+        displayName,
+        email,
+        cancellationToken);
+
     return TodoRequestAuthResult.Success(new TodoRequestContext(validated, fgaContext.SubjectId, fgaContext.TenantResourceId));
 }
 
@@ -661,6 +673,18 @@ static IResult CreateTodoChallenge(HttpContext httpContext, TodoSampleOptions sa
 
 static IResult CreatePermissionDenied()
     => Results.Json(new { error = "Permission denied" }, statusCode: StatusCodes.Status403Forbidden);
+
+static string GetDisplayName(ClaimsPrincipal principal, string subjectId)
+{
+    var displayName = GetClaimValue(principal, "name")
+        ?? principal.Identity?.Name
+        ?? GetClaimValue(principal, "email");
+
+    return string.IsNullOrWhiteSpace(displayName) ? subjectId : displayName.Trim();
+}
+
+static string? GetClaimValue(ClaimsPrincipal principal, string claimType)
+    => principal.Claims.FirstOrDefault(x => x.Type == claimType)?.Value;
 
 public sealed record CreateTodoRequest(string Title);
 public sealed record TodoRequestContext(SqlOSValidatedToken ValidatedToken, string SubjectId, string TenantResourceId);

--- a/examples/SqlOS.Todo.Api/Program.cs
+++ b/examples/SqlOS.Todo.Api/Program.cs
@@ -461,17 +461,15 @@ app.MapPost("/api/todos", async (
         return CreatePermissionDenied();
     }
 
+    var todoId = Guid.NewGuid();
     var item = new TodoItem
     {
-        Id = Guid.NewGuid(),
+        Id = todoId,
+        ResourceId = TodoFgaService.GetTodoResourceId(todoId),
         SqlOSUserId = todoContext.SubjectId,
         Title = request.Title.Trim(),
         CreatedAt = DateTime.UtcNow
     };
-    item.ResourceId = await todoFgaService.CreateTodoResourceAsync(
-        item,
-        todoContext.TenantResourceId,
-        cancellationToken);
 
     dbContext.TodoItems.Add(item);
     await dbContext.SaveChangesAsync(cancellationToken);
@@ -566,7 +564,6 @@ app.MapDelete("/api/todos/{id:guid}", async (
         return CreatePermissionDenied();
     }
 
-    await todoFgaService.RemoveTodoResourceAsync(item.ResourceId, cancellationToken);
     dbContext.TodoItems.Remove(item);
     await dbContext.SaveChangesAsync(cancellationToken);
     return Results.NoContent();

--- a/examples/SqlOS.Todo.Api/Program.cs
+++ b/examples/SqlOS.Todo.Api/Program.cs
@@ -468,7 +468,7 @@ app.MapPost("/api/todos", async (
     {
         Id = todoId,
         ResourceId = TodoFgaService.GetTodoResourceId(todoId),
-        SqlOSUserId = todoContext.SubjectId,
+        OwnerSubjectId = todoContext.SubjectId,
         Title = request.Title.Trim(),
         CreatedAt = DateTime.UtcNow
     };

--- a/examples/SqlOS.Todo.Api/README.md
+++ b/examples/SqlOS.Todo.Api/README.md
@@ -55,12 +55,12 @@ That creates one first-party public PKCE application with `openid`, `profile`, `
 Resource hierarchy:
 
 - `root`
-- `tenant::{userId}`
+- `tenant::{subjectId}`
 - `todo::{todoId}`
 
 Role and permission matrix:
 
-- `tenant_owner` on `tenant::{userId}`
+- `tenant_owner` on `tenant::{subjectId}`
 - permissions: `TENANT_CREATE_TODO`, `TODO_READ`, `TODO_WRITE`
 
 Each authenticated user gets one tenant root resource under `root`. Every todo is created as a child resource beneath that tenant node, so the dashboard shows the hierarchy directly and list queries can use the SqlOS FGA filter instead of hand-written owner predicates.

--- a/examples/SqlOS.Todo.Api/Services/TodoFgaService.cs
+++ b/examples/SqlOS.Todo.Api/Services/TodoFgaService.cs
@@ -1,5 +1,3 @@
-using System.Security.Claims;
-using SqlOS.AuthServer.Contracts;
 using SqlOS.Extensions;
 using SqlOS.Todo.Api.Data;
 
@@ -22,17 +20,25 @@ public sealed class TodoFgaService
     }
 
     public async Task<TodoFgaContext> EnsureUserTenantAccessAsync(
-        SqlOSValidatedToken validated,
+        string subjectId,
+        string displayName,
+        string? email = null,
         CancellationToken cancellationToken = default)
     {
-        if (string.IsNullOrWhiteSpace(validated.UserId))
+        if (string.IsNullOrWhiteSpace(subjectId))
         {
-            throw new InvalidOperationException("Validated token must include a user id.");
+            throw new ArgumentException("Subject id is required.", nameof(subjectId));
         }
 
-        var subjectId = validated.UserId;
-        var displayName = GetDisplayName(validated.Principal, subjectId);
-        var email = GetClaimValue(validated.Principal, "email");
+        if (string.IsNullOrWhiteSpace(displayName))
+        {
+            displayName = subjectId;
+        }
+
+        subjectId = subjectId.Trim();
+        displayName = displayName.Trim();
+        email = string.IsNullOrWhiteSpace(email) ? null : email.Trim();
+
         var tenantResourceId = GetTenantResourceId(subjectId);
 
         var user = await _context.ProvisionUserSubjectAsync(
@@ -67,18 +73,6 @@ public sealed class TodoFgaService
     public static string GetTenantResourceId(string subjectId) => $"tenant::{subjectId}";
 
     public static string GetTodoResourceId(Guid todoId) => $"todo::{todoId:D}";
-
-    private static string GetDisplayName(ClaimsPrincipal principal, string subjectId)
-    {
-        var displayName = GetClaimValue(principal, "name")
-            ?? principal.Identity?.Name
-            ?? GetClaimValue(principal, "email");
-
-        return string.IsNullOrWhiteSpace(displayName) ? subjectId : displayName.Trim();
-    }
-
-    private static string? GetClaimValue(ClaimsPrincipal principal, string claimType)
-        => principal.Claims.FirstOrDefault(x => x.Type == claimType)?.Value;
 }
 
 public sealed record TodoFgaContext(string SubjectId, string TenantResourceId);

--- a/examples/SqlOS.Todo.Api/Services/TodoFgaService.cs
+++ b/examples/SqlOS.Todo.Api/Services/TodoFgaService.cs
@@ -1,10 +1,7 @@
 using System.Security.Claims;
-using Microsoft.EntityFrameworkCore;
 using SqlOS.AuthServer.Contracts;
 using SqlOS.Extensions;
-using SqlOS.Fga.Models;
 using SqlOS.Todo.Api.Data;
-using SqlOS.Todo.Api.Models;
 
 namespace SqlOS.Todo.Api.Services;
 
@@ -48,48 +45,23 @@ public sealed class TodoFgaService
         user.LastLoginAt = DateTime.UtcNow;
         user.UpdatedAt = DateTime.UtcNow;
 
-        await _context.EnsureSqlOSResourceAsync(
+        await _context.ProvisionResourceWithIdAsync(
             tenantResourceId,
-            "root",
-            displayName,
             TenantResourceTypeId,
+            displayName,
+            "root",
             $"Todo tenant for {subjectId}",
+            isActive: true,
             cancellationToken);
-        await _context.EnsureSqlOSRoleGrantAsync(
+        await _context.GrantRoleAsync(
             subjectId,
             tenantResourceId,
             TenantOwnerRole,
-            "Todo tenant owner grant.",
             cancellationToken);
 
         await _context.SaveChangesAsync(cancellationToken);
 
         return new TodoFgaContext(subjectId, tenantResourceId);
-    }
-
-    public async Task<string> CreateTodoResourceAsync(
-        TodoItem item,
-        string tenantResourceId,
-        CancellationToken cancellationToken = default)
-    {
-        var resourceId = GetTodoResourceId(item.Id);
-        await _context.EnsureSqlOSResourceAsync(
-            resourceId,
-            tenantResourceId,
-            item.Title,
-            TodoResourceTypeId,
-            cancellationToken: cancellationToken);
-        return resourceId;
-    }
-
-    public async Task RemoveTodoResourceAsync(string resourceId, CancellationToken cancellationToken = default)
-    {
-        var resource = await _context.Set<SqlOSFgaResource>()
-            .FirstOrDefaultAsync(x => x.Id == resourceId, cancellationToken);
-        if (resource != null)
-        {
-            _context.Set<SqlOSFgaResource>().Remove(resource);
-        }
     }
 
     public static string GetTenantResourceId(string userId) => $"tenant::{userId}";

--- a/examples/SqlOS.Todo.Api/Services/TodoFgaService.cs
+++ b/examples/SqlOS.Todo.Api/Services/TodoFgaService.cs
@@ -35,7 +35,7 @@ public sealed class TodoFgaService
         var email = GetClaimValue(validated.Principal, "email");
         var tenantResourceId = GetTenantResourceId(subjectId);
 
-        var user = await _context.EnsureSqlOSUserSubjectAsync(
+        var user = await _context.ProvisionUserSubjectAsync(
             subjectId,
             displayName,
             email,

--- a/examples/SqlOS.Todo.Api/Services/TodoFgaService.cs
+++ b/examples/SqlOS.Todo.Api/Services/TodoFgaService.cs
@@ -64,7 +64,7 @@ public sealed class TodoFgaService
         return new TodoFgaContext(subjectId, tenantResourceId);
     }
 
-    public static string GetTenantResourceId(string userId) => $"tenant::{userId}";
+    public static string GetTenantResourceId(string subjectId) => $"tenant::{subjectId}";
 
     public static string GetTodoResourceId(Guid todoId) => $"todo::{todoId:D}";
 

--- a/examples/SqlOS.Todo.Api/wwwroot/sample.js
+++ b/examples/SqlOS.Todo.Api/wwwroot/sample.js
@@ -240,7 +240,7 @@ async function refreshTodos(todoListElement, sessionInfoElement) {
 
   sessionInfoElement.textContent = JSON.stringify(
     {
-      userId: mePayload.userId,
+      subjectId: mePayload.subjectId,
       clientId: mePayload.clientId,
       audience: mePayload.audience,
       resource: todosPayload.resource

--- a/examples/SqlOS.Todo.IntegrationTests/TodoSampleIntegrationTests.cs
+++ b/examples/SqlOS.Todo.IntegrationTests/TodoSampleIntegrationTests.cs
@@ -384,10 +384,10 @@ public sealed class TodoSampleIntegrationTests
         var meResponse = await client.SendAsync(meRequest);
         meResponse.EnsureSuccessStatusCode();
         var meJson = JsonDocument.Parse(await meResponse.Content.ReadAsStringAsync());
-        var userId = meJson.RootElement.GetProperty("userId").GetString();
+        var subjectId = meJson.RootElement.GetProperty("subjectId").GetString();
         var tenantResourceId = meJson.RootElement.GetProperty("tenantResourceId").GetString();
 
-        tenantResourceId.Should().Be($"tenant::{userId}");
+        tenantResourceId.Should().Be($"tenant::{subjectId}");
 
         var createResponse = await CreateTodoAsync(client, tokens.AccessToken, "Trace FGA hierarchy");
         var createJson = JsonDocument.Parse(await createResponse.Content.ReadAsStringAsync());

--- a/src/SqlOS/Extensions/SqlOSErgonomicsExtensions.cs
+++ b/src/SqlOS/Extensions/SqlOSErgonomicsExtensions.cs
@@ -164,23 +164,28 @@ public static class SqlOSErgonomicsExtensions
         ArgumentNullException.ThrowIfNull(context);
 
         var normalizedResourceId = RequireValue(resourceId, nameof(resourceId));
+        var parentWasProvided = parentResourceId != null;
         var normalizedParentId = NormalizeOptional(parentResourceId);
         var normalizedResourceTypeId = RequireValue(resourceTypeId, nameof(resourceTypeId));
-        EnsureResourceParentIsNotSelf(normalizedResourceId, normalizedParentId);
         await FindRequiredResourceTypeAsync(context, normalizedResourceTypeId, cancellationToken);
-        if (normalizedParentId != null)
+        var resource = await FindResourceAsync(context, normalizedResourceId, cancellationToken);
+        var effectiveParentId = resource == null || parentWasProvided
+            ? normalizedParentId
+            : resource.ParentId;
+
+        EnsureResourceParentIsNotSelf(normalizedResourceId, effectiveParentId);
+        if (effectiveParentId != null)
         {
-            await FindRequiredResourceOrPendingEntityAsync(context, normalizedParentId, cancellationToken);
+            await FindRequiredResourceOrPendingEntityAsync(context, effectiveParentId, cancellationToken);
         }
 
-        await EnsureParentChainDoesNotCreateCycleAsync(context, normalizedResourceId, normalizedParentId, cancellationToken);
+        await EnsureParentChainDoesNotCreateCycleAsync(context, normalizedResourceId, effectiveParentId, cancellationToken);
 
-        var resource = await FindResourceAsync(context, normalizedResourceId, cancellationToken);
         if (resource == null)
         {
             resource = CreateResource(
                 normalizedResourceId,
-                normalizedParentId,
+                effectiveParentId,
                 name,
                 normalizedResourceTypeId,
                 description);
@@ -189,7 +194,7 @@ public static class SqlOSErgonomicsExtensions
             return resource;
         }
 
-        resource.ParentId = normalizedParentId;
+        resource.ParentId = effectiveParentId;
         resource.Name = RequireValue(name, nameof(name));
         resource.ResourceTypeId = normalizedResourceTypeId;
         if (description != null)
@@ -776,6 +781,7 @@ public static class SqlOSErgonomicsExtensions
         }
 
         if (context is DbContext dbContext
+            && IsSqlOSResourceEntitySyncContext(dbContext)
             && dbContext.ChangeTracker.Entries().Any(entry =>
                 entry.Entity is ISqlOSResourceEntity resourceEntity
                 && entry.State is EntityState.Added or EntityState.Modified
@@ -785,6 +791,19 @@ public static class SqlOSErgonomicsExtensions
         }
 
         throw new InvalidOperationException($"FGA resource '{resourceId}' was not found.");
+    }
+
+    private static bool IsSqlOSResourceEntitySyncContext(DbContext context)
+    {
+        for (var type = context.GetType(); type != null; type = type.BaseType)
+        {
+            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(SqlOSDbContext<>))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static async Task EnsureResourceHasNoChildrenAsync(

--- a/src/SqlOS/Extensions/SqlOSErgonomicsExtensions.cs
+++ b/src/SqlOS/Extensions/SqlOSErgonomicsExtensions.cs
@@ -95,6 +95,135 @@ public static class SqlOSErgonomicsExtensions
         return resource;
     }
 
+    public static Task<SqlOSFgaResource> CreateResourceAsync(
+        this ISqlOSFgaDbContext context,
+        string resourceTypeId,
+        string name,
+        string? parentResourceId = null,
+        string? description = null,
+        CancellationToken cancellationToken = default)
+    {
+        var normalizedResourceTypeId = RequireValue(resourceTypeId, nameof(resourceTypeId));
+        return context.CreateResourceWithIdAsync(
+            $"{normalizedResourceTypeId}::{Guid.NewGuid():N}",
+            normalizedResourceTypeId,
+            name,
+            parentResourceId,
+            description,
+            cancellationToken);
+    }
+
+    public static async Task<SqlOSFgaResource> CreateResourceWithIdAsync(
+        this ISqlOSFgaDbContext context,
+        string resourceId,
+        string resourceTypeId,
+        string name,
+        string? parentResourceId = null,
+        string? description = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var normalizedResourceId = RequireValue(resourceId, nameof(resourceId));
+        if (await FindResourceAsync(context, normalizedResourceId, cancellationToken) != null)
+        {
+            throw new InvalidOperationException($"FGA resource '{normalizedResourceId}' already exists.");
+        }
+
+        var normalizedParentId = NormalizeOptional(parentResourceId);
+        var normalizedResourceTypeId = RequireValue(resourceTypeId, nameof(resourceTypeId));
+        EnsureResourceParentIsNotSelf(normalizedResourceId, normalizedParentId);
+        await FindRequiredResourceTypeAsync(context, normalizedResourceTypeId, cancellationToken);
+        if (normalizedParentId != null)
+        {
+            await FindRequiredResourceOrPendingEntityAsync(context, normalizedParentId, cancellationToken);
+        }
+
+        await EnsureParentChainDoesNotCreateCycleAsync(context, normalizedResourceId, normalizedParentId, cancellationToken);
+
+        var resource = CreateResource(
+            normalizedResourceId,
+            normalizedParentId,
+            name,
+            normalizedResourceTypeId,
+            description);
+        context.Set<SqlOSFgaResource>().Add(resource);
+        return resource;
+    }
+
+    public static async Task<SqlOSFgaResource> ProvisionResourceWithIdAsync(
+        this ISqlOSFgaDbContext context,
+        string resourceId,
+        string resourceTypeId,
+        string name,
+        string? parentResourceId = null,
+        string? description = null,
+        bool? isActive = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var normalizedResourceId = RequireValue(resourceId, nameof(resourceId));
+        var normalizedParentId = NormalizeOptional(parentResourceId);
+        var normalizedResourceTypeId = RequireValue(resourceTypeId, nameof(resourceTypeId));
+        EnsureResourceParentIsNotSelf(normalizedResourceId, normalizedParentId);
+        await FindRequiredResourceTypeAsync(context, normalizedResourceTypeId, cancellationToken);
+        if (normalizedParentId != null)
+        {
+            await FindRequiredResourceOrPendingEntityAsync(context, normalizedParentId, cancellationToken);
+        }
+
+        await EnsureParentChainDoesNotCreateCycleAsync(context, normalizedResourceId, normalizedParentId, cancellationToken);
+
+        var resource = await FindResourceAsync(context, normalizedResourceId, cancellationToken);
+        if (resource == null)
+        {
+            resource = CreateResource(
+                normalizedResourceId,
+                normalizedParentId,
+                name,
+                normalizedResourceTypeId,
+                description);
+            resource.IsActive = isActive ?? true;
+            context.Set<SqlOSFgaResource>().Add(resource);
+            return resource;
+        }
+
+        resource.ParentId = normalizedParentId;
+        resource.Name = RequireValue(name, nameof(name));
+        resource.ResourceTypeId = normalizedResourceTypeId;
+        if (description != null)
+        {
+            resource.Description = NormalizeOptional(description);
+        }
+
+        if (isActive.HasValue)
+        {
+            resource.IsActive = isActive.Value;
+        }
+
+        resource.UpdatedAt = DateTime.UtcNow;
+        return resource;
+    }
+
+    public static async Task DeleteResourceAsync(
+        this ISqlOSFgaDbContext context,
+        string resourceId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var normalizedResourceId = RequireValue(resourceId, nameof(resourceId));
+        var resource = await FindRequiredResourceAsync(context, normalizedResourceId, cancellationToken);
+        await EnsureResourceHasNoChildrenAsync(context, normalizedResourceId, cancellationToken);
+
+        var grants = await context.Set<SqlOSFgaGrant>()
+            .Where(grant => grant.ResourceId == normalizedResourceId)
+            .ToListAsync(cancellationToken);
+        context.Set<SqlOSFgaGrant>().RemoveRange(grants);
+        context.Set<SqlOSFgaResource>().Remove(resource);
+    }
+
     public static async Task<SqlOSFgaResource> EnsureSqlOSResourceAsync(
         this ISqlOSFgaDbContext context,
         string resourceId,
@@ -151,25 +280,83 @@ public static class SqlOSErgonomicsExtensions
         string roleKeyOrId,
         string? description = null,
         CancellationToken cancellationToken = default)
+        => await GrantRoleCoreAsync(
+            context,
+            subjectId,
+            resourceId,
+            roleKeyOrId,
+            description,
+            cancellationToken);
+
+    public static async Task<SqlOSFgaGrant> GrantRoleAsync(
+        this ISqlOSFgaDbContext context,
+        string subjectId,
+        ISqlOSResourceEntity resource,
+        string roleKeyOrId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(resource);
+
+        return await GrantRoleCoreAsync(
+            context,
+            subjectId,
+            resource.ResourceId,
+            roleKeyOrId,
+            description: null,
+            cancellationToken);
+    }
+
+    public static async Task<SqlOSFgaGrant> GrantRoleAsync(
+        this ISqlOSFgaDbContext context,
+        string subjectId,
+        string resourceId,
+        string roleKeyOrId,
+        CancellationToken cancellationToken = default)
+        => await GrantRoleCoreAsync(
+            context,
+            subjectId,
+            resourceId,
+            roleKeyOrId,
+            description: null,
+            cancellationToken);
+
+    public static async Task RevokeRoleAsync(
+        this ISqlOSFgaDbContext context,
+        string subjectId,
+        ISqlOSResourceEntity resource,
+        string roleKeyOrId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(resource);
+
+        await RevokeRoleAsync(context, subjectId, resource.ResourceId, roleKeyOrId, cancellationToken);
+    }
+
+    public static async Task RevokeRoleAsync(
+        this ISqlOSFgaDbContext context,
+        string subjectId,
+        string resourceId,
+        string roleKeyOrId,
+        CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(context);
 
         var normalizedSubjectId = RequireValue(subjectId, nameof(subjectId));
         var normalizedResourceId = RequireValue(resourceId, nameof(resourceId));
         await FindRequiredSubjectAsync(context, normalizedSubjectId, cancellationToken);
-        await FindRequiredResourceAsync(context, normalizedResourceId, cancellationToken);
+        await FindRequiredResourceOrPendingEntityAsync(context, normalizedResourceId, cancellationToken);
         var roleId = await ResolveRoleIdAsync(context, roleKeyOrId, cancellationToken);
 
-        var grant = new SqlOSFgaGrant
+        var grant = await FindGrantAsync(
+            context,
+            normalizedSubjectId,
+            normalizedResourceId,
+            roleId,
+            cancellationToken);
+        if (grant != null)
         {
-            Id = BuildGrantId(normalizedSubjectId, normalizedResourceId, roleId),
-            SubjectId = normalizedSubjectId,
-            ResourceId = normalizedResourceId,
-            RoleId = roleId,
-            Description = NormalizeOptional(description)
-        };
-        context.Set<SqlOSFgaGrant>().Add(grant);
-        return grant;
+            context.Set<SqlOSFgaGrant>().Remove(grant);
+        }
     }
 
     public static async Task<SqlOSFgaGrant> EnsureSqlOSRoleGrantAsync(
@@ -195,6 +382,52 @@ public static class SqlOSErgonomicsExtensions
             roleId,
             cancellationToken);
 
+        if (grant == null)
+        {
+            return await GrantRoleCoreAsync(
+                context,
+                normalizedSubjectId,
+                normalizedResourceId,
+                roleId,
+                description,
+                cancellationToken,
+                roleAlreadyResolved: true);
+        }
+
+        if (description != null)
+        {
+            grant.Description = NormalizeOptional(description);
+        }
+
+        grant.UpdatedAt = DateTime.UtcNow;
+        return grant;
+    }
+
+    private static async Task<SqlOSFgaGrant> GrantRoleCoreAsync(
+        ISqlOSFgaDbContext context,
+        string subjectId,
+        string resourceId,
+        string roleKeyOrId,
+        string? description,
+        CancellationToken cancellationToken,
+        bool roleAlreadyResolved = false)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var normalizedSubjectId = RequireValue(subjectId, nameof(subjectId));
+        var normalizedResourceId = RequireValue(resourceId, nameof(resourceId));
+        await FindRequiredSubjectAsync(context, normalizedSubjectId, cancellationToken);
+        await FindRequiredResourceOrPendingEntityAsync(context, normalizedResourceId, cancellationToken);
+        var roleId = roleAlreadyResolved
+            ? RequireValue(roleKeyOrId, nameof(roleKeyOrId))
+            : await ResolveRoleIdAsync(context, roleKeyOrId, cancellationToken);
+
+        var grant = await FindGrantAsync(
+            context,
+            normalizedSubjectId,
+            normalizedResourceId,
+            roleId,
+            cancellationToken);
         if (grant == null)
         {
             grant = new SqlOSFgaGrant
@@ -531,6 +764,53 @@ public static class SqlOSErgonomicsExtensions
         CancellationToken cancellationToken)
         => await FindResourceAsync(context, resourceId, cancellationToken)
             ?? throw new InvalidOperationException($"FGA resource '{resourceId}' was not found.");
+
+    private static async Task FindRequiredResourceOrPendingEntityAsync(
+        ISqlOSFgaDbContext context,
+        string resourceId,
+        CancellationToken cancellationToken)
+    {
+        if (await FindResourceAsync(context, resourceId, cancellationToken) != null)
+        {
+            return;
+        }
+
+        if (context is DbContext dbContext
+            && dbContext.ChangeTracker.Entries().Any(entry =>
+                entry.Entity is ISqlOSResourceEntity resourceEntity
+                && entry.State is EntityState.Added or EntityState.Modified
+                && string.Equals(NormalizeOptional(resourceEntity.ResourceId), resourceId, StringComparison.Ordinal)))
+        {
+            return;
+        }
+
+        throw new InvalidOperationException($"FGA resource '{resourceId}' was not found.");
+    }
+
+    private static async Task EnsureResourceHasNoChildrenAsync(
+        ISqlOSFgaDbContext context,
+        string resourceId,
+        CancellationToken cancellationToken)
+    {
+        if (context is DbContext dbContext)
+        {
+            var hasLocalChild = dbContext.ChangeTracker
+                .Entries<SqlOSFgaResource>()
+                .Any(entry => entry.Entity.ParentId == resourceId && entry.State != EntityState.Deleted);
+            if (hasLocalChild)
+            {
+                throw new InvalidOperationException($"FGA resource '{resourceId}' has child resources. Delete or reparent child resources before deleting this resource.");
+            }
+        }
+
+        var hasChild = await context.Set<SqlOSFgaResource>()
+            .AsNoTracking()
+            .AnyAsync(resource => resource.ParentId == resourceId, cancellationToken);
+        if (hasChild)
+        {
+            throw new InvalidOperationException($"FGA resource '{resourceId}' has child resources. Delete or reparent child resources before deleting this resource.");
+        }
+    }
 
     private static async Task<SqlOSFgaResourceType?> FindResourceTypeAsync(
         ISqlOSFgaDbContext context,

--- a/src/SqlOS/Extensions/SqlOSErgonomicsExtensions.cs
+++ b/src/SqlOS/Extensions/SqlOSErgonomicsExtensions.cs
@@ -5,7 +5,6 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using SqlOS.AuthServer.Configuration;
-using SqlOS.AuthServer.Contracts;
 using SqlOS.AuthServer.Extensions;
 using SqlOS.AuthServer.Services;
 using SqlOS.Fga.Interfaces;
@@ -42,25 +41,6 @@ public static class SqlOSErgonomicsExtensions
             SqlOSAccessTokenEndpointFilter.InvokeAsync(context, next, options));
 
         return group;
-    }
-
-    public static SqlOSValidatedToken SqlOSToken(this HttpContext context)
-    {
-        ArgumentNullException.ThrowIfNull(context);
-
-        return context.GetSqlOSValidatedToken()
-            ?? throw new InvalidOperationException("No validated SqlOS access token is available. Protect the endpoint with RequireSqlOSAccessToken(...) or UseSqlOSAccessTokenValidation(...).");
-    }
-
-    public static string SqlOSUserId(this HttpContext context)
-    {
-        var token = context.SqlOSToken();
-        if (string.IsNullOrWhiteSpace(token.UserId))
-        {
-            throw new InvalidOperationException("The validated SqlOS access token does not include a user id.");
-        }
-
-        return token.UserId;
     }
 
     public static async Task<bool> Allows(

--- a/src/SqlOS/Extensions/SqlOSErgonomicsExtensions.cs
+++ b/src/SqlOS/Extensions/SqlOSErgonomicsExtensions.cs
@@ -75,26 +75,6 @@ public static class SqlOSErgonomicsExtensions
         return result.Allowed;
     }
 
-    public static SqlOSFgaResource AddSqlOSResource(
-        this ISqlOSFgaDbContext context,
-        string resourceId,
-        string? parentResourceId,
-        string name,
-        string resourceTypeId,
-        string? description = null)
-    {
-        ArgumentNullException.ThrowIfNull(context);
-
-        var resource = CreateResource(
-            resourceId,
-            parentResourceId,
-            name,
-            resourceTypeId,
-            description);
-        context.Set<SqlOSFgaResource>().Add(resource);
-        return resource;
-    }
-
     public static Task<SqlOSFgaResource> CreateResourceAsync(
         this ISqlOSFgaDbContext context,
         string resourceTypeId,
@@ -229,70 +209,6 @@ public static class SqlOSErgonomicsExtensions
         context.Set<SqlOSFgaResource>().Remove(resource);
     }
 
-    public static async Task<SqlOSFgaResource> EnsureSqlOSResourceAsync(
-        this ISqlOSFgaDbContext context,
-        string resourceId,
-        string? parentResourceId,
-        string name,
-        string resourceTypeId,
-        string? description = null,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(context);
-
-        var normalizedResourceId = RequireValue(resourceId, nameof(resourceId));
-        var normalizedParentId = NormalizeOptional(parentResourceId);
-        var normalizedResourceTypeId = RequireValue(resourceTypeId, nameof(resourceTypeId));
-        EnsureResourceParentIsNotSelf(normalizedResourceId, normalizedParentId);
-        await FindRequiredResourceTypeAsync(context, normalizedResourceTypeId, cancellationToken);
-        if (normalizedParentId != null)
-        {
-            await FindRequiredResourceAsync(context, normalizedParentId, cancellationToken);
-        }
-
-        await EnsureParentChainDoesNotCreateCycleAsync(context, normalizedResourceId, normalizedParentId, cancellationToken);
-
-        var resource = await FindResourceAsync(context, normalizedResourceId, cancellationToken);
-        if (resource == null)
-        {
-            resource = CreateResource(
-                normalizedResourceId,
-                normalizedParentId,
-                name,
-                normalizedResourceTypeId,
-                description);
-            context.Set<SqlOSFgaResource>().Add(resource);
-            return resource;
-        }
-
-        resource.ParentId = normalizedParentId;
-        resource.Name = RequireValue(name, nameof(name));
-        resource.ResourceTypeId = normalizedResourceTypeId;
-        if (description != null)
-        {
-            resource.Description = NormalizeOptional(description);
-        }
-
-        resource.IsActive = true;
-        resource.UpdatedAt = DateTime.UtcNow;
-        return resource;
-    }
-
-    public static async Task<SqlOSFgaGrant> GrantSqlOSRoleAsync(
-        this ISqlOSFgaDbContext context,
-        string subjectId,
-        string resourceId,
-        string roleKeyOrId,
-        string? description = null,
-        CancellationToken cancellationToken = default)
-        => await GrantRoleCoreAsync(
-            context,
-            subjectId,
-            resourceId,
-            roleKeyOrId,
-            description,
-            cancellationToken);
-
     public static async Task<SqlOSFgaGrant> GrantRoleAsync(
         this ISqlOSFgaDbContext context,
         string subjectId,
@@ -364,50 +280,6 @@ public static class SqlOSErgonomicsExtensions
         }
     }
 
-    public static async Task<SqlOSFgaGrant> EnsureSqlOSRoleGrantAsync(
-        this ISqlOSFgaDbContext context,
-        string subjectId,
-        string resourceId,
-        string roleKeyOrId,
-        string? description = null,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(context);
-
-        var normalizedSubjectId = RequireValue(subjectId, nameof(subjectId));
-        var normalizedResourceId = RequireValue(resourceId, nameof(resourceId));
-        await FindRequiredSubjectAsync(context, normalizedSubjectId, cancellationToken);
-        await FindRequiredResourceAsync(context, normalizedResourceId, cancellationToken);
-        var roleId = await ResolveRoleIdAsync(context, roleKeyOrId, cancellationToken);
-
-        var grant = await FindGrantAsync(
-            context,
-            normalizedSubjectId,
-            normalizedResourceId,
-            roleId,
-            cancellationToken);
-
-        if (grant == null)
-        {
-            return await GrantRoleCoreAsync(
-                context,
-                normalizedSubjectId,
-                normalizedResourceId,
-                roleId,
-                description,
-                cancellationToken,
-                roleAlreadyResolved: true);
-        }
-
-        if (description != null)
-        {
-            grant.Description = NormalizeOptional(description);
-        }
-
-        grant.UpdatedAt = DateTime.UtcNow;
-        return grant;
-    }
-
     private static async Task<SqlOSFgaGrant> GrantRoleCoreAsync(
         ISqlOSFgaDbContext context,
         string subjectId,
@@ -456,7 +328,7 @@ public static class SqlOSErgonomicsExtensions
         return grant;
     }
 
-    public static async Task<SqlOSFgaUser> EnsureSqlOSUserSubjectAsync(
+    public static async Task<SqlOSFgaUser> ProvisionUserSubjectAsync(
         this ISqlOSFgaDbContext context,
         string subjectId,
         string displayName,
@@ -508,7 +380,7 @@ public static class SqlOSErgonomicsExtensions
         return user;
     }
 
-    public static async Task<SqlOSFgaAgent> EnsureSqlOSAgentSubjectAsync(
+    public static async Task<SqlOSFgaAgent> ProvisionAgentSubjectAsync(
         this ISqlOSFgaDbContext context,
         string subjectId,
         string displayName,
@@ -560,7 +432,7 @@ public static class SqlOSErgonomicsExtensions
         return agent;
     }
 
-    public static async Task<SqlOSFgaServiceAccount> EnsureSqlOSServiceAccountSubjectAsync(
+    public static async Task<SqlOSFgaServiceAccount> ProvisionServiceAccountSubjectAsync(
         this ISqlOSFgaDbContext context,
         string subjectId,
         string displayName,

--- a/src/SqlOS/Fga/Dashboard/wwwroot/app.js
+++ b/src/SqlOS/Fga/Dashboard/wwwroot/app.js
@@ -104,7 +104,7 @@
     // --- Subject type to route mapping ---
 
     function subjectTypeToRoute(typeId) {
-        const map = { 'user': 'users', 'agent': 'agents', 'service_account': 'service-accounts', 'user_group': 'user-groups' };
+        const map = { 'user': 'users', 'agent': 'agents', 'service_account': 'service-accounts', 'group': 'user-groups', 'user_group': 'user-groups' };
         return map[typeId] || 'users';
     }
 

--- a/src/SqlOS/Fga/Extensions/SqlOSFgaConvenienceExtensions.cs
+++ b/src/SqlOS/Fga/Extensions/SqlOSFgaConvenienceExtensions.cs
@@ -14,12 +14,14 @@ public static class SqlOSFgaConvenienceExtensions
     private const int DefaultMaxResourceHierarchyDepth = 10;
 
     /// <summary>
-    /// Creates a <see cref="SqlOSFgaResource"/> and adds it to the context (not yet saved).
-    /// Returns the generated resource ID so you can assign it to your domain entity.
+    /// Lower-level/manual helper that creates a <see cref="SqlOSFgaResource"/> and adds it to
+    /// the context (not yet saved). Use this for manual or ad hoc resource lifecycles. For
+    /// protected application rows, prefer <see cref="ISqlOSResourceEntity"/> on the domain
+    /// entity and <c>SqlOSDbContext&lt;TContext&gt;</c> resource synchronization.
     /// <example>
     /// <code>
     /// var resourceId = context.CreateResource("retail_root", request.Name, "chain");
-    /// chain.ResourceId = resourceId;
+    /// chain.ResourceId = resourceId; // manual lifecycle sample
     /// await context.SaveChangesAsync();
     /// </code>
     /// </example>

--- a/src/SqlOS/Fga/Interfaces/ISqlOSResourceEntity.cs
+++ b/src/SqlOS/Fga/Interfaces/ISqlOSResourceEntity.cs
@@ -1,0 +1,13 @@
+namespace SqlOS.Fga.Interfaces;
+
+/// <summary>
+/// Implement on application entities that should be mirrored into the SqlOS FGA resource hierarchy.
+/// </summary>
+public interface ISqlOSResourceEntity : IHasResourceId
+{
+    string ResourceTypeId { get; }
+    string ResourceName { get; }
+    string? ParentResourceId { get; }
+    string? ResourceDescription { get; }
+    bool ResourceIsActive { get; }
+}

--- a/src/SqlOS/Fga/SqlOSResourceEntitySynchronizer.cs
+++ b/src/SqlOS/Fga/SqlOSResourceEntitySynchronizer.cs
@@ -533,14 +533,30 @@ internal static class SqlOSResourceEntitySynchronizer
         bool ResourceIsActive)
     {
         public static ResourceEntityChange From(EntityEntry entry, ISqlOSResourceEntity entity)
-            => new(
+        {
+            var resourceId = RequireValue(entity.ResourceId, nameof(ISqlOSResourceEntity.ResourceId));
+            if (entry.State == EntityState.Deleted)
+            {
+                return new(
+                    entry,
+                    entry.State,
+                    resourceId,
+                    string.Empty,
+                    string.Empty,
+                    null,
+                    null,
+                    true);
+            }
+
+            return new(
                 entry,
                 entry.State,
-                RequireValue(entity.ResourceId, nameof(ISqlOSResourceEntity.ResourceId)),
+                resourceId,
                 RequireValue(entity.ResourceTypeId, nameof(ISqlOSResourceEntity.ResourceTypeId)),
                 RequireValue(entity.ResourceName, nameof(ISqlOSResourceEntity.ResourceName)),
                 NormalizeOptional(entity.ParentResourceId),
                 NormalizeOptional(entity.ResourceDescription),
                 entity.ResourceIsActive);
+        }
     }
 }

--- a/src/SqlOS/Fga/SqlOSResourceEntitySynchronizer.cs
+++ b/src/SqlOS/Fga/SqlOSResourceEntitySynchronizer.cs
@@ -1,0 +1,546 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using SqlOS.Fga.Interfaces;
+using SqlOS.Fga.Models;
+
+namespace SqlOS.Fga;
+
+internal static class SqlOSResourceEntitySynchronizer
+{
+    private const int DefaultMaxResourceHierarchyDepth = 10;
+
+    public static void Sync(DbContext context)
+    {
+        var changes = GetResourceEntityChanges(context);
+        if (changes.Count == 0)
+        {
+            return;
+        }
+
+        ValidateUniqueResourceIds(changes);
+        var changesById = changes.ToDictionary(change => change.ResourceId, StringComparer.Ordinal);
+        ValidateResourceChanges(context, changes, changesById);
+        ApplyResourceChanges(context, changes);
+    }
+
+    public static async Task SyncAsync(DbContext context, CancellationToken cancellationToken)
+    {
+        var changes = GetResourceEntityChanges(context);
+        if (changes.Count == 0)
+        {
+            return;
+        }
+
+        ValidateUniqueResourceIds(changes);
+        var changesById = changes.ToDictionary(change => change.ResourceId, StringComparer.Ordinal);
+        await ValidateResourceChangesAsync(context, changes, changesById, cancellationToken);
+        await ApplyResourceChangesAsync(context, changes, cancellationToken);
+    }
+
+    private static List<ResourceEntityChange> GetResourceEntityChanges(DbContext context)
+        => context.ChangeTracker
+            .Entries()
+            .Where(entry => entry.Entity is ISqlOSResourceEntity
+                && entry.State is EntityState.Added or EntityState.Modified or EntityState.Deleted)
+            .Select(entry => ResourceEntityChange.From(entry, (ISqlOSResourceEntity)entry.Entity))
+            .ToList();
+
+    private static void ValidateUniqueResourceIds(IReadOnlyCollection<ResourceEntityChange> changes)
+    {
+        var duplicate = changes
+            .GroupBy(change => change.ResourceId, StringComparer.Ordinal)
+            .FirstOrDefault(group => group.Count() > 1);
+        if (duplicate != null)
+        {
+            throw new InvalidOperationException($"Multiple tracked SqlOS resource entities use resource id '{duplicate.Key}'. Resource ids must be unique in a save operation.");
+        }
+    }
+
+    private static void ValidateResourceChanges(
+        DbContext context,
+        IReadOnlyCollection<ResourceEntityChange> changes,
+        IReadOnlyDictionary<string, ResourceEntityChange> changesById)
+    {
+        foreach (var change in changes.Where(change => change.State != EntityState.Deleted))
+        {
+            EnsureResourceParentIsNotSelf(change.ResourceId, change.ParentResourceId);
+
+            if (!ResourceTypeExists(context, change.ResourceTypeId))
+            {
+                throw new InvalidOperationException($"FGA resource type '{change.ResourceTypeId}' was not found. Seed or create the resource type before saving resource-backed entities.");
+            }
+
+            if (change.ParentResourceId != null && !ResourceExistsOrIsPending(context, change.ParentResourceId, changesById))
+            {
+                throw new InvalidOperationException($"FGA resource '{change.ParentResourceId}' was not found.");
+            }
+
+            EnsureParentChainDoesNotCreateCycle(context, change, changesById);
+        }
+
+        foreach (var added in changes.Where(change => change.State == EntityState.Added))
+        {
+            if (ResourceExists(context, added.ResourceId))
+            {
+                throw new InvalidOperationException($"FGA resource '{added.ResourceId}' already exists for a new resource-backed entity.");
+            }
+        }
+
+        foreach (var modified in changes.Where(change => change.State == EntityState.Modified))
+        {
+            if (FindResource(context, modified.ResourceId) == null)
+            {
+                throw new InvalidOperationException($"FGA resource '{modified.ResourceId}' was not found for a modified resource-backed entity.");
+            }
+        }
+
+        var deletingResourceIds = changes
+            .Where(change => change.State == EntityState.Deleted)
+            .Select(change => change.ResourceId)
+            .ToHashSet(StringComparer.Ordinal);
+
+        foreach (var deleted in changes.Where(change => change.State == EntityState.Deleted))
+        {
+            if (FindResource(context, deleted.ResourceId) == null)
+            {
+                throw new InvalidOperationException($"FGA resource '{deleted.ResourceId}' was not found for a deleted resource-backed entity.");
+            }
+
+            EnsureResourceHasNoRemainingChildren(context, deleted.ResourceId, deletingResourceIds);
+        }
+    }
+
+    private static async Task ValidateResourceChangesAsync(
+        DbContext context,
+        IReadOnlyCollection<ResourceEntityChange> changes,
+        IReadOnlyDictionary<string, ResourceEntityChange> changesById,
+        CancellationToken cancellationToken)
+    {
+        foreach (var change in changes.Where(change => change.State != EntityState.Deleted))
+        {
+            EnsureResourceParentIsNotSelf(change.ResourceId, change.ParentResourceId);
+
+            if (!await ResourceTypeExistsAsync(context, change.ResourceTypeId, cancellationToken))
+            {
+                throw new InvalidOperationException($"FGA resource type '{change.ResourceTypeId}' was not found. Seed or create the resource type before saving resource-backed entities.");
+            }
+
+            if (change.ParentResourceId != null && !await ResourceExistsOrIsPendingAsync(context, change.ParentResourceId, changesById, cancellationToken))
+            {
+                throw new InvalidOperationException($"FGA resource '{change.ParentResourceId}' was not found.");
+            }
+
+            await EnsureParentChainDoesNotCreateCycleAsync(context, change, changesById, cancellationToken);
+        }
+
+        foreach (var added in changes.Where(change => change.State == EntityState.Added))
+        {
+            if (await ResourceExistsAsync(context, added.ResourceId, cancellationToken))
+            {
+                throw new InvalidOperationException($"FGA resource '{added.ResourceId}' already exists for a new resource-backed entity.");
+            }
+        }
+
+        foreach (var modified in changes.Where(change => change.State == EntityState.Modified))
+        {
+            if (await FindResourceAsync(context, modified.ResourceId, cancellationToken) == null)
+            {
+                throw new InvalidOperationException($"FGA resource '{modified.ResourceId}' was not found for a modified resource-backed entity.");
+            }
+        }
+
+        var deletingResourceIds = changes
+            .Where(change => change.State == EntityState.Deleted)
+            .Select(change => change.ResourceId)
+            .ToHashSet(StringComparer.Ordinal);
+
+        foreach (var deleted in changes.Where(change => change.State == EntityState.Deleted))
+        {
+            if (await FindResourceAsync(context, deleted.ResourceId, cancellationToken) == null)
+            {
+                throw new InvalidOperationException($"FGA resource '{deleted.ResourceId}' was not found for a deleted resource-backed entity.");
+            }
+
+            await EnsureResourceHasNoRemainingChildrenAsync(context, deleted.ResourceId, deletingResourceIds, cancellationToken);
+        }
+    }
+
+    private static void ApplyResourceChanges(DbContext context, IReadOnlyCollection<ResourceEntityChange> changes)
+    {
+        foreach (var added in changes.Where(change => change.State == EntityState.Added))
+        {
+            context.Set<SqlOSFgaResource>().Add(CreateResource(added));
+        }
+
+        foreach (var modified in changes.Where(change => change.State == EntityState.Modified))
+        {
+            var resource = FindResource(context, modified.ResourceId)!;
+            ApplyResourceValues(resource, modified);
+        }
+
+        foreach (var deleted in changes.Where(change => change.State == EntityState.Deleted))
+        {
+            RemoveResourceAndGrants(context, deleted.ResourceId);
+        }
+    }
+
+    private static async Task ApplyResourceChangesAsync(
+        DbContext context,
+        IReadOnlyCollection<ResourceEntityChange> changes,
+        CancellationToken cancellationToken)
+    {
+        foreach (var added in changes.Where(change => change.State == EntityState.Added))
+        {
+            context.Set<SqlOSFgaResource>().Add(CreateResource(added));
+        }
+
+        foreach (var modified in changes.Where(change => change.State == EntityState.Modified))
+        {
+            var resource = await FindResourceAsync(context, modified.ResourceId, cancellationToken);
+            ApplyResourceValues(resource!, modified);
+        }
+
+        foreach (var deleted in changes.Where(change => change.State == EntityState.Deleted))
+        {
+            await RemoveResourceAndGrantsAsync(context, deleted.ResourceId, cancellationToken);
+        }
+    }
+
+    private static SqlOSFgaResource CreateResource(ResourceEntityChange change)
+        => new()
+        {
+            Id = change.ResourceId,
+            ParentId = change.ParentResourceId,
+            Name = change.ResourceName,
+            ResourceTypeId = change.ResourceTypeId,
+            Description = change.ResourceDescription,
+            IsActive = change.ResourceIsActive
+        };
+
+    private static void ApplyResourceValues(SqlOSFgaResource resource, ResourceEntityChange change)
+    {
+        resource.ParentId = change.ParentResourceId;
+        resource.Name = change.ResourceName;
+        resource.ResourceTypeId = change.ResourceTypeId;
+        resource.Description = change.ResourceDescription;
+        resource.IsActive = change.ResourceIsActive;
+        resource.UpdatedAt = DateTime.UtcNow;
+    }
+
+    private static void RemoveResourceAndGrants(DbContext context, string resourceId)
+    {
+        var grants = context.Set<SqlOSFgaGrant>()
+            .Where(grant => grant.ResourceId == resourceId)
+            .ToList();
+        context.Set<SqlOSFgaGrant>().RemoveRange(grants);
+
+        var resource = FindResource(context, resourceId)!;
+        context.Set<SqlOSFgaResource>().Remove(resource);
+    }
+
+    private static async Task RemoveResourceAndGrantsAsync(
+        DbContext context,
+        string resourceId,
+        CancellationToken cancellationToken)
+    {
+        var grants = await context.Set<SqlOSFgaGrant>()
+            .Where(grant => grant.ResourceId == resourceId)
+            .ToListAsync(cancellationToken);
+        context.Set<SqlOSFgaGrant>().RemoveRange(grants);
+
+        var resource = await FindResourceAsync(context, resourceId, cancellationToken);
+        context.Set<SqlOSFgaResource>().Remove(resource!);
+    }
+
+    private static void EnsureParentChainDoesNotCreateCycle(
+        DbContext context,
+        ResourceEntityChange change,
+        IReadOnlyDictionary<string, ResourceEntityChange> changesById)
+    {
+        var visited = new HashSet<string>(StringComparer.Ordinal) { change.ResourceId };
+        var currentId = change.ParentResourceId;
+        var depth = 0;
+
+        while (!string.IsNullOrWhiteSpace(currentId))
+        {
+            if (!visited.Add(currentId))
+            {
+                throw new InvalidOperationException("FGA resource hierarchy contains a cycle.");
+            }
+
+            if (depth > DefaultMaxResourceHierarchyDepth)
+            {
+                throw new InvalidOperationException($"FGA resource hierarchy exceeds the maximum depth of {DefaultMaxResourceHierarchyDepth}.");
+            }
+
+            currentId = GetParentId(context, currentId, changesById);
+            depth++;
+        }
+    }
+
+    private static async Task EnsureParentChainDoesNotCreateCycleAsync(
+        DbContext context,
+        ResourceEntityChange change,
+        IReadOnlyDictionary<string, ResourceEntityChange> changesById,
+        CancellationToken cancellationToken)
+    {
+        var visited = new HashSet<string>(StringComparer.Ordinal) { change.ResourceId };
+        var currentId = change.ParentResourceId;
+        var depth = 0;
+
+        while (!string.IsNullOrWhiteSpace(currentId))
+        {
+            if (!visited.Add(currentId))
+            {
+                throw new InvalidOperationException("FGA resource hierarchy contains a cycle.");
+            }
+
+            if (depth > DefaultMaxResourceHierarchyDepth)
+            {
+                throw new InvalidOperationException($"FGA resource hierarchy exceeds the maximum depth of {DefaultMaxResourceHierarchyDepth}.");
+            }
+
+            currentId = await GetParentIdAsync(context, currentId, changesById, cancellationToken);
+            depth++;
+        }
+    }
+
+    private static string? GetParentId(
+        DbContext context,
+        string resourceId,
+        IReadOnlyDictionary<string, ResourceEntityChange> changesById)
+    {
+        if (changesById.TryGetValue(resourceId, out var change) && change.State != EntityState.Deleted)
+        {
+            return change.ParentResourceId;
+        }
+
+        var localEntry = FindLocalResourceEntry(context, resourceId);
+        if (localEntry != null)
+        {
+            return localEntry.State == EntityState.Deleted ? null : localEntry.Entity.ParentId;
+        }
+
+        return context.Set<SqlOSFgaResource>()
+            .AsNoTracking()
+            .Where(resource => resource.Id == resourceId)
+            .Select(resource => resource.ParentId)
+            .FirstOrDefault();
+    }
+
+    private static async Task<string?> GetParentIdAsync(
+        DbContext context,
+        string resourceId,
+        IReadOnlyDictionary<string, ResourceEntityChange> changesById,
+        CancellationToken cancellationToken)
+    {
+        if (changesById.TryGetValue(resourceId, out var change) && change.State != EntityState.Deleted)
+        {
+            return change.ParentResourceId;
+        }
+
+        var localEntry = FindLocalResourceEntry(context, resourceId);
+        if (localEntry != null)
+        {
+            return localEntry.State == EntityState.Deleted ? null : localEntry.Entity.ParentId;
+        }
+
+        return await context.Set<SqlOSFgaResource>()
+            .AsNoTracking()
+            .Where(resource => resource.Id == resourceId)
+            .Select(resource => resource.ParentId)
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    private static bool ResourceTypeExists(DbContext context, string resourceTypeId)
+    {
+        var localEntry = context.ChangeTracker
+            .Entries<SqlOSFgaResourceType>()
+            .FirstOrDefault(entry => entry.Entity.Id == resourceTypeId);
+        if (localEntry != null)
+        {
+            return localEntry.State != EntityState.Deleted;
+        }
+
+        return context.Set<SqlOSFgaResourceType>().Any(resourceType => resourceType.Id == resourceTypeId);
+    }
+
+    private static async Task<bool> ResourceTypeExistsAsync(
+        DbContext context,
+        string resourceTypeId,
+        CancellationToken cancellationToken)
+    {
+        var localEntry = context.ChangeTracker
+            .Entries<SqlOSFgaResourceType>()
+            .FirstOrDefault(entry => entry.Entity.Id == resourceTypeId);
+        if (localEntry != null)
+        {
+            return localEntry.State != EntityState.Deleted;
+        }
+
+        return await context.Set<SqlOSFgaResourceType>()
+            .AnyAsync(resourceType => resourceType.Id == resourceTypeId, cancellationToken);
+    }
+
+    private static bool ResourceExistsOrIsPending(
+        DbContext context,
+        string resourceId,
+        IReadOnlyDictionary<string, ResourceEntityChange> changesById)
+    {
+        if (changesById.TryGetValue(resourceId, out var change))
+        {
+            return change.State != EntityState.Deleted;
+        }
+
+        return ResourceExists(context, resourceId);
+    }
+
+    private static async Task<bool> ResourceExistsOrIsPendingAsync(
+        DbContext context,
+        string resourceId,
+        IReadOnlyDictionary<string, ResourceEntityChange> changesById,
+        CancellationToken cancellationToken)
+    {
+        if (changesById.TryGetValue(resourceId, out var change))
+        {
+            return change.State != EntityState.Deleted;
+        }
+
+        return await ResourceExistsAsync(context, resourceId, cancellationToken);
+    }
+
+    private static bool ResourceExists(DbContext context, string resourceId)
+        => FindResource(context, resourceId) != null;
+
+    private static async Task<bool> ResourceExistsAsync(
+        DbContext context,
+        string resourceId,
+        CancellationToken cancellationToken)
+        => await FindResourceAsync(context, resourceId, cancellationToken) != null;
+
+    private static SqlOSFgaResource? FindResource(DbContext context, string resourceId)
+    {
+        var localEntry = FindLocalResourceEntry(context, resourceId);
+        if (localEntry != null)
+        {
+            return localEntry.State == EntityState.Deleted ? null : localEntry.Entity;
+        }
+
+        return context.Set<SqlOSFgaResource>().FirstOrDefault(resource => resource.Id == resourceId);
+    }
+
+    private static async Task<SqlOSFgaResource?> FindResourceAsync(
+        DbContext context,
+        string resourceId,
+        CancellationToken cancellationToken)
+    {
+        var localEntry = FindLocalResourceEntry(context, resourceId);
+        if (localEntry != null)
+        {
+            return localEntry.State == EntityState.Deleted ? null : localEntry.Entity;
+        }
+
+        return await context.Set<SqlOSFgaResource>()
+            .FirstOrDefaultAsync(resource => resource.Id == resourceId, cancellationToken);
+    }
+
+    private static EntityEntry<SqlOSFgaResource>? FindLocalResourceEntry(DbContext context, string resourceId)
+        => context.ChangeTracker
+            .Entries<SqlOSFgaResource>()
+            .FirstOrDefault(entry => entry.Entity.Id == resourceId);
+
+    private static void EnsureResourceHasNoRemainingChildren(
+        DbContext context,
+        string resourceId,
+        ISet<string> deletingResourceIds)
+    {
+        var hasLocalChild = context.ChangeTracker
+            .Entries<SqlOSFgaResource>()
+            .Any(entry => entry.Entity.ParentId == resourceId
+                && !deletingResourceIds.Contains(entry.Entity.Id)
+                && entry.State != EntityState.Deleted);
+        if (hasLocalChild)
+        {
+            throw ChildResourceException(resourceId);
+        }
+
+        var hasStoredChild = context.Set<SqlOSFgaResource>()
+            .AsNoTracking()
+            .Any(resource => resource.ParentId == resourceId && !deletingResourceIds.Contains(resource.Id));
+        if (hasStoredChild)
+        {
+            throw ChildResourceException(resourceId);
+        }
+    }
+
+    private static async Task EnsureResourceHasNoRemainingChildrenAsync(
+        DbContext context,
+        string resourceId,
+        ISet<string> deletingResourceIds,
+        CancellationToken cancellationToken)
+    {
+        var hasLocalChild = context.ChangeTracker
+            .Entries<SqlOSFgaResource>()
+            .Any(entry => entry.Entity.ParentId == resourceId
+                && !deletingResourceIds.Contains(entry.Entity.Id)
+                && entry.State != EntityState.Deleted);
+        if (hasLocalChild)
+        {
+            throw ChildResourceException(resourceId);
+        }
+
+        var hasStoredChild = await context.Set<SqlOSFgaResource>()
+            .AsNoTracking()
+            .AnyAsync(resource => resource.ParentId == resourceId && !deletingResourceIds.Contains(resource.Id), cancellationToken);
+        if (hasStoredChild)
+        {
+            throw ChildResourceException(resourceId);
+        }
+    }
+
+    private static InvalidOperationException ChildResourceException(string resourceId)
+        => new($"FGA resource '{resourceId}' has child resources. Delete or reparent child resources before deleting this resource.");
+
+    private static void EnsureResourceParentIsNotSelf(string resourceId, string? parentId)
+    {
+        if (string.Equals(resourceId, parentId, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("FGA resource parent cannot be the resource itself.");
+        }
+    }
+
+    private static string RequireValue(string value, string name)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new InvalidOperationException($"{name} is required.");
+        }
+
+        return value.Trim();
+    }
+
+    private static string? NormalizeOptional(string? value)
+        => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private sealed record ResourceEntityChange(
+        EntityEntry Entry,
+        EntityState State,
+        string ResourceId,
+        string ResourceTypeId,
+        string ResourceName,
+        string? ParentResourceId,
+        string? ResourceDescription,
+        bool ResourceIsActive)
+    {
+        public static ResourceEntityChange From(EntityEntry entry, ISqlOSResourceEntity entity)
+            => new(
+                entry,
+                entry.State,
+                RequireValue(entity.ResourceId, nameof(ISqlOSResourceEntity.ResourceId)),
+                RequireValue(entity.ResourceTypeId, nameof(ISqlOSResourceEntity.ResourceTypeId)),
+                RequireValue(entity.ResourceName, nameof(ISqlOSResourceEntity.ResourceName)),
+                NormalizeOptional(entity.ParentResourceId),
+                NormalizeOptional(entity.ResourceDescription),
+                entity.ResourceIsActive);
+    }
+}

--- a/src/SqlOS/SqlOSDbContext.cs
+++ b/src/SqlOS/SqlOSDbContext.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using SqlOS.AuthServer.Interfaces;
 using SqlOS.Extensions;
+using SqlOS.Fga;
 using SqlOS.Fga.Interfaces;
 using SqlOS.Fga.Models;
 
@@ -31,5 +32,25 @@ public abstract class SqlOSDbContext<TContext>(DbContextOptions<TContext> option
     /// </summary>
     protected virtual void OnApplicationModelCreating(ModelBuilder modelBuilder)
     {
+    }
+
+    public override int SaveChanges()
+        => SaveChanges(acceptAllChangesOnSuccess: true);
+
+    public override int SaveChanges(bool acceptAllChangesOnSuccess)
+    {
+        SqlOSResourceEntitySynchronizer.Sync(this);
+        return base.SaveChanges(acceptAllChangesOnSuccess);
+    }
+
+    public override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+        => SaveChangesAsync(acceptAllChangesOnSuccess: true, cancellationToken);
+
+    public override async Task<int> SaveChangesAsync(
+        bool acceptAllChangesOnSuccess,
+        CancellationToken cancellationToken = default)
+    {
+        await SqlOSResourceEntitySynchronizer.SyncAsync(this, cancellationToken);
+        return await base.SaveChangesAsync(acceptAllChangesOnSuccess, cancellationToken);
     }
 }

--- a/tests/SqlOS.Tests/SqlOS.Tests.csproj
+++ b/tests/SqlOS.Tests/SqlOS.Tests.csproj
@@ -14,6 +14,7 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.12.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.6.3" />
     <PackageReference Include="MSTest.TestFramework" Version="3.6.3" />

--- a/tests/SqlOS.Tests/SqlOSErgonomicsExtensionsTests.cs
+++ b/tests/SqlOS.Tests/SqlOSErgonomicsExtensionsTests.cs
@@ -312,6 +312,23 @@ public sealed class SqlOSErgonomicsExtensionsTests
     }
 
     [TestMethod]
+    public async Task CreateResourceAsync_GeneratesResourceId()
+    {
+        using var context = CreateContext();
+        SeedFgaCore(context);
+        await context.SaveChangesAsync();
+
+        var resource = await context.CreateResourceAsync(
+            "workspace",
+            "Generated workspace",
+            "root");
+        await context.SaveChangesAsync();
+
+        resource.Id.Should().StartWith("workspace::");
+        (await context.Set<SqlOSFgaResource>().AnyAsync(x => x.Id == resource.Id)).Should().BeTrue();
+    }
+
+    [TestMethod]
     public async Task DeleteResourceAsync_FailsWhenChildResourcesStillExist()
     {
         using var context = CreateContext();

--- a/tests/SqlOS.Tests/SqlOSErgonomicsExtensionsTests.cs
+++ b/tests/SqlOS.Tests/SqlOSErgonomicsExtensionsTests.cs
@@ -312,6 +312,23 @@ public sealed class SqlOSErgonomicsExtensionsTests
     }
 
     [TestMethod]
+    public async Task ProvisionResourceWithIdAsync_PreservesExistingParentWhenParentIsOmitted()
+    {
+        using var context = CreateContext();
+        SeedFgaCore(context);
+        await context.CreateResourceWithIdAsync("workspace_parent", "workspace", "Workspace parent", "root");
+        await context.CreateResourceWithIdAsync("workspace_child", "workspace", "Workspace child", "workspace_parent");
+        await context.SaveChangesAsync();
+
+        await context.ProvisionResourceWithIdAsync("workspace_child", "workspace", "Workspace child renamed");
+        await context.SaveChangesAsync();
+
+        var resource = await context.Set<SqlOSFgaResource>().SingleAsync(x => x.Id == "workspace_child");
+        resource.Name.Should().Be("Workspace child renamed");
+        resource.ParentId.Should().Be("workspace_parent");
+    }
+
+    [TestMethod]
     public async Task CreateResourceAsync_GeneratesResourceId()
     {
         using var context = CreateContext();

--- a/tests/SqlOS.Tests/SqlOSErgonomicsExtensionsTests.cs
+++ b/tests/SqlOS.Tests/SqlOSErgonomicsExtensionsTests.cs
@@ -50,16 +50,16 @@ public sealed class SqlOSErgonomicsExtensionsTests
         SeedFgaCore(context);
         await context.SaveChangesAsync();
 
-        var user = await context.EnsureSqlOSUserSubjectAsync("usr_1", "User One", "user@example.test");
-        var agent = await context.EnsureSqlOSAgentSubjectAsync("agt_1", "Agent One", "worker", "Background worker");
-        var serviceAccount = await context.EnsureSqlOSServiceAccountSubjectAsync(
+        var user = await context.ProvisionUserSubjectAsync("usr_1", "User One", "user@example.test");
+        var agent = await context.ProvisionAgentSubjectAsync("agt_1", "Agent One", "worker", "Background worker");
+        var serviceAccount = await context.ProvisionServiceAccountSubjectAsync(
             "sa_1",
             "Service Account One",
             "client_1",
             "hashed-secret",
             "API integration");
-        var resource = await context.EnsureSqlOSResourceAsync("workspace_1", "root", "Workspace 1", "workspace");
-        var grant = await context.GrantSqlOSRoleAsync("usr_1", "workspace_1", "owner", "Workspace owner");
+        var resource = await context.CreateResourceWithIdAsync("workspace_1", "workspace", "Workspace 1", "root");
+        var grant = await context.GrantRoleAsync("usr_1", "workspace_1", "owner");
         await context.SaveChangesAsync();
 
         user.SubjectId.Should().Be("usr_1");
@@ -70,65 +70,59 @@ public sealed class SqlOSErgonomicsExtensionsTests
         (await context.Set<SqlOSFgaUser>().SingleAsync(x => x.SubjectId == "usr_1")).Email.Should().Be("user@example.test");
         (await context.Set<SqlOSFgaAgent>().SingleAsync(x => x.SubjectId == "agt_1")).AgentType.Should().Be("worker");
         (await context.Set<SqlOSFgaServiceAccount>().SingleAsync(x => x.SubjectId == "sa_1")).ClientId.Should().Be("client_1");
-
-        var ensuredResource = await context.EnsureSqlOSResourceAsync(
-            "workspace_1",
-            "root",
-            "Workspace One",
-            "workspace",
-            "Updated");
-        var ensuredGrant = await context.EnsureSqlOSRoleGrantAsync(
-            "usr_1",
-            "workspace_1",
-            "owner",
-            "Updated owner grant");
-        await context.SaveChangesAsync();
-
-        ensuredResource.Name.Should().Be("Workspace One");
-        ensuredResource.Description.Should().Be("Updated");
-        ensuredGrant.Description.Should().Be("Updated owner grant");
-        context.Set<SqlOSFgaGrant>().Count(x => x.SubjectId == "usr_1" && x.ResourceId == "workspace_1").Should().Be(1);
     }
 
     [TestMethod]
-    public void GrantSqlOSRole_HasNoPublicSyncOverload()
+    public void LegacyErgonomicsHelperNames_AreNotPublic()
     {
+        var legacyNames = new[]
+        {
+            string.Concat("Ensure", "SqlOS", "User", "Subject", "Async"),
+            string.Concat("Ensure", "SqlOS", "Agent", "Subject", "Async"),
+            string.Concat("Ensure", "SqlOS", "Service", "Account", "Subject", "Async"),
+            string.Concat("Ensure", "SqlOS", "Resource", "Async"),
+            string.Concat("Ensure", "SqlOS", "Role", "Grant", "Async"),
+            string.Concat("Grant", "SqlOS", "Role"),
+            string.Concat("Grant", "SqlOS", "Role", "Async"),
+            string.Concat("Add", "SqlOS", "Resource")
+        };
+
         typeof(SqlOSErgonomicsExtensions)
             .GetMethods()
-            .Where(x => x.Name == "GrantSqlOSRole")
+            .Where(method => legacyNames.Contains(method.Name, StringComparer.Ordinal))
             .Should()
-            .BeEmpty("role grants must validate subject/resource existence and resolve role keys asynchronously");
+            .BeEmpty("the ergonomics API should have one canonical path before it ships");
     }
 
     [TestMethod]
-    public async Task EnsureSqlOSRoleGrantAsync_RequiresExistingSubjectAndResource()
+    public async Task GrantRoleAsync_RequiresExistingSubjectAndResource()
     {
         using var context = CreateContext();
         SeedFgaCore(context);
         await context.SaveChangesAsync();
 
-        var missingSubject = async () => await context.EnsureSqlOSRoleGrantAsync("missing_user", "root", "owner");
+        var missingSubject = async () => await context.GrantRoleAsync("missing_user", "root", "owner");
         await missingSubject.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("*subject 'missing_user' was not found*");
 
-        await context.EnsureSqlOSUserSubjectAsync("usr_1", "User One");
-        var missingResource = async () => await context.EnsureSqlOSRoleGrantAsync("usr_1", "missing_resource", "owner");
+        await context.ProvisionUserSubjectAsync("usr_1", "User One");
+        var missingResource = async () => await context.GrantRoleAsync("usr_1", "missing_resource", "owner");
         await missingResource.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("*resource 'missing_resource' was not found*");
     }
 
     [TestMethod]
-    public async Task EnsureSqlOSResourceAsync_RequiresExistingParentResource()
+    public async Task CreateResourceWithIdAsync_RequiresExistingParentResource()
     {
         using var context = CreateContext();
         SeedFgaCore(context);
         await context.SaveChangesAsync();
 
-        var missingParent = async () => await context.EnsureSqlOSResourceAsync(
+        var missingParent = async () => await context.CreateResourceWithIdAsync(
             "workspace_1",
-            "missing_parent",
+            "workspace",
             "Workspace 1",
-            "workspace");
+            "missing_parent");
 
         await missingParent.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("*resource 'missing_parent' was not found*");
@@ -136,17 +130,17 @@ public sealed class SqlOSErgonomicsExtensionsTests
     }
 
     [TestMethod]
-    public async Task EnsureSqlOSResourceAsync_RequiresExistingResourceType()
+    public async Task CreateResourceWithIdAsync_RequiresExistingResourceType()
     {
         using var context = CreateContext();
         SeedFgaCore(context);
         await context.SaveChangesAsync();
 
-        var missingResourceType = async () => await context.EnsureSqlOSResourceAsync(
+        var missingResourceType = async () => await context.CreateResourceWithIdAsync(
             "workspace_1",
-            "root",
+            "workpsace",
             "Workspace 1",
-            "workpsace");
+            "root");
 
         await missingResourceType.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("*resource type 'workpsace' was not found*");
@@ -154,28 +148,28 @@ public sealed class SqlOSErgonomicsExtensionsTests
     }
 
     [TestMethod]
-    public async Task EnsureSqlOSResourceAsync_ValidatesParentAndResourceTypeWhenUpdating()
+    public async Task ProvisionResourceWithIdAsync_ValidatesParentAndResourceTypeWhenUpdating()
     {
         using var context = CreateContext();
         SeedFgaCore(context);
         await context.SaveChangesAsync();
 
-        await context.EnsureSqlOSResourceAsync("workspace_1", "root", "Workspace 1", "workspace");
+        await context.CreateResourceWithIdAsync("workspace_1", "workspace", "Workspace 1", "root");
         await context.SaveChangesAsync();
 
-        var missingParent = async () => await context.EnsureSqlOSResourceAsync(
+        var missingParent = async () => await context.ProvisionResourceWithIdAsync(
             "workspace_1",
-            "missing_parent",
+            "workspace",
             "Workspace 1",
-            "workspace");
+            "missing_parent");
         await missingParent.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("*resource 'missing_parent' was not found*");
 
-        var missingResourceType = async () => await context.EnsureSqlOSResourceAsync(
+        var missingResourceType = async () => await context.ProvisionResourceWithIdAsync(
             "workspace_1",
-            "root",
+            "workpsace",
             "Workspace 1",
-            "workpsace");
+            "root");
         await missingResourceType.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("*resource type 'workpsace' was not found*");
 
@@ -185,27 +179,27 @@ public sealed class SqlOSErgonomicsExtensionsTests
     }
 
     [TestMethod]
-    public async Task EnsureHelpers_PreserveExistingOptionalMetadataWhenArgumentsAreOmitted()
+    public async Task ProvisionSubjectHelpers_PreserveExistingOptionalMetadataWhenArgumentsAreOmitted()
     {
         using var context = CreateContext();
         SeedFgaCore(context);
         await context.SaveChangesAsync();
 
-        await context.EnsureSqlOSUserSubjectAsync(
+        await context.ProvisionUserSubjectAsync(
             "usr_1",
             "User One",
             "user@example.test",
             "org_1",
             "external_1",
             false);
-        await context.EnsureSqlOSAgentSubjectAsync(
+        await context.ProvisionAgentSubjectAsync(
             "agt_1",
             "Agent One",
             "worker",
             "Initial description",
             "org_1",
             "agent_external_1");
-        await context.EnsureSqlOSServiceAccountSubjectAsync(
+        await context.ProvisionServiceAccountSubjectAsync(
             "sa_1",
             "Service Account One",
             "client_1",
@@ -214,24 +208,11 @@ public sealed class SqlOSErgonomicsExtensionsTests
             new DateTime(2030, 1, 1, 0, 0, 0, DateTimeKind.Utc),
             "org_1",
             "sa_external_1");
-        await context.EnsureSqlOSResourceAsync(
-            "workspace_1",
-            "root",
-            "Workspace 1",
-            "workspace",
-            "Initial resource");
-        await context.EnsureSqlOSRoleGrantAsync(
-            "usr_1",
-            "workspace_1",
-            "owner",
-            "Initial grant");
         await context.SaveChangesAsync();
 
-        await context.EnsureSqlOSUserSubjectAsync("usr_1", "User One Updated");
-        await context.EnsureSqlOSAgentSubjectAsync("agt_1", "Agent One Updated");
-        await context.EnsureSqlOSServiceAccountSubjectAsync("sa_1", "Service Account One Updated", "client_2", "secret_2");
-        await context.EnsureSqlOSResourceAsync("workspace_1", "root", "Workspace 1 Updated", "workspace");
-        await context.EnsureSqlOSRoleGrantAsync("usr_1", "workspace_1", "owner");
+        await context.ProvisionUserSubjectAsync("usr_1", "User One Updated");
+        await context.ProvisionAgentSubjectAsync("agt_1", "Agent One Updated");
+        await context.ProvisionServiceAccountSubjectAsync("sa_1", "Service Account One Updated", "client_2", "secret_2");
         await context.SaveChangesAsync();
 
         var subject = await context.Set<SqlOSFgaSubject>().SingleAsync(x => x.Id == "usr_1");
@@ -258,13 +239,6 @@ public sealed class SqlOSErgonomicsExtensionsTests
         serviceAccount.ClientSecretHash.Should().Be("secret_2");
         serviceAccount.Description.Should().Be("Initial account");
         serviceAccount.ExpiresAt.Should().Be(new DateTime(2030, 1, 1, 0, 0, 0, DateTimeKind.Utc));
-
-        var resource = await context.Set<SqlOSFgaResource>().SingleAsync(x => x.Id == "workspace_1");
-        resource.Name.Should().Be("Workspace 1 Updated");
-        resource.Description.Should().Be("Initial resource");
-
-        var grant = await context.Set<SqlOSFgaGrant>().SingleAsync(x => x.SubjectId == "usr_1" && x.ResourceId == "workspace_1");
-        grant.Description.Should().Be("Initial grant");
     }
 
     [TestMethod]
@@ -272,7 +246,7 @@ public sealed class SqlOSErgonomicsExtensionsTests
     {
         using var context = CreateContext();
         SeedFgaCore(context);
-        await context.EnsureSqlOSUserSubjectAsync("usr_1", "User One");
+        await context.ProvisionUserSubjectAsync("usr_1", "User One");
         await context.SaveChangesAsync();
 
         await context.CreateResourceWithIdAsync(
@@ -365,7 +339,7 @@ public sealed class SqlOSErgonomicsExtensionsTests
     {
         using var context = CreateContext();
         SeedFgaCore(context);
-        await context.EnsureSqlOSUserSubjectAsync("usr_1", "User One");
+        await context.ProvisionUserSubjectAsync("usr_1", "User One");
         await context.SaveChangesAsync();
 
         var byKey = await context.GrantRoleAsync("usr_1", "root", "owner");
@@ -393,7 +367,7 @@ public sealed class SqlOSErgonomicsExtensionsTests
         await missingSubject.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("*subject 'missing_user' was not found*");
 
-        await context.EnsureSqlOSUserSubjectAsync("usr_1", "User One");
+        await context.ProvisionUserSubjectAsync("usr_1", "User One");
         var missingResource = async () => await context.GrantRoleAsync("usr_1", "missing_resource", "owner");
         await missingResource.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("*resource 'missing_resource' was not found*");

--- a/tests/SqlOS.Tests/SqlOSErgonomicsExtensionsTests.cs
+++ b/tests/SqlOS.Tests/SqlOSErgonomicsExtensionsTests.cs
@@ -1,6 +1,5 @@
 using System.Linq.Expressions;
 using FluentAssertions;
-using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SqlOS.AuthServer.Configuration;
@@ -16,23 +15,6 @@ namespace SqlOS.Tests;
 [TestClass]
 public sealed class SqlOSErgonomicsExtensionsTests
 {
-    [TestMethod]
-    public void SqlOSToken_AndSqlOSUserId_ReadValidatedToken()
-    {
-        var httpContext = new DefaultHttpContext();
-        var token = new SqlOS.AuthServer.Contracts.SqlOSValidatedToken(
-            new System.Security.Claims.ClaimsPrincipal(),
-            "sess_1",
-            "usr_1",
-            "org_1",
-            "client_1",
-            "api");
-        httpContext.Items[SqlOSAccessTokenValidationExtensions.ValidatedTokenItemKey] = token;
-
-        httpContext.SqlOSToken().Should().BeSameAs(token);
-        httpContext.SqlOSUserId().Should().Be("usr_1");
-    }
-
     [TestMethod]
     public async Task Allows_ReturnsCheckAccessDecision()
     {
@@ -84,7 +66,9 @@ public sealed class SqlOSErgonomicsExtensionsTests
             string.Concat("Ensure", "SqlOS", "Role", "Grant", "Async"),
             string.Concat("Grant", "SqlOS", "Role"),
             string.Concat("Grant", "SqlOS", "Role", "Async"),
-            string.Concat("Add", "SqlOS", "Resource")
+            string.Concat("Add", "SqlOS", "Resource"),
+            "SqlOSUserId",
+            "SqlOSToken"
         };
 
         typeof(SqlOSErgonomicsExtensions)

--- a/tests/SqlOS.Tests/SqlOSErgonomicsExtensionsTests.cs
+++ b/tests/SqlOS.Tests/SqlOSErgonomicsExtensionsTests.cs
@@ -268,6 +268,106 @@ public sealed class SqlOSErgonomicsExtensionsTests
     }
 
     [TestMethod]
+    public async Task ManualResourceApis_CreateProvisionAndDeleteResourceAndGrants()
+    {
+        using var context = CreateContext();
+        SeedFgaCore(context);
+        await context.EnsureSqlOSUserSubjectAsync("usr_1", "User One");
+        await context.SaveChangesAsync();
+
+        await context.CreateResourceWithIdAsync(
+            "workspace_1",
+            "workspace",
+            "Workspace 1",
+            "root",
+            "Initial resource");
+        await context.SaveChangesAsync();
+
+        var duplicateCreate = async () => await context.CreateResourceWithIdAsync(
+            "workspace_1",
+            "workspace",
+            "Workspace Duplicate",
+            "root");
+        await duplicateCreate.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*resource 'workspace_1' already exists*");
+
+        await context.ProvisionResourceWithIdAsync(
+            "workspace_1",
+            "workspace",
+            "Workspace One",
+            "root");
+        await context.GrantRoleAsync("usr_1", "workspace_1", "owner");
+        await context.SaveChangesAsync();
+
+        var resource = await context.Set<SqlOSFgaResource>().SingleAsync(x => x.Id == "workspace_1");
+        resource.Name.Should().Be("Workspace One");
+        resource.Description.Should().Be("Initial resource");
+        context.Set<SqlOSFgaGrant>().Count(x => x.ResourceId == "workspace_1").Should().Be(1);
+
+        await context.DeleteResourceAsync("workspace_1");
+        await context.SaveChangesAsync();
+
+        (await context.Set<SqlOSFgaResource>().AnyAsync(x => x.Id == "workspace_1")).Should().BeFalse();
+        (await context.Set<SqlOSFgaGrant>().AnyAsync(x => x.ResourceId == "workspace_1")).Should().BeFalse();
+    }
+
+    [TestMethod]
+    public async Task DeleteResourceAsync_FailsWhenChildResourcesStillExist()
+    {
+        using var context = CreateContext();
+        SeedFgaCore(context);
+        await context.CreateResourceWithIdAsync("workspace_1", "workspace", "Workspace 1", "root");
+        await context.CreateResourceWithIdAsync("workspace_child", "workspace", "Workspace child", "workspace_1");
+        await context.SaveChangesAsync();
+
+        var deleteParent = async () => await context.DeleteResourceAsync("workspace_1");
+
+        await deleteParent.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*has child resources*Delete or reparent child resources*");
+    }
+
+    [TestMethod]
+    public async Task GrantRoleAsync_ResolvesRoleKeyOrIdAndIsIdempotent()
+    {
+        using var context = CreateContext();
+        SeedFgaCore(context);
+        await context.EnsureSqlOSUserSubjectAsync("usr_1", "User One");
+        await context.SaveChangesAsync();
+
+        var byKey = await context.GrantRoleAsync("usr_1", "root", "owner");
+        var byId = await context.GrantRoleAsync("usr_1", "root", "role_owner");
+        await context.SaveChangesAsync();
+
+        byKey.RoleId.Should().Be("role_owner");
+        byId.RoleId.Should().Be("role_owner");
+        context.Set<SqlOSFgaGrant>().Count(x => x.SubjectId == "usr_1" && x.ResourceId == "root").Should().Be(1);
+
+        await context.RevokeRoleAsync("usr_1", "root", "owner");
+        await context.SaveChangesAsync();
+
+        context.Set<SqlOSFgaGrant>().Count(x => x.SubjectId == "usr_1" && x.ResourceId == "root").Should().Be(0);
+    }
+
+    [TestMethod]
+    public async Task GrantRoleAsync_RequiresExistingSubjectAndResourceWithoutProvisioningSubjects()
+    {
+        using var context = CreateContext();
+        SeedFgaCore(context);
+        await context.SaveChangesAsync();
+
+        var missingSubject = async () => await context.GrantRoleAsync("missing_user", "root", "owner");
+        await missingSubject.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*subject 'missing_user' was not found*");
+
+        await context.EnsureSqlOSUserSubjectAsync("usr_1", "User One");
+        var missingResource = async () => await context.GrantRoleAsync("usr_1", "missing_resource", "owner");
+        await missingResource.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*resource 'missing_resource' was not found*");
+
+        context.Set<SqlOSFgaSubject>().Local.Should().NotContain(x => x.Id == "missing_user");
+    }
+
+    [TestMethod]
     public void FgaSeedDsl_CreatesPermissionsRolesAndRolePermissions()
     {
         var seed = new SqlOSFgaSeedBuilder();

--- a/tests/SqlOS.Tests/SqlOSResourceBindingTests.cs
+++ b/tests/SqlOS.Tests/SqlOSResourceBindingTests.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IdentityModel.Tokens.Jwt;
 using FluentAssertions;
 using SqlOS.AuthServer.Configuration;
 using SqlOS.AuthServer.Contracts;
@@ -149,7 +150,7 @@ public sealed class SqlOSResourceBindingTests
             ctx =>
             {
                 nextCalled = true;
-                ctx.HttpContext.SqlOSUserId().Should().Be(user.Id);
+                ctx.HttpContext.User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value.Should().Be(user.Id);
                 return ValueTask.FromResult<object?>("ok");
             },
             optionsValue);

--- a/tests/SqlOS.Tests/SqlOSResourceEntitySyncTests.cs
+++ b/tests/SqlOS.Tests/SqlOSResourceEntitySyncTests.cs
@@ -11,6 +11,247 @@ namespace SqlOS.Tests;
 public sealed class SqlOSResourceEntitySyncTests
 {
     [TestMethod]
+    public void SaveChanges_ReturnsWhenNoResourceEntityChanged()
+    {
+        using var context = CreateContext();
+
+        context.SaveChanges().Should().Be(0);
+    }
+
+    [TestMethod]
+    public void SaveChanges_CreatesUpdatesAndDeletesBackingResourceAndGrants()
+    {
+        using var context = CreateContext();
+        SeedFgaCore(context);
+        context.Set<SqlOSFgaSubject>().Add(new SqlOSFgaSubject
+        {
+            Id = "usr_1",
+            SubjectTypeId = "user",
+            DisplayName = "User One"
+        });
+        var entity = new ResourceBackedEntity
+        {
+            Id = "workspace_1",
+            Name = "Workspace 1",
+            Description = "Initial workspace"
+        };
+        context.Resources.Add(entity);
+
+        context.SaveChanges();
+
+        var resource = context.Set<SqlOSFgaResource>().Single(x => x.Id == "workspace_1");
+        resource.Name.Should().Be("Workspace 1");
+        resource.Description.Should().Be("Initial workspace");
+
+        entity.Name = "Workspace One";
+        entity.Description = "Updated workspace";
+        entity.IsActive = false;
+        context.SaveChanges();
+
+        resource = context.Set<SqlOSFgaResource>().Single(x => x.Id == "workspace_1");
+        resource.Name.Should().Be("Workspace One");
+        resource.Description.Should().Be("Updated workspace");
+        resource.IsActive.Should().BeFalse();
+
+        context.Set<SqlOSFgaGrant>().Add(new SqlOSFgaGrant
+        {
+            Id = "grant_1",
+            SubjectId = "usr_1",
+            ResourceId = "workspace_1",
+            RoleId = "role_owner"
+        });
+        context.SaveChanges();
+
+        context.Resources.Remove(entity);
+        context.SaveChanges();
+
+        context.Set<SqlOSFgaResource>().Any(x => x.Id == "workspace_1").Should().BeFalse();
+        context.Set<SqlOSFgaGrant>().Any(x => x.ResourceId == "workspace_1").Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void SaveChanges_AllowsParentAndChildAddedTogetherOnSyncPath()
+    {
+        using var context = CreateContext();
+        SeedFgaCore(context);
+        context.Resources.AddRange(
+            new ResourceBackedEntity
+            {
+                Id = "workspace_parent",
+                Name = "Workspace parent"
+            },
+            new ResourceBackedEntity
+            {
+                Id = "workspace_child",
+                Name = "Workspace child",
+                ParentId = "workspace_parent"
+            });
+
+        context.SaveChanges();
+
+        context.Set<SqlOSFgaResource>()
+            .Single(x => x.Id == "workspace_child")
+            .ParentId
+            .Should()
+            .Be("workspace_parent");
+    }
+
+    [TestMethod]
+    public void SaveChanges_RejectsDuplicateResourceIdsOnSyncPath()
+    {
+        using var context = CreateContext();
+        SeedFgaCore(context);
+        context.Resources.AddRange(
+            new ResourceBackedEntity
+            {
+                Id = "entity_1",
+                ResourceKey = "workspace_1",
+                Name = "Workspace 1"
+            },
+            new ResourceBackedEntity
+            {
+                Id = "entity_2",
+                ResourceKey = "workspace_1",
+                Name = "Workspace duplicate"
+            });
+
+        Action act = () => context.SaveChanges();
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Multiple tracked SqlOS resource entities use resource id 'workspace_1'*");
+    }
+
+    [TestMethod]
+    public void SaveChanges_RejectsMissingResourceTypeOnSyncPath()
+    {
+        using var context = CreateContext();
+        SeedFgaCore(context);
+        context.Resources.Add(new ResourceBackedEntity
+        {
+            Id = "workspace_1",
+            Name = "Workspace 1",
+            TypeId = "workpsace"
+        });
+
+        Action act = () => context.SaveChanges();
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*resource type 'workpsace' was not found*");
+    }
+
+    [TestMethod]
+    public void SaveChanges_RejectsMissingParentOnSyncPath()
+    {
+        using var context = CreateContext();
+        SeedFgaCore(context);
+        context.Resources.Add(new ResourceBackedEntity
+        {
+            Id = "workspace_1",
+            Name = "Workspace 1",
+            ParentId = "missing_parent"
+        });
+
+        Action act = () => context.SaveChanges();
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*resource 'missing_parent' was not found*");
+    }
+
+    [TestMethod]
+    public void SaveChanges_RejectsExistingBackingResourceForAddedEntityOnSyncPath()
+    {
+        using var context = CreateContext();
+        SeedFgaCore(context);
+        context.Set<SqlOSFgaResource>().Add(new SqlOSFgaResource
+        {
+            Id = "workspace_1",
+            Name = "Existing workspace",
+            ResourceTypeId = "workspace",
+            ParentId = "root"
+        });
+        context.SaveChanges();
+        context.Resources.Add(new ResourceBackedEntity
+        {
+            Id = "workspace_1",
+            Name = "Workspace 1"
+        });
+
+        Action act = () => context.SaveChanges();
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*already exists*new resource-backed entity*");
+    }
+
+    [TestMethod]
+    public void SaveChanges_RejectsMissingBackingResourceForModifiedEntityOnSyncPath()
+    {
+        using var context = CreateContext();
+        SeedFgaCore(context);
+        var entity = new ResourceBackedEntity { Id = "workspace_1", Name = "Workspace 1" };
+        context.Resources.Add(entity);
+        context.SaveChanges();
+
+        var resource = context.Set<SqlOSFgaResource>().Single(x => x.Id == "workspace_1");
+        context.Set<SqlOSFgaResource>().Remove(resource);
+        context.SaveChanges();
+
+        entity.Name = "Workspace One";
+        Action act = () => context.SaveChanges();
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*was not found for a modified resource-backed entity*");
+    }
+
+    [TestMethod]
+    public void SaveChanges_DeleteFailsForLocalChildOnSyncPath()
+    {
+        using var context = CreateContext();
+        SeedFgaCore(context);
+        var entity = new ResourceBackedEntity { Id = "workspace_1", Name = "Workspace 1" };
+        context.Resources.Add(entity);
+        context.SaveChanges();
+
+        context.Set<SqlOSFgaResource>().Add(new SqlOSFgaResource
+        {
+            Id = "workspace_child",
+            ParentId = "workspace_1",
+            Name = "Workspace child",
+            ResourceTypeId = "workspace"
+        });
+        context.Resources.Remove(entity);
+
+        Action act = () => context.SaveChanges();
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*has child resources*Delete or reparent child resources*");
+    }
+
+    [TestMethod]
+    public void SaveChanges_RejectsCycleOnSyncPath()
+    {
+        using var context = CreateContext();
+        SeedFgaCore(context);
+        context.Resources.AddRange(
+            new ResourceBackedEntity
+            {
+                Id = "workspace_a",
+                Name = "Workspace A",
+                ParentId = "workspace_b"
+            },
+            new ResourceBackedEntity
+            {
+                Id = "workspace_b",
+                Name = "Workspace B",
+                ParentId = "workspace_a"
+            });
+
+        Action act = () => context.SaveChanges();
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*hierarchy contains a cycle*");
+    }
+
+    [TestMethod]
     public async Task SaveChangesAsync_CreatesBackingResourceForAddedEntity()
     {
         using var context = CreateContext();
@@ -316,13 +557,14 @@ public sealed class SqlOSResourceEntitySyncTests
     private sealed class ResourceBackedEntity : ISqlOSResourceEntity
     {
         public string Id { get; set; } = string.Empty;
+        public string? ResourceKey { get; set; }
         public string TypeId { get; set; } = "workspace";
         public string Name { get; set; } = string.Empty;
         public string? ParentId { get; set; } = "root";
         public string? Description { get; set; }
         public bool IsActive { get; set; } = true;
 
-        public string ResourceId => Id;
+        public string ResourceId => ResourceKey ?? Id;
         public string ResourceTypeId => TypeId;
         public string ResourceName => Name;
         public string? ParentResourceId => ParentId;

--- a/tests/SqlOS.Tests/SqlOSResourceEntitySyncTests.cs
+++ b/tests/SqlOS.Tests/SqlOSResourceEntitySyncTests.cs
@@ -299,7 +299,7 @@ public sealed class SqlOSResourceEntitySyncTests
     {
         using var context = CreateContext();
         SeedFgaCore(context);
-        await context.EnsureSqlOSUserSubjectAsync("usr_1", "User One");
+        await context.ProvisionUserSubjectAsync("usr_1", "User One");
         var entity = new ResourceBackedEntity { Id = "workspace_1", Name = "Workspace 1" };
         context.Resources.Add(entity);
         await context.SaveChangesAsync();
@@ -522,7 +522,7 @@ public sealed class SqlOSResourceEntitySyncTests
     {
         using var context = CreateContext();
         SeedFgaCore(context);
-        await context.EnsureSqlOSUserSubjectAsync("usr_1", "User One");
+        await context.ProvisionUserSubjectAsync("usr_1", "User One");
         var entity = new ResourceBackedEntity { Id = "workspace_1", Name = "Workspace 1" };
         context.Resources.Add(entity);
 
@@ -539,7 +539,7 @@ public sealed class SqlOSResourceEntitySyncTests
     {
         await using var context = CreateManualContext();
         SeedFgaCore(context);
-        await context.EnsureSqlOSUserSubjectAsync("usr_1", "User One");
+        await context.ProvisionUserSubjectAsync("usr_1", "User One");
         await context.SaveChangesAsync();
         var entity = new ResourceBackedEntity { Id = "workspace_1", Name = "Workspace 1" };
         context.Resources.Add(entity);

--- a/tests/SqlOS.Tests/SqlOSResourceEntitySyncTests.cs
+++ b/tests/SqlOS.Tests/SqlOSResourceEntitySyncTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SqlOS.AuthServer.Interfaces;
 using SqlOS.Extensions;
 using SqlOS.Fga.Interfaces;
 using SqlOS.Fga.Models;
@@ -314,6 +315,37 @@ public sealed class SqlOSResourceEntitySyncTests
     }
 
     [TestMethod]
+    public async Task SaveChangesAsync_DeletesBackingResourceForDisconnectedStubEntity()
+    {
+        var databaseName = Guid.NewGuid().ToString("N");
+        await using (var setup = CreateContext(databaseName))
+        {
+            SeedFgaCore(setup);
+            setup.Resources.Add(new ResourceBackedEntity
+            {
+                Id = "workspace_1",
+                ResourceKey = "workspace_1",
+                Name = "Workspace 1"
+            });
+            await setup.SaveChangesAsync();
+        }
+
+        await using var context = CreateContext(databaseName);
+        var stub = new ResourceBackedEntity
+        {
+            Id = "workspace_1",
+            ResourceKey = "workspace_1",
+            TypeId = string.Empty,
+            Name = string.Empty,
+            ParentId = null
+        };
+        context.Resources.Remove(stub);
+        await context.SaveChangesAsync();
+
+        (await context.Set<SqlOSFgaResource>().AnyAsync(x => x.Id == "workspace_1")).Should().BeFalse();
+    }
+
+    [TestMethod]
     public async Task SaveChangesAsync_DeleteFailsWhenChildResourcesStillExist()
     {
         using var context = CreateContext();
@@ -502,15 +534,39 @@ public sealed class SqlOSResourceEntitySyncTests
         (await context.Set<SqlOSFgaGrant>().AnyAsync(x => x.ResourceId == "workspace_1")).Should().BeTrue();
     }
 
-    private static ResourceEntityTestDbContext CreateContext()
+    [TestMethod]
+    public async Task GrantRoleAsync_RejectsPendingResourceEntityWhenContextDoesNotSyncResources()
+    {
+        await using var context = CreateManualContext();
+        SeedFgaCore(context);
+        await context.EnsureSqlOSUserSubjectAsync("usr_1", "User One");
+        await context.SaveChangesAsync();
+        var entity = new ResourceBackedEntity { Id = "workspace_1", Name = "Workspace 1" };
+        context.Resources.Add(entity);
+
+        var act = async () => await context.GrantRoleAsync("usr_1", entity, "owner");
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*resource 'workspace_1' was not found*");
+    }
+
+    private static ResourceEntityTestDbContext CreateContext(string? databaseName = null)
     {
         var options = new DbContextOptionsBuilder<ResourceEntityTestDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .UseInMemoryDatabase(databaseName ?? Guid.NewGuid().ToString("N"))
             .Options;
         return new ResourceEntityTestDbContext(options);
     }
 
-    private static void SeedFgaCore(ResourceEntityTestDbContext context)
+    private static ManualResourceEntityTestDbContext CreateManualContext()
+    {
+        var options = new DbContextOptionsBuilder<ManualResourceEntityTestDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .Options;
+        return new ManualResourceEntityTestDbContext(options);
+    }
+
+    private static void SeedFgaCore(DbContext context)
     {
         context.Set<SqlOSFgaSubjectType>().Add(new SqlOSFgaSubjectType { Id = "user", Name = "User" });
         context.Set<SqlOSFgaResourceType>().AddRange(
@@ -536,21 +592,43 @@ public sealed class SqlOSResourceEntitySyncTests
         public DbSet<ResourceBackedEntity> Resources => Set<ResourceBackedEntity>();
 
         protected override void OnApplicationModelCreating(ModelBuilder modelBuilder)
+            => ConfigureResourceBackedEntity(modelBuilder);
+    }
+
+    private static void ConfigureResourceBackedEntity(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<ResourceBackedEntity>(entity =>
         {
-            modelBuilder.Entity<ResourceBackedEntity>(entity =>
-            {
-                entity.HasKey(x => x.Id);
-                entity.Property(x => x.Id).HasMaxLength(128);
-                entity.Property(x => x.Name).HasMaxLength(128).IsRequired();
-                entity.Property(x => x.TypeId).HasMaxLength(128).IsRequired();
-                entity.Property(x => x.ParentId).HasMaxLength(128);
-                entity.Ignore(x => x.ResourceId);
-                entity.Ignore(x => x.ResourceTypeId);
-                entity.Ignore(x => x.ResourceName);
-                entity.Ignore(x => x.ParentResourceId);
-                entity.Ignore(x => x.ResourceDescription);
-                entity.Ignore(x => x.ResourceIsActive);
-            });
+            entity.HasKey(x => x.Id);
+            entity.Property(x => x.Id).HasMaxLength(128);
+            entity.Property(x => x.Name).HasMaxLength(128).IsRequired();
+            entity.Property(x => x.TypeId).HasMaxLength(128).IsRequired();
+            entity.Property(x => x.ParentId).HasMaxLength(128);
+            entity.Ignore(x => x.ResourceId);
+            entity.Ignore(x => x.ResourceTypeId);
+            entity.Ignore(x => x.ResourceName);
+            entity.Ignore(x => x.ParentResourceId);
+            entity.Ignore(x => x.ResourceDescription);
+            entity.Ignore(x => x.ResourceIsActive);
+        });
+    }
+
+    private sealed class ManualResourceEntityTestDbContext(DbContextOptions<ManualResourceEntityTestDbContext> options)
+        : DbContext(options), ISqlOSAuthServerDbContext, ISqlOSFgaDbContext
+    {
+        public DbSet<ResourceBackedEntity> Resources => Set<ResourceBackedEntity>();
+
+        public IQueryable<SqlOSFgaAccessibleResource> IsResourceAccessible(
+            string resourceId,
+            string subjectIds,
+            string permissionId)
+            => throw new NotSupportedException("TVFs are not supported for the in-memory test context.");
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            modelBuilder.UseSqlOS();
+            ConfigureResourceBackedEntity(modelBuilder);
         }
     }
 

--- a/tests/SqlOS.Tests/SqlOSResourceEntitySyncTests.cs
+++ b/tests/SqlOS.Tests/SqlOSResourceEntitySyncTests.cs
@@ -1,0 +1,332 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SqlOS.Extensions;
+using SqlOS.Fga.Interfaces;
+using SqlOS.Fga.Models;
+
+namespace SqlOS.Tests;
+
+[TestClass]
+public sealed class SqlOSResourceEntitySyncTests
+{
+    [TestMethod]
+    public async Task SaveChangesAsync_CreatesBackingResourceForAddedEntity()
+    {
+        using var context = CreateContext();
+        SeedFgaCore(context);
+        context.Resources.Add(new ResourceBackedEntity
+        {
+            Id = "workspace_1",
+            Name = "Workspace 1",
+            Description = "Initial workspace"
+        });
+
+        await context.SaveChangesAsync();
+
+        var resource = await context.Set<SqlOSFgaResource>().SingleAsync(x => x.Id == "workspace_1");
+        resource.Name.Should().Be("Workspace 1");
+        resource.Description.Should().Be("Initial workspace");
+        resource.ResourceTypeId.Should().Be("workspace");
+        resource.ParentId.Should().Be("root");
+        resource.IsActive.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public async Task SaveChangesAsync_UpdatesBackingResourceForModifiedEntity()
+    {
+        using var context = CreateContext();
+        SeedFgaCore(context);
+        var entity = new ResourceBackedEntity { Id = "workspace_1", Name = "Workspace 1" };
+        context.Resources.Add(entity);
+        await context.SaveChangesAsync();
+
+        entity.Name = "Workspace One";
+        entity.Description = "Updated";
+        entity.IsActive = false;
+        await context.SaveChangesAsync();
+
+        var resource = await context.Set<SqlOSFgaResource>().SingleAsync(x => x.Id == "workspace_1");
+        resource.Name.Should().Be("Workspace One");
+        resource.Description.Should().Be("Updated");
+        resource.IsActive.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public async Task SaveChangesAsync_DeletesBackingResourceAndGrantsForDeletedEntity()
+    {
+        using var context = CreateContext();
+        SeedFgaCore(context);
+        await context.EnsureSqlOSUserSubjectAsync("usr_1", "User One");
+        var entity = new ResourceBackedEntity { Id = "workspace_1", Name = "Workspace 1" };
+        context.Resources.Add(entity);
+        await context.SaveChangesAsync();
+
+        await context.GrantRoleAsync("usr_1", entity, "owner");
+        await context.SaveChangesAsync();
+
+        context.Resources.Remove(entity);
+        await context.SaveChangesAsync();
+
+        (await context.Set<SqlOSFgaResource>().AnyAsync(x => x.Id == "workspace_1")).Should().BeFalse();
+        (await context.Set<SqlOSFgaGrant>().AnyAsync(x => x.ResourceId == "workspace_1")).Should().BeFalse();
+    }
+
+    [TestMethod]
+    public async Task SaveChangesAsync_DeleteFailsWhenChildResourcesStillExist()
+    {
+        using var context = CreateContext();
+        SeedFgaCore(context);
+        var entity = new ResourceBackedEntity { Id = "workspace_1", Name = "Workspace 1" };
+        context.Resources.Add(entity);
+        await context.SaveChangesAsync();
+        context.Set<SqlOSFgaResource>().Add(new SqlOSFgaResource
+        {
+            Id = "workspace_child",
+            ParentId = "workspace_1",
+            Name = "Workspace child",
+            ResourceTypeId = "workspace"
+        });
+        await context.SaveChangesAsync();
+
+        context.Resources.Remove(entity);
+        var act = async () => await context.SaveChangesAsync();
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*has child resources*Delete or reparent child resources*");
+    }
+
+    [TestMethod]
+    public async Task SaveChangesAsync_RequiresExistingResourceType()
+    {
+        using var context = CreateContext();
+        SeedFgaCore(context);
+        context.Resources.Add(new ResourceBackedEntity
+        {
+            Id = "workspace_1",
+            Name = "Workspace 1",
+            TypeId = "workpsace"
+        });
+
+        var act = async () => await context.SaveChangesAsync();
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*resource type 'workpsace' was not found*");
+    }
+
+    [TestMethod]
+    public async Task SaveChangesAsync_RequiresExistingParent()
+    {
+        using var context = CreateContext();
+        SeedFgaCore(context);
+        context.Resources.Add(new ResourceBackedEntity
+        {
+            Id = "workspace_1",
+            Name = "Workspace 1",
+            ParentId = "missing_parent"
+        });
+
+        var act = async () => await context.SaveChangesAsync();
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*resource 'missing_parent' was not found*");
+    }
+
+    [TestMethod]
+    public async Task SaveChangesAsync_AllowsParentAndChildAddedTogether()
+    {
+        using var context = CreateContext();
+        SeedFgaCore(context);
+        context.Resources.AddRange(
+            new ResourceBackedEntity
+            {
+                Id = "workspace_1",
+                Name = "Workspace 1"
+            },
+            new ResourceBackedEntity
+            {
+                Id = "workspace_child",
+                Name = "Workspace child",
+                ParentId = "workspace_1"
+            });
+
+        await context.SaveChangesAsync();
+
+        var child = await context.Set<SqlOSFgaResource>().SingleAsync(x => x.Id == "workspace_child");
+        child.ParentId.Should().Be("workspace_1");
+    }
+
+    [TestMethod]
+    public async Task SaveChangesAsync_RejectsSelfParent()
+    {
+        using var context = CreateContext();
+        SeedFgaCore(context);
+        context.Resources.Add(new ResourceBackedEntity
+        {
+            Id = "workspace_1",
+            Name = "Workspace 1",
+            ParentId = "workspace_1"
+        });
+
+        var act = async () => await context.SaveChangesAsync();
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*parent cannot be the resource itself*");
+    }
+
+    [TestMethod]
+    public async Task SaveChangesAsync_RejectsPendingCycle()
+    {
+        using var context = CreateContext();
+        SeedFgaCore(context);
+        context.Resources.AddRange(
+            new ResourceBackedEntity
+            {
+                Id = "workspace_a",
+                Name = "Workspace A",
+                ParentId = "workspace_b"
+            },
+            new ResourceBackedEntity
+            {
+                Id = "workspace_b",
+                Name = "Workspace B",
+                ParentId = "workspace_a"
+            });
+
+        var act = async () => await context.SaveChangesAsync();
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*hierarchy contains a cycle*");
+    }
+
+    [TestMethod]
+    public async Task SaveChangesAsync_RejectsAddedEntityWhenBackingResourceAlreadyExists()
+    {
+        using var context = CreateContext();
+        SeedFgaCore(context);
+        context.Set<SqlOSFgaResource>().Add(new SqlOSFgaResource
+        {
+            Id = "workspace_1",
+            Name = "Existing workspace",
+            ResourceTypeId = "workspace",
+            ParentId = "root"
+        });
+        await context.SaveChangesAsync();
+        context.Resources.Add(new ResourceBackedEntity
+        {
+            Id = "workspace_1",
+            Name = "Workspace 1"
+        });
+
+        var act = async () => await context.SaveChangesAsync();
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*already exists*new resource-backed entity*");
+    }
+
+    [TestMethod]
+    public async Task SaveChangesAsync_RejectsModifiedEntityWhenBackingResourceIsMissing()
+    {
+        using var context = CreateContext();
+        SeedFgaCore(context);
+        var entity = new ResourceBackedEntity { Id = "workspace_1", Name = "Workspace 1" };
+        context.Resources.Add(entity);
+        await context.SaveChangesAsync();
+
+        var resource = await context.Set<SqlOSFgaResource>().SingleAsync(x => x.Id == "workspace_1");
+        context.Set<SqlOSFgaResource>().Remove(resource);
+        await context.SaveChangesAsync();
+
+        entity.Name = "Workspace One";
+        var act = async () => await context.SaveChangesAsync();
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*was not found for a modified resource-backed entity*");
+    }
+
+    [TestMethod]
+    public async Task GrantRoleAsync_AllowsPendingResourceEntity()
+    {
+        using var context = CreateContext();
+        SeedFgaCore(context);
+        await context.EnsureSqlOSUserSubjectAsync("usr_1", "User One");
+        var entity = new ResourceBackedEntity { Id = "workspace_1", Name = "Workspace 1" };
+        context.Resources.Add(entity);
+
+        var grant = await context.GrantRoleAsync("usr_1", entity, "owner");
+        await context.SaveChangesAsync();
+
+        grant.ResourceId.Should().Be("workspace_1");
+        (await context.Set<SqlOSFgaResource>().AnyAsync(x => x.Id == "workspace_1")).Should().BeTrue();
+        (await context.Set<SqlOSFgaGrant>().AnyAsync(x => x.ResourceId == "workspace_1")).Should().BeTrue();
+    }
+
+    private static ResourceEntityTestDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<ResourceEntityTestDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .Options;
+        return new ResourceEntityTestDbContext(options);
+    }
+
+    private static void SeedFgaCore(ResourceEntityTestDbContext context)
+    {
+        context.Set<SqlOSFgaSubjectType>().Add(new SqlOSFgaSubjectType { Id = "user", Name = "User" });
+        context.Set<SqlOSFgaResourceType>().AddRange(
+            new SqlOSFgaResourceType { Id = "root", Name = "Root" },
+            new SqlOSFgaResourceType { Id = "workspace", Name = "Workspace" });
+        context.Set<SqlOSFgaResource>().Add(new SqlOSFgaResource
+        {
+            Id = "root",
+            Name = "Root",
+            ResourceTypeId = "root"
+        });
+        context.Set<SqlOSFgaRole>().Add(new SqlOSFgaRole
+        {
+            Id = "role_owner",
+            Key = "owner",
+            Name = "Owner"
+        });
+    }
+
+    private sealed class ResourceEntityTestDbContext(DbContextOptions<ResourceEntityTestDbContext> options)
+        : SqlOSDbContext<ResourceEntityTestDbContext>(options)
+    {
+        public DbSet<ResourceBackedEntity> Resources => Set<ResourceBackedEntity>();
+
+        protected override void OnApplicationModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<ResourceBackedEntity>(entity =>
+            {
+                entity.HasKey(x => x.Id);
+                entity.Property(x => x.Id).HasMaxLength(128);
+                entity.Property(x => x.Name).HasMaxLength(128).IsRequired();
+                entity.Property(x => x.TypeId).HasMaxLength(128).IsRequired();
+                entity.Property(x => x.ParentId).HasMaxLength(128);
+                entity.Ignore(x => x.ResourceId);
+                entity.Ignore(x => x.ResourceTypeId);
+                entity.Ignore(x => x.ResourceName);
+                entity.Ignore(x => x.ParentResourceId);
+                entity.Ignore(x => x.ResourceDescription);
+                entity.Ignore(x => x.ResourceIsActive);
+            });
+        }
+    }
+
+    private sealed class ResourceBackedEntity : ISqlOSResourceEntity
+    {
+        public string Id { get; set; } = string.Empty;
+        public string TypeId { get; set; } = "workspace";
+        public string Name { get; set; } = string.Empty;
+        public string? ParentId { get; set; } = "root";
+        public string? Description { get; set; }
+        public bool IsActive { get; set; } = true;
+
+        public string ResourceId => Id;
+        public string ResourceTypeId => TypeId;
+        public string ResourceName => Name;
+        public string? ParentResourceId => ParentId;
+        public string? ResourceDescription => Description;
+        public bool ResourceIsActive => IsActive;
+    }
+}

--- a/tests/SqlOS.Tests/SqlOSResourceEntitySyncTests.cs
+++ b/tests/SqlOS.Tests/SqlOSResourceEntitySyncTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SqlOS.AuthServer.Interfaces;
@@ -295,6 +296,51 @@ public sealed class SqlOSResourceEntitySyncTests
     }
 
     [TestMethod]
+    public async Task SaveChangesAsync_ReparentsBackingResourceForModifiedEntity()
+    {
+        using var context = CreateContext();
+        SeedFgaCore(context);
+        var parentA = new ResourceBackedEntity { Id = "workspace_a", Name = "Workspace A" };
+        var parentB = new ResourceBackedEntity { Id = "workspace_b", Name = "Workspace B" };
+        var child = new ResourceBackedEntity
+        {
+            Id = "workspace_child",
+            Name = "Workspace child",
+            ParentId = "workspace_a"
+        };
+        context.Resources.AddRange(parentA, parentB, child);
+        await context.SaveChangesAsync();
+
+        child.ParentId = "workspace_b";
+        await context.SaveChangesAsync();
+
+        var resource = await context.Set<SqlOSFgaResource>().SingleAsync(x => x.Id == "workspace_child");
+        resource.ParentId.Should().Be("workspace_b");
+    }
+
+    [TestMethod]
+    public async Task SaveChangesAsync_RejectsReparentThatCreatesCycle()
+    {
+        using var context = CreateContext();
+        SeedFgaCore(context);
+        var parent = new ResourceBackedEntity { Id = "workspace_parent", Name = "Workspace parent" };
+        var child = new ResourceBackedEntity
+        {
+            Id = "workspace_child",
+            Name = "Workspace child",
+            ParentId = "workspace_parent"
+        };
+        context.Resources.AddRange(parent, child);
+        await context.SaveChangesAsync();
+
+        parent.ParentId = "workspace_child";
+        var act = async () => await context.SaveChangesAsync();
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*hierarchy contains a cycle*");
+    }
+
+    [TestMethod]
     public async Task SaveChangesAsync_DeletesBackingResourceAndGrantsForDeletedEntity()
     {
         using var context = CreateContext();
@@ -343,6 +389,34 @@ public sealed class SqlOSResourceEntitySyncTests
         await context.SaveChangesAsync();
 
         (await context.Set<SqlOSFgaResource>().AnyAsync(x => x.Id == "workspace_1")).Should().BeFalse();
+    }
+
+    [TestMethod]
+    public async Task SaveChangesAsync_DeletesParentAndChildInSameSaveOnRelationalProvider()
+    {
+        await using var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+        await using var context = CreateSqliteContext(connection);
+        await context.Database.EnsureCreatedAsync();
+        await CreateSqliteFgaTablesAsync(context);
+        SeedFgaCore(context);
+        await context.SaveChangesAsync();
+
+        var parent = new ResourceBackedEntity { Id = "workspace_parent", Name = "Workspace parent" };
+        var child = new ResourceBackedEntity
+        {
+            Id = "workspace_child",
+            Name = "Workspace child",
+            ParentId = "workspace_parent"
+        };
+        context.Resources.AddRange(parent, child);
+        await context.SaveChangesAsync();
+
+        context.Resources.RemoveRange(parent, child);
+        await context.SaveChangesAsync();
+
+        (await context.Set<SqlOSFgaResource>().AnyAsync(x => x.Id == "workspace_parent")).Should().BeFalse();
+        (await context.Set<SqlOSFgaResource>().AnyAsync(x => x.Id == "workspace_child")).Should().BeFalse();
     }
 
     [TestMethod]
@@ -566,6 +640,14 @@ public sealed class SqlOSResourceEntitySyncTests
         return new ManualResourceEntityTestDbContext(options);
     }
 
+    private static ResourceEntityTestDbContext CreateSqliteContext(SqliteConnection connection)
+    {
+        var options = new DbContextOptionsBuilder<ResourceEntityTestDbContext>()
+            .UseSqlite(connection)
+            .Options;
+        return new ResourceEntityTestDbContext(options);
+    }
+
     private static void SeedFgaCore(DbContext context)
     {
         context.Set<SqlOSFgaSubjectType>().Add(new SqlOSFgaSubjectType { Id = "user", Name = "User" });
@@ -584,6 +666,76 @@ public sealed class SqlOSResourceEntitySyncTests
             Key = "owner",
             Name = "Owner"
         });
+    }
+
+    private static async Task CreateSqliteFgaTablesAsync(DbContext context)
+    {
+        await context.Database.ExecuteSqlRawAsync("PRAGMA foreign_keys=ON;");
+        await context.Database.ExecuteSqlRawAsync("""
+            CREATE TABLE SqlOSFgaSubjectTypes (
+                Id TEXT NOT NULL PRIMARY KEY,
+                Name TEXT NOT NULL,
+                Description TEXT NULL
+            );
+            """);
+        await context.Database.ExecuteSqlRawAsync("""
+            CREATE TABLE SqlOSFgaSubjects (
+                Id TEXT NOT NULL PRIMARY KEY,
+                SubjectTypeId TEXT NOT NULL,
+                DisplayName TEXT NOT NULL,
+                OrganizationId TEXT NULL,
+                ExternalRef TEXT NULL,
+                CreatedAt TEXT NOT NULL,
+                UpdatedAt TEXT NOT NULL,
+                FOREIGN KEY (SubjectTypeId) REFERENCES SqlOSFgaSubjectTypes(Id) ON DELETE RESTRICT
+            );
+            """);
+        await context.Database.ExecuteSqlRawAsync("""
+            CREATE TABLE SqlOSFgaResourceTypes (
+                Id TEXT NOT NULL PRIMARY KEY,
+                Name TEXT NOT NULL,
+                Description TEXT NULL
+            );
+            """);
+        await context.Database.ExecuteSqlRawAsync("""
+            CREATE TABLE SqlOSFgaResources (
+                Id TEXT NOT NULL PRIMARY KEY,
+                ParentId TEXT NULL,
+                Name TEXT NOT NULL,
+                Description TEXT NULL,
+                ResourceTypeId TEXT NOT NULL,
+                IsActive INTEGER NOT NULL,
+                CreatedAt TEXT NOT NULL,
+                UpdatedAt TEXT NOT NULL,
+                FOREIGN KEY (ParentId) REFERENCES SqlOSFgaResources(Id) ON DELETE RESTRICT,
+                FOREIGN KEY (ResourceTypeId) REFERENCES SqlOSFgaResourceTypes(Id) ON DELETE RESTRICT
+            );
+            """);
+        await context.Database.ExecuteSqlRawAsync("""
+            CREATE TABLE SqlOSFgaRoles (
+                Id TEXT NOT NULL PRIMARY KEY,
+                "Key" TEXT NOT NULL,
+                Name TEXT NOT NULL,
+                Description TEXT NULL,
+                IsVirtual INTEGER NOT NULL
+            );
+            """);
+        await context.Database.ExecuteSqlRawAsync("""
+            CREATE TABLE SqlOSFgaGrants (
+                Id TEXT NOT NULL PRIMARY KEY,
+                SubjectId TEXT NOT NULL,
+                ResourceId TEXT NOT NULL,
+                RoleId TEXT NOT NULL,
+                Description TEXT NULL,
+                EffectiveFrom TEXT NULL,
+                EffectiveTo TEXT NULL,
+                CreatedAt TEXT NOT NULL,
+                UpdatedAt TEXT NOT NULL,
+                FOREIGN KEY (SubjectId) REFERENCES SqlOSFgaSubjects(Id) ON DELETE RESTRICT,
+                FOREIGN KEY (ResourceId) REFERENCES SqlOSFgaResources(Id) ON DELETE RESTRICT,
+                FOREIGN KEY (RoleId) REFERENCES SqlOSFgaRoles(Id) ON DELETE RESTRICT
+            );
+            """);
     }
 
     private sealed class ResourceEntityTestDbContext(DbContextOptions<ResourceEntityTestDbContext> options)

--- a/web/content/blog/auth0-fga-vs-sqlos-shrbac.mdx
+++ b/web/content/blog/auth0-fga-vs-sqlos-shrbac.mdx
@@ -101,21 +101,23 @@ The filter calls the SQL Server function that walks resource ancestors and match
 
 With Auth0 FGA, app data and authorization data are deliberately separate. When a document is created, the app writes its row to SQL Server and writes a tuple or relationship to FGA. For many systems, that decoupling is the point.
 
-With SqlOS, the resource can be created beside the row:
+With SqlOS, the domain row can describe its FGA resource and `SqlOSDbContext<TContext>` syncs the backing resource during the same EF save:
 
 ```csharp
+var documentId = Guid.NewGuid();
 var document = new Document
 {
-    Id = Guid.NewGuid(),
+    Id = documentId,
     ProjectId = project.Id,
+    ProjectResourceId = project.ResourceId,
+    ResourceId = $"document::{documentId:D}",
     Title = request.Title
 };
 
-document.ResourceId = dbContext.CreateResource(
-    parentId: project.ResourceId,
-    name: document.Title,
-    resourceTypeId: "document",
-    id: $"document::{document.Id:D}");
+// Document implements ISqlOSResourceEntity:
+// ResourceTypeId => "document"
+// ParentResourceId => ProjectResourceId
+// ResourceName => Title
 
 dbContext.Documents.Add(document);
 await dbContext.SaveChangesAsync(cancellationToken);

--- a/web/content/blog/authorized-list-queries-ef-core-sqlos.mdx
+++ b/web/content/blog/authorized-list-queries-ef-core-sqlos.mdx
@@ -74,14 +74,15 @@ TODO_WRITE
 
 Every child todo inherits access from the tenant resource. The sample could add shared projects or organization workspaces later without changing the list endpoint shape. The row points to a resource, and the resource tree explains who can see it.
 
-## The Todo item carries a ResourceId
+## The Todo item describes its FGA resource
 
-Every protected entity implements `IHasResourceId`:
+Every protected entity implements `ISqlOSResourceEntity`. The stored `ResourceId` remains the bridge for SQL query filtering, while the other properties tell SqlOS how to maintain the backing FGA resource:
 
 ```csharp
 using SqlOS.Fga.Interfaces;
+using SqlOS.Todo.Api.Services;
 
-public sealed class TodoItem : IHasResourceId
+public sealed class TodoItem : ISqlOSResourceEntity
 {
     public Guid Id { get; set; }
     public string ResourceId { get; set; } = string.Empty;
@@ -90,33 +91,35 @@ public sealed class TodoItem : IHasResourceId
     public bool IsCompleted { get; set; }
     public DateTime CreatedAt { get; set; }
     public DateTime? CompletedAt { get; set; }
+
+    public string ResourceTypeId => TodoFgaService.TodoResourceTypeId;
+    public string ResourceName => Title;
+    public string? ParentResourceId => TodoFgaService.GetTenantResourceId(SqlOSUserId);
+    public string? ResourceDescription => null;
+    public bool ResourceIsActive => true;
 }
 ```
 
-The `ResourceId` is the bridge between business data and authorization data. The todo row can still have app-specific columns, indexes, and constraints. SqlOS only needs the resource ID to compose the authorization predicate.
+The todo row can still have app-specific columns, indexes, and constraints. SqlOS uses `ResourceId` to compose the authorization predicate and uses the entity-backed resource contract to sync the FGA resource row during `SaveChangesAsync`.
 
 ## The DbContext maps the SQL function
 
-The Todo sample context implements both SqlOS interfaces and exposes `IsResourceAccessible`:
+The Todo sample context derives from `SqlOSDbContext<TContext>`, which registers the SqlOS EF model and TVF mapping:
 
 ```csharp
-public sealed class TodoSampleDbContext(
-    DbContextOptions<TodoSampleDbContext> options)
-    : DbContext(options), ISqlOSAuthServerDbContext, ISqlOSFgaDbContext
+public sealed class TodoSampleDbContext(DbContextOptions<TodoSampleDbContext> options)
+    : SqlOSDbContext<TodoSampleDbContext>(options)
 {
     public DbSet<TodoItem> TodoItems => Set<TodoItem>();
 
-    public IQueryable<SqlOSFgaAccessibleResource> IsResourceAccessible(
-        string resourceId,
-        string subjectIds,
-        string permissionId)
-        => FromExpression(() =>
-            IsResourceAccessible(resourceId, subjectIds, permissionId));
-
-    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    protected override void OnApplicationModelCreating(ModelBuilder modelBuilder)
     {
-        base.OnModelCreating(modelBuilder);
-        modelBuilder.UseSqlOS(Database.IsRelational() ? GetType() : null);
+        modelBuilder.Entity<TodoItem>(entity =>
+        {
+            entity.HasKey(x => x.Id);
+            entity.Property(x => x.ResourceId).HasMaxLength(450).IsRequired();
+            entity.HasIndex(x => x.ResourceId).IsUnique();
+        });
     }
 }
 ```
@@ -164,45 +167,40 @@ That filter composes with search, sort, projection, and pagination. It does not 
 
 ## Creating rows and resources together
 
-When a todo is created, the app creates a domain row and an FGA resource in the same `DbContext` unit of work:
+When a todo is created, the app creates the domain row with a stable `ResourceId`. `SqlOSDbContext<TContext>` creates the backing FGA resource in the same `SaveChangesAsync` call:
 
 ```csharp
+var todoId = Guid.NewGuid();
 var item = new TodoItem
 {
-    Id = Guid.NewGuid(),
+    Id = todoId,
+    ResourceId = TodoFgaService.GetTodoResourceId(todoId),
     SqlOSUserId = todoContext.SubjectId,
     Title = request.Title.Trim(),
     CreatedAt = DateTime.UtcNow
 };
 
-item.ResourceId = await todoFgaService.CreateTodoResourceAsync(
-    item,
-    todoContext.TenantResourceId,
-    cancellationToken);
-
 dbContext.TodoItems.Add(item);
 await dbContext.SaveChangesAsync(cancellationToken);
 ```
 
-The helper creates `todo::{todoId}` under the tenant resource:
+The tenant root is the one resource in this sample that is not backed by a domain entity, so the service provisions it explicitly and keeps grants explicit:
 
 ```csharp
-public async Task<string> CreateTodoResourceAsync(
-    TodoItem item,
-    string tenantResourceId,
-    CancellationToken cancellationToken = default)
-{
-    var resourceId = GetTodoResourceId(item.Id);
+await _context.ProvisionResourceWithIdAsync(
+    tenantResourceId,
+    TodoFgaService.TenantResourceTypeId,
+    displayName,
+    "root",
+    $"Todo tenant for {subjectId}",
+    isActive: true,
+    cancellationToken);
 
-    await _context.EnsureSqlOSResourceAsync(
-        resourceId,
-        tenantResourceId,
-        item.Title,
-        TodoResourceTypeId,
-        cancellationToken: cancellationToken);
-
-    return resourceId;
-}
+await _context.GrantRoleAsync(
+    subjectId,
+    tenantResourceId,
+    TodoFgaService.TenantOwnerRole,
+    cancellationToken);
 ```
 
 That is the practical advantage of keeping app data and authorization data in the same database. If the business write fails, the resource write fails with it. If the resource cannot be created, the todo is not silently created with no authorization node.

--- a/web/content/blog/authorized-list-queries-ef-core-sqlos.mdx
+++ b/web/content/blog/authorized-list-queries-ef-core-sqlos.mdx
@@ -11,7 +11,7 @@ Most authorization bugs do not start with a dramatic exploit. They start with a 
 The detail endpoint has a check:
 
 ```csharp
-if (!await CanEdit(userId, documentId))
+if (!await CanEdit(subjectId, documentId))
     return Results.Forbid();
 ```
 
@@ -19,7 +19,7 @@ But the list endpoint quietly returns too much:
 
 ```csharp
 var todos = await db.TodoItems
-    .Where(x => x.SqlOSUserId == userId)
+    .Where(x => x.OwnerSubjectId == subjectId)
     .OrderBy(x => x.CreatedAt)
     .ToListAsync();
 ```
@@ -52,7 +52,7 @@ The resource hierarchy is:
 
 ```text
 root
-  tenant::{userId}
+  tenant::{subjectId}
     todo::{todoId}
 ```
 
@@ -86,7 +86,7 @@ public sealed class TodoItem : ISqlOSResourceEntity
 {
     public Guid Id { get; set; }
     public string ResourceId { get; set; } = string.Empty;
-    public string SqlOSUserId { get; set; } = string.Empty;
+    public string OwnerSubjectId { get; set; } = string.Empty;
     public string Title { get; set; } = string.Empty;
     public bool IsCompleted { get; set; }
     public DateTime CreatedAt { get; set; }
@@ -94,7 +94,7 @@ public sealed class TodoItem : ISqlOSResourceEntity
 
     public string ResourceTypeId => TodoFgaService.TodoResourceTypeId;
     public string ResourceName => Title;
-    public string? ParentResourceId => TodoFgaService.GetTenantResourceId(SqlOSUserId);
+    public string? ParentResourceId => TodoFgaService.GetTenantResourceId(OwnerSubjectId);
     public string? ResourceDescription => null;
     public bool ResourceIsActive => true;
 }
@@ -133,7 +133,7 @@ The fragile version asks the app table to carry all authorization meaning:
 ```csharp
 var items = await dbContext.TodoItems
     .AsNoTracking()
-    .Where(x => x.SqlOSUserId == currentUserId)
+    .Where(x => x.OwnerSubjectId == currentSubjectId)
     .OrderBy(x => x.IsCompleted)
     .ThenBy(x => x.CreatedAt)
     .ToListAsync();
@@ -175,7 +175,7 @@ var item = new TodoItem
 {
     Id = todoId,
     ResourceId = TodoFgaService.GetTodoResourceId(todoId),
-    SqlOSUserId = todoContext.SubjectId,
+    OwnerSubjectId = todoContext.SubjectId,
     Title = request.Title.Trim(),
     CreatedAt = DateTime.UtcNow
 };

--- a/web/content/blog/workos-fga-vs-sqlos-shrbac.mdx
+++ b/web/content/blog/workos-fga-vs-sqlos-shrbac.mdx
@@ -91,14 +91,23 @@ It is less attractive for high-volume rows:
 
 WorkOS documentation recommends keeping very high-cardinality content in your database with a reference to a parent FGA resource. That avoids syncing millions of leaf records, but it means the authorization decision is often about the parent, while the actual rows still live in your database.
 
-SqlOS takes the opposite default for a SQL Server app. Resources are database rows, so creating a resource beside a domain row is just part of the app write:
+SqlOS takes the opposite default for a SQL Server app. Resources are database rows, so a protected domain row can describe its resource and `SqlOSDbContext<TContext>` syncs the backing `SqlOSFgaResource` during the app write:
 
 ```csharp
-project.ResourceId = dbContext.CreateResource(
-    parentId: workspace.ResourceId,
-    name: project.Name,
-    resourceTypeId: "project",
-    id: $"project::{project.Id:D}");
+var projectId = Guid.NewGuid();
+var project = new Project
+{
+    Id = projectId,
+    WorkspaceId = workspace.Id,
+    WorkspaceResourceId = workspace.ResourceId,
+    ResourceId = $"project::{projectId:D}",
+    Name = request.Name
+};
+
+// Project implements ISqlOSResourceEntity:
+// ResourceTypeId => "project"
+// ParentResourceId => WorkspaceResourceId
+// ResourceName => Name
 
 dbContext.Projects.Add(project);
 await dbContext.SaveChangesAsync(cancellationToken);

--- a/web/content/docs/authserver/token-validation.mdx
+++ b/web/content/docs/authserver/token-validation.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Token Validation"
-description: "Validate access tokens and extract user claims."
+description: "Validate access tokens for protected APIs."
 order: 28
 section: authserver
 ---
@@ -23,12 +23,17 @@ The middleware rejects requests at startup if `ExpectedAudience` is empty. On su
 
 ```csharp
 var validated = httpContext.GetSqlOSValidatedToken();
-var userId = validated?.UserId;
+var clientId = validated?.ClientId;
+var audience = validated?.Audience;
 ```
+
+Use `GetSqlOSValidatedToken()` for token diagnostics or auth-server metadata. Your app should still resolve the current FGA subject explicitly from the authenticated principal or from its own API-key/session mapping.
 
 ## Validate with the SDK
 
 ```csharp
+using System.IdentityModel.Tokens.Jwt;
+
 var bearerToken = httpContext.Request.Headers.Authorization.ToString();
 if (!bearerToken.StartsWith("Bearer "))
     return Results.Unauthorized();
@@ -42,40 +47,31 @@ var validated = await authService.ValidateAccessTokenAsync(
 if (validated == null)
     return Results.Unauthorized();
 
-// Use the validated claims
-var userId = validated.UserId;
+var subjectId = validated.Principal.FindFirst(JwtRegisteredClaimNames.Sub)?.Value;
+if (string.IsNullOrWhiteSpace(subjectId))
+    return Results.Unauthorized();
+
 var orgId = validated.OrganizationId;
 ```
 
-## Middleware pattern
+## Resolve subjects in application code
 
-The example app uses middleware to extract the subject ID from multiple auth methods:
+SqlOS FGA APIs take explicit `subjectId` values. For bearer tokens, a typical app-owned resolver reads the JWT subject claim from the authenticated principal:
 
 ```csharp
-public static string? GetSubjectId(this HttpContext http, string expectedAudience)
-{
-    // Bearer JWT
-    var auth = http.Request.Headers.Authorization.ToString();
-    if (auth.StartsWith("Bearer "))
-    {
-        var token = auth["Bearer ".Length..].Trim();
-        var validated = http.RequestServices
-            .GetRequiredService<SqlOSAuthService>()
-            .ValidateAccessTokenAsync(token, expectedAudience, ct).Result;
-        return validated?.UserId;
-    }
+using System.IdentityModel.Tokens.Jwt;
 
-    // API key (service accounts)
-    if (http.Request.Headers.TryGetValue("X-Api-Key", out var apiKey))
-        return apiKey.ToString();
+var subjectId = http.User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value;
+if (string.IsNullOrWhiteSpace(subjectId))
+    return Results.Unauthorized();
 
-    // Agent token
-    if (http.Request.Headers.TryGetValue("X-Agent-Token", out var agentToken))
-        return agentToken.ToString();
-
-    return null;
-}
+await db.ProvisionUserSubjectAsync(
+    subjectId,
+    displayName: subjectId,
+    cancellationToken: ct);
 ```
+
+If your app accepts API keys, agent tokens, or another credential type, resolve those credentials to the relevant service-account or agent subject ID in your own request layer, then pass that explicit subject ID to FGA.
 
 `ValidateAccessTokenWithoutAudienceForIntrospectionOnlyAsync` exists only for diagnostics and token introspection flows that do not authenticate a protected API request. It validates issuer, signature, lifetime, and session state, but it intentionally does not validate `aud`.
 
@@ -97,7 +93,7 @@ GET /sqlos/auth/.well-known/oauth-authorization-server
 
 | Claim | Description |
 | --- | --- |
-| `sub` | User ID |
+| `sub` | User subject ID |
 | `sid` | Session ID |
 | `client_id` | OAuth client |
 | `org_id` | Organization (if scoped) |

--- a/web/content/docs/fga/checking-a-permission.mdx
+++ b/web/content/docs/fga/checking-a-permission.mdx
@@ -57,7 +57,10 @@ app.MapPost("/api/workspaces", async (
     HttpContext http,
     CancellationToken ct) =>
 {
-    var subjectId = http.SqlOSUserId();
+    var subjectId = http.User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value;
+    if (string.IsNullOrWhiteSpace(subjectId))
+        return Results.Unauthorized();
+
     var organizationResourceId = $"org::{request.OrganizationId}";
 
     var access = await authService.CheckAccessAsync(

--- a/web/content/docs/fga/checking-a-permission.mdx
+++ b/web/content/docs/fga/checking-a-permission.mdx
@@ -12,9 +12,8 @@ Use `CheckAccessAsync` for a yes/no answer: can this subject perform this action
 ```csharp
 var access = await authService.CheckAccessAsync(
     subjectId,
-    "CHAIN_EDIT",
-    resourceId
-);
+    "WORKSPACE_MANAGE",
+    resourceId);
 
 if (!access.Allowed)
     return Results.Json(new { error = "Permission denied" }, statusCode: 403);
@@ -22,20 +21,20 @@ if (!access.Allowed)
 
 Use this for:
 
-- **Mutations** -- check before creating, updating, or deleting
-- **Single-resource gates** -- when you already have the resource ID
+- **Mutations** -- check before creating, updating, or deleting.
+- **Single-resource gates** -- when you already have the resource ID.
 
 ## HasCapabilityAsync
 
-Check if a subject has a permission anywhere in the tree (effectively a root-level check):
+Check if a subject has a permission anywhere in the tree:
 
 ```csharp
-var canManageChains = await authService.HasCapabilityAsync(subjectId, "CHAIN_EDIT");
+var canManageWorkspaces = await authService.HasCapabilityAsync(subjectId, "WORKSPACE_MANAGE");
 ```
 
 Use this for:
 
-- **Global UI toggles** -- show/hide "Create Chain" button
+- **Global UI toggles** -- show/hide "Create workspace" button.
 - **Broad capability gates** -- "can this user create anything at all?"
 
 ## Access Tester (dashboard)
@@ -48,39 +47,38 @@ Select a subject, permission, and resource to see whether access is allowed and 
 
 ## Full mutation example
 
-From the retail example -- creating a chain with authorization:
+Create a protected entity after checking access to its parent resource. `SqlOSDbContext<TContext>` syncs the backing FGA resource row when the entity is saved.
 
 ```csharp
-app.MapPost("/api/chains", async (
-    CreateChainRequest request,
-    ExampleAppDbContext context,
+app.MapPost("/api/workspaces", async (
+    CreateWorkspaceRequest request,
+    AppDbContext db,
     ISqlOSFgaAuthService authService,
-    HttpContext http) =>
+    HttpContext http,
+    CancellationToken ct) =>
 {
-    var subjectId = http.GetSubjectId();
+    var subjectId = http.SqlOSUserId();
+    var organizationResourceId = $"org::{request.OrganizationId}";
 
-    // 1. Check permission on the parent resource
     var access = await authService.CheckAccessAsync(
-        subjectId, "CHAIN_EDIT", "retail_root");
+        subjectId,
+        "WORKSPACE_MANAGE",
+        organizationResourceId);
     if (!access.Allowed)
         return Results.Json(new { error = "Permission denied" }, statusCode: 403);
 
-    // 2. Create FGA resource as child of parent
-    var resourceId = context.CreateResource(
-        "retail_root", request.Name, "chain");
-
-    // 3. Create domain entity with the resource ID
-    var chain = new Chain
+    var workspaceId = Guid.NewGuid();
+    var workspace = new Workspace
     {
-        ResourceId = resourceId,
-        Name = request.Name,
-        Description = request.Description
+        Id = workspaceId,
+        ResourceId = $"workspace::{workspaceId:D}",
+        OrganizationId = request.OrganizationId,
+        Name = request.Name.Trim()
     };
-    context.Chains.Add(chain);
 
-    // 4. Save in one transaction
-    await context.SaveChangesAsync();
+    db.Workspaces.Add(workspace);
+    await db.SaveChangesAsync(ct);
 
-    return Results.Created($"/api/chains/{chain.Id}", chain);
+    return Results.Created($"/api/workspaces/{workspace.Id}", workspace);
 });
 ```

--- a/web/content/docs/fga/core-concepts.mdx
+++ b/web/content/docs/fga/core-concepts.mdx
@@ -32,7 +32,7 @@ A subject is the entity being authorized. SqlOS supports four subject types:
 | `user` | Human users synced from AuthServer |
 | `agent` | Automated bots or AI agents |
 | `service_account` | Service-to-service access with API keys |
-| `user_group` | Groups of users sharing permissions |
+| `group` | Groups of users sharing permissions |
 
 See [Subject Types](/docs/fga/subject-types).
 

--- a/web/content/docs/fga/creating-resources.mdx
+++ b/web/content/docs/fga/creating-resources.mdx
@@ -1,60 +1,60 @@
 ---
 title: "Creating Resources"
-description: "Add resources to the FGA hierarchy."
+description: "Create FGA resources through entity-backed sync or manual APIs."
 order: 13
 section: fga
 ---
 
-`CreateResource` is a convenience extension on `ISqlOSFgaDbContext` that creates an `SqlOSFgaResource` and adds it to the change tracker.
+The recommended path for protected application rows is to make the EF entity implement `ISqlOSResourceEntity`. When the app derives its DbContext from `SqlOSDbContext<TContext>`, SqlOS creates, updates, and deletes the backing `SqlOSFgaResource` row during `SaveChanges` / `SaveChangesAsync`.
 
-## Usage
+## Entity-backed resources
 
 ```csharp
-// Auto-generated ID
-var resourceId = context.CreateResource(
-    parentId: "retail_root",
-    name: "Walmart",
-    resourceTypeId: "chain"
-);
+public sealed class Workspace : ISqlOSResourceEntity
+{
+    public Guid Id { get; set; }
+    public string ResourceId { get; set; } = "";
+    public string Name { get; set; } = "";
+    public string OrganizationId { get; set; } = "";
 
-// Custom ID
-var orgResourceId = context.CreateResource(
-    parentId: "root",
-    name: "Acme Corp",
+    public string ResourceTypeId => "workspace";
+    public string ResourceName => Name;
+    public string ParentResourceId => $"org::{OrganizationId}";
+    public string? ResourceDescription => null;
+    public bool ResourceIsActive => true;
+}
+```
+
+Assign a stable `ResourceId` before saving the entity:
+
+```csharp
+var workspaceId = Guid.NewGuid();
+var workspace = new Workspace
+{
+    Id = workspaceId,
+    ResourceId = $"workspace::{workspaceId:D}",
+    OrganizationId = organizationId,
+    Name = request.Name.Trim()
+};
+
+db.Workspaces.Add(workspace);
+await db.SaveChangesAsync(ct);
+```
+
+`SqlOSDbContext<TContext>` validates the resource type, parent resource, self-parenting, and obvious cycles before it writes the `SqlOSFgaResource` row.
+
+## Manual resources
+
+Use manual resource APIs only for resources that are not represented by an application entity, such as tenant roots, organization roots, or external resources.
+
+```csharp
+await db.ProvisionResourceWithIdAsync(
+    $"org::{organization.Id}",
     resourceTypeId: "organization",
-    id: $"org::{org.Id}"
-);
+    name: organization.Name,
+    parentResourceId: "root",
+    isActive: organization.IsActive,
+    cancellationToken: ct);
 ```
 
-## Method signature
-
-```csharp
-public static string CreateResource(
-    this ISqlOSFgaDbContext context,
-    string parentId,
-    string name,
-    string resourceTypeId,
-    string? id = null);
-```
-
-| Parameter | Description |
-| --- | --- |
-| `parentId` | Parent resource ID in the hierarchy |
-| `name` | Display name |
-| `resourceTypeId` | Resource type (e.g., `chain`, `location`) |
-| `id` | Optional. If null, a GUID is generated |
-
-Returns the resource ID (generated or custom).
-
-## Transaction behavior
-
-`CreateResource` adds the resource to the EF Core change tracker but does not call `SaveChangesAsync`. Save it alongside your domain entity in one transaction:
-
-```csharp
-var resourceId = context.CreateResource("retail_root", request.Name, "chain");
-
-var chain = new Chain { ResourceId = resourceId, Name = request.Name };
-context.Chains.Add(chain);
-
-await context.SaveChangesAsync(); // saves both the resource and the chain
-```
+For strict creates, use `CreateResourceAsync(...)` or `CreateResourceWithIdAsync(...)`. For deletes, use `DeleteResourceAsync(...)`; it deletes the resource and direct grants, but it does not cascade child resources.

--- a/web/content/docs/fga/detail-endpoint.mdx
+++ b/web/content/docs/fga/detail-endpoint.mdx
@@ -7,6 +7,8 @@ section: fga
 
 `AuthorizedDetailAsync` fetches a single entity, checks authorization, and returns the appropriate HTTP result. It handles 404, 403, and 200 in one call.
 
+This helper is for read-side authorization. Lifecycle-managed domain rows normally implement `ISqlOSResourceEntity`; `AuthorizedDetailAsync` only needs the inherited `IHasResourceId` contract to check access for a fetched row.
+
 ## Usage
 
 ```csharp

--- a/web/content/docs/fga/detail-endpoint.mdx
+++ b/web/content/docs/fga/detail-endpoint.mdx
@@ -12,13 +12,17 @@ This helper is for read-side authorization. Lifecycle-managed domain rows normal
 ## Usage
 
 ```csharp
+using System.IdentityModel.Tokens.Jwt;
+
 app.MapGet("/api/chains/{id}", async (
     string id,
     ExampleAppDbContext context,
     ISqlOSFgaAuthService authService,
     HttpContext http) =>
 {
-    var subjectId = http.GetSubjectId();
+    var subjectId = http.User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value;
+    if (string.IsNullOrWhiteSpace(subjectId))
+        return Results.Unauthorized();
 
     return await authService.AuthorizedDetailAsync(
         context.Chains.Include(c => c.Locations),

--- a/web/content/docs/fga/grants.mdx
+++ b/web/content/docs/fga/grants.mdx
@@ -16,14 +16,11 @@ A grant links a subject, a role, and a resource. The subject gains all permissio
 **SDK**:
 
 ```csharp
-context.Set<SqlOSFgaGrant>().Add(new SqlOSFgaGrant
-{
-    Id = SqlOSCryptoService.GenerateId("grant"),
-    SubjectId = userId,
-    ResourceId = "org::acme",
-    RoleId = companyAdminRole.Id,
-    Description = "Full access to Acme Corp"
-});
+await context.GrantRoleAsync(
+    subjectId,
+    "org::acme",
+    "company_admin",
+    ct);
 await context.SaveChangesAsync(ct);
 ```
 

--- a/web/content/docs/fga/i-has-resource-id.mdx
+++ b/web/content/docs/fga/i-has-resource-id.mdx
@@ -1,13 +1,11 @@
 ---
 title: "IHasResourceId"
-description: "Connect your EF Core entities to the FGA resource tree."
+description: "The lower-level resource ID contract used by FGA filters."
 order: 7
 section: fga
 ---
 
-`IHasResourceId` is the interface that connects your domain entities to the FGA resource tree. Any entity that needs authorization filtering must implement it.
-
-## Interface
+`IHasResourceId` is the lower-level contract used by authorization filters. It exposes the FGA resource ID on a domain entity so query filters can join app rows to accessible resources.
 
 ```csharp
 public interface IHasResourceId
@@ -16,48 +14,34 @@ public interface IHasResourceId
 }
 ```
 
-## Implementation
-
-Add `ResourceId` to your entity and implement the interface:
+For protected domain entities whose resource lifecycle should be managed by SqlOS, prefer `ISqlOSResourceEntity`. It extends `IHasResourceId` with resource metadata used by `SqlOSDbContext<TContext>` during `SaveChanges` / `SaveChangesAsync`.
 
 ```csharp
-public class Chain : IHasResourceId
+public sealed class Workspace : ISqlOSResourceEntity
 {
-    public string Id { get; set; } = Guid.NewGuid().ToString();
+    public Guid Id { get; set; }
     public string ResourceId { get; set; } = "";
     public string Name { get; set; } = "";
-    public string? Description { get; set; }
-    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public string OrganizationId { get; set; } = "";
+
+    public string ResourceTypeId => "workspace";
+    public string ResourceName => Name;
+    public string ParentResourceId => $"org::{OrganizationId}";
+    public string? ResourceDescription => null;
+    public bool ResourceIsActive => true;
 }
 ```
 
-## Assigning the ResourceId
-
-When creating an entity, create the FGA resource first and assign the ID:
-
-```csharp
-var resourceId = context.CreateResource("org::acme", request.Name, "chain");
-
-var chain = new Chain
-{
-    ResourceId = resourceId,
-    Name = request.Name
-};
-
-context.Chains.Add(chain);
-await context.SaveChangesAsync(ct);
-```
-
-## How it's used
-
-When you call `GetAuthorizationFilterAsync<T>`, the filter joins your entity's `ResourceId` against the set of accessible resources for the subject:
+When you call `GetAuthorizationFilterAsync<T>`, the filter uses `ResourceId` to restrict the query to resources the subject can access:
 
 ```csharp
 var filter = await authService
-    .GetAuthorizationFilterAsync<Chain>(subjectId, "CHAIN_VIEW");
+    .GetAuthorizationFilterAsync<Workspace>(subjectId, "WORKSPACE_VIEW");
 
-// The filter expression uses chain.ResourceId to check access
-var chains = await dbContext.Chains.Where(filter).ToListAsync();
+var workspaces = await db.Workspaces
+    .Where(filter)
+    .OrderBy(x => x.Name)
+    .ToListAsync(ct);
 ```
 
-This translates to a SQL Server table-valued function join, so authorization happens at the database level.
+Use plain `IHasResourceId` directly for lower-level/manual resources where your application owns the FGA resource lifecycle. Use `ISqlOSResourceEntity` for the normal SDK path.

--- a/web/content/docs/fga/list-filter.mdx
+++ b/web/content/docs/fga/list-filter.mdx
@@ -54,6 +54,8 @@ var result = await executor.ExecuteAsync(
 From the retail example app:
 
 ```csharp
+using System.IdentityModel.Tokens.Jwt;
+
 app.MapGet("/api/chains", async (
     ExampleAppDbContext context,
     ISqlOSFgaAuthService authService,
@@ -62,7 +64,9 @@ app.MapGet("/api/chains", async (
     string? search, int? pageSize, string? cursor,
     string? sortBy, string? sortDir) =>
 {
-    var subjectId = http.GetSubjectId();
+    var subjectId = http.User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value;
+    if (string.IsNullOrWhiteSpace(subjectId))
+        return Results.Unauthorized();
 
     var spec = PagedSpec.For<Chain>(c => c.Id)
         .RequirePermission(RetailPermissionKeys.ChainView)

--- a/web/content/docs/fga/list-filter.mdx
+++ b/web/content/docs/fga/list-filter.mdx
@@ -7,6 +7,8 @@ section: fga
 
 `GetAuthorizationFilterAsync` returns a filter for `Where(...)`. Lists only rows the subject may see. Use this on list endpoints.
 
+This is a read-side helper. Lifecycle-managed domain rows normally implement `ISqlOSResourceEntity`; the filter only needs the inherited `ResourceId` contract to join application rows to accessible FGA resources.
+
 ## Basic usage
 
 ```csharp

--- a/web/content/docs/fga/mutation-create-resource.mdx
+++ b/web/content/docs/fga/mutation-create-resource.mdx
@@ -1,101 +1,110 @@
 ---
 title: "Mutations"
-description: "Authorize writes and create resources in the hierarchy."
+description: "Authorize writes while SqlOS syncs entity-backed resources."
 order: 11
 section: fga
 ---
 
-For create, update, and delete operations, check authorization first with `CheckAccessAsync`, then perform the mutation.
+For create, update, and delete operations, check authorization first with `CheckAccessAsync`, then mutate your EF entity. If the entity implements `ISqlOSResourceEntity` and the DbContext derives from `SqlOSDbContext<TContext>`, SqlOS keeps the backing FGA resource row synchronized when EF saves.
 
 ## Create pattern
 
-1. Check permission on the parent resource
-2. Create the FGA resource
-3. Create your domain entity with the resource ID
-4. Save in one transaction
+1. Check permission on the parent resource.
+2. Create the domain entity.
+3. Assign a stable `ResourceId` before save.
+4. Save the entity. SqlOS syncs the `SqlOSFgaResource` row in the same EF save.
 
 ```csharp
-app.MapPost("/api/chains/{chainId}/locations", async (
-    string chainId,
-    CreateLocationRequest request,
-    ExampleAppDbContext context,
+app.MapPost("/api/workspaces", async (
+    CreateWorkspaceRequest request,
+    AppDbContext db,
     ISqlOSFgaAuthService authService,
-    HttpContext http) =>
+    HttpContext http,
+    CancellationToken ct) =>
 {
-    var subjectId = http.GetSubjectId();
-    var chain = await context.Chains.FindAsync(chainId);
-    if (chain == null) return Results.NotFound();
+    var subjectId = http.SqlOSUserId();
+    var organizationResourceId = $"org::{request.OrganizationId}";
 
     var access = await authService.CheckAccessAsync(
-        subjectId, "LOCATION_EDIT", chain.ResourceId);
+        subjectId,
+        "WORKSPACE_MANAGE",
+        organizationResourceId);
     if (!access.Allowed)
         return Results.Json(new { error = "Permission denied" }, statusCode: 403);
 
-    var resourceId = context.CreateResource(
-        chain.ResourceId, request.Name, "location");
-
-    var location = new Location
+    var workspaceId = Guid.NewGuid();
+    var workspace = new Workspace
     {
-        ResourceId = resourceId,
-        ChainId = chainId,
-        Name = request.Name,
-        Address = request.Address
+        Id = workspaceId,
+        ResourceId = $"workspace::{workspaceId:D}",
+        OrganizationId = request.OrganizationId,
+        Name = request.Name.Trim()
     };
-    context.Locations.Add(location);
-    await context.SaveChangesAsync();
 
-    return Results.Created($"/api/locations/{location.Id}", location);
+    db.Workspaces.Add(workspace);
+    await db.SaveChangesAsync(ct);
+
+    return Results.Created($"/api/workspaces/{workspace.Id}", workspace);
 });
 ```
 
 ## Update pattern
 
 ```csharp
-app.MapPut("/api/chains/{id}", async (
-    string id,
-    UpdateChainRequest request,
-    ExampleAppDbContext context,
+app.MapPut("/api/workspaces/{id}", async (
+    Guid id,
+    UpdateWorkspaceRequest request,
+    AppDbContext db,
     ISqlOSFgaAuthService authService,
-    HttpContext http) =>
+    HttpContext http,
+    CancellationToken ct) =>
 {
-    var subjectId = http.GetSubjectId();
-    var chain = await context.Chains.FindAsync(id);
-    if (chain == null) return Results.NotFound();
+    var subjectId = http.SqlOSUserId();
+    var workspace = await db.Workspaces.FindAsync([id], ct);
+    if (workspace == null) return Results.NotFound();
 
     var access = await authService.CheckAccessAsync(
-        subjectId, "CHAIN_EDIT", chain.ResourceId);
+        subjectId,
+        "WORKSPACE_MANAGE",
+        workspace.ResourceId);
     if (!access.Allowed)
         return Results.Json(new { error = "Permission denied" }, statusCode: 403);
 
-    chain.Name = request.Name;
-    chain.Description = request.Description;
-    await context.SaveChangesAsync();
+    workspace.Name = request.Name.Trim();
+    await db.SaveChangesAsync(ct);
 
-    return Results.Ok(chain);
+    return Results.Ok(workspace);
 });
 ```
+
+Because `ResourceName => Name`, the backing FGA resource display name updates with the entity.
 
 ## Delete pattern
 
 ```csharp
-app.MapDelete("/api/chains/{id}", async (
-    string id,
-    ExampleAppDbContext context,
+app.MapDelete("/api/workspaces/{id}", async (
+    Guid id,
+    AppDbContext db,
     ISqlOSFgaAuthService authService,
-    HttpContext http) =>
+    HttpContext http,
+    CancellationToken ct) =>
 {
-    var subjectId = http.GetSubjectId();
-    var chain = await context.Chains.FindAsync(id);
-    if (chain == null) return Results.NotFound();
+    var subjectId = http.SqlOSUserId();
+    var workspace = await db.Workspaces.FindAsync([id], ct);
+    if (workspace == null) return Results.NotFound();
 
     var access = await authService.CheckAccessAsync(
-        subjectId, "CHAIN_EDIT", chain.ResourceId);
+        subjectId,
+        "WORKSPACE_MANAGE",
+        workspace.ResourceId);
     if (!access.Allowed)
         return Results.Json(new { error = "Permission denied" }, statusCode: 403);
 
-    context.Chains.Remove(chain);
-    await context.SaveChangesAsync();
+    db.Workspaces.Remove(workspace);
+    await db.SaveChangesAsync(ct);
 
     return Results.NoContent();
 });
 ```
+
+Deletes remove the backing resource and direct grants. If child resources still reference the resource, SqlOS throws a clear exception so the application can delete or reparent children first.

--- a/web/content/docs/fga/mutation-create-resource.mdx
+++ b/web/content/docs/fga/mutation-create-resource.mdx
@@ -22,7 +22,10 @@ app.MapPost("/api/workspaces", async (
     HttpContext http,
     CancellationToken ct) =>
 {
-    var subjectId = http.SqlOSUserId();
+    var subjectId = http.User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value;
+    if (string.IsNullOrWhiteSpace(subjectId))
+        return Results.Unauthorized();
+
     var organizationResourceId = $"org::{request.OrganizationId}";
 
     var access = await authService.CheckAccessAsync(
@@ -59,7 +62,10 @@ app.MapPut("/api/workspaces/{id}", async (
     HttpContext http,
     CancellationToken ct) =>
 {
-    var subjectId = http.SqlOSUserId();
+    var subjectId = http.User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value;
+    if (string.IsNullOrWhiteSpace(subjectId))
+        return Results.Unauthorized();
+
     var workspace = await db.Workspaces.FindAsync([id], ct);
     if (workspace == null) return Results.NotFound();
 
@@ -89,7 +95,10 @@ app.MapDelete("/api/workspaces/{id}", async (
     HttpContext http,
     CancellationToken ct) =>
 {
-    var subjectId = http.SqlOSUserId();
+    var subjectId = http.User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value;
+    if (string.IsNullOrWhiteSpace(subjectId))
+        return Results.Unauthorized();
+
     var workspace = await db.Workspaces.FindAsync([id], ct);
     if (workspace == null) return Results.NotFound();
 

--- a/web/content/docs/fga/resource-hierarchy.mdx
+++ b/web/content/docs/fga/resource-hierarchy.mdx
@@ -5,7 +5,7 @@ order: 5
 section: fga
 ---
 
-Resources are a tree. One parent per node (root has none). For access checks, FGA walks **up** from the target node to root and looks for grants.
+Resources are a tree. One parent per node; root has none. For access checks, FGA walks **up** from the target node to root and looks for grants.
 
 ## Tree structure
 
@@ -14,51 +14,70 @@ Model your app's hierarchy as nested resources:
 ```
 root
 ├── org::acme (Organization)
-│   ├── chain-1 (Chain)
-│   │   ├── location-1 (Location)
-│   │   │   ├── item-1 (Inventory)
-│   │   │   └── item-2 (Inventory)
-│   │   └── location-2 (Location)
-│   └── chain-2 (Chain)
+│   ├── workspace::1 (Workspace)
+│   │   └── document::1 (Document)
+│   └── workspace::2 (Workspace)
 └── org::globex (Organization)
-    └── chain-3 (Chain)
+    └── workspace::3 (Workspace)
 ```
 
-## Create a resource
+## Entity-backed hierarchy
 
-Use `CreateResource` to add a node to the tree:
+For protected application rows, implement `ISqlOSResourceEntity` and return the parent resource ID from `ParentResourceId`.
 
 ```csharp
-var resourceId = context.CreateResource(
-    parentId: "org::acme",
-    name: "New Chain",
-    resourceTypeId: "chain"
-);
+public sealed class Workspace : ISqlOSResourceEntity
+{
+    public Guid Id { get; set; }
+    public string ResourceId { get; set; } = "";
+    public string OrganizationId { get; set; } = "";
+    public string Name { get; set; } = "";
+
+    public string ResourceTypeId => "workspace";
+    public string ResourceName => Name;
+    public string ParentResourceId => $"org::{OrganizationId}";
+    public string? ResourceDescription => null;
+    public bool ResourceIsActive => true;
+}
 ```
 
-With a custom ID:
+When the entity is saved, `SqlOSDbContext<TContext>` creates or updates the resource at that point in the hierarchy.
 
 ```csharp
-var resourceId = context.CreateResource(
-    parentId: "root",
-    name: "Acme Corp",
-    resourceTypeId: "organization",
-    id: $"org::{org.Id}"
-);
+db.Workspaces.Add(new Workspace
+{
+    Id = workspaceId,
+    ResourceId = $"workspace::{workspaceId:D}",
+    OrganizationId = organizationId,
+    Name = "Operations"
+});
+
+await db.SaveChangesAsync(ct);
 ```
 
-`CreateResource` adds the resource to the EF Core change tracker. Call `SaveChangesAsync` to persist.
+## Non-entity roots
+
+Use manual resource APIs for hierarchy nodes that are not application rows, such as tenant or organization roots:
+
+```csharp
+await db.ProvisionResourceWithIdAsync(
+    $"org::{organization.Id}",
+    "organization",
+    organization.Name,
+    parentResourceId: "root",
+    cancellationToken: ct);
+```
 
 ## How inheritance works
 
-When checking `CHAIN_VIEW` on `chain-1`:
+When checking `WORKSPACE_VIEW` on `workspace::1`:
 
-1. Check grants directly on `chain-1`
-2. Check grants on `org::acme` (parent)
-3. Check grants on `root` (grandparent)
-4. If any ancestor has a grant with a role that includes `CHAIN_VIEW`, access is allowed
+1. Check grants directly on `workspace::1`.
+2. Check grants on `org::acme`.
+3. Check grants on `root`.
+4. If any ancestor has a grant with a role that includes `WORKSPACE_VIEW`, access is allowed.
 
-This means a single grant at the organization level gives access to everything underneath, without creating per-resource grants.
+This means a single grant at the organization level can authorize resources underneath it without creating per-resource grants.
 
 ## Browse in the dashboard
 

--- a/web/content/docs/fga/subject-types.mdx
+++ b/web/content/docs/fga/subject-types.mdx
@@ -14,59 +14,71 @@ A subject is the entity being authorized. Every grant links a subject to a role 
 | `user` | `SqlOSFgaUser` | Human users (synced from AuthServer) |
 | `agent` | `SqlOSFgaAgent` | AI agents, bots, automated processes |
 | `service_account` | `SqlOSFgaServiceAccount` | API keys for service-to-service access |
-| `user_group` | `SqlOSFgaUserGroup` | Logical groups of users |
+| `group` | `SqlOSFgaUserGroup` | Logical groups of subjects |
 
-## Create a subject
+## Provision subjects
 
-**Users** are typically synced from AuthServer on login (see [Syncing Auth to FGA](/docs/fga/syncing-auth-to-fga)):
-
-```csharp
-context.Set<SqlOSFgaSubject>().Add(new SqlOSFgaSubject
-{
-    Id = user.Id,
-    SubjectTypeId = "user",
-    DisplayName = user.DisplayName,
-    OrganizationId = organizationId,
-    ExternalRef = user.Id
-});
-```
-
-**Agents** and **service accounts** can be created through the dashboard or seeded in startup:
+Use the SDK provisioning helpers for users, agents, and service accounts. The app resolves the current subject ID at its own request boundary, then passes that explicit ID into FGA.
 
 ```csharp
-context.Set<SqlOSFgaSubject>().Add(new SqlOSFgaSubject
-{
-    Id = "inventory_sync_agent",
-    SubjectTypeId = "agent",
-    DisplayName = "Inventory Sync Agent"
-});
+using SqlOS.Extensions;
+
+await context.ProvisionUserSubjectAsync(
+    subjectId,
+    displayName: displayName,
+    email: email,
+    externalRef: subjectId,
+    cancellationToken: ct);
 ```
+
+Agents and service accounts use the same explicit provisioning shape:
+
+```csharp
+await context.ProvisionAgentSubjectAsync(
+    "inventory_sync_agent",
+    displayName: "Inventory Sync Agent",
+    externalRef: "inventory-sync",
+    cancellationToken: ct);
+
+await context.ProvisionServiceAccountSubjectAsync(
+    "service_account::billing_api",
+    displayName: "Billing API",
+    clientId: "billing-api",
+    clientSecretHash: storedSecretHash,
+    description: "Billing API service account",
+    cancellationToken: ct);
+```
+
+The helpers are idempotent and update provided mutable fields without creating grants. Grants stay explicit:
+
+```csharp
+await context.GrantRoleAsync(
+    subjectId,
+    resourceId,
+    "workspace_member",
+    ct);
+```
+
+## Groups
+
+Create groups and manage group membership through `ISqlOSFgaSubjectService`:
+
+```csharp
+var group = await subjectService.CreateGroupAsync(
+    "Inventory Operators",
+    "People and agents that operate inventory workflows",
+    cancellationToken: ct);
+
+await subjectService.AddToGroupAsync(subjectId, group.Id, ct);
+```
+
+Groups are subjects with type `group`, but groups cannot be members of other groups.
 
 ## Authentication by subject type
 
-The example app supports multiple auth methods that map to different subject types:
+Authentication is application code. A bearer token, API key, or agent token can map to a user, service account, or agent subject, but FGA receives only the resolved `subjectId`.
 
-```csharp
-public static string? GetSubjectId(this HttpContext http)
-{
-    // Bearer JWT → user subject
-    var auth = http.Request.Headers.Authorization.ToString();
-    if (auth.StartsWith("Bearer "))
-        return ValidateAndGetUserId(auth);
-
-    // X-Api-Key → service account subject
-    if (http.Request.Headers.TryGetValue("X-Api-Key", out var apiKey))
-        return apiKey.ToString();
-
-    // X-Agent-Token → agent subject
-    if (http.Request.Headers.TryGetValue("X-Agent-Token", out var agent))
-        return agent.ToString();
-
-    return null;
-}
-```
-
-All subject types use the same FGA authorization -- the same `CheckAccessAsync` and `GetAuthorizationFilterAsync` calls work regardless of whether the subject is a user, agent, or service account.
+All subject types use the same FGA authorization -- the same `CheckAccessAsync` and `GetAuthorizationFilterAsync` calls work regardless of whether the subject is a user, agent, service account, or group.
 
 ## Dashboard
 

--- a/web/content/docs/fga/syncing-auth-to-fga.mdx
+++ b/web/content/docs/fga/syncing-auth-to-fga.mdx
@@ -9,34 +9,55 @@ When using both AuthServer and FGA, you need to sync authenticated users into th
 
 ## The pattern
 
-After login, ensure the user exists as an FGA subject, the organization exists as an FGA resource, and the membership is mapped to a grant:
+After login, provision the authenticated user as an FGA subject, provision any non-entity organization resource, and map the auth membership to an explicit FGA grant:
 
 ```csharp
 public async Task EnsureUserAccessAsync(
-    string userId, string organizationId, CancellationToken ct)
+    string subjectId, string organizationId, CancellationToken ct)
 {
     var user = await _context.Set<SqlOSUser>()
-        .FirstAsync(x => x.Id == userId, ct);
+        .FirstAsync(x => x.Id == subjectId, ct);
     var organization = await _context.Set<SqlOSOrganization>()
         .FirstAsync(x => x.Id == organizationId, ct);
     var membership = await _context.Set<SqlOSMembership>()
-        .FirstAsync(x => x.UserId == userId
+        .FirstAsync(x => x.UserId == subjectId
             && x.OrganizationId == organizationId
             && x.IsActive, ct);
 
-    await EnsureSubjectAsync(user, organizationId, ct);
-    await EnsureOrganizationResourceAsync(organization, ct);
-    await EnsureMembershipGrantAsync(userId, organizationId, membership.Role, ct);
+    await _context.ProvisionUserSubjectAsync(
+        subjectId,
+        displayName: user.DisplayName,
+        email: user.DefaultEmail,
+        organizationId: organizationId,
+        externalRef: subjectId,
+        isActive: user.IsActive,
+        cancellationToken: ct);
+
+    var organizationResourceId = $"org::{organizationId}";
+    await _context.ProvisionResourceWithIdAsync(
+        organizationResourceId,
+        resourceTypeId: "organization",
+        name: organization.Name,
+        parentResourceId: "root",
+        isActive: organization.IsActive,
+        cancellationToken: ct);
+
+    var roleKey = membership.Role is "admin" or "owner"
+        ? "org_admin"
+        : "org_member";
+
+    await _context.GrantRoleAsync(subjectId, organizationResourceId, roleKey, ct);
+    await _context.SaveChangesAsync(ct);
 }
 ```
 
 ## What each step does
 
-**EnsureSubjectAsync** -- creates or updates `SqlOSFgaSubject` and `SqlOSFgaUser` for the authenticated user.
+**ProvisionUserSubjectAsync** -- creates or updates the FGA subject and typed FGA user row for the authenticated user.
 
-**EnsureOrganizationResourceAsync** -- creates an `SqlOSFgaResource` for the organization under root (if it doesn't exist).
+**ProvisionResourceWithIdAsync** -- creates or updates the organization resource under root. This is a manual resource because the organization is not represented by an `ISqlOSResourceEntity` in this example.
 
-**EnsureMembershipGrantAsync** -- creates a grant linking the user to a role on the organization resource, mapping the auth membership role to an FGA role:
+**GrantRoleAsync** -- creates an idempotent grant linking the subject to a role on the organization resource, mapping the auth membership role to an FGA role:
 
 | Auth role | FGA role |
 | --- | --- |

--- a/web/content/docs/getting-started.mdx
+++ b/web/content/docs/getting-started.mdx
@@ -30,6 +30,9 @@ You'll learn how to install SqlOS, wire a minimal host, run the Todo sample, and
   <Step title="Register on your DbContext">
     Derive from `SqlOSDbContext<TContext>` and call `AddSqlOS` during host setup.
   </Step>
+  <Step title="Declare protected resources">
+    Make protected entities implement `ISqlOSResourceEntity` so SqlOS can sync FGA resource rows during EF saves.
+  </Step>
   <Step title="Map routes and verify">
     Call `MapSqlOS()`, start the app, and open the admin dashboard.
   </Step>
@@ -90,6 +93,8 @@ public sealed class AppDbContext(DbContextOptions<AppDbContext> options)
 ```
 
 If you need full EF model control, the lower-level path is still available: implement `ISqlOSAuthServerDbContext` and `ISqlOSFgaDbContext`, expose `IsResourceAccessible`, and call `modelBuilder.UseSqlOS(...)` yourself.
+
+For app data that should participate in FGA, implement `ISqlOSResourceEntity` on the domain entity. `SqlOSDbContext<TContext>` creates, updates, and deletes the matching `SqlOSFgaResource` row when you call `SaveChanges` / `SaveChangesAsync`; role grants remain explicit.
 
 `appsettings.json` needs a SQL Server connection string and optional dashboard password:
 

--- a/web/content/docs/getting-started.mdx
+++ b/web/content/docs/getting-started.mdx
@@ -141,7 +141,7 @@ options.AuthServer.SeedOwnedWebApp(
 
 ## Protect an API
 
-For API routes that accept SqlOS access tokens, protect a route group and read the validated token from `HttpContext`:
+For API routes that accept SqlOS access tokens, protect a route group with `RequireSqlOSAccessToken(...)`. It validates the token and populates `HttpContext.User`; your app still resolves the current subject explicitly at the route boundary.
 
 ```csharp
 var api = app.MapGroup("/api")
@@ -153,12 +153,15 @@ var api = app.MapGroup("/api")
 
 api.MapGet("/me", (HttpContext http) =>
 {
-    var token = http.SqlOSToken();
+    var subjectId = http.User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value;
+    if (string.IsNullOrWhiteSpace(subjectId))
+        return Results.Unauthorized();
+
     return Results.Ok(new
     {
-        userId = http.SqlOSUserId(),
-        token.ClientId,
-        token.Audience
+        subjectId,
+        clientId = http.User.FindFirst("client_id")?.Value,
+        audience = http.User.FindFirst(JwtRegisteredClaimNames.Aud)?.Value
     });
 });
 ```

--- a/web/content/docs/guides/configuration.mdx
+++ b/web/content/docs/guides/configuration.mdx
@@ -94,7 +94,7 @@ db.Workspaces.Add(workspace);
 await db.SaveChangesAsync();
 ```
 
-Manual resource APIs such as `CreateResourceWithIdAsync(...)`, `ProvisionResourceWithIdAsync(...)`, and `DeleteResourceAsync(...)` are still available for resources that are not backed by an application entity.
+Manual resource APIs such as `CreateResourceAsync(...)`, `CreateResourceWithIdAsync(...)`, `ProvisionResourceWithIdAsync(...)`, and `DeleteResourceAsync(...)` are still available for resources that are not backed by an application entity.
 
 ## Protected API helpers
 
@@ -112,10 +112,12 @@ api.MapPost("/workspaces", async (
     CreateWorkspace request,
     AppDbContext db,
     ISqlOSFgaAuthService fga,
-    HttpContext http) =>
+    HttpContext http,
+    CancellationToken ct) =>
 {
     var userId = http.SqlOSUserId();
     var workspaceId = Guid.NewGuid();
+
     var workspace = new Workspace
     {
         Id = workspaceId,
@@ -124,15 +126,24 @@ api.MapPost("/workspaces", async (
     };
 
     db.Workspaces.Add(workspace);
-    await db.EnsureSqlOSUserSubjectAsync(userId, userId);
-    await db.GrantRoleAsync(userId, workspace, "workspace_admin");
 
-    await db.SaveChangesAsync();
+    await db.ProvisionUserSubjectAsync(
+        userId,
+        displayName: userId,
+        cancellationToken: ct);
+
+    await db.GrantRoleAsync(
+        userId,
+        workspace,
+        "workspace_admin",
+        ct);
+
+    await db.SaveChangesAsync(ct);
     return Results.Created($"/api/workspaces/{workspace.Id}", workspace);
 });
 ```
 
-Grant helpers never create subjects implicitly. Provision users, agents, or service accounts explicitly with `EnsureSqlOSUserSubjectAsync(...)`, `EnsureSqlOSAgentSubjectAsync(...)`, or `EnsureSqlOSServiceAccountSubjectAsync(...)` before granting roles. Grants stay explicit; resource rows for `ISqlOSResourceEntity` instances are synced by `SaveChangesAsync()`.
+Grant helpers never create subjects implicitly. Provision users, agents, or service accounts explicitly with `ProvisionUserSubjectAsync(...)`, `ProvisionAgentSubjectAsync(...)`, or `ProvisionServiceAccountSubjectAsync(...)` before granting roles. Grants stay explicit; resource rows for `ISqlOSResourceEntity` instances are synced by `SaveChangesAsync()`.
 
 ## Client onboarding modes
 

--- a/web/content/docs/guides/configuration.mdx
+++ b/web/content/docs/guides/configuration.mdx
@@ -12,13 +12,14 @@ section: guides
   actionLabel="Getting Started"
 />
 
-You'll learn the recommended SqlOS SDK setup: host registration, DbContext inheritance, and route mapping.
+You'll learn the recommended SqlOS SDK setup: host registration, DbContext inheritance, entity-backed FGA resources, explicit role grants, and route mapping.
 
-## Wire SqlOS in three places
+## Wire SqlOS in four places
 
 1. **Host registration** — `builder.AddSqlOS<AppDbContext>(db => db.UseSqlServer(...), options => ...)`
 2. **EF model** — derive from `SqlOSDbContext<AppDbContext>` and put app entities in `OnApplicationModelCreating`
-3. **Routes** — `app.MapSqlOS()` after `Build()`
+3. **Protected resources** — make protected domain entities implement `ISqlOSResourceEntity`
+4. **Routes** — `app.MapSqlOS()` after `Build()`
 
 ## Minimal owned-app setup
 
@@ -59,6 +60,42 @@ options.Fga.Seed(seed =>
 
 Use the explicit-ID overloads when you need stable IDs that differ from public permission or role keys.
 
+## Entity-backed FGA resources
+
+For protected application data, make the domain entity describe its FGA resource. `SqlOSDbContext<TContext>` syncs the backing `SqlOSFgaResource` row when EF saves the entity.
+
+```csharp
+public sealed class Workspace : ISqlOSResourceEntity
+{
+    public Guid Id { get; set; }
+    public string ResourceId { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+
+    public string ResourceTypeId => "workspace";
+    public string ResourceName => Name;
+    public string? ParentResourceId => "root";
+    public string? ResourceDescription => null;
+    public bool ResourceIsActive => true;
+}
+```
+
+Keep `ResourceId` stable and set it before saving the entity. If you use SqlOS authorized list queries, keep `ResourceId` as an EF-visible property so it can be translated in SQL.
+
+```csharp
+var workspaceId = Guid.NewGuid();
+var workspace = new Workspace
+{
+    Id = workspaceId,
+    ResourceId = $"workspace::{workspaceId:D}",
+    Name = request.Name.Trim()
+};
+
+db.Workspaces.Add(workspace);
+await db.SaveChangesAsync();
+```
+
+Manual resource APIs such as `CreateResourceWithIdAsync(...)`, `ProvisionResourceWithIdAsync(...)`, and `DeleteResourceAsync(...)` are still available for resources that are not backed by an application entity.
+
 ## Protected API helpers
 
 Protect a route group with SqlOS access-token validation, then use the validated token and FGA helpers in endpoints:
@@ -78,19 +115,24 @@ api.MapPost("/workspaces", async (
     HttpContext http) =>
 {
     var userId = http.SqlOSUserId();
-    var workspace = new Workspace(request.Name);
+    var workspaceId = Guid.NewGuid();
+    var workspace = new Workspace
+    {
+        Id = workspaceId,
+        ResourceId = $"workspace::{workspaceId:D}",
+        Name = request.Name.Trim()
+    };
 
     db.Workspaces.Add(workspace);
     await db.EnsureSqlOSUserSubjectAsync(userId, userId);
-    await db.EnsureSqlOSResourceAsync(workspace.ResourceId, "root", workspace.Name, "workspace");
-    await db.EnsureSqlOSRoleGrantAsync(userId, workspace.ResourceId, "workspace_admin");
+    await db.GrantRoleAsync(userId, workspace, "workspace_admin");
 
     await db.SaveChangesAsync();
     return Results.Created($"/api/workspaces/{workspace.Id}", workspace);
 });
 ```
 
-Grant helpers never create subjects implicitly. Provision users, agents, or service accounts explicitly with `EnsureSqlOSUserSubjectAsync(...)`, `EnsureSqlOSAgentSubjectAsync(...)`, or `EnsureSqlOSServiceAccountSubjectAsync(...)` before granting roles.
+Grant helpers never create subjects implicitly. Provision users, agents, or service accounts explicitly with `EnsureSqlOSUserSubjectAsync(...)`, `EnsureSqlOSAgentSubjectAsync(...)`, or `EnsureSqlOSServiceAccountSubjectAsync(...)` before granting roles. Grants stay explicit; resource rows for `ISqlOSResourceEntity` instances are synced by `SaveChangesAsync()`.
 
 ## Client onboarding modes
 

--- a/web/content/docs/guides/configuration.mdx
+++ b/web/content/docs/guides/configuration.mdx
@@ -96,9 +96,9 @@ await db.SaveChangesAsync();
 
 Manual resource APIs such as `CreateResourceAsync(...)`, `CreateResourceWithIdAsync(...)`, `ProvisionResourceWithIdAsync(...)`, and `DeleteResourceAsync(...)` are still available for resources that are not backed by an application entity.
 
-## Protected API helpers
+## Protected API token validation
 
-Protect a route group with SqlOS access-token validation, then use the validated token and FGA helpers in endpoints:
+Protect a route group with SqlOS access-token validation when your API accepts SqlOS-issued tokens. The middleware validates the token and populates `HttpContext.User`; your endpoint still resolves the application subject explicitly.
 
 ```csharp
 var api = app.MapGroup("/api")
@@ -115,7 +115,10 @@ api.MapPost("/workspaces", async (
     HttpContext http,
     CancellationToken ct) =>
 {
-    var userId = http.SqlOSUserId();
+    var subjectId = http.User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value;
+    if (string.IsNullOrWhiteSpace(subjectId))
+        return Results.Unauthorized();
+
     var workspaceId = Guid.NewGuid();
 
     var workspace = new Workspace
@@ -128,12 +131,12 @@ api.MapPost("/workspaces", async (
     db.Workspaces.Add(workspace);
 
     await db.ProvisionUserSubjectAsync(
-        userId,
-        displayName: userId,
+        subjectId,
+        displayName: subjectId,
         cancellationToken: ct);
 
     await db.GrantRoleAsync(
-        userId,
+        subjectId,
         workspace,
         "workspace_admin",
         ct);

--- a/web/content/docs/guides/model-fga.mdx
+++ b/web/content/docs/guides/model-fga.mdx
@@ -38,13 +38,13 @@ options.Fga.Seed(seed =>
 });
 ```
 
-2. **Create resource instances** when your app creates domain rows (see [Creating resources](/docs/fga/creating-resources)).
+2. **Create resource-backed domain rows** by implementing `ISqlOSResourceEntity`; `SqlOSDbContext<TContext>` syncs FGA resources when EF saves. Use manual resource APIs only for non-entity roots (see [Creating resources](/docs/fga/creating-resources)).
 
 3. **Assign grants** at the right node — a grant on a workspace applies to descendant projects automatically.
 
 4. **Open `/sqlos/admin/fga/`** to inspect the tree, grants, and access tester.
 
-The retail example in `examples/SqlOS.Example.Api` (`FgaRetail`) shows chain → store → inventory hierarchies.
+The retail example in `examples/SqlOS.Example.Api` (`FgaRetail`) shows chain → store → inventory hierarchies as a lower-level/manual FGA sample. The Todo sample and configuration guide show the recommended entity-backed SDK path.
 
 ## Expected outcome
 

--- a/web/content/docs/reference/fga-api.mdx
+++ b/web/content/docs/reference/fga-api.mdx
@@ -119,9 +119,9 @@ var trace = await authService.TraceResourceAccessAsync(
 
 ---
 
-## SqlOSFgaConvenienceExtensions
+## SqlOS.Extensions
 
-Extension methods that reduce endpoint boilerplate. Available via `using SqlOS.Fga.Extensions`.
+Canonical SDK helpers for resource lifecycle, subject provisioning, and role grants. Available via `using SqlOS.Extensions`.
 
 ---
 
@@ -154,8 +154,6 @@ Manual resource APIs remain available for resources that are not backed by domai
 | `ProvisionResourceWithIdAsync(...)` | Idempotent create/update for explicit non-entity resources. |
 | `DeleteResourceAsync(...)` | Delete one resource and its direct grants without cascading child resources. |
 
-`SqlOS.Fga.Extensions.CreateResource(...)` is a lower-level/manual lifecycle helper kept for manual FGA samples and existing code. Do not use it as the normal protected-entity creation path.
-
 ---
 
 ### Subject and Grant APIs
@@ -169,6 +167,21 @@ Subjects are provisioned explicitly. Grants never create subjects implicitly.
 | `ProvisionServiceAccountSubjectAsync(...)` | Idempotently provision a service-account FGA subject and typed service-account row. |
 | `GrantRoleAsync(...)` | Idempotently grant a role by key or ID to an existing subject/resource. |
 | `RevokeRoleAsync(...)` | Remove a role grant by key or ID if it exists. |
+
+---
+
+## SqlOS.Fga.Extensions
+
+Lower-level/read-side FGA convenience extensions. Available via `using SqlOS.Fga.Extensions`.
+
+### CreateResource
+
+`CreateResource(...)` is a lower-level/manual lifecycle helper kept for manual FGA samples and existing code. Do not use it as the normal protected-entity creation path. For protected application rows, prefer `ISqlOSResourceEntity` plus `SqlOSDbContext<TContext>`.
+
+```csharp
+// Manual lifecycle sample only.
+var resourceId = context.CreateResource("retail_root", request.Name, "chain");
+```
 
 ---
 

--- a/web/content/docs/reference/fga-api.mdx
+++ b/web/content/docs/reference/fga-api.mdx
@@ -1,11 +1,11 @@
 ---
 title: "FGA API Reference"
-description: "Complete method reference for CheckAccess, GetAuthorizationFilter, CreateResource, PagedSpec, and more."
+description: "Complete method reference for access checks, entity-backed resources, grants, and FGA query helpers."
 order: 10
 section: reference
 ---
 
-Complete reference for every public method in the FGA module.
+Complete reference for the public FGA SDK surface. The recommended application path is `SqlOSDbContext<TContext>` plus `ISqlOSResourceEntity` for protected domain rows, explicit subject provisioning, and explicit role grants.
 
 ## ISqlOSFgaAuthService
 
@@ -87,7 +87,7 @@ var chains = await dbContext.Chains
 | `subjectId` | `string` | The subject to filter for. |
 | `permissionKey` | `string` | The permission key that determines which resources are visible. |
 
-**Type constraint**: `T : IHasResourceId` — the entity must expose a `ResourceId` property.
+**Type constraint**: `T : IHasResourceId` — the entity must expose a `ResourceId` property. Protected domain entities should usually implement `ISqlOSResourceEntity`, which extends `IHasResourceId` and lets `SqlOSDbContext<TContext>` sync backing resource rows during EF saves.
 
 **Returns**
 
@@ -125,35 +125,50 @@ Extension methods that reduce endpoint boilerplate. Available via `using SqlOS.F
 
 ---
 
-### CreateResource
+### Resource Lifecycle APIs
 
-Create an `SqlOSFgaResource` in the hierarchy. Adds to the change tracker but does **not** call `SaveChangesAsync`. Returns the resource ID so you can assign it to your domain entity.
+For protected application rows, implement `ISqlOSResourceEntity` and let `SqlOSDbContext<TContext>` synchronize `SqlOSFgaResource` rows during `SaveChanges` / `SaveChangesAsync`.
 
 ```csharp
-var resourceId = context.CreateResource(
-    parentId: "retail_root",
-    name: request.Name,
-    resourceTypeId: "chain"
-);
+public sealed class Workspace : ISqlOSResourceEntity
+{
+    public Guid Id { get; set; }
+    public string ResourceId { get; set; } = "";
+    public string OrganizationId { get; set; } = "";
+    public string Name { get; set; } = "";
 
-var chain = new Chain { ResourceId = resourceId, Name = request.Name };
-context.Chains.Add(chain);
-await context.SaveChangesAsync();
+    public string ResourceTypeId => "workspace";
+    public string ResourceName => Name;
+    public string ParentResourceId => $"org::{OrganizationId}";
+    public string? ResourceDescription => null;
+    public bool ResourceIsActive => true;
+}
 ```
 
-**Parameters**
+Manual resource APIs remain available for resources that are not backed by domain entities:
 
-| Name | Type | Required | Description |
-|------|------|----------|-------------|
-| `context` | `ISqlOSFgaDbContext` | Yes | The DbContext (called as extension method). |
-| `parentId` | `string` | Yes | Parent resource ID in the hierarchy. |
-| `name` | `string` | Yes | Display name for the resource. |
-| `resourceTypeId` | `string` | Yes | Resource type identifier (e.g., `"chain"`, `"location"`). |
-| `id` | `string?` | No | Custom resource ID. If `null`, a GUID is generated. |
+| Method | Use |
+| --- | --- |
+| `CreateResourceAsync(...)` | Strict create with a generated resource ID. |
+| `CreateResourceWithIdAsync(...)` | Strict create with an explicit stable resource ID. |
+| `ProvisionResourceWithIdAsync(...)` | Idempotent create/update for explicit non-entity resources. |
+| `DeleteResourceAsync(...)` | Delete one resource and its direct grants without cascading child resources. |
 
-**Returns**
+`SqlOS.Fga.Extensions.CreateResource(...)` is a lower-level/manual lifecycle helper kept for manual FGA samples and existing code. Do not use it as the normal protected-entity creation path.
 
-`string` — the resource ID (either the provided `id` or the auto-generated GUID).
+---
+
+### Subject and Grant APIs
+
+Subjects are provisioned explicitly. Grants never create subjects implicitly.
+
+| Method | Use |
+| --- | --- |
+| `ProvisionUserSubjectAsync(...)` | Idempotently provision a user FGA subject and typed user row. |
+| `ProvisionAgentSubjectAsync(...)` | Idempotently provision an agent FGA subject and typed agent row. |
+| `ProvisionServiceAccountSubjectAsync(...)` | Idempotently provision a service-account FGA subject and typed service-account row. |
+| `GrantRoleAsync(...)` | Idempotently grant a role by key or ID to an existing subject/resource. |
+| `RevokeRoleAsync(...)` | Remove a role grant by key or ID if it exists. |
 
 ---
 
@@ -305,9 +320,26 @@ var total = await executor.CountAsync(context.Chains, spec, subjectId);
 
 ---
 
+## ISqlOSResourceEntity
+
+Recommended resource lifecycle contract for protected application rows. It extends `IHasResourceId` and gives `SqlOSDbContext<TContext>` enough metadata to create, update, and delete backing FGA resources during EF saves.
+
+```csharp
+public interface ISqlOSResourceEntity : IHasResourceId
+{
+    string ResourceTypeId { get; }
+    string ResourceName { get; }
+    string? ParentResourceId { get; }
+    string? ResourceDescription { get; }
+    bool ResourceIsActive { get; }
+}
+```
+
+---
+
 ## IHasResourceId
 
-Interface that connects domain entities to FGA resources. Required for `GetAuthorizationFilterAsync`, `AuthorizedDetailAsync`, and `ISpecificationExecutor`.
+Lower-level filter contract that exposes an entity's FGA resource ID. Required for `GetAuthorizationFilterAsync`, `AuthorizedDetailAsync`, and `ISpecificationExecutor`. `ISqlOSResourceEntity` extends this interface and is the recommended contract for normal protected domain rows.
 
 ```csharp
 public interface IHasResourceId
@@ -316,7 +348,7 @@ public interface IHasResourceId
 }
 ```
 
-**Implementation**
+**Lower-level implementation**
 
 ```csharp
 public class Chain : IHasResourceId

--- a/web/content/docs/reference/sdk-reference.mdx
+++ b/web/content/docs/reference/sdk-reference.mdx
@@ -221,11 +221,33 @@ var chains = await dbContext.Chains.Where(filter).ToListAsync();
 var trace = await authService.TraceResourceAccessAsync(subjectId, resourceId, "CHAIN_VIEW");
 ```
 
-### CreateResource Extension
+### Resource Lifecycle
 
 ```csharp
-var resourceId = context.CreateResource(parentId, name, resourceTypeId);
-var resourceId = context.CreateResource(parentId, name, resourceTypeId, id: "custom-id");
+public sealed class Workspace : ISqlOSResourceEntity
+{
+    public string Name { get; set; } = "";
+    public string OrganizationResourceId { get; set; } = "";
+    public string ResourceId { get; set; } = "";
+
+    public string ResourceTypeId => "workspace";
+    public string ResourceName => Name;
+    public string? ParentResourceId => OrganizationResourceId;
+    public string? ResourceDescription => null;
+    public bool ResourceIsActive => true;
+}
+
+await db.SaveChangesAsync(ct); // syncs the backing SqlOSFgaResource row
+```
+
+Manual non-entity resources use `CreateResourceAsync(...)`, `CreateResourceWithIdAsync(...)`, `ProvisionResourceWithIdAsync(...)`, and `DeleteResourceAsync(...)`.
+
+### Subject and Grant Helpers
+
+```csharp
+await db.ProvisionUserSubjectAsync(userId, displayName: userId, cancellationToken: ct);
+await db.GrantRoleAsync(userId, workspace, "workspace_admin", ct);
+await db.RevokeRoleAsync(userId, workspace.ResourceId, "workspace_admin", ct);
 ```
 
 ### AuthorizedDetailAsync Extension
@@ -280,11 +302,12 @@ var result = await executor.ExecuteAsync(dbContext.Chains, spec, subjectId, chai
 
 | Namespace | Contents |
 | --- | --- |
-| `SqlOS` | Bootstrap, options |
+| `SqlOS` | Bootstrap, options, `SqlOSDbContext<TContext>` |
 | `SqlOS.AuthServer.Services` | Auth service classes |
 | `SqlOS.AuthServer.Contracts` | Request/response types |
 | `SqlOS.AuthServer.Models` | EF Core entities |
-| `SqlOS.Fga.Interfaces` | `ISqlOSFgaAuthService`, `IHasResourceId` |
+| `SqlOS.Fga.Interfaces` | `ISqlOSFgaAuthService`, `IHasResourceId`, `ISqlOSResourceEntity` |
+| `SqlOS.Extensions` | `ProvisionUserSubjectAsync`, `ProvisionAgentSubjectAsync`, `ProvisionServiceAccountSubjectAsync`, `GrantRoleAsync`, `RevokeRoleAsync`, manual resource APIs |
 | `SqlOS.Fga.Extensions` | Convenience extensions |
 | `SqlOS.Fga.Models` | FGA entities |
 | `SqlOS.Fga.Specifications` | PagedSpec, ISpecificationExecutor |

--- a/web/content/docs/reference/sdk-reference.mdx
+++ b/web/content/docs/reference/sdk-reference.mdx
@@ -245,9 +245,9 @@ Manual non-entity resources use `CreateResourceAsync(...)`, `CreateResourceWithI
 ### Subject and Grant Helpers
 
 ```csharp
-await db.ProvisionUserSubjectAsync(userId, displayName: userId, cancellationToken: ct);
-await db.GrantRoleAsync(userId, workspace, "workspace_admin", ct);
-await db.RevokeRoleAsync(userId, workspace.ResourceId, "workspace_admin", ct);
+await db.ProvisionUserSubjectAsync(subjectId, displayName: subjectId, cancellationToken: ct);
+await db.GrantRoleAsync(subjectId, workspace, "workspace_admin", ct);
+await db.RevokeRoleAsync(subjectId, workspace.ResourceId, "workspace_admin", ct);
 ```
 
 ### AuthorizedDetailAsync Extension


### PR DESCRIPTION
## Summary
- add ISqlOSResourceEntity and have SqlOSDbContext sync backing FGA resource rows during SaveChanges/SaveChangesAsync
- add explicit manual resource APIs plus idempotent GrantRoleAsync/RevokeRoleAsync helpers
- update the Todo sample, configuration docs, getting started, and authorized-list blog to lead with entity-backed resources

## Validation
- dotnet test tests/SqlOS.Tests/SqlOS.Tests.csproj
- ./scripts/docs-check.sh
- dotnet build examples/SqlOS.Todo.Api/SqlOS.Todo.Api.csproj
- git diff origin/main...HEAD --check