### PR TITLE
P2: Add calendar integration for Google and Microsoft

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Think **WorkOS / AuthKit**, but **self-hosted** and **your database**.
 - **Sessions & Refresh Tokens** — full lifecycle management with revocation
 - **Signing Key Rotation** — automatic RS256 key rotation with configurable intervals
 - **Email OTP** — passwordless sign-in with Azure Communication Services Email
+- **Calendar Integration** — Google Calendar and Microsoft 365 connections per user or organization with encrypted tokens and connection-only, read-pull, or two-way modes
 - **Audit Logging** — track authentication events across your system
 
 ### FGA (Fine-Grained Authorization)

--- a/examples/SqlOS.Example.Api/Endpoints/ExampleCalendarEndpoints.cs
+++ b/examples/SqlOS.Example.Api/Endpoints/ExampleCalendarEndpoints.cs
@@ -1,0 +1,191 @@
+using System.IdentityModel.Tokens.Jwt;
+using SqlOS.AuthServer.Services;
+using SqlOS.Calendar.Contracts;
+using SqlOS.Calendar.Models;
+using SqlOS.Calendar.Services;
+
+namespace SqlOS.Example.Api.Endpoints;
+
+/// <summary>
+/// Demonstrates SqlOS calendar integration from a consuming app:
+/// starting a connect flow for the signed-in user, reading normalized events
+/// imported by read-pull sync, and using the connection-only token accessor.
+/// The seeded Google/Microsoft social connections provide the OAuth apps, so
+/// no extra provider registration is needed beyond granting calendar scopes.
+/// </summary>
+public static class ExampleCalendarEndpoints
+{
+    public static void MapExampleCalendarEndpoints(this WebApplication app)
+    {
+        var calendar = app.MapGroup("/api/calendar");
+        calendar.ExcludeFromDescription();
+
+        // Start a calendar connect flow for the signed-in user. The response contains the
+        // provider authorization URL; the SPA redirects the browser there, SqlOS handles the
+        // provider callback, and the user lands back on returnUri with ?calendarConnectionId=...
+        calendar.MapPost("/connect/start", async (
+            StartCalendarConnectBody body,
+            HttpContext httpContext,
+            SqlOSCalendarService calendarService,
+            SqlOSOidcAuthService oidcAuthService,
+            CancellationToken cancellationToken) =>
+        {
+            var userId = httpContext.User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value;
+            if (string.IsNullOrWhiteSpace(userId))
+            {
+                return Results.Unauthorized();
+            }
+
+            var providers = await oidcAuthService.ListEnabledProvidersAsync(cancellationToken);
+            var provider = providers.FirstOrDefault(x =>
+                string.Equals(x.ProviderType, body.Provider, StringComparison.OrdinalIgnoreCase));
+            if (provider == null)
+            {
+                return Results.BadRequest(new
+                {
+                    message = $"No enabled '{body.Provider}' social connection is seeded. Configure SqlOS:Oidc:{body.Provider}:* first."
+                });
+            }
+
+            if (!Enum.TryParse<SqlOSCalendarIntegrationMode>(body.Mode, ignoreCase: true, out var mode))
+            {
+                mode = SqlOSCalendarIntegrationMode.ReadPull;
+            }
+
+            try
+            {
+                var result = await calendarService.StartConnectAsync(
+                    new SqlOSStartCalendarConnectRequest(
+                        provider.ConnectionId,
+                        mode,
+                        body.ReturnUri,
+                        UserId: userId,
+                        LoginHintEmail: httpContext.User.FindFirst("email")?.Value),
+                    httpContext,
+                    cancellationToken);
+
+                return Results.Ok(new
+                {
+                    authorizationUrl = result.AuthorizationUrl,
+                    provider = result.ProviderType.ToString(),
+                    mode = result.Mode.ToString()
+                });
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.BadRequest(new { message = ex.Message });
+            }
+        });
+
+        // List the signed-in user's calendar connections.
+        calendar.MapGet("/connections", async (
+            HttpContext httpContext,
+            SqlOSCalendarService calendarService,
+            CancellationToken cancellationToken) =>
+        {
+            var userId = httpContext.User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value;
+            if (string.IsNullOrWhiteSpace(userId))
+            {
+                return Results.Unauthorized();
+            }
+
+            return Results.Ok(await calendarService.ListConnectionsAsync(userId: userId, cancellationToken: cancellationToken));
+        });
+
+        // Read-pull demo: normalized events imported by SqlOS sync for one connection.
+        calendar.MapGet("/connections/{connectionId}/events", async (
+            string connectionId,
+            DateTime? from,
+            DateTime? to,
+            HttpContext httpContext,
+            SqlOSCalendarService calendarService,
+            CancellationToken cancellationToken) =>
+        {
+            var userId = httpContext.User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value;
+            if (string.IsNullOrWhiteSpace(userId))
+            {
+                return Results.Unauthorized();
+            }
+
+            try
+            {
+                var events = await calendarService.ListEventsAsync(
+                    connectionId,
+                    from ?? DateTime.UtcNow.Date,
+                    to ?? DateTime.UtcNow.Date.AddDays(30),
+                    forUserId: userId,
+                    cancellationToken: cancellationToken);
+                return Results.Ok(events);
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.BadRequest(new { message = ex.Message });
+            }
+        });
+
+        // Trigger a sync now instead of waiting for the background scheduler.
+        calendar.MapPost("/connections/{connectionId}/sync", async (
+            string connectionId,
+            HttpContext httpContext,
+            SqlOSCalendarService calendarService,
+            SqlOSCalendarSyncService syncService,
+            CancellationToken cancellationToken) =>
+        {
+            var userId = httpContext.User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value;
+            if (string.IsNullOrWhiteSpace(userId))
+            {
+                return Results.Unauthorized();
+            }
+
+            try
+            {
+                // Ownership check before the admin-shaped sync call.
+                await calendarService.GetConnectionAsync(connectionId, forUserId: userId, cancellationToken: cancellationToken);
+                return Results.Ok(await syncService.SyncConnectionAsync(connectionId, cancellationToken));
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.BadRequest(new { message = ex.Message });
+            }
+        });
+
+        // Connection-only demo: fetch a short-lived provider access token and call
+        // Google/Microsoft directly from the app. SqlOS never stores event copies here.
+        calendar.MapGet("/connections/{connectionId}/token", async (
+            string connectionId,
+            HttpContext httpContext,
+            SqlOSCalendarService calendarService,
+            CancellationToken cancellationToken) =>
+        {
+            var userId = httpContext.User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value;
+            if (string.IsNullOrWhiteSpace(userId))
+            {
+                return Results.Unauthorized();
+            }
+
+            try
+            {
+                var token = await calendarService.GetAccessTokenAsync(
+                    connectionId,
+                    forUserId: userId,
+                    cancellationToken: cancellationToken);
+                return Results.Ok(new
+                {
+                    accessToken = token.AccessToken,
+                    expiresAt = token.ExpiresAt,
+                    provider = token.ProviderType.ToString(),
+                    scopes = token.Scopes
+                });
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.BadRequest(new { message = ex.Message });
+            }
+        });
+    }
+
+    public sealed record StartCalendarConnectBody(
+        string Provider,
+        string ReturnUri,
+        string? Mode = null);
+}

--- a/examples/SqlOS.Example.Api/Program.cs
+++ b/examples/SqlOS.Example.Api/Program.cs
@@ -353,6 +353,7 @@ app.Use(async (context, next) =>
 
 app.MapExampleAuthEndpoints();
 app.MapExampleEndpoints();
+app.MapExampleCalendarEndpoints();
 app.MapDemoEndpoints();
 app.MapChainEndpoints();
 app.MapLocationEndpoints();

--- a/src/SqlOS/AuthServer/Schema/026_CalendarIntegration.sql
+++ b/src/SqlOS/AuthServer/Schema/026_CalendarIntegration.sql
@@ -1,0 +1,99 @@
+IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'SqlOSCalendarConnections' AND schema_id = SCHEMA_ID('{Schema}'))
+BEGIN
+    CREATE TABLE [{Schema}].[SqlOSCalendarConnections] (
+        [Id] NVARCHAR(64) NOT NULL PRIMARY KEY,
+        [ProviderType] NVARCHAR(40) NOT NULL,
+        [Mode] NVARCHAR(40) NOT NULL,
+        [Status] NVARCHAR(40) NOT NULL,
+        [OidcConnectionId] NVARCHAR(64) NOT NULL,
+        [UserId] NVARCHAR(64) NULL,
+        [OrganizationId] NVARCHAR(64) NULL,
+        [DisplayName] NVARCHAR(200) NOT NULL,
+        [ProviderAccountEmail] NVARCHAR(320) NULL,
+        [ProviderAccountSubject] NVARCHAR(256) NULL,
+        [ScopesJson] NVARCHAR(MAX) NOT NULL,
+        [AccessTokenEncrypted] NVARCHAR(MAX) NULL,
+        [RefreshTokenEncrypted] NVARCHAR(MAX) NULL,
+        [AccessTokenExpiresAt] DATETIME2 NULL,
+        [LastSyncAt] DATETIME2 NULL,
+        [LastError] NVARCHAR(1000) NULL,
+        [LastErrorAt] DATETIME2 NULL,
+        [CreatedAt] DATETIME2 NOT NULL,
+        [UpdatedAt] DATETIME2 NOT NULL,
+        [RevokedAt] DATETIME2 NULL,
+        [RevokedReason] NVARCHAR(160) NULL,
+        CONSTRAINT [FK_SqlOSCalendarConnections_Users]
+            FOREIGN KEY ([UserId]) REFERENCES [{Schema}].[SqlOSUsers]([Id]),
+        CONSTRAINT [FK_SqlOSCalendarConnections_Organizations]
+            FOREIGN KEY ([OrganizationId]) REFERENCES [{Schema}].[SqlOSOrganizations]([Id]),
+        CONSTRAINT [FK_SqlOSCalendarConnections_OidcConnections]
+            FOREIGN KEY ([OidcConnectionId]) REFERENCES [{Schema}].[SqlOSAuthOidcConnections]([Id])
+    );
+
+    CREATE INDEX [IX_SqlOSCalendarConnections_UserId_RevokedAt]
+        ON [{Schema}].[SqlOSCalendarConnections] ([UserId], [RevokedAt]);
+    CREATE INDEX [IX_SqlOSCalendarConnections_OrganizationId_RevokedAt]
+        ON [{Schema}].[SqlOSCalendarConnections] ([OrganizationId], [RevokedAt]);
+    CREATE INDEX [IX_SqlOSCalendarConnections_Mode_Status]
+        ON [{Schema}].[SqlOSCalendarConnections] ([Mode], [Status]);
+END
+
+GO
+
+IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'SqlOSCalendarSyncStates' AND schema_id = SCHEMA_ID('{Schema}'))
+BEGIN
+    CREATE TABLE [{Schema}].[SqlOSCalendarSyncStates] (
+        [Id] NVARCHAR(64) NOT NULL PRIMARY KEY,
+        [CalendarConnectionId] NVARCHAR(64) NOT NULL,
+        [ProviderCalendarId] NVARCHAR(256) NOT NULL,
+        [DisplayName] NVARCHAR(200) NULL,
+        [IsSyncEnabled] BIT NOT NULL,
+        [SyncCursor] NVARCHAR(MAX) NULL,
+        [LastSyncStartedAt] DATETIME2 NULL,
+        [LastSyncCompletedAt] DATETIME2 NULL,
+        [LastSyncStatus] NVARCHAR(40) NULL,
+        [LastSyncError] NVARCHAR(1000) NULL,
+        [EventCount] INT NOT NULL CONSTRAINT [DF_SqlOSCalendarSyncStates_EventCount] DEFAULT (0),
+        [CreatedAt] DATETIME2 NOT NULL,
+        [UpdatedAt] DATETIME2 NOT NULL,
+        CONSTRAINT [FK_SqlOSCalendarSyncStates_Connections]
+            FOREIGN KEY ([CalendarConnectionId]) REFERENCES [{Schema}].[SqlOSCalendarConnections]([Id]) ON DELETE CASCADE
+    );
+
+    CREATE UNIQUE INDEX [IX_SqlOSCalendarSyncStates_Connection_Calendar]
+        ON [{Schema}].[SqlOSCalendarSyncStates] ([CalendarConnectionId], [ProviderCalendarId]);
+END
+
+GO
+
+IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'SqlOSCalendarEvents' AND schema_id = SCHEMA_ID('{Schema}'))
+BEGIN
+    CREATE TABLE [{Schema}].[SqlOSCalendarEvents] (
+        [Id] NVARCHAR(64) NOT NULL PRIMARY KEY,
+        [CalendarConnectionId] NVARCHAR(64) NOT NULL,
+        [ProviderCalendarId] NVARCHAR(256) NOT NULL,
+        [ProviderEventId] NVARCHAR(512) NOT NULL,
+        [Subject] NVARCHAR(500) NULL,
+        [StartsAtUtc] DATETIME2 NOT NULL,
+        [EndsAtUtc] DATETIME2 NOT NULL,
+        [IsAllDay] BIT NOT NULL,
+        [ShowAs] NVARCHAR(20) NOT NULL,
+        [Status] NVARCHAR(20) NOT NULL,
+        [Location] NVARCHAR(500) NULL,
+        [Origin] NVARCHAR(20) NOT NULL,
+        [CreatedAt] DATETIME2 NOT NULL,
+        [UpdatedAt] DATETIME2 NOT NULL,
+        CONSTRAINT [FK_SqlOSCalendarEvents_Connections]
+            FOREIGN KEY ([CalendarConnectionId]) REFERENCES [{Schema}].[SqlOSCalendarConnections]([Id]) ON DELETE CASCADE
+    );
+
+    CREATE UNIQUE INDEX [IX_SqlOSCalendarEvents_ProviderEvent]
+        ON [{Schema}].[SqlOSCalendarEvents] ([CalendarConnectionId], [ProviderCalendarId], [ProviderEventId]);
+    CREATE INDEX [IX_SqlOSCalendarEvents_Connection_StartsAtUtc]
+        ON [{Schema}].[SqlOSCalendarEvents] ([CalendarConnectionId], [StartsAtUtc]);
+END
+
+GO
+
+DELETE FROM [{Schema}].[SqlOSSchema];
+INSERT INTO [{Schema}].[SqlOSSchema] ([Version]) VALUES (26);

--- a/src/SqlOS/AuthServer/Schema/026_CalendarIntegration.sql
+++ b/src/SqlOS/AuthServer/Schema/026_CalendarIntegration.sql
@@ -1,4 +1,7 @@
 IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'SqlOSCalendarConnections' AND schema_id = SCHEMA_ID('{Schema}'))
+   AND OBJECT_ID('{Schema}.SqlOSUsers', 'U') IS NOT NULL
+   AND OBJECT_ID('{Schema}.SqlOSOrganizations', 'U') IS NOT NULL
+   AND OBJECT_ID('{Schema}.SqlOSAuthOidcConnections', 'U') IS NOT NULL
 BEGIN
     CREATE TABLE [{Schema}].[SqlOSCalendarConnections] (
         [Id] NVARCHAR(64) NOT NULL PRIMARY KEY,
@@ -41,6 +44,7 @@ END
 GO
 
 IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'SqlOSCalendarSyncStates' AND schema_id = SCHEMA_ID('{Schema}'))
+   AND OBJECT_ID('{Schema}.SqlOSCalendarConnections', 'U') IS NOT NULL
 BEGIN
     CREATE TABLE [{Schema}].[SqlOSCalendarSyncStates] (
         [Id] NVARCHAR(64) NOT NULL PRIMARY KEY,
@@ -67,6 +71,7 @@ END
 GO
 
 IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'SqlOSCalendarEvents' AND schema_id = SCHEMA_ID('{Schema}'))
