### PR TITLE
Release SqlOS 3.15.0

### DIFF
--- a/src/SqlOS/SqlOS.csproj
+++ b/src/SqlOS/SqlOS.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>SqlOS</PackageId>
-    <Version>3.14.4</Version>
+    <Version>3.15.0</Version>
     <Authors>Ross Slaney</Authors>
     <Description>Embedded auth server and fine-grained authorization runtime for .NET + SQL Server + EF Core.</Description>
     <PackageTags>authentication;authorization;fga;saml;jwt;sessions;efcore;sqlserver</PackageTags>


### PR DESCRIPTION
## Summary
- Bump SqlOS package version from 3.14.4 to 3.15.0 after the merged resource/entity ergonomics work.

## Validation
- git diff --check
- dotnet build src/SqlOS/SqlOS.csproj