+   AND OBJECT_ID('{Schema}.SqlOSCalendarConnections', 'U') IS NOT NULL
 BEGIN
     CREATE TABLE [{Schema}].[SqlOSCalendarEvents] (
         [Id] NVARCHAR(64) NOT NULL PRIMARY KEY,

--- a/src/SqlOS/Calendar/Configuration/SqlOSCalendarModelConfiguration.cs
+++ b/src/SqlOS/Calendar/Configuration/SqlOSCalendarModelConfiguration.cs
@@ -1,0 +1,93 @@
+using Microsoft.EntityFrameworkCore;
+using SqlOS.Calendar.Models;
+
+namespace SqlOS.Calendar.Configuration;
+
+public static class SqlOSCalendarModelConfiguration
+{
+    public static void Configure(ModelBuilder modelBuilder, string schema)
+    {
+        modelBuilder.Entity<SqlOSCalendarConnection>(entity =>
+        {
+            entity.ToTable("SqlOSCalendarConnections", schema, t => t.ExcludeFromMigrations());
+            entity.HasKey(x => x.Id);
+            entity.HasIndex(x => new { x.UserId, x.RevokedAt });
+            entity.HasIndex(x => new { x.OrganizationId, x.RevokedAt });
+            entity.HasIndex(x => new { x.Mode, x.Status });
+            entity.Property(x => x.Id).HasMaxLength(64);
+            entity.Property(x => x.ProviderType)
+                .HasConversion<string>()
+                .HasMaxLength(40);
+            entity.Property(x => x.Mode)
+                .HasConversion<string>()
+                .HasMaxLength(40);
+            entity.Property(x => x.Status)
+                .HasConversion<string>()
+                .HasMaxLength(40);
+            entity.Property(x => x.OidcConnectionId).HasMaxLength(64);
+            entity.Property(x => x.UserId).HasMaxLength(64);
+            entity.Property(x => x.OrganizationId).HasMaxLength(64);
+            entity.Property(x => x.DisplayName).HasMaxLength(200);
+            entity.Property(x => x.ProviderAccountEmail).HasMaxLength(320);
+            entity.Property(x => x.ProviderAccountSubject).HasMaxLength(256);
+            entity.Property(x => x.ScopesJson).HasColumnType("nvarchar(max)");
+            entity.Property(x => x.AccessTokenEncrypted).HasColumnType("nvarchar(max)");
+            entity.Property(x => x.RefreshTokenEncrypted).HasColumnType("nvarchar(max)");
+            entity.Property(x => x.LastError).HasMaxLength(1000);
+            entity.Property(x => x.RevokedReason).HasMaxLength(160);
+            entity.HasOne(x => x.User)
+                .WithMany()
+                .HasForeignKey(x => x.UserId)
+                .OnDelete(DeleteBehavior.Restrict);
+            entity.HasOne(x => x.Organization)
+                .WithMany()
+                .HasForeignKey(x => x.OrganizationId)
+                .OnDelete(DeleteBehavior.Restrict);
+            entity.HasOne(x => x.OidcConnection)
+                .WithMany()
+                .HasForeignKey(x => x.OidcConnectionId)
+                .OnDelete(DeleteBehavior.Restrict);
+        });
+
+        modelBuilder.Entity<SqlOSCalendarSyncState>(entity =>
+        {
+            entity.ToTable("SqlOSCalendarSyncStates", schema, t => t.ExcludeFromMigrations());
+            entity.HasKey(x => x.Id);
+            entity.HasIndex(x => new { x.CalendarConnectionId, x.ProviderCalendarId }).IsUnique();
+            entity.Property(x => x.Id).HasMaxLength(64);
+            entity.Property(x => x.CalendarConnectionId).HasMaxLength(64);
+            entity.Property(x => x.ProviderCalendarId).HasMaxLength(256);
+            entity.Property(x => x.DisplayName).HasMaxLength(200);
+            entity.Property(x => x.SyncCursor).HasColumnType("nvarchar(max)");
+            entity.Property(x => x.LastSyncStatus).HasMaxLength(40);
+            entity.Property(x => x.LastSyncError).HasMaxLength(1000);
+            entity.HasOne(x => x.CalendarConnection)
+                .WithMany(x => x.SyncStates)
+                .HasForeignKey(x => x.CalendarConnectionId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<SqlOSCalendarEvent>(entity =>
+        {
+            entity.ToTable("SqlOSCalendarEvents", schema, t => t.ExcludeFromMigrations());
+            entity.HasKey(x => x.Id);
+            entity.HasIndex(x => new { x.CalendarConnectionId, x.ProviderCalendarId, x.ProviderEventId })
+                .IsUnique()
+                .HasDatabaseName("IX_SqlOSCalendarEvents_ProviderEvent");
+            entity.HasIndex(x => new { x.CalendarConnectionId, x.StartsAtUtc });
+            entity.Property(x => x.Id).HasMaxLength(64);
+            entity.Property(x => x.CalendarConnectionId).HasMaxLength(64);
+            entity.Property(x => x.ProviderCalendarId).HasMaxLength(256);
+            entity.Property(x => x.ProviderEventId).HasMaxLength(512);
+            entity.Property(x => x.Subject).HasMaxLength(500);
+            entity.Property(x => x.ShowAs).HasMaxLength(20);
+            entity.Property(x => x.Status).HasMaxLength(20);
+            entity.Property(x => x.Location).HasMaxLength(500);
+            entity.Property(x => x.Origin).HasMaxLength(20);
+            entity.HasOne(x => x.CalendarConnection)
+                .WithMany(x => x.Events)
+                .HasForeignKey(x => x.CalendarConnectionId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+    }
+}

--- a/src/SqlOS/Calendar/Configuration/SqlOSCalendarOptions.cs
+++ b/src/SqlOS/Calendar/Configuration/SqlOSCalendarOptions.cs
@@ -1,0 +1,78 @@
+using SqlOS.Calendar.Contracts;
+
+namespace SqlOS.Calendar.Configuration;
+
+/// <summary>
+/// Options for SqlOS calendar integration. Calendar connections reuse the consumer's
+/// seeded Google/Microsoft OIDC connections for OAuth app credentials, so no additional
+/// provider registration is required beyond granting the documented calendar scopes.
+/// </summary>
+public sealed class SqlOSCalendarOptions
+{
+    /// <summary>Default Google scopes for read-only calendar access.</summary>
+    public static readonly IReadOnlyList<string> DefaultGoogleReadScopes =
+        ["https://www.googleapis.com/auth/calendar.readonly"];
+
+    /// <summary>Default Google scopes when two-way sync needs event writes.</summary>
+    public static readonly IReadOnlyList<string> DefaultGoogleWriteScopes =
+        ["https://www.googleapis.com/auth/calendar.events"];
+
+    /// <summary>Default Microsoft Graph scopes for read-only calendar access.</summary>
+    public static readonly IReadOnlyList<string> DefaultMicrosoftReadScopes =
+        ["offline_access", "Calendars.Read"];
+
+    /// <summary>Default Microsoft Graph scopes when two-way sync needs event writes.</summary>
+    public static readonly IReadOnlyList<string> DefaultMicrosoftWriteScopes =
+        ["offline_access", "Calendars.ReadWrite"];
+
+    /// <summary>
+    /// Enables the hosted calendar connect/callback endpoints and admin API. Connections can
+    /// still be managed through <see cref="Services.SqlOSCalendarService"/> when disabled.
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>How long a pending calendar connect session stays valid.</summary>
+    public TimeSpan ConnectSessionLifetime { get; set; } = TimeSpan.FromMinutes(15);
+
+    /// <summary>Access tokens are refreshed when they expire within this window.</summary>
+    public TimeSpan AccessTokenRefreshSkew { get; set; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>How far back read-pull sync imports events.</summary>
+    public int SyncWindowPastDays { get; set; } = 30;
+
+    /// <summary>How far ahead read-pull sync imports events.</summary>
+    public int SyncWindowFutureDays { get; set; } = 90;
+
+    public SqlOSCalendarSyncSchedulerOptions SyncScheduler { get; } = new();
+
+    /// <summary>
+    /// Two-way conflict policy callback. Invoked when a provider change collides with a local
+    /// copy that was created or modified through SqlOS. When null, provider changes win
+    /// (<see cref="SqlOSCalendarConflictDecision.PreferProvider"/>).
+    /// </summary>
+    public Func<SqlOSCalendarConflictContext, CancellationToken, Task<SqlOSCalendarConflictDecision>>? OnTwoWayConflictAsync { get; set; }
+
+    public SqlOSCalendarOptions ConfigureSyncScheduler(Action<SqlOSCalendarSyncSchedulerOptions> configure)
+    {
+        configure(SyncScheduler);
+        return this;
+    }
+}
+
+/// <summary>Background scheduler options for read-pull and two-way connections.</summary>
+public sealed class SqlOSCalendarSyncSchedulerOptions
+{
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>Delay before the first scheduler pass, letting the bootstrapper finish.</summary>
+    public TimeSpan InitialDelay { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>How often the scheduler scans for connections that are due for a sync.</summary>
+    public TimeSpan Interval { get; set; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>A connection is due when its last sync is older than this.</summary>
+    public TimeSpan SyncEvery { get; set; } = TimeSpan.FromMinutes(15);
+
+    /// <summary>Upper bound of connections synced per scheduler pass.</summary>
+    public int MaxConnectionsPerRun { get; set; } = 25;
+}

--- a/src/SqlOS/Calendar/Contracts/SqlOSCalendarContracts.cs
+++ b/src/SqlOS/Calendar/Contracts/SqlOSCalendarContracts.cs
@@ -1,0 +1,129 @@
+using SqlOS.Calendar.Models;
+
+namespace SqlOS.Calendar.Contracts;
+
+/// <summary>
+/// Starts a calendar connect flow. The provider OAuth app credentials come from the
+/// referenced social/OIDC connection; exactly one of <paramref name="UserId"/> and
+/// <paramref name="OrganizationId"/> must be provided.
+/// </summary>
+public sealed record SqlOSStartCalendarConnectRequest(
+    string OidcConnectionId,
+    SqlOSCalendarIntegrationMode Mode,
+    string ReturnUri,
+    string? UserId = null,
+    string? OrganizationId = null,
+    string? DisplayName = null,
+    IReadOnlyList<string>? Scopes = null,
+    string? LoginHintEmail = null);
+
+public sealed record SqlOSStartCalendarConnectResult(
+    string AuthorizationUrl,
+    string OidcConnectionId,
+    SqlOSCalendarProviderType ProviderType,
+    SqlOSCalendarIntegrationMode Mode);
+
+public sealed record SqlOSCompleteCalendarConnectResult(
+    string CalendarConnectionId,
+    SqlOSCalendarProviderType ProviderType,
+    SqlOSCalendarIntegrationMode Mode,
+    string? UserId,
+    string? OrganizationId,
+    string? ProviderAccountEmail,
+    string ReturnUri);
+
+public sealed record SqlOSCalendarConnectionSummary(
+    string Id,
+    string ProviderType,
+    string Mode,
+    string Status,
+    string? UserId,
+    string? OrganizationId,
+    string DisplayName,
+    string? ProviderAccountEmail,
+    IReadOnlyList<string> Scopes,
+    DateTime? AccessTokenExpiresAt,
+    bool HasRefreshToken,
+    DateTime? LastSyncAt,
+    string? LastError,
+    DateTime? LastErrorAt,
+    DateTime CreatedAt,
+    DateTime? RevokedAt);
+
+/// <summary>
+/// Short-lived provider access token returned to the authorized application in
+/// <see cref="SqlOSCalendarIntegrationMode.ConnectionOnly"/> mode (and available in every
+/// mode). SqlOS refreshes the token transparently when it is close to expiry.
+/// </summary>
+public sealed record SqlOSCalendarAccessTokenResult(
+    string AccessToken,
+    DateTime ExpiresAt,
+    IReadOnlyList<string> Scopes,
+    SqlOSCalendarProviderType ProviderType);
+
+/// <summary>A calendar owned by the connected provider account.</summary>
+public sealed record SqlOSCalendarSummary(
+    string ProviderCalendarId,
+    string DisplayName,
+    bool IsPrimary,
+    string? TimeZone);
+
+/// <summary>A normalized provider event, independent of Google/Microsoft payload shapes.</summary>
+public sealed record SqlOSCalendarEventSnapshot(
+    string ProviderEventId,
+    string? Subject,
+    DateTime StartsAtUtc,
+    DateTime EndsAtUtc,
+    bool IsAllDay,
+    string ShowAs,
+    string Status,
+    string? Location);
+
+/// <summary>One page of provider events plus the provider's incremental cursor when offered.</summary>
+public sealed record SqlOSCalendarEventPage(
+    IReadOnlyList<SqlOSCalendarEventSnapshot> Events,
+    string? NextSyncCursor);
+
+/// <summary>A new event pushed to the provider through two-way sync.</summary>
+public sealed record SqlOSCalendarEventDraft(
+    string? Subject,
+    DateTime StartsAtUtc,
+    DateTime EndsAtUtc,
+    bool IsAllDay = false,
+    string? Location = null,
+    string? Description = null);
+
+/// <summary>Token payload returned by provider token endpoints.</summary>
+public sealed record SqlOSCalendarTokenResult(
+    string AccessToken,
+    string? RefreshToken,
+    DateTime ExpiresAt,
+    IReadOnlyList<string> Scopes,
+    string? IdToken = null);
+
+public sealed record SqlOSCalendarSyncResult(
+    string CalendarConnectionId,
+    int CalendarsSynced,
+    int EventsUpserted,
+    int EventsRemoved,
+    IReadOnlyList<string> Errors);
+
+public enum SqlOSCalendarConflictDecision
+{
+    /// <summary>The provider version wins; the local copy is overwritten.</summary>
+    PreferProvider = 0,
+
+    /// <summary>The local copy wins; the provider change is ignored for this sync pass.</summary>
+    PreferLocal = 1
+}
+
+/// <summary>
+/// Context handed to the app's two-way conflict callback when a pulled provider event
+/// differs from a local copy that originated through SqlOS.
+/// </summary>
+public sealed record SqlOSCalendarConflictContext(
+    string CalendarConnectionId,
+    string ProviderCalendarId,
+    string ProviderEventId,
+    SqlOSCalendarEventSnapshot Local,
+    SqlOSCalendarEventSnapshot Remote);

--- a/src/SqlOS/Calendar/Extensions/EndpointRouteBuilderExtensions.cs
+++ b/src/SqlOS/Calendar/Extensions/EndpointRouteBuilderExtensions.cs
@@ -1,0 +1,207 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using SqlOS.Calendar.Services;
+using SqlOS.Configuration;
+using SqlOS.Dashboard;
+
+namespace SqlOS.Calendar.Extensions;
+
+public static class EndpointRouteBuilderExtensions
+{
+    /// <summary>
+    /// Maps the browser-facing calendar connect callback under the auth server base path
+    /// (<c>{authBasePath}/calendar/callback</c>). The connect flow itself is started
+    /// server-side through <see cref="SqlOSCalendarService.StartConnectAsync"/>.
+    /// </summary>
+    public static IEndpointRouteBuilder MapSqlOSCalendarConnect(
+        this IEndpointRouteBuilder endpoints,
+        string authBasePath)
+    {
+        var calendar = endpoints.MapGroup($"{authBasePath.TrimEnd('/')}/calendar");
+        calendar.ExcludeFromDescription();
+
+        calendar.MapGet("/callback", async (
+            HttpContext context,
+            SqlOSCalendarService calendarService,
+            CancellationToken cancellationToken) =>
+            await calendarService.HandleConnectCallbackAsync(context, cancellationToken));
+
+        return endpoints;
+    }
+
+    /// <summary>
+    /// Maps the calendar admin API under <c>{dashboardBasePath}/admin/calendar/api</c>,
+    /// guarded by the same dashboard session rules as the other admin surfaces.
+    /// </summary>
+    public static IEndpointRouteBuilder MapSqlOSCalendarAdmin(
+        this IEndpointRouteBuilder endpoints,
+        string dashboardBasePath)
+    {
+        var prefix = $"{dashboardBasePath.TrimEnd('/')}/admin/calendar";
+        var admin = endpoints.MapGroup(prefix);
+        admin.ExcludeFromDescription();
+
+        var api = admin.MapGroup("/api");
+
+        api.MapGet("/connections", async (
+            HttpContext context,
+            string? search,
+            bool? includeRevoked,
+            int? page,
+            int? pageSize,
+            SqlOSCalendarService calendarService,
+            IOptions<SqlOSOptions> options,
+            IHostEnvironment environment,
+            CancellationToken cancellationToken) =>
+        {
+            if (!await IsAdminAuthorizedAsync(context, options.Value.Dashboard, environment))
+            {
+                return Results.NotFound();
+            }
+
+            return Results.Ok(await calendarService.GetAdminConnectionsAsync(search, includeRevoked ?? true, page, pageSize, cancellationToken));
+        });
+
+        api.MapGet("/connections/{connectionId}", async (
+            HttpContext context,
+            string connectionId,
+            SqlOSCalendarService calendarService,
+            IOptions<SqlOSOptions> options,
+            IHostEnvironment environment,
+            CancellationToken cancellationToken) =>
+        {
+            if (!await IsAdminAuthorizedAsync(context, options.Value.Dashboard, environment))
+            {
+                return Results.NotFound();
+            }
+
+            try
+            {
+                return Results.Ok(await calendarService.GetAdminConnectionAsync(connectionId, cancellationToken));
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.BadRequest(new { message = ex.Message });
+            }
+        });
+
+        api.MapPost("/connections/{connectionId}/sync", async (
+            HttpContext context,
+            string connectionId,
+            SqlOSCalendarSyncService syncService,
+            IOptions<SqlOSOptions> options,
+            IHostEnvironment environment,
+            CancellationToken cancellationToken) =>
+        {
+            if (!await IsAdminAuthorizedAsync(context, options.Value.Dashboard, environment))
+            {
+                return Results.NotFound();
+            }
+
+            try
+            {
+                return Results.Ok(await syncService.SyncConnectionAsync(connectionId, cancellationToken));
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.BadRequest(new { message = ex.Message });
+            }
+        });
+
+        api.MapPost("/connections/{connectionId}/refresh", async (
+            HttpContext context,
+            string connectionId,
+            SqlOSCalendarService calendarService,
+            IOptions<SqlOSOptions> options,
+            IHostEnvironment environment,
+            CancellationToken cancellationToken) =>
+        {
+            if (!await IsAdminAuthorizedAsync(context, options.Value.Dashboard, environment))
+            {
+                return Results.NotFound();
+            }
+
+            try
+            {
+                return Results.Ok(await calendarService.ForceRefreshAsync(connectionId, cancellationToken));
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.BadRequest(new { message = ex.Message });
+            }
+        });
+
+        api.MapPost("/connections/{connectionId}/disconnect", async (
+            HttpContext context,
+            string connectionId,
+            SqlOSCalendarService calendarService,
+            IOptions<SqlOSOptions> options,
+            IHostEnvironment environment,
+            CancellationToken cancellationToken) =>
+        {
+            if (!await IsAdminAuthorizedAsync(context, options.Value.Dashboard, environment))
+            {
+                return Results.NotFound();
+            }
+
+            try
+            {
+                return Results.Ok(await calendarService.DisconnectAsync(connectionId, "admin_disconnected", cancellationToken: cancellationToken));
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.BadRequest(new { message = ex.Message });
+            }
+        });
+
+        api.MapGet("/summary", async (
+            HttpContext context,
+            SqlOSCalendarService calendarService,
+            IOptions<SqlOSOptions> options,
+            IHostEnvironment environment,
+            CancellationToken cancellationToken) =>
+        {
+            if (!await IsAdminAuthorizedAsync(context, options.Value.Dashboard, environment))
+            {
+                return Results.NotFound();
+            }
+
+            return Results.Ok(await calendarService.GetAdminSummaryAsync(cancellationToken));
+        });
+
+        return endpoints;
+    }
+
+    private static async Task<bool> IsAdminAuthorizedAsync(
+        HttpContext context,
+        SqlOSDashboardOptions options,
+        IHostEnvironment environment)
+    {
+        if (options.AuthMode == SqlOSDashboardAuthMode.Password)
+        {
+            var sessionService = context.RequestServices.GetService<SqlOSDashboardSessionService>();
+            if (sessionService == null || !sessionService.HasActiveSession(context))
+            {
+                return false;
+            }
+
+            if (options.AuthorizationCallback != null)
+            {
+                return await options.AuthorizationCallback(context);
+            }
+
+            return true;
+        }
+
+        if (options.AuthorizationCallback != null)
+        {
+            return await options.AuthorizationCallback(context);
+        }
+
+        return environment.IsDevelopment();
+    }
+}

--- a/src/SqlOS/Calendar/Interfaces/ISqlOSCalendarProviderAdapter.cs
+++ b/src/SqlOS/Calendar/Interfaces/ISqlOSCalendarProviderAdapter.cs
@@ -1,0 +1,60 @@
+using SqlOS.Calendar.Contracts;
+using SqlOS.Calendar.Models;
+
+namespace SqlOS.Calendar.Interfaces;
+
+/// <summary>
+/// Minimal provider client for calendar integration. Implementations call the provider's
+/// REST APIs directly through <see cref="IHttpClientFactory"/> so tests can substitute a
+/// fake HTTP handler, mirroring the OIDC login test strategy.
+/// </summary>
+public interface ISqlOSCalendarProviderAdapter
+{
+    SqlOSCalendarProviderType ProviderType { get; }
+
+    /// <summary>Exchanges an authorization code for calendar tokens at the connection's token endpoint.</summary>
+    Task<SqlOSCalendarTokenResult> ExchangeAuthorizationCodeAsync(
+        SqlOSCalendarProviderContext context,
+        string code,
+        string redirectUri,
+        string codeVerifier,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Exchanges a refresh token for a new access token.</summary>
+    Task<SqlOSCalendarTokenResult> RefreshAccessTokenAsync(
+        SqlOSCalendarProviderContext context,
+        string refreshToken,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Lists the calendars owned by the connected account.</summary>
+    Task<IReadOnlyList<SqlOSCalendarSummary>> ListCalendarsAsync(
+        string accessToken,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lists events for one calendar inside the window. When <paramref name="syncCursor"/> is
+    /// provided and the provider supports incremental sync, only changes are returned.
+    /// </summary>
+    Task<SqlOSCalendarEventPage> ListEventsAsync(
+        string accessToken,
+        string providerCalendarId,
+        DateTime windowStartUtc,
+        DateTime windowEndUtc,
+        string? syncCursor,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Creates an event on the provider calendar (two-way mode).</summary>
+    Task<SqlOSCalendarEventSnapshot> CreateEventAsync(
+        string accessToken,
+        string providerCalendarId,
+        SqlOSCalendarEventDraft draft,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// OAuth client configuration resolved from the underlying social/OIDC connection.
+/// </summary>
+public sealed record SqlOSCalendarProviderContext(
+    string ClientId,
+    string ClientSecret,
+    string TokenEndpoint);

--- a/src/SqlOS/Calendar/Models/SqlOSCalendarEntities.cs
+++ b/src/SqlOS/Calendar/Models/SqlOSCalendarEntities.cs
@@ -1,0 +1,157 @@
+using SqlOS.AuthServer.Models;
+
+namespace SqlOS.Calendar.Models;
+
+public enum SqlOSCalendarProviderType
+{
+    Google = 0,
+    Microsoft = 1
+}
+
+/// <summary>
+/// How a consuming application uses a calendar connection. The mode is chosen by
+/// the app when the connection is created and controls what SqlOS persists.
+/// </summary>
+public enum SqlOSCalendarIntegrationMode
+{
+    /// <summary>SqlOS stores and refreshes OAuth tokens; the app calls provider APIs directly.</summary>
+    ConnectionOnly = 0,
+
+    /// <summary>SqlOS imports events/busy blocks from the provider on a schedule.</summary>
+    ReadPull = 1,
+
+    /// <summary>SqlOS pushes app-created events and pulls provider changes, delegating conflicts to the app.</summary>
+    TwoWay = 2
+}
+
+public enum SqlOSCalendarConnectionStatus
+{
+    Active = 0,
+
+    /// <summary>The last token refresh or sync failed; see <see cref="SqlOSCalendarConnection.LastError"/>.</summary>
+    Error = 1,
+
+    /// <summary>The connection was disconnected; tokens have been cleared.</summary>
+    Revoked = 2
+}
+
+/// <summary>
+/// A calendar resource connection for a user or an organization. The provider OAuth app
+/// (client id/secret, tenant) is reused from the referenced <see cref="SqlOSOidcConnection"/>,
+/// so consumers register Google/Microsoft apps exactly once. Calendar connections are
+/// deliberately separate from sign-in: login flows never request calendar scopes.
+/// </summary>
+public sealed class SqlOSCalendarConnection
+{
+    public string Id { get; set; } = string.Empty;
+    public SqlOSCalendarProviderType ProviderType { get; set; }
+    public SqlOSCalendarIntegrationMode Mode { get; set; } = SqlOSCalendarIntegrationMode.ConnectionOnly;
+    public SqlOSCalendarConnectionStatus Status { get; set; } = SqlOSCalendarConnectionStatus.Active;
+
+    /// <summary>The social/OIDC connection whose OAuth app credentials are used for calendar consent.</summary>
+    public string OidcConnectionId { get; set; } = string.Empty;
+
+    /// <summary>Owning user. Exactly one of <see cref="UserId"/> and <see cref="OrganizationId"/> is set.</summary>
+    public string? UserId { get; set; }
+
+    /// <summary>Owning organization. Exactly one of <see cref="UserId"/> and <see cref="OrganizationId"/> is set.</summary>
+    public string? OrganizationId { get; set; }
+
+    public string DisplayName { get; set; } = string.Empty;
+
+    /// <summary>The provider account (email) that granted calendar consent.</summary>
+    public string? ProviderAccountEmail { get; set; }
+
+    /// <summary>The provider subject (stable account id) that granted calendar consent.</summary>
+    public string? ProviderAccountSubject { get; set; }
+
+    /// <summary>Granted OAuth scopes as a JSON string array.</summary>
+    public string ScopesJson { get; set; } = "[]";
+
+    /// <summary>Access token protected via <see cref="AuthServer.Services.SqlOSCryptoService.ProtectSecret"/>.</summary>
+    public string? AccessTokenEncrypted { get; set; }
+
+    /// <summary>Refresh token protected via <see cref="AuthServer.Services.SqlOSCryptoService.ProtectSecret"/>.</summary>
+    public string? RefreshTokenEncrypted { get; set; }
+
+    public DateTime? AccessTokenExpiresAt { get; set; }
+
+    public DateTime? LastSyncAt { get; set; }
+    public string? LastError { get; set; }
+    public DateTime? LastErrorAt { get; set; }
+
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+    public DateTime? RevokedAt { get; set; }
+    public string? RevokedReason { get; set; }
+
+    public SqlOSUser? User { get; set; }
+    public SqlOSOrganization? Organization { get; set; }
+    public SqlOSOidcConnection? OidcConnection { get; set; }
+    public ICollection<SqlOSCalendarSyncState> SyncStates { get; set; } = new List<SqlOSCalendarSyncState>();
+    public ICollection<SqlOSCalendarEvent> Events { get; set; } = new List<SqlOSCalendarEvent>();
+}
+
+/// <summary>
+/// Per-provider-calendar sync cursor and health for <see cref="SqlOSCalendarIntegrationMode.ReadPull"/>
+/// and <see cref="SqlOSCalendarIntegrationMode.TwoWay"/> connections.
+/// </summary>
+public sealed class SqlOSCalendarSyncState
+{
+    public string Id { get; set; } = string.Empty;
+    public string CalendarConnectionId { get; set; } = string.Empty;
+
+    /// <summary>Provider calendar id (Google calendarId / Microsoft Graph calendar id).</summary>
+    public string ProviderCalendarId { get; set; } = string.Empty;
+
+    public string? DisplayName { get; set; }
+    public bool IsSyncEnabled { get; set; } = true;
+
+    /// <summary>Provider incremental cursor (Google syncToken / Microsoft delta token), when available.</summary>
+    public string? SyncCursor { get; set; }
+
+    public DateTime? LastSyncStartedAt { get; set; }
+    public DateTime? LastSyncCompletedAt { get; set; }
+    public string? LastSyncStatus { get; set; }
+    public string? LastSyncError { get; set; }
+    public int EventCount { get; set; }
+
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+
+    public SqlOSCalendarConnection? CalendarConnection { get; set; }
+}
+
+/// <summary>
+/// A normalized event copy imported from a provider calendar. Only populated for
+/// <see cref="SqlOSCalendarIntegrationMode.ReadPull"/> and <see cref="SqlOSCalendarIntegrationMode.TwoWay"/>
+/// connections; <see cref="SqlOSCalendarIntegrationMode.ConnectionOnly"/> never persists event copies.
+/// </summary>
+public sealed class SqlOSCalendarEvent
+{
+    public string Id { get; set; } = string.Empty;
+    public string CalendarConnectionId { get; set; } = string.Empty;
+    public string ProviderCalendarId { get; set; } = string.Empty;
+    public string ProviderEventId { get; set; } = string.Empty;
+
+    public string? Subject { get; set; }
+    public DateTime StartsAtUtc { get; set; }
+    public DateTime EndsAtUtc { get; set; }
+    public bool IsAllDay { get; set; }
+
+    /// <summary>Availability classification: busy, free, tentative, or oof.</summary>
+    public string ShowAs { get; set; } = "busy";
+
+    /// <summary>Provider event status: confirmed, tentative, or cancelled.</summary>
+    public string Status { get; set; } = "confirmed";
+
+    public string? Location { get; set; }
+
+    /// <summary>Where the copy originated: "pull" (provider import) or "push" (created through SqlOS two-way).</summary>
+    public string Origin { get; set; } = "pull";
+
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+
+    public SqlOSCalendarConnection? CalendarConnection { get; set; }
+}

--- a/src/SqlOS/Calendar/Services/SqlOSCalendarProviderHttp.cs
+++ b/src/SqlOS/Calendar/Services/SqlOSCalendarProviderHttp.cs
@@ -1,0 +1,138 @@
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using SqlOS.Calendar.Contracts;
+
+namespace SqlOS.Calendar.Services;
+
+/// <summary>Shared HTTP/JSON helpers for the calendar provider adapters.</summary>
+internal static class SqlOSCalendarProviderHttp
+{
+    public static async Task<SqlOSCalendarTokenResult> PostTokenFormAsync(
+        HttpClient httpClient,
+        string tokenEndpoint,
+        IReadOnlyDictionary<string, string> formValues,
+        CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, tokenEndpoint)
+        {
+            Content = new FormUrlEncodedContent(formValues)
+        };
+        using var response = await httpClient.SendAsync(request, cancellationToken);
+        using var payload = await ReadJsonAsync(response, cancellationToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new InvalidOperationException(payload.RootElement.TryGetProperty("error_description", out var description)
+                ? description.GetString() ?? "The calendar provider token request failed."
+                : "The calendar provider token request failed.");
+        }
+
+        var accessToken = GetString(payload.RootElement, "access_token");
+        if (string.IsNullOrWhiteSpace(accessToken))
+        {
+            throw new InvalidOperationException("The calendar provider token response did not include an access token.");
+        }
+
+        var expiresIn = payload.RootElement.TryGetProperty("expires_in", out var expiresElement) && expiresElement.TryGetInt32(out var seconds)
+            ? seconds
+            : 3600;
+        var scopes = (GetString(payload.RootElement, "scope") ?? string.Empty)
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        return new SqlOSCalendarTokenResult(
+            accessToken!,
+            GetString(payload.RootElement, "refresh_token"),
+            DateTime.UtcNow.AddSeconds(expiresIn),
+            scopes,
+            GetString(payload.RootElement, "id_token"));
+    }
+
+    public static async Task<JsonDocument> GetJsonAsync(
+        HttpClient httpClient,
+        string url,
+        string accessToken,
+        string errorMessage,
+        CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", accessToken);
+        using var response = await httpClient.SendAsync(request, cancellationToken);
+        var payload = await ReadJsonAsync(response, cancellationToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            var detail = TryReadProviderError(payload.RootElement);
+            payload.Dispose();
+            throw new InvalidOperationException(detail == null ? errorMessage : $"{errorMessage} {detail}");
+        }
+
+        return payload;
+    }
+
+    public static async Task<JsonDocument> PostJsonAsync(
+        HttpClient httpClient,
+        string url,
+        string accessToken,
+        object body,
+        string errorMessage,
+        CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, url)
+        {
+            Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json")
+        };
+        request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", accessToken);
+        using var response = await httpClient.SendAsync(request, cancellationToken);
+        var payload = await ReadJsonAsync(response, cancellationToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            var detail = TryReadProviderError(payload.RootElement);
+            payload.Dispose();
+            throw new InvalidOperationException(detail == null ? errorMessage : $"{errorMessage} {detail}");
+        }
+
+        return payload;
+    }
+
+    public static string? GetString(JsonElement element, string propertyName)
+        => element.ValueKind == JsonValueKind.Object &&
+           element.TryGetProperty(propertyName, out var value) &&
+           value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+
+    public static string FormatUtc(DateTime value)
+        => DateTime.SpecifyKind(value, DateTimeKind.Utc).ToString("yyyy-MM-dd'T'HH:mm:ss'Z'", CultureInfo.InvariantCulture);
+
+    private static string? TryReadProviderError(JsonElement root)
+    {
+        if (root.ValueKind != JsonValueKind.Object || !root.TryGetProperty("error", out var error))
+        {
+            return null;
+        }
+
+        if (error.ValueKind == JsonValueKind.String)
+        {
+            return error.GetString();
+        }
+
+        if (error.ValueKind == JsonValueKind.Object)
+        {
+            return GetString(error, "message") ?? GetString(error, "code");
+        }
+
+        return null;
+    }
+
+    private static async Task<JsonDocument> ReadJsonAsync(HttpResponseMessage response, CancellationToken cancellationToken)
+    {
+        var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        try
+        {
+            return await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);
+        }
+        catch (JsonException)
+        {
+            return JsonDocument.Parse("{}");
+        }
+    }
+}

--- a/src/SqlOS/Calendar/Services/SqlOSCalendarService.cs
+++ b/src/SqlOS/Calendar/Services/SqlOSCalendarService.cs
@@ -1,0 +1,927 @@
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using SqlOS.AuthServer.Configuration;
+using SqlOS.AuthServer.Contracts;
+using SqlOS.AuthServer.Interfaces;
+using SqlOS.AuthServer.Models;
+using SqlOS.AuthServer.Services;
+using SqlOS.Calendar.Configuration;
+using SqlOS.Calendar.Contracts;
+using SqlOS.Calendar.Interfaces;
+using SqlOS.Calendar.Models;
+using SqlOS.Configuration;
+
+namespace SqlOS.Calendar.Services;
+
+/// <summary>
+/// Calendar resource connections for users and organizations. Reuses the consumer's seeded
+/// Google/Microsoft OIDC connections for OAuth app credentials while keeping calendar consent
+/// completely separate from sign-in: login flows never request calendar scopes.
+/// </summary>
+public sealed class SqlOSCalendarService
+{
+    internal const string ConnectRequestTokenPurpose = "calendar_connect_request";
+
+    private readonly ISqlOSAuthServerDbContext _context;
+    private readonly SqlOSAdminService _adminService;
+    private readonly SqlOSCryptoService _cryptoService;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IEnumerable<ISqlOSCalendarProviderAdapter> _adapters;
+    private readonly SqlOSCalendarOptions _calendarOptions;
+    private readonly SqlOSAuthServerOptions _authOptions;
+    private readonly ILogger<SqlOSCalendarService> _logger;
+
+    public SqlOSCalendarService(
+        ISqlOSAuthServerDbContext context,
+        SqlOSAdminService adminService,
+        SqlOSCryptoService cryptoService,
+        IHttpClientFactory httpClientFactory,
+        IEnumerable<ISqlOSCalendarProviderAdapter> adapters,
+        IOptions<SqlOSOptions> options,
+        ILogger<SqlOSCalendarService> logger)
+    {
+        _context = context;
+        _adminService = adminService;
+        _cryptoService = cryptoService;
+        _httpClientFactory = httpClientFactory;
+        _adapters = adapters;
+        _calendarOptions = options.Value.Calendar;
+        _authOptions = options.Value.AuthServer;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Starts a calendar connect flow and returns the provider authorization URL the user's
+    /// browser should be redirected to. The provider callback lands on the SqlOS-owned
+    /// <c>{BasePath}/calendar/callback</c> endpoint, which finishes the connection and then
+    /// redirects to the request's <see cref="SqlOSStartCalendarConnectRequest.ReturnUri"/>.
+    /// </summary>
+    public async Task<SqlOSStartCalendarConnectResult> StartConnectAsync(
+        SqlOSStartCalendarConnectRequest request,
+        HttpContext? httpContext = null,
+        CancellationToken cancellationToken = default)
+    {
+        var hasUser = !string.IsNullOrWhiteSpace(request.UserId);
+        var hasOrganization = !string.IsNullOrWhiteSpace(request.OrganizationId);
+        if (hasUser == hasOrganization)
+        {
+            throw new InvalidOperationException("A calendar connection must be bound to exactly one user or one organization.");
+        }
+
+        if (string.IsNullOrWhiteSpace(request.ReturnUri) || !Uri.TryCreate(request.ReturnUri, UriKind.Absolute, out _))
+        {
+            throw new InvalidOperationException("The calendar connect return URI must be an absolute URI.");
+        }
+
+        if (hasUser)
+        {
+            _ = await _context.Set<SqlOSUser>().FirstOrDefaultAsync(x => x.Id == request.UserId, cancellationToken)
+                ?? throw new InvalidOperationException("The calendar connection user was not found.");
+        }
+        else
+        {
+            _ = await _context.Set<SqlOSOrganization>().FirstOrDefaultAsync(x => x.Id == request.OrganizationId, cancellationToken)
+                ?? throw new InvalidOperationException("The calendar connection organization was not found.");
+        }
+
+        var oidcConnection = await RequireCalendarCapableOidcConnectionAsync(request.OidcConnectionId, cancellationToken);
+        var providerType = MapProviderType(oidcConnection.ProviderType);
+        var endpoints = await ResolveProviderEndpointsAsync(oidcConnection, cancellationToken);
+        var scopes = ResolveScopes(providerType, request.Mode, request.Scopes);
+        var callbackUri = BuildCallbackUri(httpContext);
+        var codeVerifier = _cryptoService.GenerateOpaqueToken();
+
+        var state = await _cryptoService.CreateTemporaryTokenAsync(
+            ConnectRequestTokenPurpose,
+            request.UserId,
+            null,
+            request.OrganizationId,
+            new CalendarConnectRequestPayload(
+                oidcConnection.Id,
+                request.Mode,
+                request.UserId,
+                request.OrganizationId,
+                request.DisplayName,
+                scopes,
+                request.ReturnUri,
+                codeVerifier,
+                callbackUri,
+                endpoints.TokenEndpoint),
+            _calendarOptions.ConnectSessionLifetime,
+            cancellationToken);
+
+        var authorizationParameters = new Dictionary<string, string?>
+        {
+            ["client_id"] = oidcConnection.ClientId,
+            ["redirect_uri"] = callbackUri,
+            ["response_type"] = "code",
+            ["scope"] = string.Join(' ', scopes),
+            ["state"] = state,
+            ["code_challenge"] = _cryptoService.CreatePkceCodeChallenge(codeVerifier),
+            ["code_challenge_method"] = "S256",
+            ["login_hint"] = request.LoginHintEmail
+        };
+
+        if (providerType == SqlOSCalendarProviderType.Google)
+        {
+            // Google only issues refresh tokens for offline access with forced consent.
+            authorizationParameters["access_type"] = "offline";
+            authorizationParameters["prompt"] = "consent";
+        }
+
+        var authorizationUrl = QueryHelpers.AddQueryString(endpoints.AuthorizationEndpoint, authorizationParameters);
+
+        await _adminService.RecordAuditAsync(
+            "calendar.connect.start",
+            "oidc_connection",
+            oidcConnection.Id,
+            userId: request.UserId,
+            organizationId: request.OrganizationId,
+            ipAddress: GetIp(httpContext),
+            data: new
+            {
+                provider = providerType.ToString(),
+                mode = request.Mode.ToString(),
+                scopes
+            },
+            cancellationToken: cancellationToken);
+
+        return new SqlOSStartCalendarConnectResult(authorizationUrl, oidcConnection.Id, providerType, request.Mode);
+    }
+
+    /// <summary>
+    /// Handles the provider redirect on <c>{BasePath}/calendar/callback</c>: exchanges the code,
+    /// stores encrypted tokens, and redirects the browser to the app's return URI with either
+    /// <c>calendarConnectionId</c> or <c>error</c> appended.
+    /// </summary>
+    public async Task<IResult> HandleConnectCallbackAsync(HttpContext httpContext, CancellationToken cancellationToken = default)
+    {
+        var query = httpContext.Request.Query;
+        var state = query["state"].ToString();
+        if (string.IsNullOrWhiteSpace(state))
+        {
+            return RenderCallbackError("The calendar connect callback was missing the provider state.");
+        }
+
+        var requestToken = await _cryptoService.ConsumeTemporaryTokenAsync(ConnectRequestTokenPurpose, state, cancellationToken);
+        if (requestToken == null)
+        {
+            return RenderCallbackError("The calendar connect request is invalid or expired.");
+        }
+
+        var payload = _cryptoService.DeserializePayload<CalendarConnectRequestPayload>(requestToken);
+        if (payload == null)
+        {
+            return RenderCallbackError("The calendar connect request payload is invalid.");
+        }
+
+        var error = query["error"].ToString();
+        if (!string.IsNullOrWhiteSpace(error))
+        {
+            var description = query["error_description"].ToString();
+            return Results.Redirect(AppendQuery(payload.ReturnUri, new Dictionary<string, string?>
+            {
+                ["error"] = string.IsNullOrWhiteSpace(description) ? error : description
+            }));
+        }
+
+        var code = query["code"].ToString();
+        if (string.IsNullOrWhiteSpace(code))
+        {
+            return Results.Redirect(AppendQuery(payload.ReturnUri, new Dictionary<string, string?>
+            {
+                ["error"] = "The calendar connect callback was missing the provider code."
+            }));
+        }
+
+        try
+        {
+            var result = await CompleteConnectAsync(payload, code, GetIp(httpContext), cancellationToken);
+            return Results.Redirect(AppendQuery(payload.ReturnUri, new Dictionary<string, string?>
+            {
+                ["calendarConnectionId"] = result.CalendarConnectionId
+            }));
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Results.Redirect(AppendQuery(payload.ReturnUri, new Dictionary<string, string?>
+            {
+                ["error"] = ex.Message
+            }));
+        }
+    }
+
+    /// <summary>
+    /// Exchanges the provider authorization code and persists the calendar connection with
+    /// encrypted tokens. Exposed for headless flows and tests; browser flows should go through
+    /// <see cref="HandleConnectCallbackAsync"/>.
+    /// </summary>
+    public async Task<SqlOSCompleteCalendarConnectResult> CompleteConnectAsync(
+        CalendarConnectRequestPayload payload,
+        string code,
+        string? ipAddress = null,
+        CancellationToken cancellationToken = default)
+    {
+        var oidcConnection = await RequireCalendarCapableOidcConnectionAsync(payload.OidcConnectionId, cancellationToken);
+        var providerType = MapProviderType(oidcConnection.ProviderType);
+        var adapter = RequireAdapter(providerType);
+
+        try
+        {
+            var providerContext = CreateProviderContext(oidcConnection, payload.TokenEndpoint);
+            var tokens = await adapter.ExchangeAuthorizationCodeAsync(
+                providerContext,
+                code,
+                payload.CallbackUri,
+                payload.CodeVerifier,
+                cancellationToken);
+
+            if (payload.Mode != SqlOSCalendarIntegrationMode.ConnectionOnly && string.IsNullOrWhiteSpace(tokens.RefreshToken))
+            {
+                throw new InvalidOperationException(
+                    "The provider did not return a refresh token, which read-pull and two-way connections require. " +
+                    "Ensure offline access is granted and consent was not silently skipped.");
+            }
+
+            var account = ParseIdTokenAccount(tokens);
+            var now = DateTime.UtcNow;
+            var grantedScopes = tokens.Scopes.Count > 0 ? tokens.Scopes : payload.Scopes;
+            var connection = new SqlOSCalendarConnection
+            {
+                Id = _cryptoService.GenerateId("cal"),
+                ProviderType = providerType,
+                Mode = payload.Mode,
+                Status = SqlOSCalendarConnectionStatus.Active,
+                OidcConnectionId = oidcConnection.Id,
+                UserId = payload.UserId,
+                OrganizationId = payload.OrganizationId,
+                DisplayName = string.IsNullOrWhiteSpace(payload.DisplayName)
+                    ? $"{oidcConnection.DisplayName} Calendar"
+                    : payload.DisplayName!.Trim(),
+                ProviderAccountEmail = account.Email,
+                ProviderAccountSubject = account.Subject,
+                ScopesJson = JsonSerializer.Serialize(grantedScopes),
+                AccessTokenEncrypted = _cryptoService.ProtectSecret(tokens.AccessToken),
+                RefreshTokenEncrypted = string.IsNullOrWhiteSpace(tokens.RefreshToken)
+                    ? null
+                    : _cryptoService.ProtectSecret(tokens.RefreshToken!),
+                AccessTokenExpiresAt = tokens.ExpiresAt,
+                CreatedAt = now,
+                UpdatedAt = now
+            };
+
+            _context.Set<SqlOSCalendarConnection>().Add(connection);
+            await _context.SaveChangesAsync(cancellationToken);
+
+            await _adminService.RecordAuditAsync(
+                "calendar.connection.created",
+                "calendar_connection",
+                connection.Id,
+                userId: payload.UserId,
+                organizationId: payload.OrganizationId,
+                ipAddress: ipAddress,
+                data: new
+                {
+                    provider = providerType.ToString(),
+                    mode = payload.Mode.ToString(),
+                    providerAccountEmail = account.Email
+                },
+                cancellationToken: cancellationToken);
+
+            return new SqlOSCompleteCalendarConnectResult(
+                connection.Id,
+                providerType,
+                payload.Mode,
+                payload.UserId,
+                payload.OrganizationId,
+                account.Email,
+                payload.ReturnUri);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Calendar connect failed for OIDC connection {ConnectionId}.", payload.OidcConnectionId);
+            await _adminService.RecordAuditAsync(
+                "calendar.connect.error",
+                "oidc_connection",
+                payload.OidcConnectionId,
+                userId: payload.UserId,
+                organizationId: payload.OrganizationId,
+                ipAddress: ipAddress,
+                data: new { error = ex.Message },
+                cancellationToken: cancellationToken);
+            throw;
+        }
+    }
+
+    public async Task<IReadOnlyList<SqlOSCalendarConnectionSummary>> ListConnectionsAsync(
+        string? userId = null,
+        string? organizationId = null,
+        bool includeRevoked = false,
+        CancellationToken cancellationToken = default)
+    {
+        var query = _context.Set<SqlOSCalendarConnection>().AsQueryable();
+        if (!string.IsNullOrWhiteSpace(userId))
+        {
+            query = query.Where(x => x.UserId == userId);
+        }
+
+        if (!string.IsNullOrWhiteSpace(organizationId))
+        {
+            query = query.Where(x => x.OrganizationId == organizationId);
+        }
+
+        if (!includeRevoked)
+        {
+            query = query.Where(x => x.RevokedAt == null);
+        }
+
+        var connections = await query
+            .OrderByDescending(x => x.CreatedAt)
+            .ToListAsync(cancellationToken);
+        return connections.Select(ToSummary).ToList();
+    }
+
+    public async Task<SqlOSCalendarConnectionSummary> GetConnectionAsync(
+        string calendarConnectionId,
+        string? forUserId = null,
+        string? forOrganizationId = null,
+        CancellationToken cancellationToken = default)
+        => ToSummary(await RequireConnectionAsync(calendarConnectionId, forUserId, forOrganizationId, includeRevoked: true, cancellationToken));
+
+    /// <summary>
+    /// Returns a short-lived provider access token for the authorized caller, refreshing it
+    /// transparently when it is close to expiry. This is the whole surface an app needs in
+    /// <see cref="SqlOSCalendarIntegrationMode.ConnectionOnly"/> mode — SqlOS never stores
+    /// event copies for those connections.
+    /// </summary>
+    public async Task<SqlOSCalendarAccessTokenResult> GetAccessTokenAsync(
+        string calendarConnectionId,
+        string? forUserId = null,
+        string? forOrganizationId = null,
+        CancellationToken cancellationToken = default)
+    {
+        var connection = await RequireConnectionAsync(calendarConnectionId, forUserId, forOrganizationId, includeRevoked: false, cancellationToken);
+        var accessToken = await EnsureFreshAccessTokenAsync(connection, cancellationToken);
+        return new SqlOSCalendarAccessTokenResult(
+            accessToken,
+            connection.AccessTokenExpiresAt ?? DateTime.UtcNow,
+            ParseScopes(connection.ScopesJson),
+            connection.ProviderType);
+    }
+
+    /// <summary>Lists the calendars available on the connected provider account.</summary>
+    public async Task<IReadOnlyList<SqlOSCalendarSummary>> ListProviderCalendarsAsync(
+        string calendarConnectionId,
+        string? forUserId = null,
+        string? forOrganizationId = null,
+        CancellationToken cancellationToken = default)
+    {
+        var connection = await RequireConnectionAsync(calendarConnectionId, forUserId, forOrganizationId, includeRevoked: false, cancellationToken);
+        var accessToken = await EnsureFreshAccessTokenAsync(connection, cancellationToken);
+        return await RequireAdapter(connection.ProviderType).ListCalendarsAsync(accessToken, cancellationToken);
+    }
+
+    /// <summary>
+    /// Chooses which provider calendar a read-pull or two-way connection synchronizes.
+    /// Repeat calls upsert; passing <paramref name="isSyncEnabled"/> false pauses one calendar.
+    /// </summary>
+    public async Task EnableCalendarSyncAsync(
+        string calendarConnectionId,
+        string providerCalendarId,
+        string? displayName = null,
+        bool isSyncEnabled = true,
+        string? forUserId = null,
+        string? forOrganizationId = null,
+        CancellationToken cancellationToken = default)
+    {
+        var connection = await RequireConnectionAsync(calendarConnectionId, forUserId, forOrganizationId, includeRevoked: false, cancellationToken);
+        if (connection.Mode == SqlOSCalendarIntegrationMode.ConnectionOnly)
+        {
+            throw new InvalidOperationException("Connection-only calendar connections do not synchronize events.");
+        }
+
+        if (string.IsNullOrWhiteSpace(providerCalendarId))
+        {
+            throw new InvalidOperationException("A provider calendar id is required.");
+        }
+
+        var now = DateTime.UtcNow;
+        var state = await _context.Set<SqlOSCalendarSyncState>()
+            .FirstOrDefaultAsync(x => x.CalendarConnectionId == connection.Id && x.ProviderCalendarId == providerCalendarId, cancellationToken);
+        if (state == null)
+        {
+            state = new SqlOSCalendarSyncState
+            {
+                Id = _cryptoService.GenerateId("csy"),
+                CalendarConnectionId = connection.Id,
+                ProviderCalendarId = providerCalendarId,
+                CreatedAt = now
+            };
+            _context.Set<SqlOSCalendarSyncState>().Add(state);
+        }
+
+        state.DisplayName = displayName ?? state.DisplayName;
+        state.IsSyncEnabled = isSyncEnabled;
+        state.UpdatedAt = now;
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Reads normalized events imported by read-pull/two-way sync. Connection-only
+    /// connections never persist events and therefore always throw here.
+    /// </summary>
+    public async Task<IReadOnlyList<SqlOSCalendarEventSnapshot>> ListEventsAsync(
+        string calendarConnectionId,
+        DateTime fromUtc,
+        DateTime toUtc,
+        string? forUserId = null,
+        string? forOrganizationId = null,
+        CancellationToken cancellationToken = default)
+    {
+        var connection = await RequireConnectionAsync(calendarConnectionId, forUserId, forOrganizationId, includeRevoked: false, cancellationToken);
+        if (connection.Mode == SqlOSCalendarIntegrationMode.ConnectionOnly)
+        {
+            throw new InvalidOperationException("Connection-only calendar connections do not store events. Use GetAccessTokenAsync and call the provider directly.");
+        }
+
+        var events = await _context.Set<SqlOSCalendarEvent>()
+            .Where(x => x.CalendarConnectionId == connection.Id && x.StartsAtUtc < toUtc && x.EndsAtUtc > fromUtc)
+            .OrderBy(x => x.StartsAtUtc)
+            .ToListAsync(cancellationToken);
+
+        return events
+            .Select(x => new SqlOSCalendarEventSnapshot(
+                x.ProviderEventId,
+                x.Subject,
+                x.StartsAtUtc,
+                x.EndsAtUtc,
+                x.IsAllDay,
+                x.ShowAs,
+                x.Status,
+                x.Location))
+            .ToList();
+    }
+
+    /// <summary>Disconnects a calendar connection and clears its stored tokens.</summary>
+    public async Task<SqlOSCalendarConnectionSummary> DisconnectAsync(
+        string calendarConnectionId,
+        string reason = "disconnected",
+        string? forUserId = null,
+        string? forOrganizationId = null,
+        CancellationToken cancellationToken = default)
+    {
+        var connection = await RequireConnectionAsync(calendarConnectionId, forUserId, forOrganizationId, includeRevoked: true, cancellationToken);
+        if (connection.RevokedAt == null)
+        {
+            var now = DateTime.UtcNow;
+            connection.Status = SqlOSCalendarConnectionStatus.Revoked;
+            connection.AccessTokenEncrypted = null;
+            connection.RefreshTokenEncrypted = null;
+            connection.AccessTokenExpiresAt = null;
+            connection.RevokedAt = now;
+            connection.RevokedReason = reason;
+            connection.UpdatedAt = now;
+            await _context.SaveChangesAsync(cancellationToken);
+
+            await _adminService.RecordAuditAsync(
+                "calendar.connection.disconnected",
+                "calendar_connection",
+                connection.Id,
+                userId: connection.UserId,
+                organizationId: connection.OrganizationId,
+                data: new { reason },
+                cancellationToken: cancellationToken);
+        }
+
+        return ToSummary(connection);
+    }
+
+    /// <summary>
+    /// Returns a valid provider access token for the connection, refreshing when it expires
+    /// within <see cref="SqlOSCalendarOptions.AccessTokenRefreshSkew"/> (or on demand).
+    /// </summary>
+    public async Task<string> EnsureFreshAccessTokenAsync(
+        SqlOSCalendarConnection connection,
+        CancellationToken cancellationToken = default,
+        bool forceRefresh = false)
+    {
+        if (connection.RevokedAt != null)
+        {
+            throw new InvalidOperationException("This calendar connection has been disconnected.");
+        }
+
+        var needsRefresh = forceRefresh
+            || string.IsNullOrWhiteSpace(connection.AccessTokenEncrypted)
+            || connection.AccessTokenExpiresAt == null
+            || connection.AccessTokenExpiresAt <= DateTime.UtcNow.Add(_calendarOptions.AccessTokenRefreshSkew);
+
+        if (!needsRefresh)
+        {
+            return _cryptoService.UnprotectSecret(connection.AccessTokenEncrypted!);
+        }
+
+        if (string.IsNullOrWhiteSpace(connection.RefreshTokenEncrypted))
+        {
+            throw new InvalidOperationException("The calendar access token expired and no refresh token is stored for this connection.");
+        }
+
+        var oidcConnection = await RequireCalendarCapableOidcConnectionAsync(connection.OidcConnectionId, cancellationToken);
+        var endpoints = await ResolveProviderEndpointsAsync(oidcConnection, cancellationToken);
+        var adapter = RequireAdapter(connection.ProviderType);
+
+        try
+        {
+            var tokens = await adapter.RefreshAccessTokenAsync(
+                CreateProviderContext(oidcConnection, endpoints.TokenEndpoint),
+                _cryptoService.UnprotectSecret(connection.RefreshTokenEncrypted!),
+                cancellationToken);
+
+            var now = DateTime.UtcNow;
+            connection.AccessTokenEncrypted = _cryptoService.ProtectSecret(tokens.AccessToken);
+            connection.AccessTokenExpiresAt = tokens.ExpiresAt;
+            if (!string.IsNullOrWhiteSpace(tokens.RefreshToken))
+            {
+                // Providers may rotate refresh tokens; always keep the newest one.
+                connection.RefreshTokenEncrypted = _cryptoService.ProtectSecret(tokens.RefreshToken!);
+            }
+
+            connection.Status = SqlOSCalendarConnectionStatus.Active;
+            connection.LastError = null;
+            connection.LastErrorAt = null;
+            connection.UpdatedAt = now;
+            await _context.SaveChangesAsync(cancellationToken);
+            return tokens.AccessToken;
+        }
+        catch (InvalidOperationException ex)
+        {
+            var now = DateTime.UtcNow;
+            connection.Status = SqlOSCalendarConnectionStatus.Error;
+            connection.LastError = ex.Message;
+            connection.LastErrorAt = now;
+            connection.UpdatedAt = now;
+            await _context.SaveChangesAsync(cancellationToken);
+
+            await _adminService.RecordAuditAsync(
+                "calendar.connection.refresh_failed",
+                "calendar_connection",
+                connection.Id,
+                userId: connection.UserId,
+                organizationId: connection.OrganizationId,
+                data: new { error = ex.Message },
+                cancellationToken: cancellationToken);
+            throw;
+        }
+    }
+
+    /// <summary>Force-refreshes the access token (admin surface).</summary>
+    public async Task<SqlOSCalendarConnectionSummary> ForceRefreshAsync(
+        string calendarConnectionId,
+        CancellationToken cancellationToken = default)
+    {
+        var connection = await RequireConnectionAsync(calendarConnectionId, null, null, includeRevoked: false, cancellationToken);
+        await EnsureFreshAccessTokenAsync(connection, cancellationToken, forceRefresh: true);
+        return ToSummary(connection);
+    }
+
+    /// <summary>Paginated admin listing for the dashboard.</summary>
+    public async Task<object> GetAdminConnectionsAsync(
+        string? search = null,
+        bool includeRevoked = true,
+        int? page = null,
+        int? pageSize = null,
+        CancellationToken cancellationToken = default)
+    {
+        var resolvedPage = Math.Max(1, page.GetValueOrDefault(1));
+        var resolvedPageSize = Math.Clamp(pageSize.GetValueOrDefault(25), 1, 100);
+        var query = _context.Set<SqlOSCalendarConnection>().AsNoTracking();
+
+        if (!includeRevoked)
+        {
+            query = query.Where(x => x.RevokedAt == null);
+        }
+
+        if (!string.IsNullOrWhiteSpace(search))
+        {
+            var trimmed = search.Trim();
+            query = query.Where(x =>
+                x.DisplayName.Contains(trimmed) ||
+                (x.ProviderAccountEmail != null && x.ProviderAccountEmail.Contains(trimmed)) ||
+                (x.UserId != null && x.UserId.Contains(trimmed)) ||
+                (x.OrganizationId != null && x.OrganizationId.Contains(trimmed)));
+        }
+
+        query = query.OrderByDescending(x => x.CreatedAt);
+        var totalCount = await query.CountAsync(cancellationToken);
+        var totalPages = Math.Max(1, (int)Math.Ceiling(totalCount / (double)resolvedPageSize));
+        var currentPage = Math.Min(resolvedPage, totalPages);
+        var data = await query
+            .Skip((currentPage - 1) * resolvedPageSize)
+            .Take(resolvedPageSize)
+            .ToListAsync(cancellationToken);
+
+        return new
+        {
+            Data = data.Select(ToSummary).ToList(),
+            Page = currentPage,
+            PageSize = resolvedPageSize,
+            TotalCount = totalCount,
+            TotalPages = totalPages
+        };
+    }
+
+    /// <summary>Admin detail view including per-calendar sync health.</summary>
+    public async Task<object> GetAdminConnectionAsync(string calendarConnectionId, CancellationToken cancellationToken = default)
+    {
+        var connection = await RequireConnectionAsync(calendarConnectionId, null, null, includeRevoked: true, cancellationToken);
+        var syncStates = await _context.Set<SqlOSCalendarSyncState>()
+            .AsNoTracking()
+            .Where(x => x.CalendarConnectionId == connection.Id)
+            .OrderBy(x => x.ProviderCalendarId)
+            .ToListAsync(cancellationToken);
+        var eventCount = await _context.Set<SqlOSCalendarEvent>()
+            .CountAsync(x => x.CalendarConnectionId == connection.Id, cancellationToken);
+
+        return new
+        {
+            Connection = ToSummary(connection),
+            EventCount = eventCount,
+            Calendars = syncStates.Select(state => new
+            {
+                state.ProviderCalendarId,
+                state.DisplayName,
+                state.IsSyncEnabled,
+                HasSyncCursor = !string.IsNullOrWhiteSpace(state.SyncCursor),
+                state.LastSyncStartedAt,
+                state.LastSyncCompletedAt,
+                state.LastSyncStatus,
+                state.LastSyncError,
+                state.EventCount
+            }).ToList()
+        };
+    }
+
+    /// <summary>Aggregate counts for the dashboard overview cards.</summary>
+    public async Task<object> GetAdminSummaryAsync(CancellationToken cancellationToken = default)
+    {
+        var connections = await _context.Set<SqlOSCalendarConnection>().CountAsync(cancellationToken);
+        var active = await _context.Set<SqlOSCalendarConnection>()
+            .CountAsync(x => x.Status == SqlOSCalendarConnectionStatus.Active && x.RevokedAt == null, cancellationToken);
+        var errored = await _context.Set<SqlOSCalendarConnection>()
+            .CountAsync(x => x.Status == SqlOSCalendarConnectionStatus.Error && x.RevokedAt == null, cancellationToken);
+        var events = await _context.Set<SqlOSCalendarEvent>().CountAsync(cancellationToken);
+        return new { connections, active, errored, events };
+    }
+
+    internal async Task<SqlOSCalendarConnection> RequireConnectionAsync(
+        string calendarConnectionId,
+        string? forUserId,
+        string? forOrganizationId,
+        bool includeRevoked,
+        CancellationToken cancellationToken)
+    {
+        var connection = await _context.Set<SqlOSCalendarConnection>()
+            .FirstOrDefaultAsync(x => x.Id == calendarConnectionId, cancellationToken)
+            ?? throw new InvalidOperationException("The calendar connection was not found.");
+
+        if (!string.IsNullOrWhiteSpace(forUserId) && !string.Equals(connection.UserId, forUserId, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("The calendar connection was not found.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(forOrganizationId) && !string.Equals(connection.OrganizationId, forOrganizationId, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("The calendar connection was not found.");
+        }
+
+        if (!includeRevoked && connection.RevokedAt != null)
+        {
+            throw new InvalidOperationException("This calendar connection has been disconnected.");
+        }
+
+        return connection;
+    }
+
+    internal async Task<SqlOSProviderEndpoints> ResolveProviderEndpointsAsync(
+        SqlOSOidcConnection connection,
+        CancellationToken cancellationToken)
+    {
+        if (!connection.UseDiscovery)
+        {
+            return new SqlOSProviderEndpoints(
+                connection.AuthorizationEndpoint
+                    ?? throw new InvalidOperationException("The social login connection is missing an authorization endpoint."),
+                connection.TokenEndpoint
+                    ?? throw new InvalidOperationException("The social login connection is missing a token endpoint."));
+        }
+
+        var discoveryUrl = connection.DiscoveryUrl
+            ?? throw new InvalidOperationException("The OIDC connection is missing a discovery URL.");
+        var httpClient = _httpClientFactory.CreateClient(nameof(SqlOSCalendarService));
+        using var response = await httpClient.GetAsync(discoveryUrl, cancellationToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new InvalidOperationException("The OIDC discovery endpoint failed.");
+        }
+
+        using var payload = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync(cancellationToken), cancellationToken: cancellationToken);
+        var authorizationEndpoint = payload.RootElement.GetProperty("authorization_endpoint").GetString()
+            ?? throw new InvalidOperationException("The OIDC discovery document is missing an authorization endpoint.");
+        var tokenEndpoint = payload.RootElement.GetProperty("token_endpoint").GetString()
+            ?? throw new InvalidOperationException("The OIDC discovery document is missing a token endpoint.");
+        return new SqlOSProviderEndpoints(authorizationEndpoint, tokenEndpoint);
+    }
+
+    internal ISqlOSCalendarProviderAdapter RequireAdapter(SqlOSCalendarProviderType providerType)
+        => _adapters.FirstOrDefault(x => x.ProviderType == providerType)
+            ?? throw new InvalidOperationException($"No calendar provider adapter is registered for '{providerType}'.");
+
+    internal SqlOSCalendarProviderContext CreateProviderContext(SqlOSOidcConnection connection, string tokenEndpoint)
+        => new(
+            connection.ClientId,
+            !string.IsNullOrWhiteSpace(connection.ClientSecretEncrypted)
+                ? _cryptoService.UnprotectSecret(connection.ClientSecretEncrypted)
+                : throw new InvalidOperationException("The social login connection is missing a client secret."),
+            tokenEndpoint);
+
+    internal async Task<SqlOSOidcConnection> RequireCalendarCapableOidcConnectionAsync(string oidcConnectionId, CancellationToken cancellationToken)
+    {
+        var connection = await _context.Set<SqlOSOidcConnection>()
+            .FirstOrDefaultAsync(x => x.Id == oidcConnectionId && x.IsEnabled, cancellationToken)
+            ?? throw new InvalidOperationException("No enabled OIDC connection was found for this calendar request.");
+
+        if (connection.ProviderType is not (SqlOSOidcProviderType.Google or SqlOSOidcProviderType.Microsoft))
+        {
+            throw new InvalidOperationException("Calendar integration supports Google and Microsoft connections only.");
+        }
+
+        return connection;
+    }
+
+    internal static SqlOSCalendarProviderType MapProviderType(SqlOSOidcProviderType providerType)
+        => providerType switch
+        {
+            SqlOSOidcProviderType.Google => SqlOSCalendarProviderType.Google,
+            SqlOSOidcProviderType.Microsoft => SqlOSCalendarProviderType.Microsoft,
+            _ => throw new InvalidOperationException("Calendar integration supports Google and Microsoft connections only.")
+        };
+
+    internal static IReadOnlyList<string> ResolveScopes(
+        SqlOSCalendarProviderType providerType,
+        SqlOSCalendarIntegrationMode mode,
+        IReadOnlyList<string>? requested)
+    {
+        if (requested is { Count: > 0 })
+        {
+            return requested
+                .Where(static scope => !string.IsNullOrWhiteSpace(scope))
+                .Select(static scope => scope.Trim())
+                .Distinct(StringComparer.Ordinal)
+                .ToList();
+        }
+
+        // Identity scopes let SqlOS record which provider account granted consent.
+        var scopes = new List<string> { "openid", "email" };
+        if (providerType == SqlOSCalendarProviderType.Google)
+        {
+            scopes.AddRange(SqlOSCalendarOptions.DefaultGoogleReadScopes);
+            if (mode == SqlOSCalendarIntegrationMode.TwoWay)
+            {
+                scopes.AddRange(SqlOSCalendarOptions.DefaultGoogleWriteScopes);
+            }
+        }
+        else
+        {
+            scopes.AddRange(mode == SqlOSCalendarIntegrationMode.TwoWay
+                ? SqlOSCalendarOptions.DefaultMicrosoftWriteScopes
+                : SqlOSCalendarOptions.DefaultMicrosoftReadScopes);
+        }
+
+        return scopes.Distinct(StringComparer.Ordinal).ToList();
+    }
+
+    private string BuildCallbackUri(HttpContext? httpContext)
+    {
+        var origin = !string.IsNullOrWhiteSpace(_authOptions.PublicOrigin)
+            ? _authOptions.PublicOrigin!.TrimEnd('/')
+            : httpContext != null
+                ? $"{httpContext.Request.Scheme}://{httpContext.Request.Host}".TrimEnd('/')
+                : throw new InvalidOperationException("Set AuthServer.PublicOrigin (or pass an HttpContext) so the calendar callback URI can be built.");
+
+        return $"{origin}{_authOptions.BasePath.TrimEnd('/')}/calendar/callback";
+    }
+
+    private static (string? Email, string? Subject) ParseIdTokenAccount(SqlOSCalendarTokenResult tokens)
+    {
+        if (string.IsNullOrWhiteSpace(tokens.IdToken))
+        {
+            return (null, null);
+        }
+
+        try
+        {
+            var parts = tokens.IdToken!.Split('.');
+            if (parts.Length < 2)
+            {
+                return (null, null);
+            }
+
+            var payloadJson = Encoding.UTF8.GetString(DecodeBase64Url(parts[1]));
+            using var document = JsonDocument.Parse(payloadJson);
+            var email = SqlOSCalendarProviderHttp.GetString(document.RootElement, "email")
+                ?? SqlOSCalendarProviderHttp.GetString(document.RootElement, "preferred_username");
+            var subject = SqlOSCalendarProviderHttp.GetString(document.RootElement, "sub");
+            return (email, subject);
+        }
+        catch
+        {
+            return (null, null);
+        }
+    }
+
+    private static byte[] DecodeBase64Url(string value)
+    {
+        var padded = value.Replace('-', '+').Replace('_', '/');
+        switch (padded.Length % 4)
+        {
+            case 2: padded += "=="; break;
+            case 3: padded += "="; break;
+        }
+
+        return Convert.FromBase64String(padded);
+    }
+
+    private static IReadOnlyList<string> ParseScopes(string json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return [];
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<List<string>>(json) ?? [];
+        }
+        catch
+        {
+            return [];
+        }
+    }
+
+    private static SqlOSCalendarConnectionSummary ToSummary(SqlOSCalendarConnection connection)
+        => new(
+            connection.Id,
+            connection.ProviderType.ToString(),
+            connection.Mode.ToString(),
+            connection.Status.ToString(),
+            connection.UserId,
+            connection.OrganizationId,
+            connection.DisplayName,
+            connection.ProviderAccountEmail,
+            ParseScopes(connection.ScopesJson),
+            connection.AccessTokenExpiresAt,
+            !string.IsNullOrWhiteSpace(connection.RefreshTokenEncrypted),
+            connection.LastSyncAt,
+            connection.LastError,
+            connection.LastErrorAt,
+            connection.CreatedAt,
+            connection.RevokedAt);
+
+    private static string AppendQuery(string uri, IDictionary<string, string?> parameters)
+        => QueryHelpers.AddQueryString(uri, parameters);
+
+    private static string? GetIp(HttpContext? httpContext)
+        => httpContext?.Connection.RemoteIpAddress?.ToString();
+
+    private static IResult RenderCallbackError(string message)
+        => Results.Content(
+            $"""
+            <html>
+              <head><title>SqlOS calendar connect error</title></head>
+              <body style="font-family: ui-sans-serif, system-ui, sans-serif; padding: 32px;">
+                <h1>SqlOS calendar connect error</h1>
+                <p>{System.Net.WebUtility.HtmlEncode(message)}</p>
+              </body>
+            </html>
+            """,
+            "text/html");
+
+    internal sealed record SqlOSProviderEndpoints(string AuthorizationEndpoint, string TokenEndpoint);
+}
+
+/// <summary>Payload stored in the temporary state token for a pending calendar connect flow.</summary>
+public sealed record CalendarConnectRequestPayload(
+    string OidcConnectionId,
+    SqlOSCalendarIntegrationMode Mode,
+    string? UserId,
+    string? OrganizationId,
+    string? DisplayName,
+    IReadOnlyList<string> Scopes,
+    string ReturnUri,
+    string CodeVerifier,
+    string CallbackUri,
+    string TokenEndpoint);

--- a/src/SqlOS/Calendar/Services/SqlOSCalendarService.cs
+++ b/src/SqlOS/Calendar/Services/SqlOSCalendarService.cs
@@ -366,7 +366,7 @@ public sealed class SqlOSCalendarService
         CancellationToken cancellationToken = default)
     {
         var connection = await RequireConnectionAsync(calendarConnectionId, forUserId, forOrganizationId, includeRevoked: false, cancellationToken);
-        var accessToken = await EnsureFreshAccessTokenAsync(connection, cancellationToken);
+        var accessToken = await EnsureFreshAccessTokenAsync(connection, forceRefresh: false, cancellationToken);
         return new SqlOSCalendarAccessTokenResult(
             accessToken,
             connection.AccessTokenExpiresAt ?? DateTime.UtcNow,
@@ -382,7 +382,7 @@ public sealed class SqlOSCalendarService
         CancellationToken cancellationToken = default)
     {
         var connection = await RequireConnectionAsync(calendarConnectionId, forUserId, forOrganizationId, includeRevoked: false, cancellationToken);
-        var accessToken = await EnsureFreshAccessTokenAsync(connection, cancellationToken);
+        var accessToken = await EnsureFreshAccessTokenAsync(connection, forceRefresh: false, cancellationToken);
         return await RequireAdapter(connection.ProviderType).ListCalendarsAsync(accessToken, cancellationToken);
     }
 
@@ -507,8 +507,8 @@ public sealed class SqlOSCalendarService
     /// </summary>
     public async Task<string> EnsureFreshAccessTokenAsync(
         SqlOSCalendarConnection connection,
-        CancellationToken cancellationToken = default,
-        bool forceRefresh = false)
+        bool forceRefresh = false,
+        CancellationToken cancellationToken = default)
     {
         if (connection.RevokedAt != null)
         {
@@ -584,7 +584,7 @@ public sealed class SqlOSCalendarService
         CancellationToken cancellationToken = default)
     {
         var connection = await RequireConnectionAsync(calendarConnectionId, null, null, includeRevoked: false, cancellationToken);
-        await EnsureFreshAccessTokenAsync(connection, cancellationToken, forceRefresh: true);
+        await EnsureFreshAccessTokenAsync(connection, forceRefresh: true, cancellationToken);
         return ToSummary(connection);
     }
 

--- a/src/SqlOS/Calendar/Services/SqlOSCalendarSyncHostedService.cs
+++ b/src/SqlOS/Calendar/Services/SqlOSCalendarSyncHostedService.cs
@@ -1,0 +1,69 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using SqlOS.Configuration;
+
+namespace SqlOS.Calendar.Services;
+
+/// <summary>
+/// Background scheduler for read-pull and two-way calendar connections. Follows the
+/// <see cref="Services"/> hosted-service conventions: initial delay for the bootstrapper,
+/// a <see cref="PeriodicTimer"/> loop, and a fresh DI scope per pass.
+/// </summary>
+public sealed class SqlOSCalendarSyncHostedService : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly SqlOSOptions _options;
+    private readonly ILogger<SqlOSCalendarSyncHostedService> _logger;
+
+    public SqlOSCalendarSyncHostedService(
+        IServiceScopeFactory scopeFactory,
+        IOptions<SqlOSOptions> options,
+        ILogger<SqlOSCalendarSyncHostedService> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var scheduler = _options.Calendar.SyncScheduler;
+        if (!_options.Calendar.Enabled || !scheduler.Enabled)
+        {
+            return;
+        }
+
+        // Delay the first pass to let the bootstrapper finish
+        await Task.Delay(scheduler.InitialDelay, stoppingToken);
+
+        using var timer = new PeriodicTimer(scheduler.Interval);
+        while (await timer.WaitForNextTickAsync(stoppingToken))
+        {
+            try
+            {
+                await SyncDueConnectionsAsync(stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error during scheduled calendar sync pass.");
+            }
+        }
+    }
+
+    private async Task SyncDueConnectionsAsync(CancellationToken cancellationToken)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var syncService = scope.ServiceProvider.GetRequiredService<SqlOSCalendarSyncService>();
+        var synced = await syncService.SyncDueConnectionsAsync(cancellationToken);
+        if (synced > 0)
+        {
+            _logger.LogInformation("Scheduled calendar sync completed for {Count} connection(s).", synced);
+        }
+    }
+}

--- a/src/SqlOS/Calendar/Services/SqlOSCalendarSyncService.cs
+++ b/src/SqlOS/Calendar/Services/SqlOSCalendarSyncService.cs
@@ -68,7 +68,7 @@ public sealed class SqlOSCalendarSyncService
 
         try
         {
-            var accessToken = await _calendarService.EnsureFreshAccessTokenAsync(connection, cancellationToken);
+            var accessToken = await _calendarService.EnsureFreshAccessTokenAsync(connection, forceRefresh: false, cancellationToken);
             var adapter = _calendarService.RequireAdapter(connection.ProviderType);
 
             var syncStates = await _context.Set<SqlOSCalendarSyncState>()
@@ -193,7 +193,7 @@ public sealed class SqlOSCalendarSyncService
             throw new InvalidOperationException("The event end time must be after its start time.");
         }
 
-        var accessToken = await _calendarService.EnsureFreshAccessTokenAsync(connection, cancellationToken);
+        var accessToken = await _calendarService.EnsureFreshAccessTokenAsync(connection, forceRefresh: false, cancellationToken);
         var adapter = _calendarService.RequireAdapter(connection.ProviderType);
         var created = await adapter.CreateEventAsync(accessToken, providerCalendarId, draft, cancellationToken);
 

--- a/src/SqlOS/Calendar/Services/SqlOSCalendarSyncService.cs
+++ b/src/SqlOS/Calendar/Services/SqlOSCalendarSyncService.cs
@@ -1,0 +1,425 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using SqlOS.AuthServer.Interfaces;
+using SqlOS.AuthServer.Services;
+using SqlOS.Calendar.Configuration;
+using SqlOS.Calendar.Contracts;
+using SqlOS.Calendar.Models;
+using SqlOS.Configuration;
+
+namespace SqlOS.Calendar.Services;
+
+/// <summary>
+/// Read-pull and two-way sync engine. Pulls provider events into the normalized
+/// <see cref="SqlOSCalendarEvent"/> table, keeps per-calendar incremental cursors, and
+/// delegates two-way conflicts to the app callback configured on
+/// <see cref="SqlOSCalendarOptions.OnTwoWayConflictAsync"/>.
+/// </summary>
+public sealed class SqlOSCalendarSyncService
+{
+    private readonly ISqlOSAuthServerDbContext _context;
+    private readonly SqlOSAdminService _adminService;
+    private readonly SqlOSCryptoService _cryptoService;
+    private readonly SqlOSCalendarService _calendarService;
+    private readonly SqlOSCalendarOptions _options;
+    private readonly ILogger<SqlOSCalendarSyncService> _logger;
+
+    public SqlOSCalendarSyncService(
+        ISqlOSAuthServerDbContext context,
+        SqlOSAdminService adminService,
+        SqlOSCryptoService cryptoService,
+        SqlOSCalendarService calendarService,
+        IOptions<SqlOSOptions> options,
+        ILogger<SqlOSCalendarSyncService> logger)
+    {
+        _context = context;
+        _adminService = adminService;
+        _cryptoService = cryptoService;
+        _calendarService = calendarService;
+        _options = options.Value.Calendar;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Synchronizes one read-pull or two-way connection. When the connection has no explicit
+    /// calendar selection yet, the provider's primary/default calendar is enrolled first.
+    /// </summary>
+    public async Task<SqlOSCalendarSyncResult> SyncConnectionAsync(
+        string calendarConnectionId,
+        CancellationToken cancellationToken = default)
+    {
+        var connection = await _calendarService.RequireConnectionAsync(
+            calendarConnectionId,
+            forUserId: null,
+            forOrganizationId: null,
+            includeRevoked: false,
+            cancellationToken);
+
+        if (connection.Mode == SqlOSCalendarIntegrationMode.ConnectionOnly)
+        {
+            throw new InvalidOperationException("Connection-only calendar connections do not synchronize events.");
+        }
+
+        var errors = new List<string>();
+        var eventsUpserted = 0;
+        var eventsRemoved = 0;
+        var calendarsSynced = 0;
+
+        try
+        {
+            var accessToken = await _calendarService.EnsureFreshAccessTokenAsync(connection, cancellationToken);
+            var adapter = _calendarService.RequireAdapter(connection.ProviderType);
+
+            var syncStates = await _context.Set<SqlOSCalendarSyncState>()
+                .Where(x => x.CalendarConnectionId == connection.Id && x.IsSyncEnabled)
+                .ToListAsync(cancellationToken);
+
+            if (syncStates.Count == 0)
+            {
+                var calendars = await adapter.ListCalendarsAsync(accessToken, cancellationToken);
+                var primary = calendars.FirstOrDefault(x => x.IsPrimary) ?? calendars.FirstOrDefault();
+                if (primary == null)
+                {
+                    throw new InvalidOperationException("The provider account does not expose any calendars to synchronize.");
+                }
+
+                var now = DateTime.UtcNow;
+                var state = new SqlOSCalendarSyncState
+                {
+                    Id = _cryptoService.GenerateId("csy"),
+                    CalendarConnectionId = connection.Id,
+                    ProviderCalendarId = primary.ProviderCalendarId,
+                    DisplayName = primary.DisplayName,
+                    CreatedAt = now,
+                    UpdatedAt = now
+                };
+                _context.Set<SqlOSCalendarSyncState>().Add(state);
+                await _context.SaveChangesAsync(cancellationToken);
+                syncStates.Add(state);
+            }
+
+            foreach (var state in syncStates)
+            {
+                try
+                {
+                    var (upserted, removed) = await SyncCalendarAsync(connection, adapter, accessToken, state, cancellationToken);
+                    eventsUpserted += upserted;
+                    eventsRemoved += removed;
+                    calendarsSynced++;
+                }
+                catch (InvalidOperationException ex)
+                {
+                    errors.Add($"{state.ProviderCalendarId}: {ex.Message}");
+                    state.LastSyncStatus = "error";
+                    state.LastSyncError = Truncate(ex.Message, 1000);
+                    state.UpdatedAt = DateTime.UtcNow;
+                    await _context.SaveChangesAsync(cancellationToken);
+                }
+            }
+
+            var finishedAt = DateTime.UtcNow;
+            connection.LastSyncAt = finishedAt;
+            if (errors.Count == 0)
+            {
+                connection.Status = SqlOSCalendarConnectionStatus.Active;
+                connection.LastError = null;
+                connection.LastErrorAt = null;
+            }
+            else
+            {
+                connection.Status = SqlOSCalendarConnectionStatus.Error;
+                connection.LastError = Truncate(string.Join("; ", errors), 1000);
+                connection.LastErrorAt = finishedAt;
+            }
+
+            connection.UpdatedAt = finishedAt;
+            await _context.SaveChangesAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            var now = DateTime.UtcNow;
+            errors.Add(ex.Message);
+            connection.Status = SqlOSCalendarConnectionStatus.Error;
+            connection.LastError = Truncate(ex.Message, 1000);
+            connection.LastErrorAt = now;
+            connection.UpdatedAt = now;
+            await _context.SaveChangesAsync(cancellationToken);
+            _logger.LogWarning(ex, "Calendar sync failed for connection {ConnectionId}.", connection.Id);
+        }
+
+        var result = new SqlOSCalendarSyncResult(connection.Id, calendarsSynced, eventsUpserted, eventsRemoved, errors);
+
+        await _adminService.RecordAuditAsync(
+            errors.Count == 0 ? "calendar.connection.synced" : "calendar.sync.failed",
+            "calendar_connection",
+            connection.Id,
+            userId: connection.UserId,
+            organizationId: connection.OrganizationId,
+            data: new
+            {
+                calendarsSynced,
+                eventsUpserted,
+                eventsRemoved,
+                errors
+            },
+            cancellationToken: cancellationToken);
+
+        return result;
+    }
+
+    /// <summary>
+    /// Creates an event on the provider calendar (two-way mode) and stores the local copy
+    /// with <c>Origin = "push"</c> so later pulls can detect conflicts.
+    /// </summary>
+    public async Task<SqlOSCalendarEventSnapshot> CreateEventAsync(
+        string calendarConnectionId,
+        string providerCalendarId,
+        SqlOSCalendarEventDraft draft,
+        string? forUserId = null,
+        string? forOrganizationId = null,
+        CancellationToken cancellationToken = default)
+    {
+        var connection = await _calendarService.RequireConnectionAsync(
+            calendarConnectionId, forUserId, forOrganizationId, includeRevoked: false, cancellationToken);
+
+        if (connection.Mode != SqlOSCalendarIntegrationMode.TwoWay)
+        {
+            throw new InvalidOperationException("Only two-way calendar connections can create provider events through SqlOS.");
+        }
+
+        if (draft.EndsAtUtc <= draft.StartsAtUtc)
+        {
+            throw new InvalidOperationException("The event end time must be after its start time.");
+        }
+
+        var accessToken = await _calendarService.EnsureFreshAccessTokenAsync(connection, cancellationToken);
+        var adapter = _calendarService.RequireAdapter(connection.ProviderType);
+        var created = await adapter.CreateEventAsync(accessToken, providerCalendarId, draft, cancellationToken);
+
+        var now = DateTime.UtcNow;
+        _context.Set<SqlOSCalendarEvent>().Add(new SqlOSCalendarEvent
+        {
+            Id = _cryptoService.GenerateId("cev"),
+            CalendarConnectionId = connection.Id,
+            ProviderCalendarId = providerCalendarId,
+            ProviderEventId = created.ProviderEventId,
+            Subject = created.Subject,
+            StartsAtUtc = created.StartsAtUtc,
+            EndsAtUtc = created.EndsAtUtc,
+            IsAllDay = created.IsAllDay,
+            ShowAs = created.ShowAs,
+            Status = created.Status,
+            Location = created.Location,
+            Origin = "push",
+            CreatedAt = now,
+            UpdatedAt = now
+        });
+        await _context.SaveChangesAsync(cancellationToken);
+
+        await _adminService.RecordAuditAsync(
+            "calendar.event.created",
+            "calendar_connection",
+            connection.Id,
+            userId: connection.UserId,
+            organizationId: connection.OrganizationId,
+            data: new
+            {
+                providerCalendarId,
+                providerEventId = created.ProviderEventId
+            },
+            cancellationToken: cancellationToken);
+
+        return created;
+    }
+
+    /// <summary>Synchronizes connections that are due, oldest first. Used by the background scheduler.</summary>
+    public async Task<int> SyncDueConnectionsAsync(CancellationToken cancellationToken = default)
+    {
+        var cutoff = DateTime.UtcNow - _options.SyncScheduler.SyncEvery;
+        var due = await _context.Set<SqlOSCalendarConnection>()
+            .Where(x => x.RevokedAt == null
+                && x.Mode != SqlOSCalendarIntegrationMode.ConnectionOnly
+                && (x.LastSyncAt == null || x.LastSyncAt < cutoff))
+            .OrderBy(x => x.LastSyncAt ?? DateTime.MinValue)
+            .Take(_options.SyncScheduler.MaxConnectionsPerRun)
+            .Select(x => x.Id)
+            .ToListAsync(cancellationToken);
+
+        foreach (var connectionId in due)
+        {
+            try
+            {
+                await SyncConnectionAsync(connectionId, cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Scheduled calendar sync failed for connection {ConnectionId}.", connectionId);
+            }
+        }
+
+        return due.Count;
+    }
+
+    private async Task<(int Upserted, int Removed)> SyncCalendarAsync(
+        SqlOSCalendarConnection connection,
+        Interfaces.ISqlOSCalendarProviderAdapter adapter,
+        string accessToken,
+        SqlOSCalendarSyncState state,
+        CancellationToken cancellationToken)
+    {
+        var windowStart = DateTime.UtcNow.AddDays(-_options.SyncWindowPastDays);
+        var windowEnd = DateTime.UtcNow.AddDays(_options.SyncWindowFutureDays);
+        state.LastSyncStartedAt = DateTime.UtcNow;
+
+        SqlOSCalendarEventPage page;
+        try
+        {
+            page = await adapter.ListEventsAsync(accessToken, state.ProviderCalendarId, windowStart, windowEnd, state.SyncCursor, cancellationToken);
+        }
+        catch (InvalidOperationException) when (!string.IsNullOrWhiteSpace(state.SyncCursor))
+        {
+            // Incremental cursors expire (e.g. Google 410 GONE). Fall back to a full window pull.
+            state.SyncCursor = null;
+            page = await adapter.ListEventsAsync(accessToken, state.ProviderCalendarId, windowStart, windowEnd, syncCursor: null, cancellationToken);
+        }
+
+        var existing = await _context.Set<SqlOSCalendarEvent>()
+            .Where(x => x.CalendarConnectionId == connection.Id && x.ProviderCalendarId == state.ProviderCalendarId)
+            .ToListAsync(cancellationToken);
+        var existingByProviderId = existing.ToDictionary(x => x.ProviderEventId, StringComparer.Ordinal);
+
+        var upserted = 0;
+        var removed = 0;
+        var now = DateTime.UtcNow;
+
+        foreach (var snapshot in page.Events)
+        {
+            existingByProviderId.TryGetValue(snapshot.ProviderEventId, out var local);
+
+            if (string.Equals(snapshot.Status, "cancelled", StringComparison.OrdinalIgnoreCase))
+            {
+                if (local != null)
+                {
+                    _context.Set<SqlOSCalendarEvent>().Remove(local);
+                    existingByProviderId.Remove(snapshot.ProviderEventId);
+                    removed++;
+                }
+
+                continue;
+            }
+
+            if (local == null)
+            {
+                var created = new SqlOSCalendarEvent
+                {
+                    Id = _cryptoService.GenerateId("cev"),
+                    CalendarConnectionId = connection.Id,
+                    ProviderCalendarId = state.ProviderCalendarId,
+                    ProviderEventId = snapshot.ProviderEventId,
+                    Origin = "pull",
+                    CreatedAt = now
+                };
+                ApplySnapshot(created, snapshot, now);
+                _context.Set<SqlOSCalendarEvent>().Add(created);
+                existingByProviderId[snapshot.ProviderEventId] = created;
+                upserted++;
+                continue;
+            }
+
+            if (SnapshotMatches(local, snapshot))
+            {
+                continue;
+            }
+
+            if (connection.Mode == SqlOSCalendarIntegrationMode.TwoWay
+                && string.Equals(local.Origin, "push", StringComparison.Ordinal))
+            {
+                var decision = await ResolveConflictAsync(connection, state, local, snapshot, cancellationToken);
+                if (decision == SqlOSCalendarConflictDecision.PreferLocal)
+                {
+                    continue;
+                }
+            }
+
+            ApplySnapshot(local, snapshot, now);
+            upserted++;
+        }
+
+        state.SyncCursor = page.NextSyncCursor ?? state.SyncCursor;
+        state.LastSyncCompletedAt = DateTime.UtcNow;
+        state.LastSyncStatus = "ok";
+        state.LastSyncError = null;
+        state.EventCount = existingByProviderId.Count;
+        state.UpdatedAt = DateTime.UtcNow;
+        await _context.SaveChangesAsync(cancellationToken);
+
+        return (upserted, removed);
+    }
+
+    private async Task<SqlOSCalendarConflictDecision> ResolveConflictAsync(
+        SqlOSCalendarConnection connection,
+        SqlOSCalendarSyncState state,
+        SqlOSCalendarEvent local,
+        SqlOSCalendarEventSnapshot remote,
+        CancellationToken cancellationToken)
+    {
+        if (_options.OnTwoWayConflictAsync == null)
+        {
+            return SqlOSCalendarConflictDecision.PreferProvider;
+        }
+
+        var context = new SqlOSCalendarConflictContext(
+            connection.Id,
+            state.ProviderCalendarId,
+            remote.ProviderEventId,
+            new SqlOSCalendarEventSnapshot(
+                local.ProviderEventId,
+                local.Subject,
+                local.StartsAtUtc,
+                local.EndsAtUtc,
+                local.IsAllDay,
+                local.ShowAs,
+                local.Status,
+                local.Location),
+            remote);
+
+        try
+        {
+            return await _options.OnTwoWayConflictAsync(context, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Two-way conflict callback failed for connection {ConnectionId}; preferring the provider version.", connection.Id);
+            return SqlOSCalendarConflictDecision.PreferProvider;
+        }
+    }
+
+    private static void ApplySnapshot(SqlOSCalendarEvent target, SqlOSCalendarEventSnapshot snapshot, DateTime now)
+    {
+        target.Subject = snapshot.Subject;
+        target.StartsAtUtc = snapshot.StartsAtUtc;
+        target.EndsAtUtc = snapshot.EndsAtUtc;
+        target.IsAllDay = snapshot.IsAllDay;
+        target.ShowAs = snapshot.ShowAs;
+        target.Status = snapshot.Status;
+        target.Location = snapshot.Location;
+        target.UpdatedAt = now;
+    }
+
+    private static bool SnapshotMatches(SqlOSCalendarEvent local, SqlOSCalendarEventSnapshot snapshot)
+        => string.Equals(local.Subject, snapshot.Subject, StringComparison.Ordinal)
+           && local.StartsAtUtc == snapshot.StartsAtUtc
+           && local.EndsAtUtc == snapshot.EndsAtUtc
+           && local.IsAllDay == snapshot.IsAllDay
+           && string.Equals(local.ShowAs, snapshot.ShowAs, StringComparison.Ordinal)
+           && string.Equals(local.Status, snapshot.Status, StringComparison.Ordinal)
+           && string.Equals(local.Location, snapshot.Location, StringComparison.Ordinal);
+
+    private static string Truncate(string value, int maxLength)
+        => value.Length <= maxLength ? value : value[..maxLength];
+}

--- a/src/SqlOS/Calendar/Services/SqlOSGoogleCalendarAdapter.cs
+++ b/src/SqlOS/Calendar/Services/SqlOSGoogleCalendarAdapter.cs
@@ -100,38 +100,55 @@ public sealed class SqlOSGoogleCalendarAdapter : ISqlOSCalendarProviderAdapter
         string? syncCursor,
         CancellationToken cancellationToken = default)
     {
-        var url = new StringBuilder($"{CalendarApiBaseUrl}/calendars/{Uri.EscapeDataString(providerCalendarId)}/events?singleEvents=true");
+        var baseUrl = new StringBuilder($"{CalendarApiBaseUrl}/calendars/{Uri.EscapeDataString(providerCalendarId)}/events?singleEvents=true");
         if (string.IsNullOrWhiteSpace(syncCursor))
         {
-            url.Append("&timeMin=").Append(Uri.EscapeDataString(SqlOSCalendarProviderHttp.FormatUtc(windowStartUtc)));
-            url.Append("&timeMax=").Append(Uri.EscapeDataString(SqlOSCalendarProviderHttp.FormatUtc(windowEndUtc)));
+            baseUrl.Append("&timeMin=").Append(Uri.EscapeDataString(SqlOSCalendarProviderHttp.FormatUtc(windowStartUtc)));
+            baseUrl.Append("&timeMax=").Append(Uri.EscapeDataString(SqlOSCalendarProviderHttp.FormatUtc(windowEndUtc)));
         }
         else
         {
-            url.Append("&syncToken=").Append(Uri.EscapeDataString(syncCursor));
+            baseUrl.Append("&syncToken=").Append(Uri.EscapeDataString(syncCursor));
         }
 
-        using var payload = await SqlOSCalendarProviderHttp.GetJsonAsync(
-            CreateClient(),
-            url.ToString(),
-            accessToken,
-            "The Google calendar events request failed.",
-            cancellationToken);
-
         var events = new List<SqlOSCalendarEventSnapshot>();
-        if (payload.RootElement.TryGetProperty("items", out var items) && items.ValueKind == JsonValueKind.Array)
+        string? nextCursor = null;
+        string? pageToken = null;
+
+        // Follow nextPageToken pages; Google only returns nextSyncToken on the final page.
+        for (var page = 0; page < 25; page++)
         {
-            foreach (var item in items.EnumerateArray())
+            var url = pageToken == null
+                ? baseUrl.ToString()
+                : $"{baseUrl}&pageToken={Uri.EscapeDataString(pageToken)}";
+
+            using var payload = await SqlOSCalendarProviderHttp.GetJsonAsync(
+                CreateClient(),
+                url,
+                accessToken,
+                "The Google calendar events request failed.",
+                cancellationToken);
+
+            if (payload.RootElement.TryGetProperty("items", out var items) && items.ValueKind == JsonValueKind.Array)
             {
-                var snapshot = MapEvent(item);
-                if (snapshot != null)
+                foreach (var item in items.EnumerateArray())
                 {
-                    events.Add(snapshot);
+                    var snapshot = MapEvent(item);
+                    if (snapshot != null)
+                    {
+                        events.Add(snapshot);
+                    }
                 }
+            }
+
+            nextCursor = SqlOSCalendarProviderHttp.GetString(payload.RootElement, "nextSyncToken") ?? nextCursor;
+            pageToken = SqlOSCalendarProviderHttp.GetString(payload.RootElement, "nextPageToken");
+            if (string.IsNullOrWhiteSpace(pageToken))
+            {
+                break;
             }
         }
 
-        var nextCursor = SqlOSCalendarProviderHttp.GetString(payload.RootElement, "nextSyncToken");
         return new SqlOSCalendarEventPage(events, nextCursor);
     }
 

--- a/src/SqlOS/Calendar/Services/SqlOSGoogleCalendarAdapter.cs
+++ b/src/SqlOS/Calendar/Services/SqlOSGoogleCalendarAdapter.cs
@@ -1,0 +1,237 @@
+using System.Text;
+using System.Text.Json;
+using SqlOS.Calendar.Contracts;
+using SqlOS.Calendar.Interfaces;
+using SqlOS.Calendar.Models;
+
+namespace SqlOS.Calendar.Services;
+
+/// <summary>
+/// Minimal Google Calendar API v3 client. Uses raw REST calls so the SqlOS package stays
+/// dependency-free and tests can fake the HTTP layer.
+/// </summary>
+public sealed class SqlOSGoogleCalendarAdapter : ISqlOSCalendarProviderAdapter
+{
+    internal const string CalendarApiBaseUrl = "https://www.googleapis.com/calendar/v3";
+
+    private readonly IHttpClientFactory _httpClientFactory;
+
+    public SqlOSGoogleCalendarAdapter(IHttpClientFactory httpClientFactory)
+    {
+        _httpClientFactory = httpClientFactory;
+    }
+
+    public SqlOSCalendarProviderType ProviderType => SqlOSCalendarProviderType.Google;
+
+    public async Task<SqlOSCalendarTokenResult> ExchangeAuthorizationCodeAsync(
+        SqlOSCalendarProviderContext context,
+        string code,
+        string redirectUri,
+        string codeVerifier,
+        CancellationToken cancellationToken = default)
+        => await SqlOSCalendarProviderHttp.PostTokenFormAsync(
+            CreateClient(),
+            context.TokenEndpoint,
+            new Dictionary<string, string>
+            {
+                ["grant_type"] = "authorization_code",
+                ["client_id"] = context.ClientId,
+                ["client_secret"] = context.ClientSecret,
+                ["code"] = code,
+                ["redirect_uri"] = redirectUri,
+                ["code_verifier"] = codeVerifier
+            },
+            cancellationToken);
+
+    public async Task<SqlOSCalendarTokenResult> RefreshAccessTokenAsync(
+        SqlOSCalendarProviderContext context,
+        string refreshToken,
+        CancellationToken cancellationToken = default)
+        => await SqlOSCalendarProviderHttp.PostTokenFormAsync(
+            CreateClient(),
+            context.TokenEndpoint,
+            new Dictionary<string, string>
+            {
+                ["grant_type"] = "refresh_token",
+                ["client_id"] = context.ClientId,
+                ["client_secret"] = context.ClientSecret,
+                ["refresh_token"] = refreshToken
+            },
+            cancellationToken);
+
+    public async Task<IReadOnlyList<SqlOSCalendarSummary>> ListCalendarsAsync(
+        string accessToken,
+        CancellationToken cancellationToken = default)
+    {
+        using var payload = await SqlOSCalendarProviderHttp.GetJsonAsync(
+            CreateClient(),
+            $"{CalendarApiBaseUrl}/users/me/calendarList",
+            accessToken,
+            "The Google calendar list request failed.",
+            cancellationToken);
+
+        var calendars = new List<SqlOSCalendarSummary>();
+        if (payload.RootElement.TryGetProperty("items", out var items) && items.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in items.EnumerateArray())
+            {
+                var id = SqlOSCalendarProviderHttp.GetString(item, "id");
+                if (string.IsNullOrWhiteSpace(id))
+                {
+                    continue;
+                }
+
+                calendars.Add(new SqlOSCalendarSummary(
+                    id!,
+                    SqlOSCalendarProviderHttp.GetString(item, "summary") ?? id!,
+                    item.TryGetProperty("primary", out var primary) && primary.ValueKind == JsonValueKind.True,
+                    SqlOSCalendarProviderHttp.GetString(item, "timeZone")));
+            }
+        }
+
+        return calendars;
+    }
+
+    public async Task<SqlOSCalendarEventPage> ListEventsAsync(
+        string accessToken,
+        string providerCalendarId,
+        DateTime windowStartUtc,
+        DateTime windowEndUtc,
+        string? syncCursor,
+        CancellationToken cancellationToken = default)
+    {
+        var url = new StringBuilder($"{CalendarApiBaseUrl}/calendars/{Uri.EscapeDataString(providerCalendarId)}/events?singleEvents=true");
+        if (string.IsNullOrWhiteSpace(syncCursor))
+        {
+            url.Append("&timeMin=").Append(Uri.EscapeDataString(SqlOSCalendarProviderHttp.FormatUtc(windowStartUtc)));
+            url.Append("&timeMax=").Append(Uri.EscapeDataString(SqlOSCalendarProviderHttp.FormatUtc(windowEndUtc)));
+        }
+        else
+        {
+            url.Append("&syncToken=").Append(Uri.EscapeDataString(syncCursor));
+        }
+
+        using var payload = await SqlOSCalendarProviderHttp.GetJsonAsync(
+            CreateClient(),
+            url.ToString(),
+            accessToken,
+            "The Google calendar events request failed.",
+            cancellationToken);
+
+        var events = new List<SqlOSCalendarEventSnapshot>();
+        if (payload.RootElement.TryGetProperty("items", out var items) && items.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in items.EnumerateArray())
+            {
+                var snapshot = MapEvent(item);
+                if (snapshot != null)
+                {
+                    events.Add(snapshot);
+                }
+            }
+        }
+
+        var nextCursor = SqlOSCalendarProviderHttp.GetString(payload.RootElement, "nextSyncToken");
+        return new SqlOSCalendarEventPage(events, nextCursor);
+    }
+
+    public async Task<SqlOSCalendarEventSnapshot> CreateEventAsync(
+        string accessToken,
+        string providerCalendarId,
+        SqlOSCalendarEventDraft draft,
+        CancellationToken cancellationToken = default)
+    {
+        object body = draft.IsAllDay
+            ? new
+            {
+                summary = draft.Subject,
+                location = draft.Location,
+                description = draft.Description,
+                start = new { date = draft.StartsAtUtc.ToString("yyyy-MM-dd") },
+                end = new { date = draft.EndsAtUtc.ToString("yyyy-MM-dd") }
+            }
+            : new
+            {
+                summary = draft.Subject,
+                location = draft.Location,
+                description = draft.Description,
+                start = new { dateTime = SqlOSCalendarProviderHttp.FormatUtc(draft.StartsAtUtc), timeZone = "UTC" },
+                end = new { dateTime = SqlOSCalendarProviderHttp.FormatUtc(draft.EndsAtUtc), timeZone = "UTC" }
+            };
+
+        using var payload = await SqlOSCalendarProviderHttp.PostJsonAsync(
+            CreateClient(),
+            $"{CalendarApiBaseUrl}/calendars/{Uri.EscapeDataString(providerCalendarId)}/events",
+            accessToken,
+            body,
+            "The Google calendar event creation failed.",
+            cancellationToken);
+
+        return MapEvent(payload.RootElement)
+            ?? throw new InvalidOperationException("Google did not return the created calendar event.");
+    }
+
+    private static SqlOSCalendarEventSnapshot? MapEvent(JsonElement item)
+    {
+        var id = SqlOSCalendarProviderHttp.GetString(item, "id");
+        if (string.IsNullOrWhiteSpace(id))
+        {
+            return null;
+        }
+
+        var status = SqlOSCalendarProviderHttp.GetString(item, "status") ?? "confirmed";
+        var (startsAt, isAllDay) = ReadEventTime(item, "start");
+        var (endsAt, _) = ReadEventTime(item, "end");
+        if (startsAt == null || endsAt == null)
+        {
+            // Cancelled incremental entries omit times; surface them so sync can remove local copies.
+            if (string.Equals(status, "cancelled", StringComparison.OrdinalIgnoreCase))
+            {
+                return new SqlOSCalendarEventSnapshot(id!, null, DateTime.MinValue, DateTime.MinValue, false, "free", "cancelled", null);
+            }
+
+            return null;
+        }
+
+        var transparency = SqlOSCalendarProviderHttp.GetString(item, "transparency");
+        var showAs = string.Equals(transparency, "transparent", StringComparison.OrdinalIgnoreCase) ? "free" : "busy";
+        if (string.Equals(status, "tentative", StringComparison.OrdinalIgnoreCase))
+        {
+            showAs = "tentative";
+        }
+
+        return new SqlOSCalendarEventSnapshot(
+            id!,
+            SqlOSCalendarProviderHttp.GetString(item, "summary"),
+            startsAt.Value,
+            endsAt.Value,
+            isAllDay,
+            showAs,
+            status.ToLowerInvariant(),
+            SqlOSCalendarProviderHttp.GetString(item, "location"));
+    }
+
+    private static (DateTime? Value, bool IsAllDay) ReadEventTime(JsonElement item, string propertyName)
+    {
+        if (!item.TryGetProperty(propertyName, out var timeElement) || timeElement.ValueKind != JsonValueKind.Object)
+        {
+            return (null, false);
+        }
+
+        var dateTime = SqlOSCalendarProviderHttp.GetString(timeElement, "dateTime");
+        if (!string.IsNullOrWhiteSpace(dateTime) && DateTimeOffset.TryParse(dateTime, out var parsed))
+        {
+            return (parsed.UtcDateTime, false);
+        }
+
+        var date = SqlOSCalendarProviderHttp.GetString(timeElement, "date");
+        if (!string.IsNullOrWhiteSpace(date) && DateTime.TryParse(date, out var parsedDate))
+        {
+            return (DateTime.SpecifyKind(parsedDate.Date, DateTimeKind.Utc), true);
+        }
+
+        return (null, false);
+    }
+
+    private HttpClient CreateClient() => _httpClientFactory.CreateClient(nameof(SqlOSGoogleCalendarAdapter));
+}

--- a/src/SqlOS/Calendar/Services/SqlOSMicrosoftGraphCalendarAdapter.cs
+++ b/src/SqlOS/Calendar/Services/SqlOSMicrosoftGraphCalendarAdapter.cs
@@ -1,0 +1,258 @@
+using System.Text;
+using System.Text.Json;
+using SqlOS.Calendar.Contracts;
+using SqlOS.Calendar.Interfaces;
+using SqlOS.Calendar.Models;
+
+namespace SqlOS.Calendar.Services;
+
+/// <summary>
+/// Minimal Microsoft Graph calendar client (v1.0). Uses raw REST calls so the SqlOS package
+/// stays dependency-free and tests can fake the HTTP layer.
+/// </summary>
+public sealed class SqlOSMicrosoftGraphCalendarAdapter : ISqlOSCalendarProviderAdapter
+{
+    internal const string GraphBaseUrl = "https://graph.microsoft.com/v1.0";
+
+    private readonly IHttpClientFactory _httpClientFactory;
+
+    public SqlOSMicrosoftGraphCalendarAdapter(IHttpClientFactory httpClientFactory)
+    {
+        _httpClientFactory = httpClientFactory;
+    }
+
+    public SqlOSCalendarProviderType ProviderType => SqlOSCalendarProviderType.Microsoft;
+
+    public async Task<SqlOSCalendarTokenResult> ExchangeAuthorizationCodeAsync(
+        SqlOSCalendarProviderContext context,
+        string code,
+        string redirectUri,
+        string codeVerifier,
+        CancellationToken cancellationToken = default)
+        => await SqlOSCalendarProviderHttp.PostTokenFormAsync(
+            CreateClient(),
+            context.TokenEndpoint,
+            new Dictionary<string, string>
+            {
+                ["grant_type"] = "authorization_code",
+                ["client_id"] = context.ClientId,
+                ["client_secret"] = context.ClientSecret,
+                ["code"] = code,
+                ["redirect_uri"] = redirectUri,
+                ["code_verifier"] = codeVerifier
+            },
+            cancellationToken);
+
+    public async Task<SqlOSCalendarTokenResult> RefreshAccessTokenAsync(
+        SqlOSCalendarProviderContext context,
+        string refreshToken,
+        CancellationToken cancellationToken = default)
+        => await SqlOSCalendarProviderHttp.PostTokenFormAsync(
+            CreateClient(),
+            context.TokenEndpoint,
+            new Dictionary<string, string>
+            {
+                ["grant_type"] = "refresh_token",
+                ["client_id"] = context.ClientId,
+                ["client_secret"] = context.ClientSecret,
+                ["refresh_token"] = refreshToken
+            },
+            cancellationToken);
+
+    public async Task<IReadOnlyList<SqlOSCalendarSummary>> ListCalendarsAsync(
+        string accessToken,
+        CancellationToken cancellationToken = default)
+    {
+        using var payload = await SqlOSCalendarProviderHttp.GetJsonAsync(
+            CreateClient(),
+            $"{GraphBaseUrl}/me/calendars",
+            accessToken,
+            "The Microsoft Graph calendar list request failed.",
+            cancellationToken);
+
+        var calendars = new List<SqlOSCalendarSummary>();
+        if (payload.RootElement.TryGetProperty("value", out var items) && items.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in items.EnumerateArray())
+            {
+                var id = SqlOSCalendarProviderHttp.GetString(item, "id");
+                if (string.IsNullOrWhiteSpace(id))
+                {
+                    continue;
+                }
+
+                calendars.Add(new SqlOSCalendarSummary(
+                    id!,
+                    SqlOSCalendarProviderHttp.GetString(item, "name") ?? id!,
+                    item.TryGetProperty("isDefaultCalendar", out var isDefault) && isDefault.ValueKind == JsonValueKind.True,
+                    TimeZone: null));
+            }
+        }
+
+        return calendars;
+    }
+
+    public async Task<SqlOSCalendarEventPage> ListEventsAsync(
+        string accessToken,
+        string providerCalendarId,
+        DateTime windowStartUtc,
+        DateTime windowEndUtc,
+        string? syncCursor,
+        CancellationToken cancellationToken = default)
+    {
+        // Graph delta links embed the original window; reuse them verbatim when present.
+        var url = !string.IsNullOrWhiteSpace(syncCursor) && syncCursor.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+            ? syncCursor
+            : new StringBuilder($"{GraphBaseUrl}/me/calendars/{Uri.EscapeDataString(providerCalendarId)}/calendarView/delta")
+                .Append("?startDateTime=").Append(Uri.EscapeDataString(SqlOSCalendarProviderHttp.FormatUtc(windowStartUtc)))
+                .Append("&endDateTime=").Append(Uri.EscapeDataString(SqlOSCalendarProviderHttp.FormatUtc(windowEndUtc)))
+                .ToString();
+
+        var events = new List<SqlOSCalendarEventSnapshot>();
+        string? nextCursor = null;
+
+        // Follow @odata.nextLink pages until Graph hands back the @odata.deltaLink cursor.
+        for (var page = 0; page < 25 && url != null; page++)
+        {
+            using var payload = await SqlOSCalendarProviderHttp.GetJsonAsync(
+                CreateClient(),
+                url,
+                accessToken,
+                "The Microsoft Graph calendar events request failed.",
+                cancellationToken);
+
+            if (payload.RootElement.TryGetProperty("value", out var items) && items.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var item in items.EnumerateArray())
+                {
+                    var snapshot = MapEvent(item);
+                    if (snapshot != null)
+                    {
+                        events.Add(snapshot);
+                    }
+                }
+            }
+
+            var nextLink = SqlOSCalendarProviderHttp.GetString(payload.RootElement, "@odata.nextLink");
+            var deltaLink = SqlOSCalendarProviderHttp.GetString(payload.RootElement, "@odata.deltaLink");
+            if (!string.IsNullOrWhiteSpace(deltaLink))
+            {
+                nextCursor = deltaLink;
+            }
+
+            url = string.IsNullOrWhiteSpace(nextLink) ? null : nextLink;
+        }
+
+        return new SqlOSCalendarEventPage(events, nextCursor);
+    }
+
+    public async Task<SqlOSCalendarEventSnapshot> CreateEventAsync(
+        string accessToken,
+        string providerCalendarId,
+        SqlOSCalendarEventDraft draft,
+        CancellationToken cancellationToken = default)
+    {
+        var body = new
+        {
+            subject = draft.Subject,
+            isAllDay = draft.IsAllDay,
+            body = draft.Description == null ? null : new { contentType = "text", content = draft.Description },
+            location = draft.Location == null ? null : new { displayName = draft.Location },
+            start = new { dateTime = SqlOSCalendarProviderHttp.FormatUtc(draft.StartsAtUtc), timeZone = "UTC" },
+            end = new { dateTime = SqlOSCalendarProviderHttp.FormatUtc(draft.EndsAtUtc), timeZone = "UTC" }
+        };
+
+        using var payload = await SqlOSCalendarProviderHttp.PostJsonAsync(
+            CreateClient(),
+            $"{GraphBaseUrl}/me/calendars/{Uri.EscapeDataString(providerCalendarId)}/events",
+            accessToken,
+            body,
+            "The Microsoft Graph event creation failed.",
+            cancellationToken);
+
+        return MapEvent(payload.RootElement)
+            ?? throw new InvalidOperationException("Microsoft Graph did not return the created calendar event.");
+    }
+
+    private static SqlOSCalendarEventSnapshot? MapEvent(JsonElement item)
+    {
+        var id = SqlOSCalendarProviderHttp.GetString(item, "id");
+        if (string.IsNullOrWhiteSpace(id))
+        {
+            return null;
+        }
+
+        // Delta payloads mark deletions with an @removed annotation.
+        if (item.TryGetProperty("@removed", out var removed) && removed.ValueKind != JsonValueKind.Null)
+        {
+            return new SqlOSCalendarEventSnapshot(id!, null, DateTime.MinValue, DateTime.MinValue, false, "free", "cancelled", null);
+        }
+
+        var startsAt = ReadEventTime(item, "start");
+        var endsAt = ReadEventTime(item, "end");
+        if (startsAt == null || endsAt == null)
+        {
+            return null;
+        }
+
+        var isCancelled = item.TryGetProperty("isCancelled", out var cancelled) && cancelled.ValueKind == JsonValueKind.True;
+        var showAs = (SqlOSCalendarProviderHttp.GetString(item, "showAs") ?? "busy").ToLowerInvariant();
+        if (showAs is not ("busy" or "free" or "tentative" or "oof"))
+        {
+            showAs = "busy";
+        }
+
+        string? location = null;
+        if (item.TryGetProperty("location", out var locationElement) && locationElement.ValueKind == JsonValueKind.Object)
+        {
+            location = SqlOSCalendarProviderHttp.GetString(locationElement, "displayName");
+        }
+
+        return new SqlOSCalendarEventSnapshot(
+            id!,
+            SqlOSCalendarProviderHttp.GetString(item, "subject"),
+            startsAt.Value,
+            endsAt.Value,
+            item.TryGetProperty("isAllDay", out var allDay) && allDay.ValueKind == JsonValueKind.True,
+            showAs,
+            isCancelled ? "cancelled" : "confirmed",
+            location);
+    }
+
+    private static DateTime? ReadEventTime(JsonElement item, string propertyName)
+    {
+        if (!item.TryGetProperty(propertyName, out var timeElement) || timeElement.ValueKind != JsonValueKind.Object)
+        {
+            return null;
+        }
+
+        var dateTime = SqlOSCalendarProviderHttp.GetString(timeElement, "dateTime");
+        if (string.IsNullOrWhiteSpace(dateTime))
+        {
+            return null;
+        }
+
+        if (!DateTime.TryParse(dateTime, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.AdjustToUniversal | System.Globalization.DateTimeStyles.AssumeUniversal, out var parsed))
+        {
+            return null;
+        }
+
+        var timeZone = SqlOSCalendarProviderHttp.GetString(timeElement, "timeZone");
+        if (!string.IsNullOrWhiteSpace(timeZone) && !string.Equals(timeZone, "UTC", StringComparison.OrdinalIgnoreCase))
+        {
+            try
+            {
+                var tz = TimeZoneInfo.FindSystemTimeZoneById(timeZone!);
+                parsed = TimeZoneInfo.ConvertTimeToUtc(DateTime.SpecifyKind(parsed, DateTimeKind.Unspecified), tz);
+            }
+            catch (TimeZoneNotFoundException)
+            {
+                // Fall back to treating the value as UTC.
+            }
+        }
+
+        return DateTime.SpecifyKind(parsed, DateTimeKind.Utc);
+    }
+
+    private HttpClient CreateClient() => _httpClientFactory.CreateClient(nameof(SqlOSMicrosoftGraphCalendarAdapter));
+}

--- a/src/SqlOS/Configuration/SqlOSOptions.cs
+++ b/src/SqlOS/Configuration/SqlOSOptions.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using SqlOS.AuthServer.Configuration;
+using SqlOS.Calendar.Configuration;
 using SqlOS.Email.Configuration;
 using SqlOS.Fga.Configuration;
 
@@ -25,6 +26,7 @@ public sealed class SqlOSOptions
     public SqlOSFgaOptions Fga { get; } = new();
     public SqlOSAuthServerOptions AuthServer { get; } = new();
     public SqlOSEmailOptions Email { get; } = new();
+    public SqlOSCalendarOptions Calendar { get; } = new();
 
     public SqlOSOptions UseSingleApplication(string name, Action<SqlOSSingleApplicationOptions>? configure = null)
     {
@@ -41,6 +43,12 @@ public sealed class SqlOSOptions
     public SqlOSOptions ConfigureEmail(Action<SqlOSEmailOptions> configure)
     {
         configure(Email);
+        return this;
+    }
+
+    public SqlOSOptions ConfigureCalendar(Action<SqlOSCalendarOptions> configure)
+    {
+        configure(Calendar);
         return this;
     }
 }

--- a/src/SqlOS/Configuration/SqlOSOptionsValidator.cs
+++ b/src/SqlOS/Configuration/SqlOSOptionsValidator.cs
@@ -1,4 +1,5 @@
 using SqlOS.AuthServer.Configuration;
+using SqlOS.Calendar.Configuration;
 using SqlOS.Email.Configuration;
 
 namespace SqlOS.Configuration;
@@ -77,6 +78,7 @@ internal static class SqlOSOptionsValidator
         ValidatePhoneOtpOptions(options.AuthServer.PhoneOtp, errors);
         ValidatePasswordResetOptions(options.AuthServer.PasswordReset, errors);
         ValidateEmailOptions(options.Email, errors);
+        ValidateCalendarOptions(options.Calendar, errors);
         ValidatePasswordLoginAbuseOptions(options.AuthServer.PasswordLogin, errors);
         ValidateClientRegistrationOptions(options.AuthServer, errors);
 
@@ -411,6 +413,49 @@ internal static class SqlOSOptionsValidator
         if (options.RenderedTextPreviewMaxLength <= 0)
         {
             errors.Add("Email.RenderedTextPreviewMaxLength must be greater than zero.");
+        }
+    }
+
+    private static void ValidateCalendarOptions(SqlOSCalendarOptions options, List<string> errors)
+    {
+        if (options.ConnectSessionLifetime <= TimeSpan.Zero)
+        {
+            errors.Add("Calendar.ConnectSessionLifetime must be greater than zero.");
+        }
+
+        if (options.AccessTokenRefreshSkew < TimeSpan.Zero)
+        {
+            errors.Add("Calendar.AccessTokenRefreshSkew must be zero or greater.");
+        }
+
+        if (options.SyncWindowPastDays < 0)
+        {
+            errors.Add("Calendar.SyncWindowPastDays must be zero or greater.");
+        }
+
+        if (options.SyncWindowFutureDays <= 0)
+        {
+            errors.Add("Calendar.SyncWindowFutureDays must be greater than zero.");
+        }
+
+        if (!options.SyncScheduler.Enabled)
+        {
+            return;
+        }
+
+        if (options.SyncScheduler.Interval <= TimeSpan.Zero)
+        {
+            errors.Add("Calendar.SyncScheduler.Interval must be greater than zero.");
+        }
+
+        if (options.SyncScheduler.SyncEvery <= TimeSpan.Zero)
+        {
+            errors.Add("Calendar.SyncScheduler.SyncEvery must be greater than zero.");
+        }
+
+        if (options.SyncScheduler.MaxConnectionsPerRun <= 0)
+        {
+            errors.Add("Calendar.SyncScheduler.MaxConnectionsPerRun must be greater than zero.");
         }
     }
 

--- a/src/SqlOS/Dashboard/SqlOSDashboardMiddleware.cs
+++ b/src/SqlOS/Dashboard/SqlOSDashboardMiddleware.cs
@@ -367,6 +367,11 @@ public sealed class SqlOSDashboardMiddleware
             return true;
         }
 
+        if (relativePath.StartsWith("admin/calendar/api/", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
         if (relativePath.StartsWith("auth/", StringComparison.OrdinalIgnoreCase)
             || relativePath.StartsWith("admin/auth/api/", StringComparison.OrdinalIgnoreCase)
             || relativePath.StartsWith("admin/auth/sso-portal", StringComparison.OrdinalIgnoreCase)
@@ -380,7 +385,8 @@ public sealed class SqlOSDashboardMiddleware
             && (relativePath.StartsWith("admin/auth/", StringComparison.OrdinalIgnoreCase)
                 || relativePath.StartsWith("admin/fga/", StringComparison.OrdinalIgnoreCase)
                 || relativePath.StartsWith("admin/audit/", StringComparison.OrdinalIgnoreCase)
-                || relativePath.StartsWith("admin/email/", StringComparison.OrdinalIgnoreCase)))
+                || relativePath.StartsWith("admin/email/", StringComparison.OrdinalIgnoreCase)
+                || relativePath.StartsWith("admin/calendar/", StringComparison.OrdinalIgnoreCase)))
         {
             return true;
         }
@@ -388,7 +394,8 @@ public sealed class SqlOSDashboardMiddleware
         if (embedMode && (relativePath.StartsWith("admin/auth", StringComparison.OrdinalIgnoreCase)
                           || relativePath.StartsWith("admin/fga", StringComparison.OrdinalIgnoreCase)
                           || relativePath.StartsWith("admin/audit", StringComparison.OrdinalIgnoreCase)
-                          || relativePath.StartsWith("admin/email", StringComparison.OrdinalIgnoreCase)))
+                          || relativePath.StartsWith("admin/email", StringComparison.OrdinalIgnoreCase)
+                          || relativePath.StartsWith("admin/calendar", StringComparison.OrdinalIgnoreCase)))
         {
             return true;
         }
@@ -419,7 +426,8 @@ public sealed class SqlOSDashboardMiddleware
 
         if (relativePath.StartsWith("admin/auth", StringComparison.OrdinalIgnoreCase)
             || relativePath.StartsWith("admin/audit", StringComparison.OrdinalIgnoreCase)
-            || relativePath.StartsWith("admin/email", StringComparison.OrdinalIgnoreCase))
+            || relativePath.StartsWith("admin/email", StringComparison.OrdinalIgnoreCase)
+            || relativePath.StartsWith("admin/calendar", StringComparison.OrdinalIgnoreCase))
         {
             return true;
         }

--- a/src/SqlOS/Dashboard/wwwroot/app.js
+++ b/src/SqlOS/Dashboard/wwwroot/app.js
@@ -6,10 +6,12 @@
     const fgaDashboardPath = `${dashboardBasePath}/admin/fga`;
     const emailDashboardPath = `${dashboardBasePath}/admin/email`;
     const auditDashboardPath = `${dashboardBasePath}/admin/audit`;
+    const calendarDashboardPath = `${dashboardBasePath}/admin/calendar`;
     const authApiBasePath = `${authDashboardPath}/api`;
     const fgaApiBasePath = `${fgaDashboardPath}/api`;
     const emailApiBasePath = `${emailDashboardPath}/api`;
     const auditApiBasePath = `${auditDashboardPath}/api`;
+    const calendarApiBasePath = `${calendarDashboardPath}/api`;
     const clientOnboardingDocsUrl = "https://sqlos.dev/docs/authserver/preregistration-vs-cimd-vs-dcr";
 
     const content = document.getElementById("content");
@@ -55,6 +57,11 @@
         search: ""
     };
     let selectedAuditEventId = null;
+    let selectedCalendarConnectionId = null;
+    const calendarConnectionFilters = {
+        search: "",
+        includeRevoked: true
+    };
 
     const authViews = {
         overview: { title: "Auth Server", description: "Organizations, users, sessions, applications, and security settings." },
@@ -270,6 +277,9 @@
         templates: { title: "Email Templates", description: "Create, edit, activate, deactivate, and preview transactional email templates." },
         messages: { title: "Email Messages", description: "Review recent transactional email deliveries and provider outcomes." }
     };
+    const calendarViews = {
+        connections: { title: "Calendar Connections", description: "Google and Microsoft calendar connections, sync health, and token status per user or organization." }
+    };
 
     configureNavLinks();
 
@@ -456,6 +466,10 @@
             return `${auditDashboardPath}/${route.slice(6)}`;
         }
 
+        if (route.startsWith("calendar-")) {
+            return `${calendarDashboardPath}/${route.slice(9)}`;
+        }
+
         return `${dashboardBasePath}/`;
     }
 
@@ -579,6 +593,16 @@
                 view,
                 key: "audit-logs",
                 canonicalPath: `${auditDashboardPath}/${view}`
+            };
+        }
+
+        if (segments[1] === "calendar") {
+            const view = calendarViews[segments[2]] ? segments[2] : "connections";
+            return {
+                kind: "calendar",
+                view,
+                key: `calendar-${view}`,
+                canonicalPath: `${calendarDashboardPath}/${view}`
             };
         }
 
@@ -1072,6 +1096,11 @@
 
             if (route.kind === "audit") {
                 await renderAuditLogs();
+                return;
+            }
+
+            if (route.kind === "calendar") {
+                await renderCalendarConnections();
                 return;
             }
 
@@ -3613,6 +3642,198 @@
             selectedAuditEventId = null;
             await render();
         });
+    }
+
+    async function renderCalendarConnections() {
+        const config = calendarViews.connections;
+        setHeader("Integrations", config.title, config.description);
+        renderLoading("Loading calendar connections...");
+
+        const pager = getPagerState("calendar-connections", 25);
+        const params = new URLSearchParams();
+        params.set("page", String(pager.page));
+        params.set("pageSize", String(pager.pageSize));
+        params.set("includeRevoked", calendarConnectionFilters.includeRevoked ? "true" : "false");
+        if (calendarConnectionFilters.search) {
+            params.set("search", calendarConnectionFilters.search);
+        }
+
+        const [summary, result] = await Promise.all([
+            fetchJson(`${calendarApiBasePath}/summary`),
+            fetchJson(`${calendarApiBasePath}/connections?${params.toString()}`)
+        ]);
+
+        let selectedConnection = null;
+        if (selectedCalendarConnectionId) {
+            try {
+                selectedConnection = await fetchJson(`${calendarApiBasePath}/connections/${encodeURIComponent(selectedCalendarConnectionId)}`);
+            } catch {
+                selectedCalendarConnectionId = null;
+            }
+        }
+
+        content.innerHTML = `
+            ${consumeFlashHtml()}
+            ${renderStatsGroup("Calendar Integration", summary, [
+                { key: "connections", label: "Connections" },
+                { key: "active", label: "Active" },
+                { key: "errored", label: "Errored" },
+                { key: "events", label: "Synced Events" }
+            ])}
+            <div class="panel-grid">
+                <section class="panel">
+                    <div class="panel-actions">
+                        <h2>Connections</h2>
+                        <div id="calendar-pagination-top">${renderPagination(result.page, result.totalPages, result.totalCount)}</div>
+                    </div>
+                    <form id="calendar-filter-form" class="inline-form">
+                        <input name="search" value="${esc(calendarConnectionFilters.search)}" placeholder="Search by name, account, user, or organization">
+                        <label class="checkbox-label">
+                            <input type="checkbox" name="includeRevoked" ${calendarConnectionFilters.includeRevoked ? "checked" : ""}>
+                            Include disconnected
+                        </label>
+                        <button type="submit">Apply</button>
+                    </form>
+                    ${renderList(
+                        result.data,
+                        item => `
+                            <div class="list-item-header">
+                                <strong>${esc(item.displayName)}</strong>
+                                <button type="button" data-calendar-connection-id="${esc(item.id)}">Inspect</button>
+                            </div>
+                            <div class="client-badge-row">
+                                <span class="client-badge client-badge--source">${esc(item.providerType)}</span>
+                                <span class="client-badge client-badge--info">${esc(item.mode)}</span>
+                                <span class="client-badge ${calendarStatusBadgeClass(item)}">${esc(item.revokedAt ? "Disconnected" : item.status)}</span>
+                            </div>
+                            ${renderMetadataRows([
+                                { label: "Owner", value: item.userId ? `User ${item.userId}` : item.organizationId ? `Org ${item.organizationId}` : "n/a" },
+                                { label: "Account", value: item.providerAccountEmail || "n/a" },
+                                { label: "Last sync", value: item.lastSyncAt ? formatDate(item.lastSyncAt) : "never" },
+                                { label: "Token expires", value: item.accessTokenExpiresAt ? formatDate(item.accessTokenExpiresAt) : "n/a" },
+                                { label: "Refresh token", value: item.hasRefreshToken ? "stored (encrypted)" : "none" },
+                                { label: "Last error", value: item.lastError || "" }
+                            ])}
+                        `,
+                        "No calendar connections yet. Apps create them through the SqlOS calendar connect flow."
+                    )}
+                </section>
+                ${renderCalendarConnectionDetail(selectedConnection)}
+            </div>
+        `;
+
+        bindForm("calendar-filter-form", async form => {
+            calendarConnectionFilters.search = String(form.get("search") || "").trim();
+            calendarConnectionFilters.includeRevoked = form.get("includeRevoked") === "on";
+            selectedCalendarConnectionId = null;
+            setPagerPage("calendar-connections", 1);
+        });
+
+        document.querySelectorAll("[data-calendar-connection-id]").forEach(button => {
+            button.addEventListener("click", async () => {
+                selectedCalendarConnectionId = button.dataset.calendarConnectionId || null;
+                await render();
+            });
+        });
+
+        bindCalendarConnectionAction("[data-calendar-sync]", "calendarSync", "sync", "Calendar sync completed.");
+        bindCalendarConnectionAction("[data-calendar-refresh]", "calendarRefresh", "refresh", "Calendar access token refreshed.");
+        bindCalendarConnectionAction("[data-calendar-disconnect]", "calendarDisconnect", "disconnect", "Calendar connection disconnected.");
+
+        bindPagination("#calendar-pagination-top", async page => {
+            pager.page = Math.max(1, page);
+            selectedCalendarConnectionId = null;
+            await render();
+        });
+    }
+
+    function bindCalendarConnectionAction(selector, dataKey, action, successMessage) {
+        document.querySelectorAll(selector).forEach(button => {
+            button.addEventListener("click", async () => {
+                try {
+                    await fetchJson(`${calendarApiBasePath}/connections/${encodeURIComponent(button.dataset[dataKey])}/${action}`, {
+                        method: "POST"
+                    });
+                    setFlash("success", successMessage);
+                } catch (error) {
+                    setFlash("error", error.message || String(error));
+                }
+
+                await render();
+            });
+        });
+    }
+
+    function calendarStatusBadgeClass(item) {
+        if (item.revokedAt) {
+            return "client-badge--muted";
+        }
+
+        if (item.status === "Error") {
+            return "client-badge--danger";
+        }
+
+        return "client-badge--success";
+    }
+
+    function renderCalendarConnectionDetail(detail) {
+        if (!detail) {
+            return `
+                <section class="panel">
+                    <h2>Connection detail</h2>
+                    <div class="empty-state-block">Select a connection to inspect sync health, calendars, and token status.</div>
+                </section>
+            `;
+        }
+
+        const connection = detail.connection;
+        const isRevoked = Boolean(connection.revokedAt);
+        return `
+            <section class="panel">
+                <div class="panel-actions">
+                    <h2>${esc(connection.displayName)}</h2>
+                    <div class="form-actions">
+                        ${isRevoked || connection.mode === "ConnectionOnly" ? "" : `<button type="button" data-calendar-sync="${esc(connection.id)}">Sync now</button>`}
+                        ${isRevoked ? "" : `<button type="button" data-calendar-refresh="${esc(connection.id)}">Refresh token</button>`}
+                        ${isRevoked ? "" : `<button type="button" data-calendar-disconnect="${esc(connection.id)}">Disconnect</button>`}
+                    </div>
+                </div>
+                ${renderMetadataRows([
+                    { label: "Provider", value: connection.providerType },
+                    { label: "Mode", value: connection.mode },
+                    { label: "Status", value: isRevoked ? `Disconnected (${connection.revokedAt ? formatDate(connection.revokedAt) : "n/a"})` : connection.status },
+                    { label: "Owner", value: connection.userId ? `User ${connection.userId}` : connection.organizationId ? `Org ${connection.organizationId}` : "n/a" },
+                    { label: "Account", value: connection.providerAccountEmail || "n/a" },
+                    { label: "Scopes", value: (connection.scopes || []).join(" ") || "n/a" },
+                    { label: "Connected", value: formatDate(connection.createdAt) },
+                    { label: "Last sync", value: connection.lastSyncAt ? formatDate(connection.lastSyncAt) : "never" },
+                    { label: "Synced events", value: String(detail.eventCount ?? 0) },
+                    { label: "Last error", value: connection.lastError || "" }
+                ])}
+                <h3>Calendars</h3>
+                ${renderList(
+                    detail.calendars,
+                    calendar => `
+                        <div class="list-item-header">
+                            <strong>${esc(calendar.displayName || calendar.providerCalendarId)}</strong>
+                            <span class="client-badge ${calendar.lastSyncStatus === "error" ? "client-badge--danger" : calendar.isSyncEnabled ? "client-badge--success" : "client-badge--muted"}">
+                                ${esc(calendar.lastSyncStatus === "error" ? "Error" : calendar.isSyncEnabled ? "Syncing" : "Paused")}
+                            </span>
+                        </div>
+                        ${renderMetadataRows([
+                            { label: "Calendar id", value: calendar.providerCalendarId },
+                            { label: "Last sync", value: calendar.lastSyncCompletedAt ? formatDate(calendar.lastSyncCompletedAt) : "never" },
+                            { label: "Cursor", value: calendar.hasSyncCursor ? "incremental" : "full window" },
+                            { label: "Events", value: String(calendar.eventCount ?? 0) },
+                            { label: "Error", value: calendar.lastSyncError || "" }
+                        ])}
+                    `,
+                    connection.mode === "ConnectionOnly"
+                        ? "Connection-only mode: the app calls the provider directly; SqlOS stores no calendars or events."
+                        : "No calendars enrolled yet. The first sync enrolls the provider's primary calendar automatically."
+                )}
+            </section>
+        `;
     }
 
     async function renderEmailRoute(view) {

--- a/src/SqlOS/Dashboard/wwwroot/index.html
+++ b/src/SqlOS/Dashboard/wwwroot/index.html
@@ -55,6 +55,10 @@
                     <a href="#" data-route="email-templates">Templates</a>
                     <a href="#" data-route="email-messages">Messages</a>
                 </div>
+                <div class="nav-group">
+                    <div class="nav-label">Integrations</div>
+                    <a href="#" data-route="calendar-connections">Calendar</a>
+                </div>
             </nav>
             <div class="sidebar-footer">
                 <button class="sidebar-action" id="dashboard-logout" type="button">Log out</button>

--- a/src/SqlOS/Extensions/ModelBuilderExtensions.cs
+++ b/src/SqlOS/Extensions/ModelBuilderExtensions.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using SqlOS.Configuration;
 using SqlOS.AuthServer.Configuration;
+using SqlOS.Calendar.Configuration;
 using SqlOS.Email.Configuration;
 using SqlOS.Fga.Configuration;
 
@@ -15,6 +16,7 @@ public static class ModelBuilderExtensions
     {
         SqlOSAuthServerModelConfiguration.Configure(modelBuilder, new SqlOSAuthServerOptions());
         SqlOSEmailModelConfiguration.Configure(modelBuilder, new SqlOSAuthServerOptions().Schema);
+        SqlOSCalendarModelConfiguration.Configure(modelBuilder, new SqlOSAuthServerOptions().Schema);
         SqlOSFgaModelConfiguration.Configure(modelBuilder, new SqlOSFgaOptions(), contextType);
         return modelBuilder;
     }

--- a/src/SqlOS/Extensions/ServiceCollectionExtensions.cs
+++ b/src/SqlOS/Extensions/ServiceCollectionExtensions.cs
@@ -7,6 +7,8 @@ using SqlOS.Configuration;
 using SqlOS.AuthServer.Configuration;
 using SqlOS.AuthServer.Interfaces;
 using SqlOS.AuthServer.Services;
+using SqlOS.Calendar.Interfaces;
+using SqlOS.Calendar.Services;
 using SqlOS.Dashboard;
 using SqlOS.Email.Configuration;
 using SqlOS.Email.Interfaces;
@@ -38,6 +40,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton(Options.Create(options.AuthServer));
         services.AddSingleton(Options.Create(options.Fga));
         services.AddSingleton(Options.Create(options.Email));
+        services.AddSingleton(Options.Create(options.Calendar));
         services.AddDataProtection();
         services.AddHttpClient();
         services.AddHttpClient<ISqlOSDomainDnsVerifier, SqlOSDnsOverHttpsDomainVerifier>(client =>
@@ -85,6 +88,10 @@ public static class ServiceCollectionExtensions
         services.AddScoped<SqlOSSsoAuthorizationService>();
         services.AddScoped<SqlOSOrganizationDomainService>();
         services.AddScoped<SqlOSSsoPortalService>();
+        services.AddSingleton<ISqlOSCalendarProviderAdapter, SqlOSGoogleCalendarAdapter>();
+        services.AddSingleton<ISqlOSCalendarProviderAdapter, SqlOSMicrosoftGraphCalendarAdapter>();
+        services.AddScoped<SqlOSCalendarService>();
+        services.AddScoped<SqlOSCalendarSyncService>();
         services.AddScoped<ISqlOSFgaAuthService, SqlOSFgaAuthService>();
         services.AddScoped<ISqlOSFgaSubjectService, SqlOSFgaSubjectService>();
         services.AddScoped<ISpecificationExecutor, SpecificationExecutor>();
@@ -92,6 +99,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<SqlOSFgaFunctionInitializer>();
         services.AddScoped<SqlOSFgaSchemaInitializer>();
         services.AddHostedService<SqlOSSigningKeyRotationService>();
+        services.AddHostedService<SqlOSCalendarSyncHostedService>();
         services.AddHostedService<SqlOSBootstrapHostedService>();
         services.AddSingleton<IStartupFilter, SqlOSPipelineStartupFilter>();
 

--- a/src/SqlOS/Extensions/WebApplicationExtensions.cs
+++ b/src/SqlOS/Extensions/WebApplicationExtensions.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Options;
 using SqlOS.AuditLogs;
 using SqlOS.AuthServer.Configuration;
 using SqlOS.AuthServer.Extensions;
+using SqlOS.Calendar.Extensions;
 using SqlOS.Configuration;
 using SqlOS.Email.Extensions;
 
@@ -21,6 +22,11 @@ public static class WebApplicationExtensions
         app.MapAuthServer(authOptions.BasePath);
         app.MapSqlOSAuditLogsAdmin(sqlosOptions.DashboardBasePath);
         app.MapSqlOSEmailAdmin(sqlosOptions.DashboardBasePath);
+        if (sqlosOptions.Calendar.Enabled)
+        {
+            app.MapSqlOSCalendarConnect(authOptions.BasePath);
+            app.MapSqlOSCalendarAdmin(sqlosOptions.DashboardBasePath);
+        }
 
         return app;
     }

--- a/src/SqlOS/SqlOS.csproj
+++ b/src/SqlOS/SqlOS.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>SqlOS</PackageId>
-    <Version>3.15.0</Version>
+    <Version>3.16.0</Version>
     <Authors>Ross Slaney</Authors>
     <Description>Embedded auth server and fine-grained authorization runtime for .NET + SQL Server + EF Core.</Description>
     <PackageTags>authentication;authorization;fga;saml;jwt;sessions;efcore;sqlserver</PackageTags>

--- a/tests/SqlOS.IntegrationTests/CalendarIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/CalendarIntegrationTests.cs
@@ -233,5 +233,15 @@ public sealed class CalendarIntegrationTests
         var connections = await context.Set<SqlOSCalendarConnection>().ToListAsync();
         context.Set<SqlOSCalendarConnection>().RemoveRange(connections);
         await context.SaveChangesAsync();
+
+        // Providers are unique per type, so clear social connections the same way the
+        // OIDC integration tests do (external identities first to satisfy the FK).
+        var externalIdentities = await context.Set<SqlOSExternalIdentity>()
+            .Where(x => x.OidcConnectionId != null)
+            .ToListAsync();
+        context.Set<SqlOSExternalIdentity>().RemoveRange(externalIdentities);
+        var oidcConnections = await context.Set<SqlOSOidcConnection>().ToListAsync();
+        context.Set<SqlOSOidcConnection>().RemoveRange(oidcConnections);
+        await context.SaveChangesAsync();
     }
 }

--- a/tests/SqlOS.IntegrationTests/CalendarIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/CalendarIntegrationTests.cs
@@ -20,6 +20,14 @@ public sealed class CalendarIntegrationTests
 {
     private const string ReturnUri = "https://app.example.local/settings/calendar";
 
+    /// <summary>
+    /// Calendar connections hold foreign keys to social connections, so leftover rows would
+    /// break other test classes that clear all OIDC connections in their own resets. Clean
+    /// up after every test (including failures) so no calendar rows outlive this class.
+    /// </summary>
+    [TestCleanup]
+    public async Task CleanupAsync() => await ResetCalendarStateAsync();
+
     [TestMethod]
     public async Task GoogleReadPull_ConnectSyncListDisconnect_WorksOnSqlServer()
     {

--- a/tests/SqlOS.IntegrationTests/CalendarIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/CalendarIntegrationTests.cs
@@ -1,0 +1,237 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SqlOS.AuthServer.Contracts;
+using SqlOS.AuthServer.Models;
+using SqlOS.AuthServer.Services;
+using SqlOS.Calendar.Contracts;
+using SqlOS.Calendar.Interfaces;
+using SqlOS.Calendar.Models;
+using SqlOS.Calendar.Services;
+using SqlOS.Configuration;
+using SqlOS.IntegrationTests.Infrastructure;
+
+namespace SqlOS.IntegrationTests;
+
+[TestClass]
+public sealed class CalendarIntegrationTests
+{
+    private const string ReturnUri = "https://app.example.local/settings/calendar";
+
+    [TestMethod]
+    public async Task GoogleReadPull_ConnectSyncListDisconnect_WorksOnSqlServer()
+    {
+        await ResetCalendarStateAsync();
+        var services = CreateServices();
+        var user = await services.Admin.CreateUserAsync(new SqlOSCreateUserRequest(
+            "Calendar User", $"calendar-{Guid.NewGuid():N}@example.com", null));
+        var oidc = await CreateGoogleConnectionAsync(services.Admin);
+
+        var completion = await services.Calendar.CompleteConnectAsync(
+            GooglePayload(oidc.Id, SqlOSCalendarIntegrationMode.ReadPull, userId: user.Id),
+            "success:calendar-int@example.com");
+
+        completion.ProviderAccountEmail.Should().Be("calendar-int@example.com");
+
+        var stored = await AspireFixture.SharedContext.Set<SqlOSCalendarConnection>()
+            .FirstAsync(x => x.Id == completion.CalendarConnectionId);
+        stored.AccessTokenEncrypted.Should().StartWith("dp:");
+        stored.RefreshTokenEncrypted.Should().StartWith("dp:");
+
+        var calendars = await services.Calendar.ListProviderCalendarsAsync(completion.CalendarConnectionId);
+        calendars.Should().Contain(x => x.ProviderCalendarId == "google-primary" && x.IsPrimary);
+
+        var sync = await services.Sync.SyncConnectionAsync(completion.CalendarConnectionId);
+        sync.Errors.Should().BeEmpty();
+        sync.EventsUpserted.Should().Be(2);
+
+        var events = await services.Calendar.ListEventsAsync(
+            completion.CalendarConnectionId,
+            new DateTime(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc),
+            forUserId: user.Id);
+        events.Select(x => x.ProviderEventId).Should().BeEquivalentTo(["google-evt-1", "google-evt-2"]);
+
+        var secondSync = await services.Sync.SyncConnectionAsync(completion.CalendarConnectionId);
+        secondSync.Errors.Should().BeEmpty();
+        secondSync.EventsRemoved.Should().Be(1);
+
+        var disconnect = await services.Calendar.DisconnectAsync(completion.CalendarConnectionId, "test_complete");
+        disconnect.Status.Should().Be(nameof(SqlOSCalendarConnectionStatus.Revoked));
+        (await AspireFixture.SharedContext.Set<SqlOSCalendarConnection>()
+            .FirstAsync(x => x.Id == completion.CalendarConnectionId)).AccessTokenEncrypted.Should().BeNull();
+    }
+
+    [TestMethod]
+    public async Task MicrosoftOrganizationConnection_MirrorsGoogle()
+    {
+        await ResetCalendarStateAsync();
+        var services = CreateServices();
+        var organization = await services.Admin.CreateOrganizationAsync(new SqlOSCreateOrganizationRequest(
+            $"Calendar Org {Guid.NewGuid():N}"[..28], $"cal-org-{Guid.NewGuid():N}"[..20]));
+        var oidc = await CreateMicrosoftConnectionAsync(services.Admin);
+
+        var completion = await services.Calendar.CompleteConnectAsync(
+            new CalendarConnectRequestPayload(
+                oidc.Id,
+                SqlOSCalendarIntegrationMode.ReadPull,
+                null,
+                organization.Id,
+                "Org Outlook",
+                ["openid", "email", "offline_access", "Calendars.Read"],
+                ReturnUri,
+                "verifier",
+                "https://tests/sqlos/auth/calendar/callback",
+                "https://login.microsoftonline.com/common/oauth2/v2.0/token"),
+            "success:calendar-ms@example.com");
+
+        completion.OrganizationId.Should().Be(organization.Id);
+
+        var sync = await services.Sync.SyncConnectionAsync(completion.CalendarConnectionId);
+        sync.Errors.Should().BeEmpty();
+        sync.EventsUpserted.Should().Be(2);
+
+        var events = await services.Calendar.ListEventsAsync(
+            completion.CalendarConnectionId,
+            new DateTime(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc),
+            forOrganizationId: organization.Id);
+        events.Should().HaveCount(2);
+    }
+
+    [TestMethod]
+    public async Task ConnectionOnly_TokenAccessorRefreshesAndNeverStoresEvents()
+    {
+        await ResetCalendarStateAsync();
+        var services = CreateServices();
+        var user = await services.Admin.CreateUserAsync(new SqlOSCreateUserRequest(
+            "Token User", $"calendar-token-{Guid.NewGuid():N}@example.com", null));
+        var oidc = await CreateGoogleConnectionAsync(services.Admin);
+
+        var completion = await services.Calendar.CompleteConnectAsync(
+            GooglePayload(oidc.Id, SqlOSCalendarIntegrationMode.ConnectionOnly, userId: user.Id),
+            "success:calendar-token@example.com");
+
+        var connection = await AspireFixture.SharedContext.Set<SqlOSCalendarConnection>()
+            .FirstAsync(x => x.Id == completion.CalendarConnectionId);
+        connection.AccessTokenExpiresAt = DateTime.UtcNow.AddMinutes(-1);
+        await AspireFixture.SharedContext.SaveChangesAsync();
+
+        var token = await services.Calendar.GetAccessTokenAsync(completion.CalendarConnectionId, forUserId: user.Id);
+
+        token.AccessToken.Should().Be("google-access-refreshed|calendar-token@example.com");
+        (await AspireFixture.SharedContext.Set<SqlOSCalendarEvent>()
+            .CountAsync(x => x.CalendarConnectionId == completion.CalendarConnectionId)).Should().Be(0);
+    }
+
+    [TestMethod]
+    public async Task RevokedRefreshToken_MarksErrorAndWrongOwnerIsRejected()
+    {
+        await ResetCalendarStateAsync();
+        var services = CreateServices();
+        var user = await services.Admin.CreateUserAsync(new SqlOSCreateUserRequest(
+            "Error User", $"calendar-error-{Guid.NewGuid():N}@example.com", null));
+        var oidc = await CreateGoogleConnectionAsync(services.Admin);
+
+        var completion = await services.Calendar.CompleteConnectAsync(
+            GooglePayload(oidc.Id, SqlOSCalendarIntegrationMode.ConnectionOnly, userId: user.Id),
+            "success:calendar-error@example.com");
+
+        var wrongOwner = () => services.Calendar.GetAccessTokenAsync(completion.CalendarConnectionId, forUserId: "usr_someone_else");
+        await wrongOwner.Should().ThrowAsync<InvalidOperationException>().WithMessage("*not found*");
+
+        var connection = await AspireFixture.SharedContext.Set<SqlOSCalendarConnection>()
+            .FirstAsync(x => x.Id == completion.CalendarConnectionId);
+        connection.AccessTokenExpiresAt = DateTime.UtcNow.AddMinutes(-1);
+        connection.RefreshTokenEncrypted = services.Crypto.ProtectSecret("revoked-refresh");
+        await AspireFixture.SharedContext.SaveChangesAsync();
+
+        var act = () => services.Calendar.GetAccessTokenAsync(completion.CalendarConnectionId, forUserId: user.Id);
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*revoked*");
+
+        (await AspireFixture.SharedContext.Set<SqlOSCalendarConnection>()
+            .FirstAsync(x => x.Id == completion.CalendarConnectionId)).Status
+            .Should().Be(SqlOSCalendarConnectionStatus.Error);
+    }
+
+    private static CalendarConnectRequestPayload GooglePayload(
+        string oidcConnectionId,
+        SqlOSCalendarIntegrationMode mode,
+        string? userId = null,
+        string? organizationId = null)
+        => new(
+            oidcConnectionId,
+            mode,
+            userId,
+            organizationId,
+            null,
+            ["openid", "email", "https://www.googleapis.com/auth/calendar.readonly"],
+            ReturnUri,
+            "verifier",
+            "https://tests/sqlos/auth/calendar/callback",
+            "https://oauth2.googleapis.com/token");
+
+    private static async Task<SqlOSOidcConnection> CreateGoogleConnectionAsync(SqlOSAdminService admin)
+        => await admin.CreateOidcConnectionAsync(new SqlOSCreateOidcConnectionRequest(
+            SqlOSOidcProviderType.Google, "Google", "google-client", "google-secret",
+            ["https://app.example.local/callback/google"], true,
+            null, null, null, null, null, null, null, null, null, null, null));
+
+    private static async Task<SqlOSOidcConnection> CreateMicrosoftConnectionAsync(SqlOSAdminService admin)
+        => await admin.CreateOidcConnectionAsync(new SqlOSCreateOidcConnectionRequest(
+            SqlOSOidcProviderType.Microsoft, "Microsoft", "ms-client", "ms-secret",
+            ["https://app.example.local/callback/microsoft"], true,
+            null, null, null, null, null, null, "common", null, null, null, null));
+
+    private sealed record CalendarIntegrationServices(
+        SqlOSAdminService Admin,
+        SqlOSCryptoService Crypto,
+        SqlOSCalendarService Calendar,
+        SqlOSCalendarSyncService Sync);
+
+    private static CalendarIntegrationServices CreateServices()
+    {
+        var authOptions = Options.Create(AspireFixture.Options);
+        var crypto = new SqlOSCryptoService(AspireFixture.SharedContext, authOptions, AspireFixture.DataProtectionProvider);
+        var admin = new SqlOSAdminService(AspireFixture.SharedContext, authOptions, crypto);
+
+        var sqlosOptions = new SqlOSOptions();
+        sqlosOptions.AuthServer.PublicOrigin = "https://tests.example.local";
+        var httpFactory = new FakeCalendarProviderHttpClientFactory();
+        var adapters = new ISqlOSCalendarProviderAdapter[]
+        {
+            new SqlOSGoogleCalendarAdapter(httpFactory),
+            new SqlOSMicrosoftGraphCalendarAdapter(httpFactory)
+        };
+        var calendar = new SqlOSCalendarService(
+            AspireFixture.SharedContext,
+            admin,
+            crypto,
+            httpFactory,
+            adapters,
+            Options.Create(sqlosOptions),
+            NullLogger<SqlOSCalendarService>.Instance);
+        var sync = new SqlOSCalendarSyncService(
+            AspireFixture.SharedContext,
+            admin,
+            crypto,
+            calendar,
+            Options.Create(sqlosOptions),
+            NullLogger<SqlOSCalendarSyncService>.Instance);
+        return new CalendarIntegrationServices(admin, crypto, calendar, sync);
+    }
+
+    private static async Task ResetCalendarStateAsync()
+    {
+        var context = AspireFixture.SharedContext;
+        var events = await context.Set<SqlOSCalendarEvent>().ToListAsync();
+        context.Set<SqlOSCalendarEvent>().RemoveRange(events);
+        var states = await context.Set<SqlOSCalendarSyncState>().ToListAsync();
+        context.Set<SqlOSCalendarSyncState>().RemoveRange(states);
+        var connections = await context.Set<SqlOSCalendarConnection>().ToListAsync();
+        context.Set<SqlOSCalendarConnection>().RemoveRange(connections);
+        await context.SaveChangesAsync();
+    }
+}

--- a/tests/SqlOS.IntegrationTests/Infrastructure/FakeCalendarProviderHttpClientFactory.cs
+++ b/tests/SqlOS.IntegrationTests/Infrastructure/FakeCalendarProviderHttpClientFactory.cs
@@ -1,0 +1,346 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+
+namespace SqlOS.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Fakes the Google/Microsoft OAuth and calendar REST APIs for calendar integration tests,
+/// mirroring the <see cref="FakeOidcProviderHttpClientFactory"/> magic-string conventions:
+/// authorization codes are "success:{email}", "norefresh:{email}", or "bad..."; refresh
+/// tokens starting with "revoked" fail with invalid_grant.
+/// </summary>
+internal sealed class FakeCalendarProviderHttpClientFactory : IHttpClientFactory
+{
+    public HttpClient CreateClient(string name)
+        => new(new FakeCalendarProviderHttpMessageHandler())
+        {
+            BaseAddress = new Uri("https://localhost")
+        };
+
+    private sealed class FakeCalendarProviderHttpMessageHandler : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var uri = request.RequestUri?.AbsoluteUri ?? string.Empty;
+
+            if (request.Method == HttpMethod.Get && uri.Contains(".well-known/openid-configuration", StringComparison.OrdinalIgnoreCase))
+            {
+                return Json(HttpStatusCode.OK, BuildDiscoveryDocument(uri));
+            }
+
+            if (request.Method == HttpMethod.Post && uri.Contains("/token", StringComparison.OrdinalIgnoreCase))
+            {
+                return await HandleTokenAsync(request, uri, cancellationToken);
+            }
+
+            if (uri.Contains("googleapis.com/calendar/v3/", StringComparison.OrdinalIgnoreCase))
+            {
+                return await HandleGoogleCalendarAsync(request, uri, cancellationToken);
+            }
+
+            if (uri.Contains("graph.microsoft.com/v1.0/", StringComparison.OrdinalIgnoreCase))
+            {
+                return await HandleGraphAsync(request, uri, cancellationToken);
+            }
+
+            return Json(HttpStatusCode.NotFound, new { error = "not_found", url = uri });
+        }
+
+        private static async Task<HttpResponseMessage> HandleTokenAsync(HttpRequestMessage request, string uri, CancellationToken cancellationToken)
+        {
+            var provider = uri.Contains("microsoftonline.com", StringComparison.OrdinalIgnoreCase) ? "microsoft" : "google";
+            var form = ParseForm(await request.Content!.ReadAsStringAsync(cancellationToken));
+            var grantType = form.GetValueOrDefault("grant_type");
+
+            if (string.Equals(grantType, "refresh_token", StringComparison.Ordinal))
+            {
+                var refreshToken = form.GetValueOrDefault("refresh_token") ?? string.Empty;
+                if (refreshToken.StartsWith("revoked", StringComparison.OrdinalIgnoreCase))
+                {
+                    return Json(HttpStatusCode.BadRequest, new { error = "invalid_grant", error_description = "The refresh token has been revoked." });
+                }
+
+                var email = refreshToken.Split('|').LastOrDefault() ?? "user@example.com";
+                return Json(HttpStatusCode.OK, new
+                {
+                    access_token = $"{provider}-access-refreshed|{email}",
+                    refresh_token = $"{provider}-refresh-rotated|{email}",
+                    token_type = "Bearer",
+                    expires_in = 3600,
+                    scope = provider == "google"
+                        ? "https://www.googleapis.com/auth/calendar.readonly"
+                        : "Calendars.Read offline_access"
+                });
+            }
+
+            var code = form.GetValueOrDefault("code") ?? string.Empty;
+            if (code.StartsWith("bad", StringComparison.OrdinalIgnoreCase))
+            {
+                return Json(HttpStatusCode.BadRequest, new { error = "invalid_grant", error_description = "The authorization code is invalid." });
+            }
+
+            var parts = code.Split(':', 2);
+            var status = parts[0];
+            var accountEmail = parts.Length > 1 ? parts[1] : "user@example.com";
+            var includeRefreshToken = !status.StartsWith("norefresh", StringComparison.OrdinalIgnoreCase);
+
+            var payload = new Dictionary<string, object?>
+            {
+                ["access_token"] = $"{provider}-access|{accountEmail}",
+                ["token_type"] = "Bearer",
+                ["expires_in"] = 3600,
+                ["scope"] = provider == "google"
+                    ? "openid email https://www.googleapis.com/auth/calendar.readonly"
+                    : "openid email Calendars.Read offline_access",
+                ["id_token"] = CreateUnsignedIdToken(provider, accountEmail)
+            };
+            if (includeRefreshToken)
+            {
+                payload["refresh_token"] = $"{provider}-refresh|{accountEmail}";
+            }
+
+            return Json(HttpStatusCode.OK, payload);
+        }
+
+        private static async Task<HttpResponseMessage> HandleGoogleCalendarAsync(HttpRequestMessage request, string uri, CancellationToken cancellationToken)
+        {
+            if (!HasBearerToken(request))
+            {
+                return Json(HttpStatusCode.Unauthorized, new { error = new { code = 401, message = "Login Required." } });
+            }
+
+            if (request.Method == HttpMethod.Get && uri.Contains("/users/me/calendarList", StringComparison.OrdinalIgnoreCase))
+            {
+                return Json(HttpStatusCode.OK, new
+                {
+                    items = new object[]
+                    {
+                        new { id = "google-primary", summary = "Primary", primary = true, timeZone = "UTC" },
+                        new { id = "google-team", summary = "Team", primary = false, timeZone = "UTC" }
+                    }
+                });
+            }
+
+            if (request.Method == HttpMethod.Post && uri.Contains("/events", StringComparison.OrdinalIgnoreCase))
+            {
+                using var body = JsonDocument.Parse(await request.Content!.ReadAsStringAsync(cancellationToken));
+                var summary = body.RootElement.TryGetProperty("summary", out var s) ? s.GetString() : null;
+                var start = body.RootElement.GetProperty("start").GetProperty("dateTime").GetString();
+                var end = body.RootElement.GetProperty("end").GetProperty("dateTime").GetString();
+                return Json(HttpStatusCode.OK, new
+                {
+                    id = "google-created-1",
+                    status = "confirmed",
+                    summary,
+                    start = new { dateTime = start },
+                    end = new { dateTime = end }
+                });
+            }
+
+            if (request.Method == HttpMethod.Get && uri.Contains("/events", StringComparison.OrdinalIgnoreCase))
+            {
+                if (uri.Contains("syncToken=expired", StringComparison.OrdinalIgnoreCase))
+                {
+                    return Json(HttpStatusCode.Gone, new { error = new { code = 410, message = "Sync token is no longer valid." } });
+                }
+
+                if (uri.Contains("syncToken=google-sync-1", StringComparison.OrdinalIgnoreCase))
+                {
+                    return Json(HttpStatusCode.OK, new
+                    {
+                        items = new object[]
+                        {
+                            new { id = "google-evt-1", status = "cancelled" },
+                            GoogleEvent("google-evt-2", "Standup (moved)", "2026-07-06T10:00:00Z", "2026-07-06T10:30:00Z"),
+                            GoogleEvent("google-evt-3", "Retro", "2026-07-08T15:00:00Z", "2026-07-08T16:00:00Z"),
+                            GoogleEvent("google-created-1", "Modified remotely", "2026-07-09T09:00:00Z", "2026-07-09T09:30:00Z")
+                        },
+                        nextSyncToken = "google-sync-2"
+                    });
+                }
+
+                return Json(HttpStatusCode.OK, new
+                {
+                    items = new object[]
+                    {
+                        GoogleEvent("google-evt-1", "Kickoff", "2026-07-05T09:00:00Z", "2026-07-05T10:00:00Z"),
+                        GoogleEvent("google-evt-2", "Standup", "2026-07-06T09:00:00Z", "2026-07-06T09:30:00Z")
+                    },
+                    nextSyncToken = "google-sync-1"
+                });
+            }
+
+            return Json(HttpStatusCode.NotFound, new { error = "not_found", url = uri });
+        }
+
+        private static async Task<HttpResponseMessage> HandleGraphAsync(HttpRequestMessage request, string uri, CancellationToken cancellationToken)
+        {
+            if (!HasBearerToken(request))
+            {
+                return Json(HttpStatusCode.Unauthorized, new { error = new { code = "InvalidAuthenticationToken", message = "Access token is empty." } });
+            }
+
+            if (request.Method == HttpMethod.Get && uri.EndsWith("/me/calendars", StringComparison.OrdinalIgnoreCase))
+            {
+                return Json(HttpStatusCode.OK, new
+                {
+                    value = new object[]
+                    {
+                        new { id = "graph-default", name = "Calendar", isDefaultCalendar = true },
+                        new { id = "graph-team", name = "Team", isDefaultCalendar = false }
+                    }
+                });
+            }
+
+            if (request.Method == HttpMethod.Post && uri.Contains("/events", StringComparison.OrdinalIgnoreCase))
+            {
+                using var body = JsonDocument.Parse(await request.Content!.ReadAsStringAsync(cancellationToken));
+                var subject = body.RootElement.TryGetProperty("subject", out var s) ? s.GetString() : null;
+                var start = body.RootElement.GetProperty("start").GetProperty("dateTime").GetString();
+                var end = body.RootElement.GetProperty("end").GetProperty("dateTime").GetString();
+                return Json(HttpStatusCode.Created, new
+                {
+                    id = "graph-created-1",
+                    subject,
+                    isCancelled = false,
+                    showAs = "busy",
+                    isAllDay = false,
+                    start = new { dateTime = start, timeZone = "UTC" },
+                    end = new { dateTime = end, timeZone = "UTC" }
+                });
+            }
+
+            if (request.Method == HttpMethod.Get && uri.Contains("/calendarView/delta", StringComparison.OrdinalIgnoreCase))
+            {
+                if (uri.Contains("%24deltatoken=ms-delta-1", StringComparison.OrdinalIgnoreCase)
+                    || uri.Contains("$deltatoken=ms-delta-1", StringComparison.OrdinalIgnoreCase))
+                {
+                    return Json(HttpStatusCode.OK, new Dictionary<string, object?>
+                    {
+                        ["value"] = new object[]
+                        {
+                            new Dictionary<string, object?>
+                            {
+                                ["id"] = "graph-evt-1",
+                                ["@removed"] = new { reason = "deleted" }
+                            },
+                            GraphEvent("graph-evt-2", "Design review (moved)", "2026-07-07T13:00:00Z", "2026-07-07T14:00:00Z")
+                        },
+                        ["@odata.deltaLink"] = "https://graph.microsoft.com/v1.0/me/calendars/graph-default/calendarView/delta?$deltatoken=ms-delta-2"
+                    });
+                }
+
+                return Json(HttpStatusCode.OK, new Dictionary<string, object?>
+                {
+                    ["value"] = new object[]
+                    {
+                        GraphEvent("graph-evt-1", "Planning", "2026-07-05T11:00:00Z", "2026-07-05T12:00:00Z"),
+                        GraphEvent("graph-evt-2", "Design review", "2026-07-07T13:00:00Z", "2026-07-07T14:00:00Z")
+                    },
+                    ["@odata.deltaLink"] = "https://graph.microsoft.com/v1.0/me/calendars/graph-default/calendarView/delta?$deltatoken=ms-delta-1"
+                });
+            }
+
+            return Json(HttpStatusCode.NotFound, new { error = "not_found", url = uri });
+        }
+
+        private static object GoogleEvent(string id, string summary, string start, string end)
+            => new
+            {
+                id,
+                status = "confirmed",
+                summary,
+                location = "HQ",
+                start = new { dateTime = start },
+                end = new { dateTime = end }
+            };
+
+        private static object GraphEvent(string id, string subject, string start, string end)
+            => new
+            {
+                id,
+                subject,
+                isCancelled = false,
+                isAllDay = false,
+                showAs = "busy",
+                location = new { displayName = "HQ" },
+                start = new { dateTime = start, timeZone = "UTC" },
+                end = new { dateTime = end, timeZone = "UTC" }
+            };
+
+        private static object BuildDiscoveryDocument(string uri)
+        {
+            if (uri.Contains("login.microsoftonline.com", StringComparison.OrdinalIgnoreCase))
+            {
+                var tenant = uri.Split('/', StringSplitOptions.RemoveEmptyEntries)
+                    .SkipWhile(part => !string.Equals(part, "login.microsoftonline.com", StringComparison.OrdinalIgnoreCase))
+                    .Skip(1)
+                    .FirstOrDefault() ?? "common";
+
+                return new
+                {
+                    issuer = $"https://login.microsoftonline.com/{tenant}/v2.0",
+                    authorization_endpoint = $"https://login.microsoftonline.com/{tenant}/oauth2/v2.0/authorize",
+                    token_endpoint = $"https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token",
+                    userinfo_endpoint = "https://graph.microsoft.com/oidc/userinfo",
+                    jwks_uri = $"https://login.microsoftonline.com/{tenant}/discovery/v2.0/keys"
+                };
+            }
+
+            return new
+            {
+                issuer = "https://accounts.google.com",
+                authorization_endpoint = "https://accounts.google.com/o/oauth2/v2/auth",
+                token_endpoint = "https://oauth2.googleapis.com/token",
+                userinfo_endpoint = "https://openidconnect.googleapis.com/v1/userinfo",
+                jwks_uri = "https://www.googleapis.com/oauth2/v3/certs"
+            };
+        }
+
+        private static string CreateUnsignedIdToken(string provider, string email)
+        {
+            var header = Base64Url(JsonSerializer.Serialize(new { alg = "none", typ = "JWT" }));
+            var payload = Base64Url(JsonSerializer.Serialize(new
+            {
+                sub = $"{provider}-cal-{email}",
+                email,
+                aud = "client"
+            }));
+            return $"{header}.{payload}.";
+        }
+
+        private static string Base64Url(string value)
+            => Convert.ToBase64String(Encoding.UTF8.GetBytes(value)).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+
+        private static bool HasBearerToken(HttpRequestMessage request)
+            => !string.IsNullOrWhiteSpace(request.Headers.Authorization?.Parameter);
+
+        private static HttpResponseMessage Json(HttpStatusCode statusCode, object payload)
+            => new(statusCode)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(payload))
+                {
+                    Headers =
+                    {
+                        ContentType = new MediaTypeHeaderValue("application/json")
+                    }
+                }
+            };
+
+        private static Dictionary<string, string> ParseForm(string payload)
+        {
+            var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var pair in payload.Split('&', StringSplitOptions.RemoveEmptyEntries))
+            {
+                var parts = pair.Split('=', 2);
+                var key = Uri.UnescapeDataString(parts[0].Replace('+', ' '));
+                var value = parts.Length > 1 ? Uri.UnescapeDataString(parts[1].Replace('+', ' ')) : string.Empty;
+                result[key] = value;
+            }
+
+            return result;
+        }
+    }
+}

--- a/tests/SqlOS.IntegrationTests/SchemaInitializerIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/SchemaInitializerIntegrationTests.cs
@@ -40,6 +40,9 @@ public sealed class SchemaInitializerIntegrationTests
                      "SqlOSTemporaryTokens",
                      "SqlOSAuditEvents",
                      "SqlOSPhoneOtpChallenges",
+                     "SqlOSCalendarConnections",
+                     "SqlOSCalendarSyncStates",
+                     "SqlOSCalendarEvents",
                      "SqlOSSchema"
                  })
         {
@@ -151,7 +154,7 @@ public sealed class SchemaInitializerIntegrationTests
             Assert.IsTrue(await IndexExistsAsync(context, "SqlOSAuditEvents", "IX_SqlOSAuditEvents_Action_OccurredAt"));
             Assert.IsTrue(await IndexExistsAsync(context, "SqlOSAuditEvents", "UX_SqlOSAuditEvents_IdempotencyKeyHash"));
             Assert.AreEqual("user.login", await ScalarStringAsync(context, "SELECT TOP 1 [Action] FROM [dbo].[SqlOSAuditEvents]"));
-            Assert.AreEqual(25, await ScalarIntAsync(context, "SELECT TOP 1 [Version] FROM [dbo].[SqlOSSchema]"));
+            Assert.AreEqual(26, await ScalarIntAsync(context, "SELECT TOP 1 [Version] FROM [dbo].[SqlOSSchema]"));
         }
         finally
         {
@@ -190,7 +193,7 @@ public sealed class SchemaInitializerIntegrationTests
             Assert.IsTrue(await IndexExistsAsync(context, "SqlOSApplicationAssignments", "IX_SqlOSApplicationAssignments_Target"));
             Assert.IsTrue(await IndexExistsAsync(context, "SqlOSApplicationAssignments", "IX_SqlOSApplicationAssignments_ClientApplicationId_RevokedAt"));
             Assert.IsTrue(await IndexExistsAsync(context, "SqlOSApplicationAssignments", "IX_SqlOSApplicationAssignments_OrganizationId_RevokedAt"));
-            Assert.AreEqual(25, await ScalarIntAsync(context, "SELECT TOP 1 [Version] FROM [dbo].[SqlOSSchema]"));
+            Assert.AreEqual(26, await ScalarIntAsync(context, "SELECT TOP 1 [Version] FROM [dbo].[SqlOSSchema]"));
         }
         finally
         {

--- a/tests/SqlOS.Tests/Infrastructure/FakeCalendarProviderHttpClientFactory.cs
+++ b/tests/SqlOS.Tests/Infrastructure/FakeCalendarProviderHttpClientFactory.cs
@@ -1,0 +1,346 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+
+namespace SqlOS.Tests.Infrastructure;
+
+/// <summary>
+/// Fakes the Google/Microsoft OAuth and calendar REST APIs for calendar integration tests,
+/// mirroring the <see cref="FakeOidcProviderHttpClientFactory"/> magic-string conventions:
+/// authorization codes are "success:{email}", "norefresh:{email}", or "bad..."; refresh
+/// tokens starting with "revoked" fail with invalid_grant.
+/// </summary>
+internal sealed class FakeCalendarProviderHttpClientFactory : IHttpClientFactory
+{
+    public HttpClient CreateClient(string name)
+        => new(new FakeCalendarProviderHttpMessageHandler())
+        {
+            BaseAddress = new Uri("https://localhost")
+        };
+
+    private sealed class FakeCalendarProviderHttpMessageHandler : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var uri = request.RequestUri?.AbsoluteUri ?? string.Empty;
+
+            if (request.Method == HttpMethod.Get && uri.Contains(".well-known/openid-configuration", StringComparison.OrdinalIgnoreCase))
+            {
+                return Json(HttpStatusCode.OK, BuildDiscoveryDocument(uri));
+            }
+
+            if (request.Method == HttpMethod.Post && uri.Contains("/token", StringComparison.OrdinalIgnoreCase))
+            {
+                return await HandleTokenAsync(request, uri, cancellationToken);
+            }
+
+            if (uri.Contains("googleapis.com/calendar/v3/", StringComparison.OrdinalIgnoreCase))
+            {
+                return await HandleGoogleCalendarAsync(request, uri, cancellationToken);
+            }
+
+            if (uri.Contains("graph.microsoft.com/v1.0/", StringComparison.OrdinalIgnoreCase))
+            {
+                return await HandleGraphAsync(request, uri, cancellationToken);
+            }
+
+            return Json(HttpStatusCode.NotFound, new { error = "not_found", url = uri });
+        }
+
+        private static async Task<HttpResponseMessage> HandleTokenAsync(HttpRequestMessage request, string uri, CancellationToken cancellationToken)
+        {
+            var provider = uri.Contains("microsoftonline.com", StringComparison.OrdinalIgnoreCase) ? "microsoft" : "google";
+            var form = ParseForm(await request.Content!.ReadAsStringAsync(cancellationToken));
+            var grantType = form.GetValueOrDefault("grant_type");
+
+            if (string.Equals(grantType, "refresh_token", StringComparison.Ordinal))
+            {
+                var refreshToken = form.GetValueOrDefault("refresh_token") ?? string.Empty;
+                if (refreshToken.StartsWith("revoked", StringComparison.OrdinalIgnoreCase))
+                {
+                    return Json(HttpStatusCode.BadRequest, new { error = "invalid_grant", error_description = "The refresh token has been revoked." });
+                }
+
+                var email = refreshToken.Split('|').LastOrDefault() ?? "user@example.com";
+                return Json(HttpStatusCode.OK, new
+                {
+                    access_token = $"{provider}-access-refreshed|{email}",
+                    refresh_token = $"{provider}-refresh-rotated|{email}",
+                    token_type = "Bearer",
+                    expires_in = 3600,
+                    scope = provider == "google"
+                        ? "https://www.googleapis.com/auth/calendar.readonly"
+                        : "Calendars.Read offline_access"
+                });
+            }
+
+            var code = form.GetValueOrDefault("code") ?? string.Empty;
+            if (code.StartsWith("bad", StringComparison.OrdinalIgnoreCase))
+            {
+                return Json(HttpStatusCode.BadRequest, new { error = "invalid_grant", error_description = "The authorization code is invalid." });
+            }
+
+            var parts = code.Split(':', 2);
+            var status = parts[0];
+            var accountEmail = parts.Length > 1 ? parts[1] : "user@example.com";
+            var includeRefreshToken = !status.StartsWith("norefresh", StringComparison.OrdinalIgnoreCase);
+
+            var payload = new Dictionary<string, object?>
+            {
+                ["access_token"] = $"{provider}-access|{accountEmail}",
+                ["token_type"] = "Bearer",
+                ["expires_in"] = 3600,
+                ["scope"] = provider == "google"
+                    ? "openid email https://www.googleapis.com/auth/calendar.readonly"
+                    : "openid email Calendars.Read offline_access",
+                ["id_token"] = CreateUnsignedIdToken(provider, accountEmail)
+            };
+            if (includeRefreshToken)
+            {
+                payload["refresh_token"] = $"{provider}-refresh|{accountEmail}";
+            }
+
+            return Json(HttpStatusCode.OK, payload);
+        }
+
+        private static async Task<HttpResponseMessage> HandleGoogleCalendarAsync(HttpRequestMessage request, string uri, CancellationToken cancellationToken)
+        {
+            if (!HasBearerToken(request))
+            {
+                return Json(HttpStatusCode.Unauthorized, new { error = new { code = 401, message = "Login Required." } });
+            }
+
+            if (request.Method == HttpMethod.Get && uri.Contains("/users/me/calendarList", StringComparison.OrdinalIgnoreCase))
+            {
+                return Json(HttpStatusCode.OK, new
+                {
+                    items = new object[]
+                    {
+                        new { id = "google-primary", summary = "Primary", primary = true, timeZone = "UTC" },
+                        new { id = "google-team", summary = "Team", primary = false, timeZone = "UTC" }
+                    }
+                });
+            }
+
+            if (request.Method == HttpMethod.Post && uri.Contains("/events", StringComparison.OrdinalIgnoreCase))
+            {
+                using var body = JsonDocument.Parse(await request.Content!.ReadAsStringAsync(cancellationToken));
+                var summary = body.RootElement.TryGetProperty("summary", out var s) ? s.GetString() : null;
+                var start = body.RootElement.GetProperty("start").GetProperty("dateTime").GetString();
+                var end = body.RootElement.GetProperty("end").GetProperty("dateTime").GetString();
+                return Json(HttpStatusCode.OK, new
+                {
+                    id = "google-created-1",
+                    status = "confirmed",
+                    summary,
+                    start = new { dateTime = start },
+                    end = new { dateTime = end }
+                });
+            }
+
+            if (request.Method == HttpMethod.Get && uri.Contains("/events", StringComparison.OrdinalIgnoreCase))
+            {
+                if (uri.Contains("syncToken=expired", StringComparison.OrdinalIgnoreCase))
+                {
+                    return Json(HttpStatusCode.Gone, new { error = new { code = 410, message = "Sync token is no longer valid." } });
+                }
+
+                if (uri.Contains("syncToken=google-sync-1", StringComparison.OrdinalIgnoreCase))
+                {
+                    return Json(HttpStatusCode.OK, new
+                    {
+                        items = new object[]
+                        {
+                            new { id = "google-evt-1", status = "cancelled" },
+                            GoogleEvent("google-evt-2", "Standup (moved)", "2026-07-06T10:00:00Z", "2026-07-06T10:30:00Z"),
+                            GoogleEvent("google-evt-3", "Retro", "2026-07-08T15:00:00Z", "2026-07-08T16:00:00Z"),
+                            GoogleEvent("google-created-1", "Modified remotely", "2026-07-09T09:00:00Z", "2026-07-09T09:30:00Z")
+                        },
+                        nextSyncToken = "google-sync-2"
+                    });
+                }
+
+                return Json(HttpStatusCode.OK, new
+                {
+                    items = new object[]
+                    {
+                        GoogleEvent("google-evt-1", "Kickoff", "2026-07-05T09:00:00Z", "2026-07-05T10:00:00Z"),
+                        GoogleEvent("google-evt-2", "Standup", "2026-07-06T09:00:00Z", "2026-07-06T09:30:00Z")
+                    },
+                    nextSyncToken = "google-sync-1"
+                });
+            }
+
+            return Json(HttpStatusCode.NotFound, new { error = "not_found", url = uri });
+        }
+
+        private static async Task<HttpResponseMessage> HandleGraphAsync(HttpRequestMessage request, string uri, CancellationToken cancellationToken)
+        {
+            if (!HasBearerToken(request))
+            {
+                return Json(HttpStatusCode.Unauthorized, new { error = new { code = "InvalidAuthenticationToken", message = "Access token is empty." } });
+            }
+
+            if (request.Method == HttpMethod.Get && uri.EndsWith("/me/calendars", StringComparison.OrdinalIgnoreCase))
+            {
+                return Json(HttpStatusCode.OK, new
+                {
+                    value = new object[]
+                    {
+                        new { id = "graph-default", name = "Calendar", isDefaultCalendar = true },
+                        new { id = "graph-team", name = "Team", isDefaultCalendar = false }
+                    }
+                });
+            }
+
+            if (request.Method == HttpMethod.Post && uri.Contains("/events", StringComparison.OrdinalIgnoreCase))
+            {
+                using var body = JsonDocument.Parse(await request.Content!.ReadAsStringAsync(cancellationToken));
+                var subject = body.RootElement.TryGetProperty("subject", out var s) ? s.GetString() : null;
+                var start = body.RootElement.GetProperty("start").GetProperty("dateTime").GetString();
+                var end = body.RootElement.GetProperty("end").GetProperty("dateTime").GetString();
+                return Json(HttpStatusCode.Created, new
+                {
+                    id = "graph-created-1",
+                    subject,
+                    isCancelled = false,
+                    showAs = "busy",
+                    isAllDay = false,
+                    start = new { dateTime = start, timeZone = "UTC" },
+                    end = new { dateTime = end, timeZone = "UTC" }
+                });
+            }
+
+            if (request.Method == HttpMethod.Get && uri.Contains("/calendarView/delta", StringComparison.OrdinalIgnoreCase))
+            {
+                if (uri.Contains("%24deltatoken=ms-delta-1", StringComparison.OrdinalIgnoreCase)
+                    || uri.Contains("$deltatoken=ms-delta-1", StringComparison.OrdinalIgnoreCase))
+                {
+                    return Json(HttpStatusCode.OK, new Dictionary<string, object?>
+                    {
+                        ["value"] = new object[]
+                        {
+                            new Dictionary<string, object?>
+                            {
+                                ["id"] = "graph-evt-1",
+                                ["@removed"] = new { reason = "deleted" }
+                            },
+                            GraphEvent("graph-evt-2", "Design review (moved)", "2026-07-07T13:00:00Z", "2026-07-07T14:00:00Z")
+                        },
+                        ["@odata.deltaLink"] = "https://graph.microsoft.com/v1.0/me/calendars/graph-default/calendarView/delta?$deltatoken=ms-delta-2"
+                    });
+                }
+
+                return Json(HttpStatusCode.OK, new Dictionary<string, object?>
+                {
+                    ["value"] = new object[]
+                    {
+                        GraphEvent("graph-evt-1", "Planning", "2026-07-05T11:00:00Z", "2026-07-05T12:00:00Z"),
+                        GraphEvent("graph-evt-2", "Design review", "2026-07-07T13:00:00Z", "2026-07-07T14:00:00Z")
+                    },
+                    ["@odata.deltaLink"] = "https://graph.microsoft.com/v1.0/me/calendars/graph-default/calendarView/delta?$deltatoken=ms-delta-1"
+                });
+            }
+
+            return Json(HttpStatusCode.NotFound, new { error = "not_found", url = uri });
+        }
+
+        private static object GoogleEvent(string id, string summary, string start, string end)
+            => new
+            {
+                id,
+                status = "confirmed",
+                summary,
+                location = "HQ",
+                start = new { dateTime = start },
+                end = new { dateTime = end }
+            };
+
+        private static object GraphEvent(string id, string subject, string start, string end)
+            => new
+            {
+                id,
+                subject,
+                isCancelled = false,
+                isAllDay = false,
+                showAs = "busy",
+                location = new { displayName = "HQ" },
+                start = new { dateTime = start, timeZone = "UTC" },
+                end = new { dateTime = end, timeZone = "UTC" }
+            };
+
+        private static object BuildDiscoveryDocument(string uri)
+        {
+            if (uri.Contains("login.microsoftonline.com", StringComparison.OrdinalIgnoreCase))
+            {
+                var tenant = uri.Split('/', StringSplitOptions.RemoveEmptyEntries)
+                    .SkipWhile(part => !string.Equals(part, "login.microsoftonline.com", StringComparison.OrdinalIgnoreCase))
+                    .Skip(1)
+                    .FirstOrDefault() ?? "common";
+
+                return new
+                {
+                    issuer = $"https://login.microsoftonline.com/{tenant}/v2.0",
+                    authorization_endpoint = $"https://login.microsoftonline.com/{tenant}/oauth2/v2.0/authorize",
+                    token_endpoint = $"https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token",
+                    userinfo_endpoint = "https://graph.microsoft.com/oidc/userinfo",
+                    jwks_uri = $"https://login.microsoftonline.com/{tenant}/discovery/v2.0/keys"
+                };
+            }
+
+            return new
+            {
+                issuer = "https://accounts.google.com",
+                authorization_endpoint = "https://accounts.google.com/o/oauth2/v2/auth",
+                token_endpoint = "https://oauth2.googleapis.com/token",
+                userinfo_endpoint = "https://openidconnect.googleapis.com/v1/userinfo",
+                jwks_uri = "https://www.googleapis.com/oauth2/v3/certs"
+            };
+        }
+
+        private static string CreateUnsignedIdToken(string provider, string email)
+        {
+            var header = Base64Url(JsonSerializer.Serialize(new { alg = "none", typ = "JWT" }));
+            var payload = Base64Url(JsonSerializer.Serialize(new
+            {
+                sub = $"{provider}-cal-{email}",
+                email,
+                aud = "client"
+            }));
+            return $"{header}.{payload}.";
+        }
+
+        private static string Base64Url(string value)
+            => Convert.ToBase64String(Encoding.UTF8.GetBytes(value)).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+
+        private static bool HasBearerToken(HttpRequestMessage request)
+            => !string.IsNullOrWhiteSpace(request.Headers.Authorization?.Parameter);
+
+        private static HttpResponseMessage Json(HttpStatusCode statusCode, object payload)
+            => new(statusCode)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(payload))
+                {
+                    Headers =
+                    {
+                        ContentType = new MediaTypeHeaderValue("application/json")
+                    }
+                }
+            };
+
+        private static Dictionary<string, string> ParseForm(string payload)
+        {
+            var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var pair in payload.Split('&', StringSplitOptions.RemoveEmptyEntries))
+            {
+                var parts = pair.Split('=', 2);
+                var key = Uri.UnescapeDataString(parts[0].Replace('+', ' '));
+                var value = parts.Length > 1 ? Uri.UnescapeDataString(parts[1].Replace('+', ' ')) : string.Empty;
+                result[key] = value;
+            }
+
+            return result;
+        }
+    }
+}

--- a/tests/SqlOS.Tests/SqlOS.Tests.csproj
+++ b/tests/SqlOS.Tests/SqlOS.Tests.csproj
@@ -13,6 +13,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.12.2" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="9.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />

--- a/tests/SqlOS.Tests/SqlOSCalendarEndpointsTests.cs
+++ b/tests/SqlOS.Tests/SqlOSCalendarEndpointsTests.cs
@@ -1,0 +1,209 @@
+using System.Net;
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SqlOS.AuthServer.Contracts;
+using SqlOS.AuthServer.Interfaces;
+using SqlOS.AuthServer.Models;
+using SqlOS.AuthServer.Services;
+using SqlOS.Calendar.Extensions;
+using SqlOS.Calendar.Interfaces;
+using SqlOS.Calendar.Models;
+using SqlOS.Calendar.Services;
+using SqlOS.Configuration;
+using SqlOS.Tests.Infrastructure;
+
+namespace SqlOS.Tests;
+
+[TestClass]
+public sealed class SqlOSCalendarEndpointsTests
+{
+    private const string ReturnUri = "https://app.example.local/settings/calendar";
+
+    [TestMethod]
+    public async Task AdminEndpoints_InDevelopment_ServeSummaryListDetailAndActions()
+    {
+        using var host = await StartHostAsync("Development");
+        var client = host.GetTestClient();
+        var connectionId = await SeedConnectionAsync(host, SqlOSCalendarIntegrationMode.ReadPull);
+
+        var summary = await client.GetAsync("/sqlos/admin/calendar/api/summary");
+        summary.StatusCode.Should().Be(HttpStatusCode.OK);
+        (await summary.Content.ReadAsStringAsync()).Should().Contain("\"connections\":1");
+
+        var list = await client.GetAsync("/sqlos/admin/calendar/api/connections?search=Google&includeRevoked=false&page=1&pageSize=10");
+        list.StatusCode.Should().Be(HttpStatusCode.OK);
+        (await list.Content.ReadAsStringAsync()).Should().Contain(connectionId);
+
+        var detail = await client.GetAsync($"/sqlos/admin/calendar/api/connections/{connectionId}");
+        detail.StatusCode.Should().Be(HttpStatusCode.OK);
+        (await detail.Content.ReadAsStringAsync()).Should().Contain("\"eventCount\"");
+
+        var missingDetail = await client.GetAsync("/sqlos/admin/calendar/api/connections/cal_missing");
+        missingDetail.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        var sync = await client.PostAsync($"/sqlos/admin/calendar/api/connections/{connectionId}/sync", content: null);
+        sync.StatusCode.Should().Be(HttpStatusCode.OK);
+        (await sync.Content.ReadAsStringAsync()).Should().Contain("\"eventsUpserted\":2");
+
+        var refresh = await client.PostAsync($"/sqlos/admin/calendar/api/connections/{connectionId}/refresh", content: null);
+        refresh.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var disconnect = await client.PostAsync($"/sqlos/admin/calendar/api/connections/{connectionId}/disconnect", content: null);
+        disconnect.StatusCode.Should().Be(HttpStatusCode.OK);
+        (await disconnect.Content.ReadAsStringAsync()).Should().Contain("\"status\":\"Revoked\"");
+
+        var syncAfterDisconnect = await client.PostAsync($"/sqlos/admin/calendar/api/connections/{connectionId}/sync", content: null);
+        syncAfterDisconnect.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [TestMethod]
+    public async Task AdminEndpoints_SyncOnConnectionOnly_ReturnsBadRequest()
+    {
+        using var host = await StartHostAsync("Development");
+        var client = host.GetTestClient();
+        var connectionId = await SeedConnectionAsync(host, SqlOSCalendarIntegrationMode.ConnectionOnly);
+
+        var sync = await client.PostAsync($"/sqlos/admin/calendar/api/connections/{connectionId}/sync", content: null);
+
+        sync.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        (await sync.Content.ReadAsStringAsync()).Should().Contain("Connection-only");
+    }
+
+    [TestMethod]
+    public async Task AdminEndpoints_OutsideDevelopment_AreHiddenWith404()
+    {
+        using var host = await StartHostAsync("Production");
+        var client = host.GetTestClient();
+        var connectionId = await SeedConnectionAsync(host, SqlOSCalendarIntegrationMode.ReadPull);
+
+        (await client.GetAsync("/sqlos/admin/calendar/api/summary")).StatusCode.Should().Be(HttpStatusCode.NotFound);
+        (await client.GetAsync("/sqlos/admin/calendar/api/connections")).StatusCode.Should().Be(HttpStatusCode.NotFound);
+        (await client.GetAsync($"/sqlos/admin/calendar/api/connections/{connectionId}")).StatusCode.Should().Be(HttpStatusCode.NotFound);
+        (await client.PostAsync($"/sqlos/admin/calendar/api/connections/{connectionId}/sync", null)).StatusCode.Should().Be(HttpStatusCode.NotFound);
+        (await client.PostAsync($"/sqlos/admin/calendar/api/connections/{connectionId}/refresh", null)).StatusCode.Should().Be(HttpStatusCode.NotFound);
+        (await client.PostAsync($"/sqlos/admin/calendar/api/connections/{connectionId}/disconnect", null)).StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [TestMethod]
+    public async Task ConnectCallbackEndpoint_CompletesFlowAndRedirects()
+    {
+        using var host = await StartHostAsync("Development");
+        var client = host.GetTestClient();
+
+        string authorizationUrl;
+        using (var scope = host.Services.CreateScope())
+        {
+            var admin = scope.ServiceProvider.GetRequiredService<SqlOSAdminService>();
+            var calendar = scope.ServiceProvider.GetRequiredService<SqlOSCalendarService>();
+            var user = await admin.CreateUserAsync(new SqlOSCreateUserRequest("Endpoint User", "endpoint@example.com", null));
+            var oidc = await CreateGoogleConnectionAsync(admin);
+            var start = await calendar.StartConnectAsync(new Calendar.Contracts.SqlOSStartCalendarConnectRequest(
+                oidc.Id,
+                SqlOSCalendarIntegrationMode.ConnectionOnly,
+                ReturnUri,
+                UserId: user.Id));
+            authorizationUrl = start.AuthorizationUrl;
+        }
+
+        var state = Microsoft.AspNetCore.WebUtilities.QueryHelpers
+            .ParseQuery(new Uri(authorizationUrl).Query)["state"].ToString();
+
+        var callback = await client.GetAsync(
+            $"/sqlos/auth/calendar/callback?code={Uri.EscapeDataString("success:endpoint@example.com")}&state={Uri.EscapeDataString(state)}");
+
+        callback.StatusCode.Should().Be(HttpStatusCode.Redirect);
+        callback.Headers.Location!.ToString().Should().StartWith(ReturnUri);
+        callback.Headers.Location!.ToString().Should().Contain("calendarConnectionId=");
+    }
+
+    [TestMethod]
+    public async Task ConnectCallbackEndpoint_MissingState_RendersErrorPage()
+    {
+        using var host = await StartHostAsync("Development");
+        var client = host.GetTestClient();
+
+        var callback = await client.GetAsync("/sqlos/auth/calendar/callback?code=success:missing@example.com");
+
+        callback.StatusCode.Should().Be(HttpStatusCode.OK);
+        (await callback.Content.ReadAsStringAsync()).Should().Contain("SqlOS calendar connect error");
+    }
+
+    private static async Task<IHost> StartHostAsync(string environment)
+    {
+        var databaseName = Guid.NewGuid().ToString("N");
+        var sqlosOptions = new SqlOSOptions();
+        sqlosOptions.AuthServer.PublicOrigin = "https://tests.example.local";
+        sqlosOptions.ConfigureCalendar(calendar => calendar.ConfigureSyncScheduler(scheduler => scheduler.Enabled = false));
+
+        var host = await new HostBuilder()
+            .ConfigureWebHost(webHost => webHost
+                .UseTestServer()
+                .UseEnvironment(environment)
+                .ConfigureServices(services =>
+                {
+                    services.AddRouting();
+                    services.AddLogging();
+                    services.AddDbContext<TestSqlOSInMemoryDbContext>(db => db.UseInMemoryDatabase(databaseName));
+                    services.AddScoped<ISqlOSAuthServerDbContext>(sp => sp.GetRequiredService<TestSqlOSInMemoryDbContext>());
+                    services.AddSingleton(Options.Create(sqlosOptions));
+                    services.AddSingleton(Options.Create(sqlosOptions.AuthServer));
+                    services.AddSingleton<IDataProtectionProvider>(new EphemeralDataProtectionProvider());
+                    services.AddSingleton<IHttpClientFactory, FakeCalendarProviderHttpClientFactory>();
+                    services.AddSingleton<ISqlOSCalendarProviderAdapter, SqlOSGoogleCalendarAdapter>();
+                    services.AddSingleton<ISqlOSCalendarProviderAdapter, SqlOSMicrosoftGraphCalendarAdapter>();
+                    services.AddScoped<SqlOSCryptoService>();
+                    services.AddScoped<SqlOSAdminService>();
+                    services.AddScoped<SqlOSCalendarService>();
+                    services.AddScoped<SqlOSCalendarSyncService>();
+                })
+                .Configure(app =>
+                {
+                    app.UseRouting();
+                    app.UseEndpoints(endpoints =>
+                    {
+                        endpoints.MapSqlOSCalendarConnect("/sqlos/auth");
+                        endpoints.MapSqlOSCalendarAdmin("/sqlos");
+                    });
+                }))
+            .StartAsync();
+
+        return host;
+    }
+
+    private static async Task<string> SeedConnectionAsync(IHost host, SqlOSCalendarIntegrationMode mode)
+    {
+        using var scope = host.Services.CreateScope();
+        var admin = scope.ServiceProvider.GetRequiredService<SqlOSAdminService>();
+        var calendar = scope.ServiceProvider.GetRequiredService<SqlOSCalendarService>();
+        var user = await admin.CreateUserAsync(new SqlOSCreateUserRequest("Cal User", $"cal-{Guid.NewGuid():N}@example.com", null));
+        var oidc = await CreateGoogleConnectionAsync(admin);
+        var completion = await calendar.CompleteConnectAsync(
+            new CalendarConnectRequestPayload(
+                oidc.Id,
+                mode,
+                user.Id,
+                null,
+                null,
+                ["openid", "email", "https://www.googleapis.com/auth/calendar.readonly"],
+                ReturnUri,
+                "verifier",
+                "https://tests.example.local/sqlos/auth/calendar/callback",
+                "https://oauth2.googleapis.com/token"),
+            "success:cal@example.com");
+        return completion.CalendarConnectionId;
+    }
+
+    private static async Task<SqlOSOidcConnection> CreateGoogleConnectionAsync(SqlOSAdminService admin)
+        => await admin.CreateOidcConnectionAsync(new SqlOSCreateOidcConnectionRequest(
+            SqlOSOidcProviderType.Google, "Google", "google-client", "google-secret",
+            ["https://app.example.local/callback/google"], true,
+            null, null, null, null, null, null, null, null, null, null, null));
+}

--- a/tests/SqlOS.Tests/SqlOSCalendarServiceTests.cs
+++ b/tests/SqlOS.Tests/SqlOSCalendarServiceTests.cs
@@ -546,6 +546,43 @@ public sealed class SqlOSCalendarServiceTests
     }
 
     [TestMethod]
+    public async Task CreateEvent_MicrosoftTwoWay_PushesToGraph()
+    {
+        using var context = CreateContext();
+        var services = CreateServices(context);
+        var organization = await services.Admin.CreateOrganizationAsync(new SqlOSCreateOrganizationRequest("Acme", "acme-ms"));
+        var oidc = await CreateMicrosoftConnectionAsync(services.Admin);
+        var completion = await services.Calendar.CompleteConnectAsync(
+            new CalendarConnectRequestPayload(
+                oidc.Id,
+                SqlOSCalendarIntegrationMode.TwoWay,
+                null,
+                organization.Id,
+                null,
+                ["openid", "email", "offline_access", "Calendars.ReadWrite"],
+                ReturnUri,
+                "verifier",
+                "https://tests.example.local/sqlos/auth/calendar/callback",
+                "https://login.microsoftonline.com/common/oauth2/v2.0/token"),
+            "success:cal-ms@example.com");
+
+        var created = await services.Sync.CreateEventAsync(
+            completion.CalendarConnectionId,
+            "graph-default",
+            new SqlOSCalendarEventDraft(
+                "Board meeting",
+                new DateTime(2026, 7, 10, 14, 0, 0, DateTimeKind.Utc),
+                new DateTime(2026, 7, 10, 15, 0, 0, DateTimeKind.Utc),
+                Location: "HQ",
+                Description: "Quarterly review"),
+            forOrganizationId: organization.Id);
+
+        created.ProviderEventId.Should().Be("graph-created-1");
+        created.Subject.Should().Be("Board meeting");
+        context.Set<SqlOSCalendarEvent>().Single().Origin.Should().Be("push");
+    }
+
+    [TestMethod]
     public async Task AdminSurface_ListsConnectionsAndSummary()
     {
         using var context = CreateContext();

--- a/tests/SqlOS.Tests/SqlOSCalendarServiceTests.cs
+++ b/tests/SqlOS.Tests/SqlOSCalendarServiceTests.cs
@@ -1,0 +1,656 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SqlOS.AuthServer.Contracts;
+using SqlOS.AuthServer.Models;
+using SqlOS.AuthServer.Services;
+using SqlOS.Calendar.Configuration;
+using SqlOS.Calendar.Contracts;
+using SqlOS.Calendar.Interfaces;
+using SqlOS.Calendar.Models;
+using SqlOS.Calendar.Services;
+using SqlOS.Configuration;
+using SqlOS.Tests.Infrastructure;
+
+namespace SqlOS.Tests;
+
+[TestClass]
+public sealed class SqlOSCalendarServiceTests
+{
+    private const string ReturnUri = "https://app.example.local/settings/calendar";
+
+    [TestMethod]
+    public async Task StartConnect_GoogleReadPull_RequestsOfflineCalendarScopes()
+    {
+        using var context = CreateContext();
+        var services = CreateServices(context);
+        var user = await services.Admin.CreateUserAsync(new SqlOSCreateUserRequest("Cal User", "cal@example.com", null));
+        var connection = await CreateGoogleConnectionAsync(services.Admin);
+
+        var result = await services.Calendar.StartConnectAsync(new SqlOSStartCalendarConnectRequest(
+            connection.Id,
+            SqlOSCalendarIntegrationMode.ReadPull,
+            ReturnUri,
+            UserId: user.Id));
+
+        result.ProviderType.Should().Be(SqlOSCalendarProviderType.Google);
+        result.AuthorizationUrl.Should().StartWith("https://accounts.google.com/o/oauth2/v2/auth");
+
+        var query = QueryHelpers.ParseQuery(new Uri(result.AuthorizationUrl).Query);
+        query["access_type"].ToString().Should().Be("offline");
+        query["prompt"].ToString().Should().Be("consent");
+        query["scope"].ToString().Should().Contain("https://www.googleapis.com/auth/calendar.readonly");
+        query["scope"].ToString().Should().NotContain("calendar.events");
+        query["code_challenge_method"].ToString().Should().Be("S256");
+        query["redirect_uri"].ToString().Should().Be("https://tests.example.local/sqlos/auth/calendar/callback");
+        query["state"].ToString().Should().NotBeNullOrWhiteSpace();
+    }
+
+    [TestMethod]
+    public async Task StartConnect_TwoWay_AddsWriteScopes()
+    {
+        using var context = CreateContext();
+        var services = CreateServices(context);
+        var user = await services.Admin.CreateUserAsync(new SqlOSCreateUserRequest("Cal User", "cal@example.com", null));
+        var connection = await CreateGoogleConnectionAsync(services.Admin);
+
+        var result = await services.Calendar.StartConnectAsync(new SqlOSStartCalendarConnectRequest(
+            connection.Id,
+            SqlOSCalendarIntegrationMode.TwoWay,
+            ReturnUri,
+            UserId: user.Id));
+
+        var query = QueryHelpers.ParseQuery(new Uri(result.AuthorizationUrl).Query);
+        query["scope"].ToString().Should().Contain("https://www.googleapis.com/auth/calendar.events");
+    }
+
+    [TestMethod]
+    public async Task StartConnect_BothUserAndOrganization_Throws()
+    {
+        using var context = CreateContext();
+        var services = CreateServices(context);
+        var connection = await CreateGoogleConnectionAsync(services.Admin);
+
+        var act = () => services.Calendar.StartConnectAsync(new SqlOSStartCalendarConnectRequest(
+            connection.Id,
+            SqlOSCalendarIntegrationMode.ReadPull,
+            ReturnUri,
+            UserId: "usr_x",
+            OrganizationId: "org_x"));
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*exactly one user or one organization*");
+    }
+
+    [TestMethod]
+    public async Task StartConnect_GitHubProvider_Throws()
+    {
+        using var context = CreateContext();
+        var services = CreateServices(context);
+        var user = await services.Admin.CreateUserAsync(new SqlOSCreateUserRequest("Cal User", "cal@example.com", null));
+        var gitHub = await services.Admin.CreateOidcConnectionAsync(new SqlOSCreateOidcConnectionRequest(
+            SqlOSOidcProviderType.GitHub, "GitHub", "gh-client", "gh-secret",
+            ["https://app.example.local/callback"], true,
+            null, null, null, null, null, null, null, null, null, null, null));
+
+        var act = () => services.Calendar.StartConnectAsync(new SqlOSStartCalendarConnectRequest(
+            gitHub.Id,
+            SqlOSCalendarIntegrationMode.ReadPull,
+            ReturnUri,
+            UserId: user.Id));
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*Google and Microsoft*");
+    }
+
+    [TestMethod]
+    public async Task CompleteConnect_Google_StoresEncryptedTokensAndAccount()
+    {
+        using var context = CreateContext();
+        var services = CreateServices(context);
+        var user = await services.Admin.CreateUserAsync(new SqlOSCreateUserRequest("Cal User", "cal@example.com", null));
+        var oidc = await CreateGoogleConnectionAsync(services.Admin);
+
+        var result = await services.Calendar.CompleteConnectAsync(
+            GooglePayload(oidc.Id, SqlOSCalendarIntegrationMode.ReadPull, userId: user.Id),
+            "success:cal@example.com");
+
+        result.ProviderAccountEmail.Should().Be("cal@example.com");
+        var stored = context.Set<SqlOSCalendarConnection>().Single();
+        stored.UserId.Should().Be(user.Id);
+        stored.Mode.Should().Be(SqlOSCalendarIntegrationMode.ReadPull);
+        stored.Status.Should().Be(SqlOSCalendarConnectionStatus.Active);
+        stored.AccessTokenEncrypted.Should().StartWith("dp:");
+        stored.AccessTokenEncrypted.Should().NotContain("google-access|cal@example.com");
+        stored.RefreshTokenEncrypted.Should().StartWith("dp:");
+        stored.ProviderAccountSubject.Should().Be("google-cal-cal@example.com");
+        stored.AccessTokenExpiresAt.Should().BeAfter(DateTime.UtcNow.AddMinutes(30));
+    }
+
+    [TestMethod]
+    public async Task CompleteConnect_ReadPullWithoutRefreshToken_Throws()
+    {
+        using var context = CreateContext();
+        var services = CreateServices(context);
+        var user = await services.Admin.CreateUserAsync(new SqlOSCreateUserRequest("Cal User", "cal@example.com", null));
+        var oidc = await CreateGoogleConnectionAsync(services.Admin);
+
+        var act = () => services.Calendar.CompleteConnectAsync(
+            GooglePayload(oidc.Id, SqlOSCalendarIntegrationMode.ReadPull, userId: user.Id),
+            "norefresh:cal@example.com");
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*refresh token*");
+        context.Set<SqlOSCalendarConnection>().Count().Should().Be(0);
+    }
+
+    [TestMethod]
+    public async Task ConnectCallback_EndToEnd_RedirectsToReturnUriWithConnectionId()
+    {
+        using var context = CreateContext();
+        var services = CreateServices(context);
+        var user = await services.Admin.CreateUserAsync(new SqlOSCreateUserRequest("Cal User", "cal@example.com", null));
+        var oidc = await CreateGoogleConnectionAsync(services.Admin);
+
+        var start = await services.Calendar.StartConnectAsync(new SqlOSStartCalendarConnectRequest(
+            oidc.Id,
+            SqlOSCalendarIntegrationMode.ConnectionOnly,
+            ReturnUri,
+            UserId: user.Id));
+        var state = QueryHelpers.ParseQuery(new Uri(start.AuthorizationUrl).Query)["state"].ToString();
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.QueryString = new QueryString($"?code={Uri.EscapeDataString("success:cal@example.com")}&state={Uri.EscapeDataString(state)}");
+
+        var result = await services.Calendar.HandleConnectCallbackAsync(httpContext);
+
+        var redirect = result.Should().BeOfType<Microsoft.AspNetCore.Http.HttpResults.RedirectHttpResult>().Subject;
+        redirect.Url.Should().StartWith(ReturnUri);
+        var connection = context.Set<SqlOSCalendarConnection>().Single();
+        redirect.Url.Should().Contain($"calendarConnectionId={connection.Id}");
+    }
+
+    [TestMethod]
+    public async Task ConnectCallback_ReplayedState_Fails()
+    {
+        using var context = CreateContext();
+        var services = CreateServices(context);
+        var user = await services.Admin.CreateUserAsync(new SqlOSCreateUserRequest("Cal User", "cal@example.com", null));
+        var oidc = await CreateGoogleConnectionAsync(services.Admin);
+
+        var start = await services.Calendar.StartConnectAsync(new SqlOSStartCalendarConnectRequest(
+            oidc.Id,
+            SqlOSCalendarIntegrationMode.ConnectionOnly,
+            ReturnUri,
+            UserId: user.Id));
+        var state = QueryHelpers.ParseQuery(new Uri(start.AuthorizationUrl).Query)["state"].ToString();
+
+        var first = new DefaultHttpContext();
+        first.Request.QueryString = new QueryString($"?code={Uri.EscapeDataString("success:cal@example.com")}&state={Uri.EscapeDataString(state)}");
+        await services.Calendar.HandleConnectCallbackAsync(first);
+
+        var replay = new DefaultHttpContext();
+        replay.Request.QueryString = new QueryString($"?code={Uri.EscapeDataString("success:cal@example.com")}&state={Uri.EscapeDataString(state)}");
+        var result = await services.Calendar.HandleConnectCallbackAsync(replay);
+
+        result.Should().NotBeOfType<Microsoft.AspNetCore.Http.HttpResults.RedirectHttpResult>();
+        context.Set<SqlOSCalendarConnection>().Count().Should().Be(1);
+    }
+
+    [TestMethod]
+    public async Task GetAccessToken_ConnectionOnly_ReturnsTokenWithoutStoringEvents()
+    {
+        using var context = CreateContext();
+        var services = CreateServices(context);
+        var connectionId = await ConnectGoogleAsync(services, context, SqlOSCalendarIntegrationMode.ConnectionOnly);
+
+        var token = await services.Calendar.GetAccessTokenAsync(connectionId);
+
+        token.AccessToken.Should().Be("google-access|cal@example.com");
+        token.ProviderType.Should().Be(SqlOSCalendarProviderType.Google);
+        context.Set<SqlOSCalendarEvent>().Count().Should().Be(0);
+        context.Set<SqlOSCalendarSyncState>().Count().Should().Be(0);
+    }
+
+    [TestMethod]
+    public async Task GetAccessToken_WrongOrganization_Throws()
+    {
+        using var context = CreateContext();
+        var services = CreateServices(context);
+        var connectionId = await ConnectGoogleAsync(services, context, SqlOSCalendarIntegrationMode.ConnectionOnly);
+
+        var act = () => services.Calendar.GetAccessTokenAsync(connectionId, forOrganizationId: "org_other");
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*not found*");
+    }
+
+    [TestMethod]
+    public async Task GetAccessToken_WrongUser_Throws()
+    {
+        using var context = CreateContext();
+        var services = CreateServices(context);
+        var connectionId = await ConnectGoogleAsync(services, context, SqlOSCalendarIntegrationMode.ConnectionOnly);
+
+        var act = () => services.Calendar.GetAccessTokenAsync(connectionId, forUserId: "usr_other");
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*not found*");
+    }
+
+    [TestMethod]
+    public async Task GetAccessToken_ExpiredToken_RefreshesAndRotatesRefreshToken()
+    {
+        using var context = CreateContext();
+        var services = CreateServices(context);
+        var connectionId = await ConnectGoogleAsync(services, context, SqlOSCalendarIntegrationMode.ConnectionOnly);
+
+        var connection = context.Set<SqlOSCalendarConnection>().Single(x => x.Id == connectionId);
+        connection.AccessTokenExpiresAt = DateTime.UtcNow.AddMinutes(-1);
+        await context.SaveChangesAsync();
+
+        var token = await services.Calendar.GetAccessTokenAsync(connectionId);
+
+        token.AccessToken.Should().Be("google-access-refreshed|cal@example.com");
+        services.Crypto.UnprotectSecret(connection.RefreshTokenEncrypted!)
+            .Should().Be("google-refresh-rotated|cal@example.com");
+        connection.Status.Should().Be(SqlOSCalendarConnectionStatus.Active);
+    }
+
+    [TestMethod]
+    public async Task GetAccessToken_RevokedRefreshToken_MarksConnectionError()
+    {
+        using var context = CreateContext();
+        var services = CreateServices(context);
+        var connectionId = await ConnectGoogleAsync(services, context, SqlOSCalendarIntegrationMode.ConnectionOnly);
+
+        var connection = context.Set<SqlOSCalendarConnection>().Single(x => x.Id == connectionId);
+        connection.AccessTokenExpiresAt = DateTime.UtcNow.AddMinutes(-1);
+        connection.RefreshTokenEncrypted = services.Crypto.ProtectSecret("revoked-refresh");
+        await context.SaveChangesAsync();
+
+        var act = () => services.Calendar.GetAccessTokenAsync(connectionId);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*revoked*");
+        connection.Status.Should().Be(SqlOSCalendarConnectionStatus.Error);
+        connection.LastError.Should().Contain("revoked");
+        context.Set<SqlOSAuditEvent>().Any(x => x.EventType == "calendar.connection.refresh_failed").Should().BeTrue();
+    }
+
+    [TestMethod]
+    public async Task ListProviderCalendars_Google_ReturnsCalendars()
+    {
+        using var context = CreateContext();
+        var services = CreateServices(context);
+        var connectionId = await ConnectGoogleAsync(services, context, SqlOSCalendarIntegrationMode.ReadPull);
+
+        var calendars = await services.Calendar.ListProviderCalendarsAsync(connectionId);
+
+        calendars.Should().HaveCount(2);
+        calendars.Single(x => x.IsPrimary).ProviderCalendarId.Should().Be("google-primary");
+    }
+
+    [TestMethod]
+    public async Task Sync_ReadPull_ImportsNormalizedEventsAndCursor()
+    {
+        using var context = CreateContext();
+        var services = CreateServices(context);
+        var connectionId = await ConnectGoogleAsync(services, context, SqlOSCalendarIntegrationMode.ReadPull);
+
+        var result = await services.Sync.SyncConnectionAsync(connectionId);
+
+        result.Errors.Should().BeEmpty();
+        result.CalendarsSynced.Should().Be(1);
+        result.EventsUpserted.Should().Be(2);
+
+        var state = context.Set<SqlOSCalendarSyncState>().Single();
+        state.ProviderCalendarId.Should().Be("google-primary");
+        state.SyncCursor.Should().Be("google-sync-1");
+        state.LastSyncStatus.Should().Be("ok");
+        state.EventCount.Should().Be(2);
+
+        var events = await services.Calendar.ListEventsAsync(
+            connectionId,
+            new DateTime(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc));
+        events.Should().HaveCount(2);
+        events.Select(x => x.ProviderEventId).Should().BeEquivalentTo(["google-evt-1", "google-evt-2"]);
+        events.All(x => x.ShowAs == "busy").Should().BeTrue();
+
+        var connection = context.Set<SqlOSCalendarConnection>().Single();
+        connection.LastSyncAt.Should().NotBeNull();
+        context.Set<SqlOSAuditEvent>().Any(x => x.EventType == "calendar.connection.synced").Should().BeTrue();
+    }
+
+    [TestMethod]
+    public async Task Sync_SecondPassWithCursor_AppliesDeltaAndRemovesCancelled()
+    {
+        using var context = CreateContext();
+        var services = CreateServices(context);
+        var connectionId = await ConnectGoogleAsync(services, context, SqlOSCalendarIntegrationMode.ReadPull);
+
+        await services.Sync.SyncConnectionAsync(connectionId);
+        var second = await services.Sync.SyncConnectionAsync(connectionId);
+
+        second.Errors.Should().BeEmpty();
+        second.EventsRemoved.Should().Be(1);
+
+        var events = context.Set<SqlOSCalendarEvent>().ToList();
+        events.Should().NotContain(x => x.ProviderEventId == "google-evt-1");
+        events.Single(x => x.ProviderEventId == "google-evt-2").Subject.Should().Be("Standup (moved)");
+        events.Should().Contain(x => x.ProviderEventId == "google-evt-3");
+        context.Set<SqlOSCalendarSyncState>().Single().SyncCursor.Should().Be("google-sync-2");
+    }
+
+    [TestMethod]
+    public async Task Sync_ExpiredCursor_FallsBackToFullWindow()
+    {
+        using var context = CreateContext();
+        var services = CreateServices(context);
+        var connectionId = await ConnectGoogleAsync(services, context, SqlOSCalendarIntegrationMode.ReadPull);
+
+        await services.Sync.SyncConnectionAsync(connectionId);
+        var state = context.Set<SqlOSCalendarSyncState>().Single();
+        state.SyncCursor = "expired";
+        await context.SaveChangesAsync();
+
+        var result = await services.Sync.SyncConnectionAsync(connectionId);
+
+        result.Errors.Should().BeEmpty();
+        context.Set<SqlOSCalendarSyncState>().Single().SyncCursor.Should().Be("google-sync-1");
+    }
+
+    [TestMethod]
+    public async Task Sync_ConnectionOnly_Throws()
+    {
+        using var context = CreateContext();
+        var services = CreateServices(context);
+        var connectionId = await ConnectGoogleAsync(services, context, SqlOSCalendarIntegrationMode.ConnectionOnly);
+
+        var act = () => services.Sync.SyncConnectionAsync(connectionId);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*Connection-only*");
+    }
+
+    [TestMethod]
+    public async Task ListEvents_ConnectionOnly_Throws()
+    {
+        using var context = CreateContext();
+        var services = CreateServices(context);
+        var connectionId = await ConnectGoogleAsync(services, context, SqlOSCalendarIntegrationMode.ConnectionOnly);
+
+        var act = () => services.Calendar.ListEventsAsync(connectionId, DateTime.UtcNow.AddDays(-1), DateTime.UtcNow.AddDays(30));
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*do not store events*");
+    }
+
+    [TestMethod]
+    public async Task CreateEvent_TwoWay_PushesToProviderAndStoresLocalCopy()
+    {
+        using var context = CreateContext();
+        var services = CreateServices(context);
+        var connectionId = await ConnectGoogleAsync(services, context, SqlOSCalendarIntegrationMode.TwoWay);
+
+        var created = await services.Sync.CreateEventAsync(
+            connectionId,
+            "google-primary",
+            new SqlOSCalendarEventDraft(
+                "Client kickoff",
+                new DateTime(2026, 7, 9, 9, 0, 0, DateTimeKind.Utc),
+                new DateTime(2026, 7, 9, 9, 30, 0, DateTimeKind.Utc)));
+
+        created.ProviderEventId.Should().Be("google-created-1");
+        var local = context.Set<SqlOSCalendarEvent>().Single();
+        local.Origin.Should().Be("push");
+        local.Subject.Should().Be("Client kickoff");
+        context.Set<SqlOSAuditEvent>().Any(x => x.EventType == "calendar.event.created").Should().BeTrue();
+    }
+
+    [TestMethod]
+    public async Task CreateEvent_ReadPull_Throws()
+    {
+        using var context = CreateContext();
+        var services = CreateServices(context);
+        var connectionId = await ConnectGoogleAsync(services, context, SqlOSCalendarIntegrationMode.ReadPull);
+
+        var act = () => services.Sync.CreateEventAsync(
+            connectionId,
+            "google-primary",
+            new SqlOSCalendarEventDraft("Nope", DateTime.UtcNow, DateTime.UtcNow.AddHours(1)));
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*two-way*");
+    }
+
+    [TestMethod]
+    public async Task Sync_TwoWayConflict_DefaultPrefersProvider()
+    {
+        using var context = CreateContext();
+        var services = CreateServices(context);
+        var connectionId = await ConnectGoogleAsync(services, context, SqlOSCalendarIntegrationMode.TwoWay);
+
+        await services.Sync.SyncConnectionAsync(connectionId);
+        await services.Sync.CreateEventAsync(
+            connectionId,
+            "google-primary",
+            new SqlOSCalendarEventDraft(
+                "Client kickoff",
+                new DateTime(2026, 7, 9, 9, 0, 0, DateTimeKind.Utc),
+                new DateTime(2026, 7, 9, 9, 30, 0, DateTimeKind.Utc)));
+
+        await services.Sync.SyncConnectionAsync(connectionId);
+
+        context.Set<SqlOSCalendarEvent>()
+            .Single(x => x.ProviderEventId == "google-created-1")
+            .Subject.Should().Be("Modified remotely");
+    }
+
+    [TestMethod]
+    public async Task Sync_TwoWayConflict_CallbackCanPreferLocal()
+    {
+        using var context = CreateContext();
+        var conflicts = new List<SqlOSCalendarConflictContext>();
+        var services = CreateServices(context, options => options.Calendar.OnTwoWayConflictAsync = (conflict, _) =>
+        {
+            conflicts.Add(conflict);
+            return Task.FromResult(SqlOSCalendarConflictDecision.PreferLocal);
+        });
+        var connectionId = await ConnectGoogleAsync(services, context, SqlOSCalendarIntegrationMode.TwoWay);
+
+        await services.Sync.SyncConnectionAsync(connectionId);
+        await services.Sync.CreateEventAsync(
+            connectionId,
+            "google-primary",
+            new SqlOSCalendarEventDraft(
+                "Client kickoff",
+                new DateTime(2026, 7, 9, 9, 0, 0, DateTimeKind.Utc),
+                new DateTime(2026, 7, 9, 9, 30, 0, DateTimeKind.Utc)));
+
+        await services.Sync.SyncConnectionAsync(connectionId);
+
+        conflicts.Should().HaveCount(1);
+        conflicts[0].Remote.Subject.Should().Be("Modified remotely");
+        context.Set<SqlOSCalendarEvent>()
+            .Single(x => x.ProviderEventId == "google-created-1")
+            .Subject.Should().Be("Client kickoff");
+    }
+
+    [TestMethod]
+    public async Task Disconnect_ClearsTokensAndBlocksAccess()
+    {
+        using var context = CreateContext();
+        var services = CreateServices(context);
+        var connectionId = await ConnectGoogleAsync(services, context, SqlOSCalendarIntegrationMode.ConnectionOnly);
+
+        var summary = await services.Calendar.DisconnectAsync(connectionId, "user_requested");
+
+        summary.Status.Should().Be(nameof(SqlOSCalendarConnectionStatus.Revoked));
+        var connection = context.Set<SqlOSCalendarConnection>().Single();
+        connection.AccessTokenEncrypted.Should().BeNull();
+        connection.RefreshTokenEncrypted.Should().BeNull();
+        connection.RevokedAt.Should().NotBeNull();
+        context.Set<SqlOSAuditEvent>().Any(x => x.EventType == "calendar.connection.disconnected").Should().BeTrue();
+
+        var act = () => services.Calendar.GetAccessTokenAsync(connectionId);
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*disconnected*");
+    }
+
+    [TestMethod]
+    public async Task Microsoft_ConnectAndSync_MirrorsGoogle()
+    {
+        using var context = CreateContext();
+        var services = CreateServices(context);
+        var organization = await services.Admin.CreateOrganizationAsync(new SqlOSCreateOrganizationRequest("Acme", "acme"));
+        var oidc = await CreateMicrosoftConnectionAsync(services.Admin);
+
+        var completion = await services.Calendar.CompleteConnectAsync(
+            new CalendarConnectRequestPayload(
+                oidc.Id,
+                SqlOSCalendarIntegrationMode.ReadPull,
+                null,
+                organization.Id,
+                null,
+                ["openid", "email", "offline_access", "Calendars.Read"],
+                ReturnUri,
+                "verifier",
+                "https://tests.example.local/sqlos/auth/calendar/callback",
+                "https://login.microsoftonline.com/common/oauth2/v2.0/token"),
+            "success:cal-ms@example.com");
+
+        completion.OrganizationId.Should().Be(organization.Id);
+        completion.ProviderAccountEmail.Should().Be("cal-ms@example.com");
+
+        var calendars = await services.Calendar.ListProviderCalendarsAsync(completion.CalendarConnectionId);
+        calendars.Single(x => x.IsPrimary).ProviderCalendarId.Should().Be("graph-default");
+
+        var first = await services.Sync.SyncConnectionAsync(completion.CalendarConnectionId);
+        first.Errors.Should().BeEmpty();
+        first.EventsUpserted.Should().Be(2);
+
+        var second = await services.Sync.SyncConnectionAsync(completion.CalendarConnectionId);
+        second.Errors.Should().BeEmpty();
+        second.EventsRemoved.Should().Be(1);
+
+        var events = context.Set<SqlOSCalendarEvent>().ToList();
+        events.Should().NotContain(x => x.ProviderEventId == "graph-evt-1");
+        events.Single(x => x.ProviderEventId == "graph-evt-2").Subject.Should().Be("Design review (moved)");
+    }
+
+    [TestMethod]
+    public async Task AdminSurface_ListsConnectionsAndSummary()
+    {
+        using var context = CreateContext();
+        var services = CreateServices(context);
+        await ConnectGoogleAsync(services, context, SqlOSCalendarIntegrationMode.ReadPull);
+
+        var summary = await services.Calendar.GetAdminSummaryAsync();
+        var list = await services.Calendar.GetAdminConnectionsAsync();
+
+        summary.Should().NotBeNull();
+        list.Should().NotBeNull();
+        var listJson = System.Text.Json.JsonSerializer.Serialize(list);
+        listJson.Should().Contain("\"TotalCount\":1");
+        listJson.Should().NotContain("google-access|", "admin projections must never expose raw tokens");
+        listJson.Should().NotContain("dp:", "admin projections must never expose encrypted token material");
+    }
+
+    private static CalendarConnectRequestPayload GooglePayload(
+        string oidcConnectionId,
+        SqlOSCalendarIntegrationMode mode,
+        string? userId = null,
+        string? organizationId = null)
+        => new(
+            oidcConnectionId,
+            mode,
+            userId,
+            organizationId,
+            null,
+            ["openid", "email", "https://www.googleapis.com/auth/calendar.readonly"],
+            ReturnUri,
+            "verifier",
+            "https://tests.example.local/sqlos/auth/calendar/callback",
+            "https://oauth2.googleapis.com/token");
+
+    private static async Task<string> ConnectGoogleAsync(
+        CalendarTestServices services,
+        TestSqlOSInMemoryDbContext context,
+        SqlOSCalendarIntegrationMode mode)
+    {
+        var user = await services.Admin.CreateUserAsync(new SqlOSCreateUserRequest("Cal User", $"cal-{Guid.NewGuid():N}@example.com", null));
+        var oidc = await CreateGoogleConnectionAsync(services.Admin);
+        var completion = await services.Calendar.CompleteConnectAsync(
+            GooglePayload(oidc.Id, mode, userId: user.Id),
+            "success:cal@example.com");
+        return completion.CalendarConnectionId;
+    }
+
+    private static async Task<SqlOSOidcConnection> CreateGoogleConnectionAsync(SqlOSAdminService admin)
+        => await admin.CreateOidcConnectionAsync(new SqlOSCreateOidcConnectionRequest(
+            SqlOSOidcProviderType.Google, "Google", "google-client", "google-secret",
+            ["https://app.example.local/callback/google"], true,
+            null, null, null, null, null, null, null, null, null, null, null));
+
+    private static async Task<SqlOSOidcConnection> CreateMicrosoftConnectionAsync(SqlOSAdminService admin)
+        => await admin.CreateOidcConnectionAsync(new SqlOSCreateOidcConnectionRequest(
+            SqlOSOidcProviderType.Microsoft, "Microsoft", "ms-client", "ms-secret",
+            ["https://app.example.local/callback/microsoft"], true,
+            null, null, null, null, null, null, "common", null, null, null, null));
+
+    private sealed record CalendarTestServices(
+        SqlOSAdminService Admin,
+        SqlOSCryptoService Crypto,
+        SqlOSCalendarService Calendar,
+        SqlOSCalendarSyncService Sync);
+
+    private static CalendarTestServices CreateServices(
+        TestSqlOSInMemoryDbContext context,
+        Action<SqlOSOptions>? configure = null)
+    {
+        var sqlosOptions = new SqlOSOptions();
+        sqlosOptions.AuthServer.PublicOrigin = "https://tests.example.local";
+        configure?.Invoke(sqlosOptions);
+
+        var authOptions = Options.Create(sqlosOptions.AuthServer);
+        var crypto = new SqlOSCryptoService(context, authOptions, new EphemeralDataProtectionProvider());
+        var admin = new SqlOSAdminService(context, authOptions, crypto);
+        var httpFactory = new FakeCalendarProviderHttpClientFactory();
+        var adapters = new ISqlOSCalendarProviderAdapter[]
+        {
+            new SqlOSGoogleCalendarAdapter(httpFactory),
+            new SqlOSMicrosoftGraphCalendarAdapter(httpFactory)
+        };
+        var calendar = new SqlOSCalendarService(
+            context,
+            admin,
+            crypto,
+            httpFactory,
+            adapters,
+            Options.Create(sqlosOptions),
+            NullLogger<SqlOSCalendarService>.Instance);
+        var sync = new SqlOSCalendarSyncService(
+            context,
+            admin,
+            crypto,
+            calendar,
+            Options.Create(sqlosOptions),
+            NullLogger<SqlOSCalendarSyncService>.Instance);
+        return new CalendarTestServices(admin, crypto, calendar, sync);
+    }
+
+    private static TestSqlOSInMemoryDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<TestSqlOSInMemoryDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .Options;
+        return new TestSqlOSInMemoryDbContext(options);
+    }
+}

--- a/tests/SqlOS.Tests/SqlOSOptionsValidationTests.cs
+++ b/tests/SqlOS.Tests/SqlOSOptionsValidationTests.cs
@@ -171,4 +171,74 @@ public sealed class SqlOSOptionsValidationTests
         act.Should().Throw<InvalidOperationException>()
             .WithMessage("*AuthServer.ClientRegistration.Dcr.RateLimitWindow must be greater than zero.*");
     }
+
+    [TestMethod]
+    public void AddSqlOS_Throws_WhenCalendarConnectSessionLifetimeIsNotPositive()
+    {
+        var services = new ServiceCollection();
+
+        Action act = () => services.AddSqlOS<TestSqlOSInMemoryDbContext>(options =>
+        {
+            options.Calendar.ConnectSessionLifetime = TimeSpan.Zero;
+        });
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Calendar.ConnectSessionLifetime must be greater than zero.*");
+    }
+
+    [TestMethod]
+    public void AddSqlOS_Throws_WhenCalendarSyncWindowsAreInvalid()
+    {
+        var services = new ServiceCollection();
+
+        Action act = () => services.AddSqlOS<TestSqlOSInMemoryDbContext>(options =>
+        {
+            options.Calendar.AccessTokenRefreshSkew = TimeSpan.FromSeconds(-1);
+            options.Calendar.SyncWindowPastDays = -1;
+            options.Calendar.SyncWindowFutureDays = 0;
+        });
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Calendar.AccessTokenRefreshSkew must be zero or greater.*")
+            .WithMessage("*Calendar.SyncWindowPastDays must be zero or greater.*")
+            .WithMessage("*Calendar.SyncWindowFutureDays must be greater than zero.*");
+    }
+
+    [TestMethod]
+    public void AddSqlOS_Throws_WhenCalendarSchedulerIsMisconfigured()
+    {
+        var services = new ServiceCollection();
+
+        Action act = () => services.AddSqlOS<TestSqlOSInMemoryDbContext>(options =>
+        {
+            options.ConfigureCalendar(calendar => calendar.ConfigureSyncScheduler(scheduler =>
+            {
+                scheduler.Interval = TimeSpan.Zero;
+                scheduler.SyncEvery = TimeSpan.Zero;
+                scheduler.MaxConnectionsPerRun = 0;
+            }));
+        });
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Calendar.SyncScheduler.Interval must be greater than zero.*")
+            .WithMessage("*Calendar.SyncScheduler.SyncEvery must be greater than zero.*")
+            .WithMessage("*Calendar.SyncScheduler.MaxConnectionsPerRun must be greater than zero.*");
+    }
+
+    [TestMethod]
+    public void AddSqlOS_Allows_DisabledCalendarSchedulerWithInvalidIntervals()
+    {
+        var services = new ServiceCollection();
+
+        Action act = () => services.AddSqlOS<TestSqlOSInMemoryDbContext>(options =>
+        {
+            options.ConfigureCalendar(calendar => calendar.ConfigureSyncScheduler(scheduler =>
+            {
+                scheduler.Enabled = false;
+                scheduler.Interval = TimeSpan.Zero;
+            }));
+        });
+
+        act.Should().NotThrow();
+    }
 }

--- a/web/content/docs/authserver/calendar-integration.mdx
+++ b/web/content/docs/authserver/calendar-integration.mdx
@@ -1,0 +1,127 @@
+---
+title: "Calendar Integration"
+description: "Google Calendar and Microsoft 365 calendar connections with connection-only, read-pull, and two-way modes."
+order: 18
+section: authserver
+---
+
+SqlOS stores calendar OAuth tokens encrypted at rest, refreshes them automatically, and optionally imports normalized events — per **user** or per **organization**. Provider credentials are reused from your seeded [Google](/docs/authserver/google-oidc) / [Microsoft](/docs/authserver/microsoft-oidc) social connections; sign-in flows never request calendar scopes.
+
+For a walkthrough, see the [calendar integration guide](/docs/guides/calendar-integration).
+
+## Integration modes
+
+```csharp
+public enum SqlOSCalendarIntegrationMode
+{
+    ConnectionOnly, // SqlOS stores tokens; your app calls Google/Graph directly
+    ReadPull,       // SqlOS imports events/busy blocks on a schedule
+    TwoWay          // SqlOS pushes app-created events and pulls changes
+}
+```
+
+`ConnectionOnly` never persists event copies. `ReadPull` and `TwoWay` require a provider refresh token; the connect flow fails fast when one is not granted.
+
+## Scopes
+
+| Provider | Read | Two-way writes |
+|----------|------|----------------|
+| Google | `https://www.googleapis.com/auth/calendar.readonly` | + `https://www.googleapis.com/auth/calendar.events` |
+| Microsoft | `offline_access`, `Calendars.Read` | `offline_access`, `Calendars.ReadWrite` |
+
+SqlOS adds `openid email` so the granting account is recorded, sends `access_type=offline&prompt=consent` to Google, and accepts a custom scope list via `SqlOSStartCalendarConnectRequest.Scopes`.
+
+## Connect flow
+
+1. Your backend calls `SqlOSCalendarService.StartConnectAsync(...)` with the OIDC connection id, mode, owner (`UserId` **or** `OrganizationId`), and an absolute `ReturnUri`.
+2. Redirect the browser to the returned `AuthorizationUrl` (PKCE + single-use state, `Calendar.ConnectSessionLifetime` window).
+3. The provider redirects to the SqlOS-owned callback: `{AuthServer.BasePath}/calendar/callback`.
+4. SqlOS exchanges the code, encrypts both tokens with Data Protection, records the granting account, and redirects to `ReturnUri` with `?calendarConnectionId=...` or `?error=...`.
+
+Add the callback URI to the provider app registration:
+
+```
+https://your-app.example.com/sqlos/auth/calendar/callback
+```
+
+## Service surface
+
+`SqlOSCalendarService` (scoped, registered by `AddSqlOS`):
+
+- `StartConnectAsync` / `HandleConnectCallbackAsync` / `CompleteConnectAsync` — connect flow
+- `ListConnectionsAsync`, `GetConnectionAsync` — summaries (never token material)
+- `GetAccessTokenAsync` — short-lived provider token, transparently refreshed within `Calendar.AccessTokenRefreshSkew`
+- `ListProviderCalendarsAsync` — live calendar list from the provider
+- `EnableCalendarSyncAsync` — choose which calendars a connection syncs
+- `ListEventsAsync` — normalized events (read-pull/two-way only)
+- `DisconnectAsync` — revokes and clears stored tokens
+- `ForceRefreshAsync` — admin force refresh
+
+`SqlOSCalendarSyncService`:
+
+- `SyncConnectionAsync` — pull one connection now (auto-enrolls the primary calendar on first sync)
+- `CreateEventAsync` — two-way event creation with a local `push` copy
+- `SyncDueConnectionsAsync` — used by the background scheduler
+
+All owner-scoped reads accept `forUserId` / `forOrganizationId` and fail closed when the connection belongs to someone else.
+
+## Options
+
+```csharp
+builder.AddSqlOS<AppDbContext>(db => db.UseSqlServer(cs), options =>
+{
+    options.ConfigureCalendar(calendar =>
+    {
+        calendar.SyncWindowPastDays = 30;        // read-pull import window
+        calendar.SyncWindowFutureDays = 90;
+        calendar.AccessTokenRefreshSkew = TimeSpan.FromMinutes(5);
+        calendar.ConfigureSyncScheduler(scheduler =>
+        {
+            scheduler.Enabled = true;            // background sync worker
+            scheduler.Interval = TimeSpan.FromMinutes(5);
+            scheduler.SyncEvery = TimeSpan.FromMinutes(15);
+            scheduler.MaxConnectionsPerRun = 25;
+        });
+        calendar.OnTwoWayConflictAsync = (conflict, ct) =>
+            Task.FromResult(SqlOSCalendarConflictDecision.PreferProvider);
+    });
+});
+```
+
+Set `options.Calendar.Enabled = false` to skip mapping the callback and admin endpoints entirely.
+
+## Sync behavior
+
+- Incremental cursors: Google `syncToken`, Microsoft Graph delta links. Expired cursors fall back to a full-window pull automatically.
+- Cancelled provider events remove the local copy.
+- Two-way conflicts (a provider change to an event created through SqlOS) are delegated to `OnTwoWayConflictAsync`; the provider version wins by default.
+- Sync results update per-calendar health (`LastSyncStatus`, `LastSyncError`, `EventCount`) and the connection status (`Active`/`Error`).
+
+## Admin API and dashboard
+
+Dashboard: **`/sqlos/admin/calendar/connections`** — status, owner, granted account, last sync, per-calendar cursor health, plus force sync, token refresh, and disconnect actions.
+
+Admin API (dashboard-session guarded, mirrors the other admin surfaces):
+
+```
+GET  /sqlos/admin/calendar/api/connections?search=&includeRevoked=&page=&pageSize=
+GET  /sqlos/admin/calendar/api/connections/{id}
+POST /sqlos/admin/calendar/api/connections/{id}/sync
+POST /sqlos/admin/calendar/api/connections/{id}/refresh
+POST /sqlos/admin/calendar/api/connections/{id}/disconnect
+GET  /sqlos/admin/calendar/api/summary
+```
+
+## Audit events
+
+`calendar.connect.start`, `calendar.connection.created`, `calendar.connect.error`, `calendar.connection.synced`, `calendar.sync.failed`, `calendar.connection.refresh_failed`, `calendar.connection.disconnected`, `calendar.event.created`.
+
+## Schema
+
+Migration `026` adds `SqlOSCalendarConnections` (encrypted tokens, mode, owner, status), `SqlOSCalendarSyncStates` (per-calendar cursors and health), and `SqlOSCalendarEvents` (normalized copies, unique per provider event).
+
+## Failure modes
+
+- **"The provider did not return a refresh token"** — the Google account previously consented without offline access; SqlOS forces `prompt=consent`, so this usually means a Workspace policy stripped it, or a custom scope list dropped `offline_access` (Microsoft).
+- **Connection status `Error`** — the last refresh or sync failed; see `LastError` in the dashboard, fix the underlying grant, then use **Refresh token** or reconnect.
+- **410 / expired cursor** — handled automatically with a full re-pull; no action needed.

--- a/web/content/docs/guides/calendar-integration.mdx
+++ b/web/content/docs/guides/calendar-integration.mdx
@@ -1,0 +1,143 @@
+---
+title: "Calendar integration"
+description: "Connect Google Calendar and Microsoft 365 calendars per user or organization with connection-only, read-pull, or two-way modes."
+order: 4
+section: guides
+---
+
+<Banner
+  eyebrow="Guide"
+  title="Connect Google and Microsoft calendars"
+  href="/docs/authserver/calendar-integration"
+  actionLabel="Calendar reference"
+/>
+
+You'll learn how to reuse your existing Google/Microsoft OAuth apps for calendar access, pick an integration mode, run the connect flow, and read normalized events.
+
+<Callout type="info" title="Prerequisites">
+  - SqlOS running with a seeded [Google](/docs/authserver/google-oidc) or [Microsoft](/docs/authserver/microsoft-oidc) social connection
+  - Admin access to `/sqlos/admin/calendar/`
+</Callout>
+
+## Goal
+
+Your app connects a user's (or an organization's) Google or Outlook calendar without writing any OAuth, token storage, or refresh code. Sign-in stays untouched: login flows never request calendar scopes, and calendar consent is a separate browser round-trip that users grant explicitly.
+
+## Pick an integration mode
+
+Apps choose per connection how much SqlOS does:
+
+| Mode | What SqlOS stores | When to use |
+|------|-------------------|-------------|
+| `ConnectionOnly` | Encrypted tokens only | Your app calls the Google/Graph APIs itself and just needs a fresh access token on demand. |
+| `ReadPull` | Encrypted tokens + normalized events | You need availability/busy data served from your own database on a schedule. |
+| `TwoWay` | Encrypted tokens + normalized events | You also create events on the provider calendar and want conflicts delegated to your code. |
+
+<Callout type="tip" title="Recommended path for scheduling products">
+  Booking and scheduling apps should start with `ReadPull`: import busy blocks on the sync schedule, keep the booking engine on your own tables, and only move to `TwoWay` when you need SqlOS to write confirmed bookings back to the provider calendar.
+</Callout>
+
+## 1. Grant calendar scopes to your OAuth apps
+
+Calendar connections reuse the client id/secret of your seeded social connection, so there is nothing new to register — only new scopes to allow.
+
+**Google Cloud Console** ([APIs & Services](https://console.cloud.google.com/apis/dashboard)):
+
+1. Enable the **Google Calendar API** for the project that owns your OAuth client.
+2. Add the scopes to the OAuth consent screen: `https://www.googleapis.com/auth/calendar.readonly` (read) and `https://www.googleapis.com/auth/calendar.events` (two-way writes).
+3. Add the SqlOS calendar callback to the client's authorized redirect URIs:
+
+```
+https://your-app.example.com/sqlos/auth/calendar/callback
+```
+
+**Microsoft Entra** ([App registrations](https://entra.microsoft.com/)):
+
+1. Under **API permissions**, add Microsoft Graph delegated permissions: `Calendars.Read` (read) or `Calendars.ReadWrite` (two-way), plus `offline_access`.
+2. Under **Authentication > Web**, add the same SqlOS calendar callback redirect URI.
+
+SqlOS requests `access_type=offline&prompt=consent` for Google and `offline_access` for Microsoft automatically so refresh tokens are always issued.
+
+## 2. Start the connect flow
+
+From your app's backend (the user is already signed in), start a connect session and redirect the browser to the returned URL:
+
+```csharp
+app.MapPost("/api/calendar/connect", async (
+    HttpContext http,
+    SqlOSCalendarService calendarService,
+    SqlOSOidcAuthService oidcAuthService,
+    CancellationToken ct) =>
+{
+    var userId = http.User.FindFirst("sub")!.Value;
+    var providers = await oidcAuthService.ListEnabledProvidersAsync(ct);
+    var google = providers.First(p => p.ProviderType == "Google");
+
+    var result = await calendarService.StartConnectAsync(
+        new SqlOSStartCalendarConnectRequest(
+            google.ConnectionId,
+            SqlOSCalendarIntegrationMode.ReadPull,
+            ReturnUri: "https://your-app.example.com/settings/calendar",
+            UserId: userId),
+        http,
+        ct);
+
+    return Results.Ok(new { url = result.AuthorizationUrl });
+});
+```
+
+SqlOS handles the provider callback at `{BasePath}/calendar/callback`, exchanges the code, encrypts the tokens at rest, and redirects the browser to your `ReturnUri` with `?calendarConnectionId=...` (or `?error=...`).
+
+Bind to an organization instead by passing `OrganizationId` — exactly one of the two must be set.
+
+## 3. Read events (ReadPull / TwoWay)
+
+The background scheduler syncs due connections automatically (every 15 minutes by default, primary calendar first). Read the normalized copies from SqlOS:
+
+```csharp
+var events = await calendarService.ListEventsAsync(
+    calendarConnectionId,
+    fromUtc: DateTime.UtcNow.Date,
+    toUtc: DateTime.UtcNow.Date.AddDays(30),
+    forUserId: userId); // ownership check: throws if the connection belongs to someone else
+```
+
+Each event carries `StartsAtUtc`, `EndsAtUtc`, `ShowAs` (`busy`, `free`, `tentative`, `oof`), `Status`, and `Subject`. Enroll additional calendars with `EnableCalendarSyncAsync`, or trigger a sync immediately with `SqlOSCalendarSyncService.SyncConnectionAsync`.
+
+## 4. Or call the provider yourself (ConnectionOnly)
+
+```csharp
+var token = await calendarService.GetAccessTokenAsync(calendarConnectionId, forUserId: userId);
+// token.AccessToken is short-lived; SqlOS refreshes it transparently when close to expiry.
+```
+
+SqlOS never stores event copies for `ConnectionOnly` connections — `ListEventsAsync` throws by design.
+
+## 5. Two-way writes and conflicts
+
+```csharp
+await syncService.CreateEventAsync(
+    calendarConnectionId,
+    providerCalendarId,
+    new SqlOSCalendarEventDraft("Kickoff", startUtc, endUtc));
+```
+
+When a later pull finds that a provider changed an event your app created through SqlOS, the conflict is delegated to your callback (provider wins when you don't set one):
+
+```csharp
+options.Calendar.OnTwoWayConflictAsync = (conflict, ct) =>
+    Task.FromResult(conflict.Remote.Status == "cancelled"
+        ? SqlOSCalendarConflictDecision.PreferProvider
+        : SqlOSCalendarConflictDecision.PreferLocal);
+```
+
+## Verify
+
+- **Dashboard**: `/sqlos/admin/calendar/connections` shows connection status, last sync, per-calendar cursors, and errors, with force sync/refresh/disconnect actions.
+- **Audit**: connect, disconnect, sync, refresh failures, and event creation are recorded as `calendar.*` audit events.
+
+## Next steps
+
+- [Calendar reference](/docs/authserver/calendar-integration) — options, scopes, service APIs, admin API
+- [Social sign-in](/docs/guides/social-oidc) — seed the Google/Microsoft connections calendar reuses
+- [Audit logs](/docs/guides/audit-logs) — query the `calendar.*` events

--- a/web/src/components/marketing/constants.ts
+++ b/web/src/components/marketing/constants.ts
@@ -87,6 +87,10 @@ export const productFeatures = [
     description: "Automatic RS256 signing key rotation with configurable intervals and grace windows.",
   },
   {
+    title: "Calendar integration",
+    description: "Google and Microsoft 365 calendar connections per user or org with encrypted tokens and scheduled sync.",
+  },
+  {
     title: "Orgs and users",
     description: "Multi-tenant user management with memberships, sessions, refresh tokens, and audit log.",
   },


### PR DESCRIPTION
Closes #144

## What this adds

First-class calendar integration for Google Calendar and Microsoft 365/Outlook, built on the existing social-OIDC infrastructure: consumers keep their one Google/Azure app registration, grant calendar scopes to it, and SqlOS handles OAuth consent, encrypted token storage, refresh-token rotation, sync, and admin visibility. Calendar connect is deliberately separate from sign-in — login flows never request calendar scopes.

### Integration modes (chosen per connection)

```csharp
public enum SqlOSCalendarIntegrationMode
{
    ConnectionOnly, // SqlOS stores tokens; app calls Google/Graph directly
    ReadPull,       // SqlOS imports events/busy blocks on a schedule
    TwoWay          // SqlOS push + pull with app-defined conflict callback
}
```

### Surfaces

| Surface | Delivered |
|---------|-----------|
| Schema | Migration `026`: `SqlOSCalendarConnections` (encrypted tokens, user/org tenancy), `SqlOSCalendarSyncStates` (per-calendar cursors), `SqlOSCalendarEvents` (normalized copies) |
| Services | `SqlOSCalendarService` (connect flow, token accessor, calendars, events, disconnect), `SqlOSCalendarSyncService` (pull sync, two-way create, conflict callback), `SqlOSCalendarSyncHostedService` (scheduler) |
| Providers | Minimal REST adapters for Google Calendar v3 and Microsoft Graph v1.0 (list calendars, incremental event pull via syncToken/delta links, create event) — no new package dependencies |
| Admin API | `/sqlos/admin/calendar/api` — list/detail/sync/refresh/disconnect/summary, dashboard-session guarded |
| Dashboard | Integrations > Calendar section: connection health, per-calendar sync state, force sync / refresh / disconnect |
| Docs | `guides/calendar-integration` (modes, Google Cloud + Azure setup, scopes) + `authserver/calendar-integration` reference; sqlos.dev feature entry |
| Example | `SqlOS.Example.Api` endpoints demonstrating connect start, read-pull events, sync trigger, and the connection-only token accessor |
| Tests | 26 unit tests + 4 SQL Server integration tests using a `FakeCalendarProviderHttpClientFactory` that mirrors the OIDC fake conventions |

### Acceptance criteria from #144

- Google connect stores encrypted (Data Protection) refresh token and lists calendars — unit + integration covered
- Microsoft Graph parity for connect + read — covered
- `ReadPull` returns normalized busy/events via `ListEventsAsync` with owner checks — covered
- `ConnectionOnly` exposes `GetAccessTokenAsync` without persisting event copies — covered (asserted zero event rows)
- `TwoWay` implements read + create with the documented `OnTwoWayConflictAsync` contract (PreferProvider default) — covered
- Dashboard shows connection health — Integrations > Calendar
- Negative tests: wrong user/org owner, revoked refresh token, replayed callback state, non-calendar provider (GitHub), missing refresh token for sync modes

## Genius consumer note

Genius will use SqlOS calendar in onboarding step 2 with `ReadPull` initially; its booking engine stays local-first. The recommended path for scheduling products is documented in the guide ("Recommended path for scheduling products": start ReadPull for availability, adopt TwoWay only when confirmed bookings must be written back). No Genius-specific logic ships in SqlOS.

## Validation

- `dotnet test SqlOS.sln` — green locally: 479/479 (339 unit, 76 integration, 52 example integration, 12 Todo integration; Aspire SQL Server containers)
- `npm run build --prefix web`, `npm run lint --prefix web`, `node scripts/validate-doc-links.mjs`, and `scripts/docs-check.sh` — green
- `node --check src/SqlOS/Dashboard/wwwroot/app.js` — green
- No secrets committed; example seeding stays behind `SqlOS:Oidc:*` configuration like the existing Microsoft login seed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
