### PR TITLE
Revamp SqlOS developer docs and API ergonomics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,283 +1,158 @@
 # SqlOS
 
-**Embedded auth server and fine-grained authorization for .NET — one NuGet package, zero external services.**
+**Embedded authentication and SQL-backed authorization for .NET B2B SaaS.**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![NuGet](https://img.shields.io/nuget/v/SqlOS)](https://www.nuget.org/packages/SqlOS)
 [![.NET 9](https://img.shields.io/badge/.NET-9.0-purple)](https://dotnet.microsoft.com)
 
-SqlOS adds auth and fine-grained authorization to your .NET app. OAuth, login UI, orgs, SAML, OIDC, and FGA live in **your** SQL Server. An embedded admin UI ships with the package.
+SqlOS 3.16.0 adds a hosted OAuth server, branded login, organizations, sessions, and optional fine-grained authorization to an ASP.NET Core application. It runs in your process and stores its data in your SQL Server database, so you do not need a separate identity or authorization service to get started.
 
-Think **WorkOS / AuthKit**, but **self-hosted** and **your database**.
+Start with one application and hosted login. Add SAML SSO, social login, Email OTP, audit logs, calendar connections, or hierarchical authorization when your product needs them.
 
-## Why SqlOS?
+## Choose your starting point
 
-| External auth services                  | SqlOS                                                  |
-| --------------------------------------- | ------------------------------------------------------ |
-| Data lives on someone else's servers    | Data lives in **your** SQL Server                      |
-| Per-MAU pricing that scales against you | **MIT-licensed**, no usage fees                        |
-| Another vendor dependency to manage     | **Single NuGet package**, ships with your app          |
-| Limited customization of login flows    | **Full control** — branded AuthPage, custom OIDC, SAML |
+### See SqlOS work first
 
-## Features
-
-### AuthServer
-
-- **OAuth 2.0 with PKCE** — `/sqlos/auth/authorize`, `/sqlos/auth/token`, metadata, and JWKS
-- **Branded AuthPage** — hosted `/sqlos/auth/login`, `/sqlos/auth/signup`, and `/sqlos/auth/logged-out`
-- **Client Onboarding Modes** — seeded/manual owned apps, `CIMD` discovered clients, and optional `DCR` compatibility clients
-- **Resource Indicators** — bind `resource` end to end and mint audience-aware access tokens
-- **Organizations & Users** — multi-tenant user management with memberships and roles
-- **Password Credentials** — secure local authentication with session management
-- **Social Login** — Google, Microsoft, GitHub, Apple, and any custom OIDC provider
-- **SAML SSO** — enterprise single sign-on with home realm discovery by verified or operator-managed email domain
-- **Delegated SSO Portal** — one-organization setup links for customer IT admins, with provider guides, DNS TXT domain verification, metadata import, and a headless setup state machine
-- **Sessions & Refresh Tokens** — full lifecycle management with revocation
-- **Signing Key Rotation** — automatic RS256 key rotation with configurable intervals
-- **Email OTP** — passwordless sign-in with Azure Communication Services Email
-- **Calendar Integration** — Google Calendar and Microsoft 365 connections per user or organization with encrypted tokens and connection-only, read-pull, or two-way modes
-- **Audit Logging** — track authentication events across your system
-
-### FGA (Fine-Grained Authorization)
-
-- **Hierarchical Resource Authorization** — define resource types, permissions, and roles
-- **Access Grants** — assign permissions to users, user groups, and service accounts
-- **EF Core Query Filters** — filter authorized resources directly in LINQ queries
-- **Access Tester** — verify authorization decisions through the dashboard
-
-### Embedded Admin Dashboard
-
-- **Auth Admin** — manage organizations, users, clients, OIDC/SAML connections, delegated SSO setup links, security settings, sessions, and audit events
-- **FGA Admin** — manage resources, grants, roles, permissions, and test access decisions
-- **Password-Protected** — optional password auth mode with dashboard-specific throttling
-
-## Quick Start
-
-Full walkthrough: **[sqlos.dev/docs/getting-started](https://sqlos.dev/docs/getting-started)**
-
-1. **Add the package**
-
-   ```bash
-   dotnet add package SqlOS
-   ```
-
-2. **Use SQL Server for your EF `DbContext`**
-   SqlOS uses the same database as your context. Point EF at SQL Server like any other app.
-
-3. **Create your `DbContext`**
-   Derive from `SqlOSDbContext<TContext>` to add the SqlOS auth server model, FGA model, and FGA TVF mapping:
-
-   ```csharp
-   public sealed class AppDbContext(DbContextOptions<AppDbContext> options)
-       : SqlOSDbContext<AppDbContext>(options)
-   {
-       public DbSet<Project> Projects => Set<Project>();
-
-       protected override void OnApplicationModelCreating(ModelBuilder modelBuilder)
-       {
-           modelBuilder.Entity<Project>();
-       }
-   }
-   ```
-
-   The low-level `ISqlOSAuthServerDbContext`, `ISqlOSFgaDbContext`, and `modelBuilder.UseSqlOS(...)` path remains available when you need custom model control.
-
-4. **Register SqlOS on the host**
-
-   ```csharp
-   builder.AddSqlOS<AppDbContext>(
-       db => db.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")),
-       options =>
-       {
-           options.AuthServer.SeedOwnedWebApp(
-               "todo-web",
-               "Todo Web App",
-               "https://app.example.com/auth/callback");
-       });
-   ```
-
-5. **Map routes after `Build()`**
-
-   ```csharp
-   var app = builder.Build();
-   app.MapSqlOS();
-   ```
-
-   For APIs that accept SqlOS access tokens, `RequireSqlOSAccessToken(audience)` validates the token and populates `HttpContext.User`; your app still chooses how to resolve its current subject. Pass explicit `subjectId`, `resourceId`, role, and permission values into FGA APIs. For protected rows, implement `ISqlOSResourceEntity`; `SqlOSDbContext<TContext>` syncs the backing FGA resources when EF saves changes. Provision users, agents, or service accounts explicitly with `ProvisionUserSubjectAsync(...)`, `ProvisionAgentSubjectAsync(...)`, or `ProvisionServiceAccountSubjectAsync(...)`, then grant roles with `GrantRoleAsync(...)`. Use manual resource helpers such as `ProvisionResourceWithIdAsync(...)` for non-entity resources, such as tenant roots.
-
-On startup, SqlOS updates its own schema. Default URLs: admin at `/sqlos`, OAuth at `/sqlos/auth`. Change the prefix with `DashboardBasePath` if you need to.
-
-## Dashboard Access
-
-Protect the dashboard in production with a password:
-
-```csharp
-options.Dashboard.AuthMode = SqlOSDashboardAuthMode.Password;
-options.Dashboard.Password = builder.Configuration["SqlOS:Dashboard:Password"];
-options.Dashboard.LoginThrottling.MaxFailuresPerIp = 5;
-options.Dashboard.LoginThrottling.MaxGlobalFailures = 25;
-options.Dashboard.LoginThrottling.Window = TimeSpan.FromMinutes(5);
-options.Dashboard.LoginThrottling.LockoutDuration = TimeSpan.FromMinutes(5);
-```
-
-Or via environment variables:
-
-```bash
-SqlOS__Dashboard__AuthMode=Password
-SqlOS__Dashboard__Password=<strong-password>
-```
-
-`/sqlos` and `/sqlos/admin` are administrative surfaces. Do not expose them directly to the public internet unless they are behind HTTPS, trusted reverse-proxy or edge rate limiting, and a stronger admin access strategy such as a private network, VPN, identity-aware proxy, or admin SSO/MFA. The built-in password mode includes per-IP throttling, global backoff, temporary lockout, and audit events for login, lockout, rate-limit rejection, and logout, but it should not be the only control for a public admin endpoint.
-
-## Email OTP with Azure Communication Services
-
-SqlOS includes an Azure Communication Services Email sender for passwordless email-code login. Provision ACS Email with the helper script:
-
-```bash
-AZURE_SUBSCRIPTION_ID=<subscription-id> \
-AZURE_RESOURCE_GROUP=<resource-group> \
-AZURE_DNS_ZONE_NAME=example.com \
-AZURE_DNS_ZONE_RESOURCE_GROUP=<dns-zone-resource-group> \
-ACS_EMAIL_DOMAIN=example.com \
-ACS_EMAIL_SENDER_USERNAME=no-reply \
-ACS_EMAIL_SENDER_DISPLAY_NAME="Example" \
-./scripts/azure/setup-acs-email.sh --apply-dns --yes
-```
-
-`AZURE_DNS_ZONE_NAME` is the DNS zone apex (for example `example.com`), not a resource group. `AZURE_DNS_ZONE_RESOURCE_GROUP` is the resource group that contains that Azure DNS zone; it defaults to `AZURE_RESOURCE_GROUP` when omitted. Set it when the zone is in a different group than the ACS Email resources, or drop that line from the command when they match.
-
-The script creates an ACS Email Service, ACS Communication Service, customer-managed email domain, sender username, and optional Azure DNS verification records. If your DNS is not hosted in Azure, omit `--apply-dns`; the script prints the records to create manually.
-
-Store the connection string securely, then configure SqlOS:
-
-```bash
-SqlOS__EmailOtp__AzureCommunicationServicesConnectionString=<acs-connection-string>
-SqlOS__EmailOtp__FromAddress=no-reply@example.com
-```
-
-```csharp
-builder.AddSqlOS<AppDbContext>(options =>
-{
-    options.AuthServer.ConfigureEmailOtp(email =>
-    {
-        email.AzureCommunicationServicesConnectionString =
-            builder.Configuration["SqlOS:EmailOtp:AzureCommunicationServicesConnectionString"];
-        email.FromAddress = builder.Configuration["SqlOS:EmailOtp:FromAddress"];
-        email.ApplicationName = "Example";
-    });
-
-    options.AuthServer.SeedAuthPage(page =>
-    {
-        page.EnabledCredentialTypes = ["password", "email_otp"];
-    });
-});
-```
-
-Hosted AuthPage, headless browser flows, invite acceptance, and backend SDK usage all use the same OTP primitives. A backend can run a passwordless signup without adding its own REST API surface:
-
-```csharp
-var start = await sqlosAuth.RequestEmailOtpSignupAsync(
-    new SqlOSEmailOtpSignupStartRequest(
-        DisplayName: "Jane Doe",
-        Email: "jane@example.com",
-        ClientId: "example-web",
-        OrganizationName: "Example Co",
-        OrganizationId: null,
-        CustomFields: null),
-    httpContext);
-
-var login = await sqlosAuth.VerifyEmailOtpSignupAsync(
-    new SqlOSEmailOtpSignupVerifyRequest(
-        start.SignupToken,
-        start.ChallengeToken,
-        code),
-    httpContext);
-```
-
-Headless browser clients use `/sqlos/auth/headless/email-otp/start`, `/sqlos/auth/headless/email-otp/verify`, `/sqlos/auth/headless/signup/email-otp/start`, and `/sqlos/auth/headless/signup/email-otp/verify`.
-
-Run `./scripts/azure/setup-acs-email.sh --help` for dry-run, DNS, and connection-string options.
-
-## Invite by Email
-
-SqlOS can send one-time organization invitations that are bound to the invited email address. The hosted accept page is:
-
-```text
-GET /sqlos/auth/invitations/accept?token=...
-```
-
-Admins can create, resend, revoke, and copy invite links from the organization **Invitations** tab in the Auth dashboard. Backend code can use the SDK facade:
-
-```csharp
-var invite = await sqlosAuth.CreateEmailInvitationAsync(
-    new SqlOSCreateEmailInvitationRequest(
-        OrganizationId: organizationId,
-        Email: "jane@example.com",
-        Role: "member",
-        ClientId: "web",
-        RedirectUri: "https://app.example.com/auth/callback"),
-    httpContext);
-```
-
-Invite acceptance works with Email OTP, password login/signup when enabled, and trusted SSO. See [Email Invitations](docs/INVITATIONS.md).
-
-## Todo Sample
-
-If your goal is:
-
-> "I want SqlOS to work with hosted auth, resource metadata, and MCP-style public clients."
-
-Start with:
+Run the Todo sample if you want a working login and authorized EF Core queries before changing your application:
 
 ```bash
 dotnet run --project examples/SqlOS.Todo.AppHost/SqlOS.Todo.AppHost.csproj
 ```
 
-That sample stays intentionally narrow:
+Open `http://localhost:5080/`. The Aspire AppHost starts SQL Server and the sample API for you.
 
-- hosted AuthPage first
-- passwordless email-code sign in/sign up when `TodoSample__EnableEmailOtp=true`
-- protected-resource metadata
-- audience-aware token validation
-- local preregistration with `todo-local`
-- public-client onboarding with `CIMD` and optional `DCR`
+[Run the Todo sample](https://sqlos.dev/docs/quickstarts/run-todo) · [Browse all documentation](https://sqlos.dev/docs)
 
-Read more:
+### Add SqlOS to an application
 
-- [Todo sample README](examples/SqlOS.Todo.Api/README.md)
-- [Todo sample guide](web/content/docs/authserver/todo-sample.mdx)
+Requirements:
 
-## Example App
+- .NET 9 (`net9.0`)
+- EF Core 9
+- SQL Server with an existing database your application can access
 
-The repo includes a full working example powered by .NET Aspire:
+Install the package:
 
 ```bash
-dotnet run --project examples/SqlOS.Example.AppHost/SqlOS.Example.AppHost.csproj
+dotnet add package SqlOS --version 3.16.0
 ```
 
-That starts SQL Server, the sample API, the Todo sample, and the web frontends in one stack. Use it when you want breadth: password login, headless auth, OIDC, SAML, sessions, org workflows, FGA, and the hosted-first MCP-oriented Todo flow side by side.
+Use `SqlOSDbContext<TContext>` so SqlOS can register its EF Core model, then declare one application with `UseSingleApplication`:
 
-If you build headless auth on a different browser origin than the SqlOS host, make those browser requests credentialed so SqlOS can persist and reuse its auth-page session cookie. Follow-up `/sqlos/auth/authorize?prompt=none` requests should then silently succeed when that session exists, or return `login_required` when it does not.
+```csharp
+using Microsoft.EntityFrameworkCore;
+using SqlOS;
+using SqlOS.Configuration;
+using SqlOS.Extensions;
 
-For enterprise SSO onboarding, open an organization in the dashboard, choose **SSO**, and create a delegated setup link. The link opens `/sqlos/admin/auth/sso-portal`, where the customer IT admin can choose Microsoft Entra, Okta, Google Workspace, or generic SAML, verify the organization's email domain through a DNS TXT record, copy SP values, paste or upload metadata XML, activate the connection, and start a test redirect. Home realm discovery prefers active verified domains and falls back to operator-managed `PrimaryDomain` values for existing setups. The example web app also has a host-launched flow at `/retail/sso` backed by `POST /api/sso-portal-links`.
+var builder = WebApplication.CreateBuilder(args);
 
-Hosts that need their own admin UI can set `SsoPortal.BuildUiUrl` and drive the same flow through the setup API at `/sqlos/admin/auth/sso-portal/api/setup`. DNS verification uses `ISqlOSDomainDnsVerifier`; the default verifier is public DNS-over-HTTPS and has no Azure dependency.
+var connectionString = builder.Configuration.GetConnectionString("DefaultConnection")
+    ?? throw new InvalidOperationException(
+        "Connection string 'DefaultConnection' was not configured.");
 
-|            | URL                                       |
-| ---------- | ----------------------------------------- |
-| Dashboard  | `http://localhost:5062/sqlos/`            |
-| Auth Admin | `http://localhost:5062/sqlos/admin/auth/` |
-| FGA Admin  | `http://localhost:5062/sqlos/admin/fga/`  |
-| Web App    | `http://localhost:3010/`                  |
-| Todo App   | `http://localhost:5080/`                  |
+const string publicOrigin = "http://localhost:5050";
+var dashboardPassword = builder.Configuration["SqlOS:Dashboard:Password"]
+    ?? throw new InvalidOperationException(
+        "Configure SqlOS:Dashboard:Password with user secrets or your secret store.");
 
-## Requirements
+builder.AddSqlOS<AppDbContext>(
+    db => db.UseSqlServer(connectionString),
+    options =>
+    {
+        options.AuthServer.PublicOrigin = publicOrigin;
+        options.AuthServer.Issuer = $"{publicOrigin}/sqlos/auth";
 
-- .NET 9.0+
-- SQL Server (any edition, including LocalDB)
-- EF Core 9.0+
+        options.UseSingleApplication("Acme", app =>
+        {
+            app.Origin = publicOrigin;
+            app.Audience = $"{publicOrigin}/api";
+        });
 
-## Testing
+        options.Dashboard.AuthMode = SqlOSDashboardAuthMode.Password;
+        options.Dashboard.Password = dashboardPassword;
+    });
+
+var app = builder.Build();
+
+app.MapSqlOS();
+app.MapGet("/", () => "SqlOS is running");
+
+app.Run();
+
+public sealed class AppDbContext(DbContextOptions<AppDbContext> options)
+    : SqlOSDbContext<AppDbContext>(options)
+{
+}
+```
+
+The configuration lookup in this example is deliberate: `AddSqlOS` does not automatically bind the `SqlOS` configuration section. Read secrets from `builder.Configuration` and assign them inside the options callback.
+
+Run the host on the origin used above:
+
+```bash
+dotnet run --urls http://localhost:5050
+```
+
+Then verify:
+
+- dashboard: `http://localhost:5050/sqlos`
+- OAuth metadata: `http://localhost:5050/sqlos/auth/.well-known/oauth-authorization-server`
+- hosted login: `http://localhost:5050/sqlos/auth/login`
+
+SqlOS initializes and upgrades its own tables when the host starts. Your EF migrations continue to own only your application tables.
+
+[Complete add-to-app quickstart](https://sqlos.dev/docs/quickstarts/add-to-app)
+
+## Protect an API
+
+`RequireSqlOSAccessToken` validates a SqlOS access token for an exact audience and populates `HttpContext.User`:
+
+```csharp
+var api = app.MapGroup("/api")
+    .RequireSqlOSAccessToken("http://localhost:5050/api");
+
+api.MapGet("/me", (HttpContext http) =>
+{
+    var token = http.GetSqlOSValidatedToken();
+    return token is null
+        ? Results.Unauthorized()
+        : Results.Ok(new
+        {
+            token.UserId,
+            token.OrganizationId,
+            token.ClientId,
+            token.Audience
+        });
+});
+```
+
+Add `using SqlOS.AuthServer.Extensions;` for `GetSqlOSValidatedToken`.
+
+[Protect an API](https://sqlos.dev/docs/quickstarts/protect-api) · [Authorize EF Core queries](https://sqlos.dev/docs/quickstarts/ef-authorization)
+
+## What you can add next
+
+- Hosted or headless login, password credentials, Email OTP, social login, and SAML SSO
+- Organizations, memberships, invitations, sessions, refresh tokens, and application access rules
+- Hierarchical roles and grants with authorization filters that remain inside EF Core queries
+- Audit logs and an embedded admin dashboard
+- Google Calendar and Microsoft 365 calendar connections
+- OAuth client modes for owned web apps, native apps, CLIs, and portable MCP clients
+
+These capabilities are available from the same package, but they are not prerequisites for the one-application path.
+
+## Documentation
+
+- [Documentation home](https://sqlos.dev/docs)
+- [Getting started](https://sqlos.dev/docs/getting-started)
+- [Quickstarts](https://sqlos.dev/docs/quickstarts/run-todo)
+- [Guides](https://sqlos.dev/docs/guides/index)
+- [SDK reference](https://sqlos.dev/docs/reference/sdk-reference)
+- [HTTP API reference](https://sqlos.dev/docs/reference/api-reference)
+
+## Build and test the repository
 
 ```bash
 dotnet build SqlOS.sln
@@ -286,125 +161,4 @@ dotnet build SqlOS.sln
 ./scripts/docs-check.sh
 ```
 
-## Repo Layout
-
-```
-src/SqlOS                                # The library
-tests/SqlOS.Tests                        # Unit tests
-tests/SqlOS.IntegrationTests             # Integration tests
-tests/SqlOS.Benchmarks                   # Performance benchmarks
-examples/SqlOS.Todo.Api                  # Canonical hosted-first Todo sample
-examples/SqlOS.Todo.AppHost              # Aspire runner for the Todo sample
-examples/SqlOS.Todo.IntegrationTests     # Todo sample end-to-end tests
-examples/SqlOS.Example.Api               # ASP.NET API example
-examples/SqlOS.Example.Web               # Next.js frontend example
-examples/SqlOS.Example.AppHost           # Aspire orchestration
-```
-
-## Documentation
-
-- [Configuration](https://sqlos.dev/docs/guides/configuration) — service registration, EF integration, dashboard setup
-- [Auth Page](docs/AUTH_PAGE.md) — hosted OAuth endpoints and branded UI
-- [Email OTP](docs/EMAIL_OTP.md) — passwordless login/signup across hosted, headless, and SDK flows
-- [SMS OTP](docs/SMS_OTP.md) — passwordless phone-code login/signup through Twilio Verify
-- [Email Invitations](docs/INVITATIONS.md) — organization invite links, dashboard, SDK, hosted, and headless flows
-- [Audit Logs](docs/AUDIT_LOGS.md) — central event model, application scoping, dashboard filters, export, and host-app ingestion
-- [Todo Sample](examples/SqlOS.Todo.Api/README.md) — hosted auth, simple FGA, and MCP-oriented protected-resource flows
-- [Client Registration DevEx](docs/CLIENT_REGISTRATION_DEVEX_2026.md) — product vocabulary and onboarding model
-- [Preregistration vs CIMD vs DCR](web/content/docs/authserver/preregistration-vs-cimd-vs-dcr.mdx) — choose the right client onboarding path
-- [Client ID Metadata Documents](web/content/docs/authserver/client-id-metadata-documents.mdx) — portable public clients with metadata URLs
-- [Dynamic Client Registration](web/content/docs/authserver/dynamic-client-registration.mdx) — compatibility-mode runtime registration
-- [MCP Resource Indicators and Audience](web/content/docs/authserver/mcp-resource-indicators-and-audience.mdx) — resource-bound tokens and audience validation
-- [OIDC Auth](web/content/docs/authserver/oidc-auth.mdx) — OpenID Connect provider support
-- [Google OIDC](https://sqlos.dev/docs/authserver/google-oidc) · [Microsoft OIDC](https://sqlos.dev/docs/authserver/microsoft-oidc) · [GitHub OIDC](https://sqlos.dev/docs/authserver/github-oidc) · [Apple OIDC](https://sqlos.dev/docs/authserver/apple-oidc) · [Custom OIDC](https://sqlos.dev/docs/authserver/custom-oidc)
-- [Guides](https://sqlos.dev/docs/guides/index) — task-oriented walkthroughs
-- [Entra SSO Testing](docs/ENTRA_SSO.md) — SAML SSO with Microsoft Entra
-- [Example App](docs/EXAMPLE_APP.md) — running the demo stack
-- [Testing](https://sqlos.dev/docs/guides/testing) — test structure and conventions
-- [Releasing](docs/RELEASE_VERSION.md) — versioning and release process
-
-## Testing Email OTP in the Todo Sample
-
-Run it like this:
-
-```bash
-ACS_COMMUNICATION_SERVICE_NAME=sqlos-dev-comm
-AZURE_RESOURCE_GROUP=rg-sqlos-web-prod
-ACS_FROM_ADDRESS=no-reply@sqlos.dev
-
-ACS_CONN=$(az communication list-key \
-  --name "$ACS_COMMUNICATION_SERVICE_NAME" \
-  --resource-group "$AZURE_RESOURCE_GROUP" \
-  --query primaryConnectionString \
-  -o tsv)
-
-TodoSample__EnableEmailOtp=true \
-SqlOS__EmailOtp__AzureCommunicationServicesConnectionString="$ACS_CONN" \
-SqlOS__EmailOtp__FromAddress="$ACS_FROM_ADDRESS" \
-dotnet run --project examples/SqlOS.Todo.AppHost/SqlOS.Todo.AppHost.csproj
-```
-
-## Testing the CLI Auth
-
-In another terminal:
-
-dotnet run --project examples/SqlOS.Todo.Cli -- login
-Open the printed URL, sign in through SqlOS AuthPage, approve the Todo CLI request, then run:
-
-dotnet run --project examples/SqlOS.Todo.Cli -- whoami
-dotnet run --project examples/SqlOS.Todo.Cli -- add "Ship CLI OAuth"
-dotnet run --project examples/SqlOS.Todo.Cli -- list
-dotnet run --project examples/SqlOS.Todo.Cli -- toggle <todo-id>
-
-Then open `http://localhost:5080/`.
-
-Use **Email code sign in** or **Email code sign up**. In this mode the Todo app only starts the OAuth request; the SqlOS hosted auth page sends the OTP, verifies the code, creates the account on signup, and redirects back with the authorization code.
-
-## Testing SMS OTP in the Todo Sample
-
-Use a Twilio pay-as-you-go account before testing arbitrary user phone numbers. Twilio trial accounts can only send OTP messages to phone numbers that are already verified on the Twilio account.
-
-Set up Twilio Verify like this:
-
-1. Sign in to the [Twilio Console](https://console.twilio.com/).
-2. On the Console dashboard, open **Account Info**.
-3. Copy **Account SID**. It starts with `AC`.
-4. Click **Show** for **Auth Token**, then copy it. Treat this as a secret.
-5. Open **Verify** in the left navigation, then **Services**.
-6. Click **Create new Service**.
-7. Set the friendly name to `SqlOS Todo Dev`.
-8. Ensure SMS is enabled and the code length is 6 digits.
-9. Save the **Service SID**. It starts with `VA`.
-
-Run the Todo sample from the repo root:
-
-```bash
-TWILIO_ACCOUNT_SID=<account-sid> \
-TWILIO_AUTH_TOKEN=<auth-token> \
-TWILIO_VERIFY_SERVICE_SID=<verify-service-sid> \
-TWILIO_DEFAULT_REGION=US \
-TodoSample__EnablePhoneOtp=true \
-dotnet run --project examples/SqlOS.Todo.AppHost/SqlOS.Todo.AppHost.csproj
-```
-
-Open `http://localhost:5080/`. The home page should show **SMS code sign in** and **SMS code sign up**. `/sample/config` should report `"phoneOtpEnabled": true`.
-
-Start SMS testing from the Todo sample home page, not directly from `/sqlos/auth/login`. A direct AuthPage sign-in creates a SqlOS auth-page session and shows `/sqlos/auth/login?status=signed-in`, but it does not give the Todo SPA an OAuth access token. The Todo app gets its token only when the flow starts at `http://localhost:5080/` and returns through `/callback.html`.
-
-Do not buy or configure a Programmable Messaging phone number for this SqlOS integration. SqlOS calls Twilio Verify v2 with the Verify Service SID and `sms` channel; Verify manages the SMS sender path for the verification message.
-
-## Running the Example App with Transactional Email
-
-```bash
-AZURE_EMAIL_CONNECTION_STRING="$(az communication list-key \
-  --name <communication-service-name> \
-  --resource-group <resource-group> \
-  --query primaryConnectionString \
-  -o tsv)" \
-AZURE_EMAIL_SENDER_ADDRESS="hello@domain.com" \
-dotnet run --project examples/SqlOS.Example.AppHost/SqlOS.Example.AppHost.csproj
-```
-
-## License
-
-MIT
+SqlOS is MIT licensed. Issues and contributions are welcome in this repository.

--- a/scripts/compile-doc-snippets.mjs
+++ b/scripts/compile-doc-snippets.mjs
@@ -1,0 +1,242 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptPath = fileURLToPath(import.meta.url);
+const repoRoot = path.resolve(path.dirname(scriptPath), "..");
+const snippetSpecs = [
+  {
+    name: "README first-run program",
+    relativePath: "README.md",
+    heading: "### Add SqlOS to an application",
+    marker: "builder.AddSqlOS<AppDbContext>",
+    wrap: asCompleteProgram,
+  },
+  ...[
+    "web/content/docs/quickstarts/add-to-app.mdx",
+    "web/content/docs/quickstarts/protect-api.mdx",
+    "web/content/docs/quickstarts/ef-authorization.mdx",
+  ].map((relativePath) => ({
+    name: "quickstart complete program",
+    relativePath,
+    heading: "## Complete program",
+    marker: "var builder = WebApplication.CreateBuilder(args);",
+    wrap: asCompleteProgram,
+  })),
+  {
+    name: "audit-log registration",
+    relativePath: "web/content/docs/reference/audit-logs.mdx",
+    heading: "## Service registration",
+    marker: "builder.AddSqlOS<ExampleAppDbContext>",
+    wrap: asAuditLogRegistrationProgram,
+  },
+  {
+    name: "audit-log record endpoint",
+    relativePath: "web/content/docs/reference/audit-logs.mdx",
+    heading: "## Service registration",
+    marker: "ISqlOSAuditLogService auditLogs",
+    wrap: asAuditLogRecordProgram,
+  },
+  {
+    name: "phone OTP host configuration",
+    relativePath: "web/content/docs/reference/authserver-api.mdx",
+    heading: "### Phone OTP sign-in and signup",
+    marker: "options.AuthServer.ConfigurePhoneOtp",
+    wrap: asPhoneOtpConfigurationProgram,
+  },
+  {
+    name: "security-settings update",
+    relativePath: "web/content/docs/reference/authserver-api.mdx",
+    heading: "### UpdateSecuritySettingsAsync",
+    marker: "new SqlOSUpdateSecuritySettingsRequest(",
+    wrap: asSecuritySettingsProgram,
+  },
+];
+
+function extractCsharpBlock({ relativePath, heading, marker }) {
+  const markdown = fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
+  const lines = markdown.split(/\r?\n/);
+  const headingLines = lines
+    .map((line, index) => (line === heading ? index : -1))
+    .filter((index) => index !== -1);
+
+  if (headingLines.length !== 1) {
+    throw new Error(
+      `${relativePath}: expected exactly one '${heading}' heading, found ${headingLines.length}.`,
+    );
+  }
+
+  const headingPrefix = /^(#{1,6})\s+/.exec(heading);
+  if (!headingPrefix) {
+    throw new Error(`Invalid snippet heading '${heading}'.`);
+  }
+
+  const headingLevel = headingPrefix[1].length;
+  const sectionStart = headingLines[0] + 1;
+  let sectionEnd = lines.length;
+
+  for (let index = sectionStart; index < lines.length; index += 1) {
+    const nextHeading = /^(#{1,6})\s+/.exec(lines[index]);
+    if (nextHeading && nextHeading[1].length <= headingLevel) {
+      sectionEnd = index;
+      break;
+    }
+  }
+
+  const blocks = [];
+  for (let index = sectionStart; index < sectionEnd; index += 1) {
+    if (lines[index].trim() !== "```csharp") {
+      continue;
+    }
+
+    const blockStart = index + 1;
+    index = blockStart;
+    while (index < sectionEnd && lines[index].trim() !== "```") {
+      index += 1;
+    }
+
+    if (index === sectionEnd) {
+      throw new Error(`${relativePath}: unterminated C# block under '${heading}'.`);
+    }
+
+    blocks.push(lines.slice(blockStart, index).join("\n"));
+  }
+
+  const matchingBlocks = blocks.filter((block) => block.includes(marker));
+  if (matchingBlocks.length !== 1) {
+    throw new Error(
+      `${relativePath}: expected exactly one C# block containing '${marker}' under '${heading}', found ${matchingBlocks.length}.`,
+    );
+  }
+
+  const markerOccurrences = matchingBlocks[0].split(marker).length - 1;
+  if (markerOccurrences !== 1) {
+    throw new Error(
+      `${relativePath}: expected '${marker}' once in its C# block, found ${markerOccurrences}.`,
+    );
+  }
+
+  return matchingBlocks[0];
+}
+
+function asCompleteProgram(snippet) {
+  return `${snippet}\n`;
+}
+
+function asAuditLogRegistrationProgram(snippet) {
+  return `using Microsoft.EntityFrameworkCore;
+using SqlOS;
+using SqlOS.Extensions;
+
+var builder = WebApplication.CreateBuilder(args);
+var connectionString = "Server=localhost;Database=Example;Trusted_Connection=True";
+
+${snippet}
+
+public sealed class ExampleAppDbContext(DbContextOptions<ExampleAppDbContext> options)
+    : SqlOSDbContext<ExampleAppDbContext>(options)
+{
+}
+`;
+}
+
+function asAuditLogRecordProgram(snippet) {
+  return `using SqlOS.AuditLogs;
+
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+${snippet}
+
+public sealed record ShareDocumentRequest(
+    string? OrganizationId,
+    string? UserId,
+    string? UserDisplayName,
+    string? DocumentName,
+    string? Role);
+`;
+}
+
+function asPhoneOtpConfigurationProgram(snippet) {
+  return `using SqlOS.Configuration;
+
+var builder = WebApplication.CreateBuilder(args);
+var options = new SqlOSOptions();
+
+${snippet}
+`;
+}
+
+function asSecuritySettingsProgram(snippet) {
+  return `using SqlOS.AuthServer.Contracts;
+using SqlOS.AuthServer.Services;
+
+SqlOSSettingsService settingsService = null!;
+
+${snippet}
+`;
+}
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "sqlos-doc-snippets-"));
+const projectPath = path.join(tempRoot, "SqlOS.Docs.Snippet.csproj");
+const sourceProject = path.join(repoRoot, "src", "SqlOS", "SqlOS.csproj");
+
+try {
+  fs.writeFileSync(
+    projectPath,
+    `<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="${sourceProject}" />
+  </ItemGroup>
+</Project>
+`,
+  );
+
+  let restored = false;
+  let failures = 0;
+  for (const spec of snippetSpecs) {
+    const description = `${spec.relativePath} (${spec.name})`;
+
+    try {
+      const snippet = extractCsharpBlock(spec);
+      fs.writeFileSync(path.join(tempRoot, "Program.cs"), spec.wrap(snippet));
+
+      const args = ["build", projectPath, "--nologo", "--verbosity", "minimal"];
+      if (restored) {
+        args.push("--no-restore");
+      }
+
+      execFileSync("dotnet", args, {
+        cwd: repoRoot,
+        encoding: "utf8",
+        stdio: "pipe",
+      });
+      restored = true;
+      console.log(`Compiled documentation snippet: ${description}`);
+    } catch (error) {
+      const stdout = error.stdout?.toString() ?? "";
+      const stderr = error.stderr?.toString() ?? "";
+      console.error(`${description}: documentation snippet check failed.\n`);
+      if (stdout || stderr) {
+        console.error(stdout);
+        console.error(stderr);
+      } else {
+        console.error(error.message ?? error);
+      }
+      failures += 1;
+    }
+  }
+
+  if (failures > 0) {
+    process.exitCode = 1;
+  }
+} finally {
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+}

--- a/scripts/docs-check.sh
+++ b/scripts/docs-check.sh
@@ -6,6 +6,8 @@ cd "$repo_root"
 
 echo "=== Running Docs Checks ==="
 
+node scripts/validate-docs-against-source.mjs
+node scripts/compile-doc-snippets.mjs
 npm ci --prefix web
 npm run lint --prefix web
 npm run build --prefix web

--- a/scripts/validate-docs-against-source.mjs
+++ b/scripts/validate-docs-against-source.mjs
@@ -1,0 +1,172 @@
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const scriptPath = fileURLToPath(import.meta.url);
+const repoRoot = path.resolve(path.dirname(scriptPath), "..");
+const projectPath = path.join(repoRoot, "src", "SqlOS", "SqlOS.csproj");
+const referenceRoot = path.join(repoRoot, "web", "content", "docs", "reference");
+const staleBlogPath = path.join(
+  repoRoot,
+  "web",
+  "content",
+  "blog",
+  "row-level-security-ef-core-sql-server-tvfs.mdx",
+);
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+function requireMatch(content, pattern, message, errors) {
+  if (!pattern.test(content)) {
+    errors.push(message);
+  }
+}
+
+const errors = [];
+const project = fs.readFileSync(projectPath, "utf8");
+const packageVersion = project.match(/<Version>([^<]+)<\/Version>/)?.[1];
+const targetFramework = project.match(/<TargetFramework>([^<]+)<\/TargetFramework>/)?.[1];
+
+if (!packageVersion) {
+  errors.push("src/SqlOS/SqlOS.csproj: could not read <Version>.");
+}
+
+if (!targetFramework) {
+  errors.push("src/SqlOS/SqlOS.csproj: could not read <TargetFramework>.");
+}
+
+requireMatch(
+  project,
+  /<GenerateDocumentationFile>true<\/GenerateDocumentationFile>/,
+  "src/SqlOS/SqlOS.csproj: XML documentation generation must remain enabled.",
+  errors,
+);
+
+const referenceFiles = fs
+  .readdirSync(referenceRoot)
+  .filter((name) => name.endsWith(".mdx"))
+  .sort();
+const referenceContents = referenceFiles
+  .map((name) => fs.readFileSync(path.join(referenceRoot, name), "utf8"))
+  .join("\n");
+const index = fs.readFileSync(path.join(referenceRoot, "index.mdx"), "utf8");
+
+if (packageVersion && !index.includes(`SqlOS ${packageVersion}`)) {
+  errors.push(
+    `web/content/docs/reference/index.mdx: expected current package marker 'SqlOS ${packageVersion}'.`,
+  );
+}
+
+if (targetFramework && !index.includes(`\`${targetFramework}\``)) {
+  errors.push(
+    `web/content/docs/reference/index.mdx: expected current target framework marker '${targetFramework}'.`,
+  );
+}
+
+const requiredSourceContracts = [
+  [
+    "src/SqlOS/SqlOSDbContext.cs",
+    /public abstract class SqlOSDbContext<TContext>/,
+    "SqlOSDbContext<TContext>",
+  ],
+  [
+    "src/SqlOS/Extensions/WebApplicationBuilderExtensions.cs",
+    /public static WebApplicationBuilder AddSqlOS<TContext>/,
+    "WebApplicationBuilder.AddSqlOS<TContext>",
+  ],
+  [
+    "src/SqlOS/Extensions/WebApplicationExtensions.cs",
+    /public static WebApplication MapSqlOS/,
+    "WebApplication.MapSqlOS",
+  ],
+  [
+    "src/SqlOS/Extensions/SqlOSErgonomicsExtensions.cs",
+    /public static RouteGroupBuilder RequireSqlOSAccessToken/,
+    "RouteGroupBuilder.RequireSqlOSAccessToken",
+  ],
+  [
+    "src/SqlOS/AuthServer/Extensions/SqlOSAccessTokenValidationExtensions.cs",
+    /public static SqlOSValidatedToken\? GetSqlOSValidatedToken/,
+    "HttpContext.GetSqlOSValidatedToken",
+  ],
+  [
+    "src/SqlOS/Fga/Specifications/PaginatedResult.cs",
+    /public class PaginatedResult<T>/,
+    "PaginatedResult<T>",
+  ],
+  [
+    "src/SqlOS/AuthServer/Configuration/SqlOSAuthServerOptions.cs",
+    /public SqlOSAuthServerOptions ConfigurePhoneOtp/,
+    "SqlOSAuthServerOptions.ConfigurePhoneOtp",
+  ],
+  [
+    "src/SqlOS/AuthServer/Services/SqlOSAuthService.cs",
+    /public async Task<SqlOSPhoneOtpStartResult> RequestPhoneOtpAsync/,
+    "SqlOSAuthService.RequestPhoneOtpAsync",
+  ],
+  [
+    "src/SqlOS/AuthServer/Services/SqlOSAuthService.cs",
+    /public async Task<SqlOSLoginResult> VerifyPhoneOtpAsync/,
+    "SqlOSAuthService.VerifyPhoneOtpAsync",
+  ],
+];
+
+for (const [relativePath, pattern, contractName] of requiredSourceContracts) {
+  requireMatch(
+    read(relativePath),
+    pattern,
+    `${relativePath}: documented contract '${contractName}' was not found. Update the reference docs with the source change.`,
+    errors,
+  );
+}
+
+const checkedDocs = `${referenceContents}\n${fs.readFileSync(staleBlogPath, "utf8")}`;
+const stalePatterns = [
+  [/new\s+SqlOSSignupRequest\(\s*email\s*,\s*password\s*,\s*displayName\s*,\s*clientId\s*\)/, "stale SqlOSSignupRequest constructor"],
+  [/new\s+SqlOSExchangeCodeRequest\(\s*code\s*,\s*state\s*\)/, "stale SqlOSExchangeCodeRequest constructor"],
+  [/new\s+SqlOSCreateVerificationTokenRequest\(\s*userId\s*,\s*email\s*\)/, "stale SqlOSCreateVerificationTokenRequest constructor"],
+  [/new\s+(?:CreateOrganizationRequest|CreateUserRequest|CreateMembershipRequest|CreateClientRequest|CreateSsoConnectionDraftRequest)\b/, "contract missing the SqlOS prefix"],
+  [/\bPagedResult<T>\b/, "stale PagedResult<T> type name"],
+  [/\bresult\.Items\b/, "stale pagination Items property"],
+  [/\bresult\.HasMore\b/, "stale pagination HasMore property"],
+  [/\bBuildFilterAsync\b/, "stale FGA BuildFilterAsync method"],
+  [/\bSqlOSSsoConnectionDraft\b/, "nonexistent SqlOSSsoConnectionDraft return type"],
+  [/\bSqlOSOidcProviderInfo\b/, "nonexistent SqlOSOidcProviderInfo return type"],
+  [/\bSqlOSHomeRealmDiscoveryResponse\b/, "nonexistent SqlOSHomeRealmDiscoveryResponse type"],
+  [/\boptions\.UseSqlServer\(/, "nonexistent SqlOSOptions.UseSqlServer configuration"],
+  [/["']password["']\s*\|\s*["']sso["']\s*\|\s*["']oidc["']/, "unsupported Home Realm Discovery oidc mode"],
+  [/\boidc_google\b/, "unsupported OIDC authentication method value"],
+  [/Join existing org instead of creating one\./i, "unsafe public-signup existing-organization claim"],
+  [/can only log in via SSO\/OIDC/i, "incomplete passwordless-login claim"],
+  [/Next\.js,\s*Angular,\s*and\s*Expo/i, "unlaunched Expo example-stack claim"],
+];
+
+for (const [pattern, description] of stalePatterns) {
+  if (pattern.test(checkedDocs)) {
+    errors.push(`reference docs: found ${description}.`);
+  }
+}
+
+const httpReference = fs.readFileSync(
+  path.join(referenceRoot, "api-reference.mdx"),
+  "utf8",
+);
+if (/^## Auth API \(Example\)/m.test(httpReference)) {
+  errors.push(
+    "web/content/docs/reference/api-reference.mdx: example-app routes must not be presented as SqlOS library endpoints.",
+  );
+}
+
+if (errors.length > 0) {
+  console.error("Documentation/source drift check failed:\n");
+  for (const error of errors) {
+    console.error(`- ${error}`);
+  }
+  process.exit(1);
+}
+
+console.log(
+  `Validated reference docs against SqlOS ${packageVersion} (${targetFramework}) source contracts.`,
+);

--- a/src/SqlOS/AuthServer/Configuration/SqlOSAccessTokenValidationOptions.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSAccessTokenValidationOptions.cs
@@ -2,13 +2,27 @@ using Microsoft.AspNetCore.Http;
 
 namespace SqlOS.AuthServer.Configuration;
 
+/// <summary>
+/// Configures bearer access-token validation for a SqlOS-protected ASP.NET Core pipeline or route group.
+/// </summary>
 public sealed class SqlOSAccessTokenValidationOptions
 {
+    /// <summary>
+    /// Gets or sets the exact audience that a validated access token must contain.
+    /// </summary>
     public string ExpectedAudience { get; set; } = string.Empty;
 
+    /// <summary>
+    /// Gets or sets an optional predicate that decides whether the current request should be validated.
+    /// </summary>
+    /// <remarks>When the predicate returns <see langword="false"/>, validation is skipped for that request.</remarks>
     public Func<HttpContext, bool>? ShouldValidate { get; set; }
 
+    /// <summary>Gets or sets the realm emitted in a failed request's Bearer challenge.</summary>
     public string Realm { get; set; } = "SqlOS API";
 
+    /// <summary>
+    /// Gets or sets an optional protected-resource metadata URL emitted in the Bearer challenge.
+    /// </summary>
     public string? ResourceMetadataUrl { get; set; }
 }

--- a/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerSeedOptions.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerSeedOptions.cs
@@ -2,18 +2,45 @@ using SqlOS.AuthServer.Contracts;
 
 namespace SqlOS.AuthServer.Configuration;
 
+/// <summary>
+/// Configures the first-party client, redirect URI, scopes, credentials, and branding used by
+/// single-application hosting mode.
+/// </summary>
 public sealed class SqlOSSingleApplicationOptions
 {
+    /// <summary>Gets or sets the application display name.</summary>
     public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the absolute application origin used to derive the default redirect URI.
+    /// </summary>
     public string? Origin { get; set; }
+
+    /// <summary>Gets or sets the OAuth client ID. When omitted, SqlOS derives it from <see cref="Name"/>.</summary>
     public string? ClientId { get; set; }
+
+    /// <summary>Gets or sets the access-token audience. When omitted, the client ID is used.</summary>
     public string? Audience { get; set; }
+
+    /// <summary>Gets or sets the callback path appended to <see cref="Origin"/>.</summary>
     public string RedirectPath { get; set; } = "/auth/callback";
+
+    /// <summary>Gets the explicit absolute redirect URIs allowed for the client.</summary>
     public List<string> RedirectUris { get; } = [];
+
+    /// <summary>Gets or sets the OAuth scopes allowed for the client.</summary>
     public List<string> AllowedScopes { get; set; } = ["openid", "profile", "email", "offline_access"];
+
+    /// <summary>Gets or sets whether the hosted sign-in page allows password sign-up.</summary>
     public bool EnablePasswordSignup { get; set; } = true;
+
+    /// <summary>Gets or sets the credential types enabled on the hosted sign-in page.</summary>
     public List<string> EnabledCredentialTypes { get; set; } = ["password"];
+
+    /// <summary>Gets or sets whether the application name and credential settings configure the hosted sign-in page.</summary>
     public bool ConfigureAuthPageBranding { get; set; } = true;
+
+    /// <summary>Gets or sets whether the application name configures transactional email branding.</summary>
     public bool ConfigureEmailBranding { get; set; } = true;
 }
 

--- a/src/SqlOS/AuthServer/Contracts/SqlOSContracts.cs
+++ b/src/SqlOS/AuthServer/Contracts/SqlOSContracts.cs
@@ -59,6 +59,15 @@ public sealed record SqlOSLoginResult(
     bool RequiresMfaEnrollment = false,
     IReadOnlyList<string>? MfaMethods = null);
 
+/// <summary>
+/// Represents the claims and SqlOS identifiers recovered from a successfully validated access token.
+/// </summary>
+/// <param name="Principal">The authenticated claims principal created from the token.</param>
+/// <param name="SessionId">The active SqlOS session identifier associated with the token.</param>
+/// <param name="UserId">The authenticated SqlOS user identifier, when present.</param>
+/// <param name="OrganizationId">The active organization identifier, when present.</param>
+/// <param name="ClientId">The OAuth client identifier, when present.</param>
+/// <param name="Audience">The validated token audience, when present.</param>
 public sealed record SqlOSValidatedToken(
     ClaimsPrincipal Principal,
     string SessionId,

--- a/src/SqlOS/AuthServer/Extensions/SqlOSAccessTokenValidationExtensions.cs
+++ b/src/SqlOS/AuthServer/Extensions/SqlOSAccessTokenValidationExtensions.cs
@@ -6,15 +6,41 @@ using SqlOS.AuthServer.Services;
 
 namespace SqlOS.AuthServer.Extensions;
 
+/// <summary>
+/// Provides ASP.NET Core middleware and request-context helpers for validating SqlOS access tokens.
+/// </summary>
 public static class SqlOSAccessTokenValidationExtensions
 {
+    /// <summary>The <see cref="HttpContext.Items"/> key used to store a successfully validated token.</summary>
     public const string ValidatedTokenItemKey = "SqlOS.AuthServer.ValidatedAccessToken";
 
+    /// <summary>
+    /// Adds SqlOS bearer access-token validation to the application pipeline for the specified audience.
+    /// </summary>
+    /// <param name="app">The application pipeline builder.</param>
+    /// <param name="expectedAudience">The exact audience required in a valid access token.</param>
+    /// <returns>The same <paramref name="app"/> instance.</returns>
+    /// <exception cref="InvalidOperationException"><paramref name="expectedAudience"/> is empty or contains only whitespace.</exception>
     public static IApplicationBuilder UseSqlOSAccessTokenValidation(
         this IApplicationBuilder app,
         string expectedAudience)
         => app.UseSqlOSAccessTokenValidation(options => options.ExpectedAudience = expectedAudience);
 
+    /// <summary>
+    /// Adds configured SqlOS bearer access-token validation to the application pipeline.
+    /// </summary>
+    /// <param name="app">The application pipeline builder.</param>
+    /// <param name="configure">A callback that configures token validation.</param>
+    /// <returns>The same <paramref name="app"/> instance.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="app"/> or <paramref name="configure"/> is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// The configured <see cref="SqlOSAccessTokenValidationOptions.ExpectedAudience"/> is empty.
+    /// </exception>
+    /// <remarks>
+    /// Successful validation sets <see cref="HttpContext.User"/> and makes the validated token
+    /// available through <see cref="GetSqlOSValidatedToken(HttpContext)"/>. Failed validation
+    /// short-circuits the request with an HTTP 401 response and a Bearer challenge.
+    /// </remarks>
     public static IApplicationBuilder UseSqlOSAccessTokenValidation(
         this IApplicationBuilder app,
         Action<SqlOSAccessTokenValidationOptions> configure)
@@ -29,6 +55,13 @@ public static class SqlOSAccessTokenValidationExtensions
         return app.UseMiddleware<SqlOSAccessTokenValidationMiddleware>(options);
     }
 
+    /// <summary>
+    /// Gets the token validated for the current request by SqlOS access-token middleware or a
+    /// SqlOS-protected route group.
+    /// </summary>
+    /// <param name="context">The current HTTP context.</param>
+    /// <returns>The validated token, or <see langword="null"/> when SqlOS did not validate a token for the request.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="context"/> is <see langword="null"/>.</exception>
     public static SqlOSValidatedToken? GetSqlOSValidatedToken(this HttpContext context)
     {
         ArgumentNullException.ThrowIfNull(context);

--- a/src/SqlOS/Configuration/SqlOSOptions.cs
+++ b/src/SqlOS/Configuration/SqlOSOptions.cs
@@ -28,12 +28,38 @@ public sealed class SqlOSOptions
     public SqlOSEmailOptions Email { get; } = new();
     public SqlOSCalendarOptions Calendar { get; } = new();
 
+    /// <summary>
+    /// Configures SqlOS for one first-party public PKCE application.
+    /// </summary>
+    /// <param name="name">The application display name. It is also used to derive the client ID when one is not configured.</param>
+    /// <param name="configure">An optional callback that overrides the single-application defaults.</param>
+    /// <returns>The same options instance so that additional configuration can be chained.</returns>
+    /// <exception cref="InvalidOperationException"><paramref name="name"/> is empty or contains only whitespace.</exception>
+    /// <remarks>
+    /// Single-application mode disables dynamic client registration and resource indicators, and
+    /// can apply the application name to the hosted sign-in page and transactional email branding.
+    /// It cannot be combined with explicit startup client seeds.
+    /// </remarks>
     public SqlOSOptions UseSingleApplication(string name, Action<SqlOSSingleApplicationOptions>? configure = null)
     {
         AuthServer.UseSingleApplication(name, configure);
         return this;
     }
 
+    /// <summary>
+    /// Configures SqlOS for one first-party public PKCE application using a configuration section.
+    /// </summary>
+    /// <param name="configuration">The application configuration containing the single-application settings.</param>
+    /// <param name="sectionName">The path of the configuration section to bind.</param>
+    /// <returns>The same options instance so that additional configuration can be chained.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// The requested configuration section does not exist or does not contain a non-empty application name.
+    /// </exception>
+    /// <remarks>
+    /// The section supports <c>Name</c>, <c>Origin</c>, <c>ClientId</c>, <c>Audience</c>,
+    /// <c>RedirectPath</c>, <c>RedirectUris</c>, <c>AllowedScopes</c>,
+    /// <c>EnabledCredentialTypes</c>, and the single-application branding switches.
+    /// </remarks>
     public SqlOSOptions UseSingleApplication(IConfiguration configuration, string sectionName = "SqlOS:Application")
     {
         AuthServer.UseSingleApplication(configuration, sectionName);

--- a/src/SqlOS/Extensions/SqlOSErgonomicsExtensions.cs
+++ b/src/SqlOS/Extensions/SqlOSErgonomicsExtensions.cs
@@ -19,6 +19,15 @@ public static class SqlOSErgonomicsExtensions
 {
     private const int DefaultMaxResourceHierarchyDepth = 10;
 
+    /// <summary>
+    /// Requires every endpoint in a route group to present a valid SqlOS bearer access token
+    /// containing the specified audience.
+    /// </summary>
+    /// <param name="group">The Minimal API route group to protect.</param>
+    /// <param name="expectedAudience">The exact audience required in a valid access token.</param>
+    /// <returns>The same <paramref name="group"/> instance.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="group"/> is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException"><paramref name="expectedAudience"/> is empty or contains only whitespace.</exception>
     public static RouteGroupBuilder RequireSqlOSAccessToken(this RouteGroupBuilder group, string expectedAudience)
     {
         ArgumentNullException.ThrowIfNull(group);
@@ -26,6 +35,21 @@ public static class SqlOSErgonomicsExtensions
         return group.RequireSqlOSAccessToken(options => options.ExpectedAudience = expectedAudience);
     }
 
+    /// <summary>
+    /// Requires endpoints in a route group to satisfy the configured SqlOS bearer access-token validation policy.
+    /// </summary>
+    /// <param name="group">The Minimal API route group to protect.</param>
+    /// <param name="configure">A callback that configures token validation.</param>
+    /// <returns>The same <paramref name="group"/> instance.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="group"/> or <paramref name="configure"/> is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// The configured <see cref="SqlOSAccessTokenValidationOptions.ExpectedAudience"/> is empty.
+    /// </exception>
+    /// <remarks>
+    /// Successful validation sets <see cref="HttpContext.User"/> and stores the validated token for
+    /// <see cref="SqlOSAccessTokenValidationExtensions.GetSqlOSValidatedToken(HttpContext)"/>.
+    /// Failed validation returns HTTP 401 with a Bearer challenge without invoking the endpoint.
+    /// </remarks>
     public static RouteGroupBuilder RequireSqlOSAccessToken(
         this RouteGroupBuilder group,
         Action<SqlOSAccessTokenValidationOptions> configure)
@@ -43,6 +67,15 @@ public static class SqlOSErgonomicsExtensions
         return group;
     }
 
+    /// <summary>
+    /// Checks whether a subject has a permission on a resource and returns only the allow/deny decision.
+    /// </summary>
+    /// <param name="authService">The SqlOS FGA authorization service.</param>
+    /// <param name="subjectId">The subject to authorize.</param>
+    /// <param name="permissionKey">The permission key to require.</param>
+    /// <param name="resourceId">The target resource identifier.</param>
+    /// <returns><see langword="true"/> when access is allowed; otherwise, <see langword="false"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="authService"/> is <see langword="null"/>.</exception>
     public static async Task<bool> Allows(
         this ISqlOSFgaAuthService authService,
         string subjectId,
@@ -55,6 +88,20 @@ public static class SqlOSErgonomicsExtensions
         return result.Allowed;
     }
 
+    /// <summary>
+    /// Creates a new manually managed FGA resource with a generated identifier and adds it to the context.
+    /// </summary>
+    /// <param name="context">The application FGA context.</param>
+    /// <param name="resourceTypeId">The identifier of an existing FGA resource type.</param>
+    /// <param name="name">The resource display name.</param>
+    /// <param name="parentResourceId">The optional identifier of the resource's parent.</param>
+    /// <param name="description">An optional resource description.</param>
+    /// <param name="cancellationToken">A token that can cancel database lookups.</param>
+    /// <returns>The new tracked resource. Call <see cref="ISqlOSFgaDbContext.SaveChangesAsync(CancellationToken)"/> to persist it.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="context"/> is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// A required value is empty, the resource type or parent does not exist, or the requested hierarchy is invalid.
+    /// </exception>
     public static Task<SqlOSFgaResource> CreateResourceAsync(
         this ISqlOSFgaDbContext context,
         string resourceTypeId,
@@ -73,6 +120,22 @@ public static class SqlOSErgonomicsExtensions
             cancellationToken);
     }
 
+    /// <summary>
+    /// Creates a new manually managed FGA resource with an explicit identifier and adds it to the context.
+    /// </summary>
+    /// <param name="context">The application FGA context.</param>
+    /// <param name="resourceId">The stable identifier for the new resource.</param>
+    /// <param name="resourceTypeId">The identifier of an existing FGA resource type.</param>
+    /// <param name="name">The resource display name.</param>
+    /// <param name="parentResourceId">The optional identifier of the resource's parent.</param>
+    /// <param name="description">An optional resource description.</param>
+    /// <param name="cancellationToken">A token that can cancel database lookups.</param>
+    /// <returns>The new tracked resource. Call <see cref="ISqlOSFgaDbContext.SaveChangesAsync(CancellationToken)"/> to persist it.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="context"/> is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// A resource with the same identifier already exists, a required value is empty, the resource type
+    /// or parent does not exist, or the requested hierarchy is invalid.
+    /// </exception>
     public static async Task<SqlOSFgaResource> CreateResourceWithIdAsync(
         this ISqlOSFgaDbContext context,
         string resourceId,
@@ -111,6 +174,28 @@ public static class SqlOSErgonomicsExtensions
         return resource;
     }
 
+    /// <summary>
+    /// Idempotently creates or updates a manually managed FGA resource with an explicit identifier.
+    /// </summary>
+    /// <param name="context">The application FGA context.</param>
+    /// <param name="resourceId">The stable resource identifier.</param>
+    /// <param name="resourceTypeId">The identifier of an existing FGA resource type.</param>
+    /// <param name="name">The resource display name.</param>
+    /// <param name="parentResourceId">
+    /// The optional parent identifier. For an existing resource, <see langword="null"/> preserves its current parent.
+    /// </param>
+    /// <param name="description">
+    /// The optional description. For an existing resource, <see langword="null"/> preserves its current description.
+    /// </param>
+    /// <param name="isActive">
+    /// The optional active state. For an existing resource, <see langword="null"/> preserves its current state.
+    /// </param>
+    /// <param name="cancellationToken">A token that can cancel database lookups.</param>
+    /// <returns>The added or updated tracked resource. Call <see cref="ISqlOSFgaDbContext.SaveChangesAsync(CancellationToken)"/> to persist it.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="context"/> is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// A required value is empty, the resource type or parent does not exist, or the requested hierarchy is invalid.
+    /// </exception>
     public static async Task<SqlOSFgaResource> ProvisionResourceWithIdAsync(
         this ISqlOSFgaDbContext context,
         string resourceId,
@@ -171,6 +256,21 @@ public static class SqlOSErgonomicsExtensions
         return resource;
     }
 
+    /// <summary>
+    /// Marks a manually managed FGA resource and all of its direct grants for deletion.
+    /// </summary>
+    /// <param name="context">The application FGA context.</param>
+    /// <param name="resourceId">The identifier of the resource to delete.</param>
+    /// <param name="cancellationToken">A token that can cancel database lookups.</param>
+    /// <returns>A task that completes when the resource and grants have been marked for deletion.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="context"/> is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// The resource does not exist, has child resources, or <paramref name="resourceId"/> is empty.
+    /// </exception>
+    /// <remarks>
+    /// Child resources are not deleted or reparented. Call
+    /// <see cref="ISqlOSFgaDbContext.SaveChangesAsync(CancellationToken)"/> to persist the deletion.
+    /// </remarks>
     public static async Task DeleteResourceAsync(
         this ISqlOSFgaDbContext context,
         string resourceId,
@@ -189,6 +289,24 @@ public static class SqlOSErgonomicsExtensions
         context.Set<SqlOSFgaResource>().Remove(resource);
     }
 
+    /// <summary>
+    /// Idempotently grants a role to an existing subject on an entity-backed FGA resource.
+    /// </summary>
+    /// <param name="context">The application FGA context.</param>
+    /// <param name="subjectId">The identifier of an explicitly provisioned subject.</param>
+    /// <param name="resource">The protected application entity that identifies the target resource.</param>
+    /// <param name="roleKeyOrId">The key or identifier of an existing FGA role.</param>
+    /// <param name="cancellationToken">A token that can cancel database lookups.</param>
+    /// <returns>The existing or newly added tracked grant.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="context"/> or <paramref name="resource"/> is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// A required value is empty, or the subject, role, or target resource cannot be resolved.
+    /// </exception>
+    /// <remarks>
+    /// A newly tracked <paramref name="resource"/> is supported when the context derives from
+    /// <c>SqlOSDbContext&lt;TContext&gt;</c>; the backing FGA resource is synchronized during save.
+    /// This method does not provision subjects or save changes.
+    /// </remarks>
     public static async Task<SqlOSFgaGrant> GrantRoleAsync(
         this ISqlOSFgaDbContext context,
         string subjectId,
@@ -207,6 +325,20 @@ public static class SqlOSErgonomicsExtensions
             cancellationToken);
     }
 
+    /// <summary>
+    /// Idempotently grants a role to an existing subject on an FGA resource.
+    /// </summary>
+    /// <param name="context">The application FGA context.</param>
+    /// <param name="subjectId">The identifier of an explicitly provisioned subject.</param>
+    /// <param name="resourceId">The target resource identifier.</param>
+    /// <param name="roleKeyOrId">The key or identifier of an existing FGA role.</param>
+    /// <param name="cancellationToken">A token that can cancel database lookups.</param>
+    /// <returns>The existing or newly added tracked grant.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="context"/> is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// A required value is empty, or the subject, role, or target resource cannot be resolved.
+    /// </exception>
+    /// <remarks>This method does not provision subjects or save changes.</remarks>
     public static async Task<SqlOSFgaGrant> GrantRoleAsync(
         this ISqlOSFgaDbContext context,
         string subjectId,
@@ -221,6 +353,19 @@ public static class SqlOSErgonomicsExtensions
             description: null,
             cancellationToken);
 
+    /// <summary>
+    /// Removes a subject's role grant from an entity-backed FGA resource when the grant exists.
+    /// </summary>
+    /// <param name="context">The application FGA context.</param>
+    /// <param name="subjectId">The identifier of an existing subject.</param>
+    /// <param name="resource">The protected application entity that identifies the target resource.</param>
+    /// <param name="roleKeyOrId">The key or identifier of an existing FGA role.</param>
+    /// <param name="cancellationToken">A token that can cancel database lookups.</param>
+    /// <returns>A task that completes when the matching grant has been marked for deletion, if present.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="context"/> or <paramref name="resource"/> is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// A required value is empty, or the subject, role, or target resource cannot be resolved.
+    /// </exception>
     public static async Task RevokeRoleAsync(
         this ISqlOSFgaDbContext context,
         string subjectId,
@@ -233,6 +378,20 @@ public static class SqlOSErgonomicsExtensions
         await RevokeRoleAsync(context, subjectId, resource.ResourceId, roleKeyOrId, cancellationToken);
     }
 
+    /// <summary>
+    /// Removes a subject's role grant from an FGA resource when the grant exists.
+    /// </summary>
+    /// <param name="context">The application FGA context.</param>
+    /// <param name="subjectId">The identifier of an existing subject.</param>
+    /// <param name="resourceId">The target resource identifier.</param>
+    /// <param name="roleKeyOrId">The key or identifier of an existing FGA role.</param>
+    /// <param name="cancellationToken">A token that can cancel database lookups.</param>
+    /// <returns>A task that completes when the matching grant has been marked for deletion, if present.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="context"/> is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// A required value is empty, or the subject, role, or target resource cannot be resolved.
+    /// </exception>
+    /// <remarks>When no matching grant exists, this method makes no change. It does not save changes.</remarks>
     public static async Task RevokeRoleAsync(
         this ISqlOSFgaDbContext context,
         string subjectId,
@@ -308,6 +467,23 @@ public static class SqlOSErgonomicsExtensions
         return grant;
     }
 
+    /// <summary>
+    /// Idempotently provisions an FGA subject of type <c>user</c> and its typed user record.
+    /// </summary>
+    /// <param name="context">The application FGA context.</param>
+    /// <param name="subjectId">The stable identifier used for authorization checks and grants.</param>
+    /// <param name="displayName">The subject's display name.</param>
+    /// <param name="email">An optional email address. When omitted for an existing user, the current value is preserved.</param>
+    /// <param name="organizationId">An optional organization identifier. When omitted for an existing subject, the current value is preserved.</param>
+    /// <param name="externalRef">An optional external identifier. New subjects default it to <paramref name="subjectId"/>.</param>
+    /// <param name="isActive">An optional active state. When omitted for an existing user, the current value is preserved.</param>
+    /// <param name="cancellationToken">A token that can cancel database lookups.</param>
+    /// <returns>The added or updated tracked user record.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="context"/> is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// A required value is empty, or <paramref name="subjectId"/> already belongs to a different subject type.
+    /// </exception>
+    /// <remarks>This method tracks changes but does not save them.</remarks>
     public static async Task<SqlOSFgaUser> ProvisionUserSubjectAsync(
         this ISqlOSFgaDbContext context,
         string subjectId,
@@ -360,6 +536,23 @@ public static class SqlOSErgonomicsExtensions
         return user;
     }
 
+    /// <summary>
+    /// Idempotently provisions an FGA subject of type <c>agent</c> and its typed agent record.
+    /// </summary>
+    /// <param name="context">The application FGA context.</param>
+    /// <param name="subjectId">The stable identifier used for authorization checks and grants.</param>
+    /// <param name="displayName">The subject's display name.</param>
+    /// <param name="agentType">An optional application-defined agent type. When omitted for an existing agent, the current value is preserved.</param>
+    /// <param name="description">An optional description. When omitted for an existing agent, the current value is preserved.</param>
+    /// <param name="organizationId">An optional organization identifier. When omitted for an existing subject, the current value is preserved.</param>
+    /// <param name="externalRef">An optional external identifier. New subjects default it to <paramref name="subjectId"/>.</param>
+    /// <param name="cancellationToken">A token that can cancel database lookups.</param>
+    /// <returns>The added or updated tracked agent record.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="context"/> is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// A required value is empty, or <paramref name="subjectId"/> already belongs to a different subject type.
+    /// </exception>
+    /// <remarks>This method tracks changes but does not save them.</remarks>
     public static async Task<SqlOSFgaAgent> ProvisionAgentSubjectAsync(
         this ISqlOSFgaDbContext context,
         string subjectId,
@@ -412,6 +605,25 @@ public static class SqlOSErgonomicsExtensions
         return agent;
     }
 
+    /// <summary>
+    /// Idempotently provisions an FGA subject of type <c>service_account</c> and its typed service-account record.
+    /// </summary>
+    /// <param name="context">The application FGA context.</param>
+    /// <param name="subjectId">The stable identifier used for authorization checks and grants.</param>
+    /// <param name="displayName">The subject's display name.</param>
+    /// <param name="clientId">The service account's client identifier.</param>
+    /// <param name="clientSecretHash">The application-provided hash of the service account secret.</param>
+    /// <param name="description">An optional description. When omitted for an existing account, the current value is preserved.</param>
+    /// <param name="expiresAt">An optional expiration time. When omitted for an existing account, the current value is preserved.</param>
+    /// <param name="organizationId">An optional organization identifier. When omitted for an existing subject, the current value is preserved.</param>
+    /// <param name="externalRef">An optional external identifier. New subjects default it to <paramref name="subjectId"/>.</param>
+    /// <param name="cancellationToken">A token that can cancel database lookups.</param>
+    /// <returns>The added or updated tracked service-account record.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="context"/> is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// A required value is empty, or <paramref name="subjectId"/> already belongs to a different subject type.
+    /// </exception>
+    /// <remarks>This method tracks changes but does not save them.</remarks>
     public static async Task<SqlOSFgaServiceAccount> ProvisionServiceAccountSubjectAsync(
         this ISqlOSFgaDbContext context,
         string subjectId,

--- a/src/SqlOS/Extensions/WebApplicationBuilderExtensions.cs
+++ b/src/SqlOS/Extensions/WebApplicationBuilderExtensions.cs
@@ -7,12 +7,26 @@ using SqlOS.Fga.Interfaces;
 
 namespace SqlOS.Extensions;
 
+/// <summary>
+/// Provides host-builder extensions for registering SqlOS in an ASP.NET Core application.
+/// </summary>
 public static class WebApplicationBuilderExtensions
 {
     /// <summary>
-    /// Registers SqlOS (auth server + FGA), runs bootstrap on startup, and wires dashboard middleware.
-    /// After <see cref="WebApplicationBuilder.Build"/>, call <see cref="WebApplicationExtensions.MapSqlOS"/> once to map OAuth and admin API routes.
+    /// Registers SqlOS for an application <typeparamref name="TContext"/> that is already
+    /// registered with dependency injection.
     /// </summary>
+    /// <typeparam name="TContext">
+    /// The application EF Core context that contains the SqlOS auth-server and FGA models.
+    /// </typeparam>
+    /// <param name="builder">The application host builder.</param>
+    /// <param name="configure">An optional callback that configures SqlOS.</param>
+    /// <returns>The same <paramref name="builder"/> instance so that additional calls can be chained.</returns>
+    /// <remarks>
+    /// This overload does not register <typeparamref name="TContext"/>. Register the context before
+    /// calling this method. After <see cref="WebApplicationBuilder.Build"/>, call
+    /// <see cref="WebApplicationExtensions.MapSqlOS"/> once to map the SqlOS endpoints.
+    /// </remarks>
     public static WebApplicationBuilder AddSqlOS<TContext>(this WebApplicationBuilder builder, Action<SqlOSOptions>? configure = null)
         where TContext : DbContext, ISqlOSAuthServerDbContext, ISqlOSFgaDbContext
     {
@@ -21,9 +35,20 @@ public static class WebApplicationBuilderExtensions
     }
 
     /// <summary>
-    /// Registers the application's EF Core DbContext and SqlOS (auth server + FGA) in one host call.
-    /// After <see cref="WebApplicationBuilder.Build"/>, call <see cref="WebApplicationExtensions.MapSqlOS"/> once to map OAuth and admin API routes.
+    /// Registers the application EF Core context and the complete SqlOS service graph in one host call.
     /// </summary>
+    /// <typeparam name="TContext">
+    /// The application EF Core context that contains the SqlOS auth-server and FGA models.
+    /// </typeparam>
+    /// <param name="builder">The application host builder.</param>
+    /// <param name="configureDbContext">A callback that configures the application EF Core context.</param>
+    /// <param name="configureSqlOS">An optional callback that configures SqlOS.</param>
+    /// <returns>The same <paramref name="builder"/> instance so that additional calls can be chained.</returns>
+    /// <remarks>
+    /// This overload calls <see cref="EntityFrameworkServiceCollectionExtensions.AddDbContext{TContext}(IServiceCollection,Action{DbContextOptionsBuilder},ServiceLifetime,ServiceLifetime)"/>
+    /// before registering SqlOS. After <see cref="WebApplicationBuilder.Build"/>, call
+    /// <see cref="WebApplicationExtensions.MapSqlOS"/> once to map the SqlOS endpoints.
+    /// </remarks>
     public static WebApplicationBuilder AddSqlOS<TContext>(
         this WebApplicationBuilder builder,
         Action<DbContextOptionsBuilder> configureDbContext,

--- a/src/SqlOS/Extensions/WebApplicationExtensions.cs
+++ b/src/SqlOS/Extensions/WebApplicationExtensions.cs
@@ -10,11 +10,21 @@ using SqlOS.Email.Extensions;
 
 namespace SqlOS.Extensions;
 
+/// <summary>
+/// Provides endpoint-mapping extensions for applications that host SqlOS.
+/// </summary>
 public static class WebApplicationExtensions
 {
     /// <summary>
-    /// Maps SqlOS auth server endpoints. Call once after <see cref="WebApplicationBuilder.Build"/> when using <see cref="WebApplicationBuilderExtensions.AddSqlOS{TContext}"/>.
+    /// Maps the SqlOS auth-server, audit-log administration, and transactional-email
+    /// administration endpoints, plus calendar endpoints when calendar integration is enabled.
     /// </summary>
+    /// <param name="app">The built ASP.NET Core application.</param>
+    /// <returns>The same <paramref name="app"/> instance.</returns>
+    /// <remarks>
+    /// Call this method once after <see cref="WebApplicationBuilder.Build"/> when using
+    /// <see cref="WebApplicationBuilderExtensions.AddSqlOS{TContext}(WebApplicationBuilder,Action{SqlOSOptions})"/>.
+    /// </remarks>
     public static WebApplication MapSqlOS(this WebApplication app)
     {
         var authOptions = app.Services.GetRequiredService<IOptions<SqlOSAuthServerOptions>>().Value;

--- a/src/SqlOS/Fga/Configuration/SqlOSFgaOptions.cs
+++ b/src/SqlOS/Fga/Configuration/SqlOSFgaOptions.cs
@@ -19,6 +19,13 @@ public class SqlOSFgaOptions
     public SqlOSFgaTableNames TableNames { get; set; } = new();
     public SqlOSFgaSeedData? StartupSeedData { get; private set; }
 
+    /// <summary>
+    /// Adds resource types, permissions, roles, and role-permission assignments to the FGA
+    /// startup seed that SqlOS reconciles during host bootstrap.
+    /// </summary>
+    /// <param name="configure">A callback that declares the authorization model to seed.</param>
+    /// <returns>The same options instance so that additional configuration can be chained.</returns>
+    /// <remarks>Multiple calls add to or replace matching entries in the accumulated startup seed.</remarks>
     public SqlOSFgaOptions Seed(Action<SqlOSFgaSeedBuilder> configure)
     {
         var builder = StartupSeedData == null

--- a/src/SqlOS/Fga/Configuration/SqlOSFgaSeedBuilder.cs
+++ b/src/SqlOS/Fga/Configuration/SqlOSFgaSeedBuilder.cs
@@ -3,6 +3,10 @@ using SqlOS.Fga.Services;
 
 namespace SqlOS.Fga.Configuration;
 
+/// <summary>
+/// Builds the resource types, permissions, roles, and role-permission assignments that SqlOS
+/// reconciles into the FGA store during host startup.
+/// </summary>
 public sealed class SqlOSFgaSeedBuilder
 {
     private readonly Dictionary<string, SqlOSFgaResourceType> _resourceTypes = new(StringComparer.Ordinal);
@@ -12,6 +16,7 @@ public sealed class SqlOSFgaSeedBuilder
     private readonly Dictionary<string, SqlOSFgaRole> _rolesByKey = new(StringComparer.Ordinal);
     private readonly Dictionary<string, HashSet<string>> _rolePermissions = new(StringComparer.Ordinal);
 
+    /// <summary>Creates an empty FGA startup seed builder.</summary>
     public SqlOSFgaSeedBuilder()
     {
     }
@@ -58,6 +63,12 @@ public sealed class SqlOSFgaSeedBuilder
         }
     }
 
+    /// <summary>Adds or replaces a resource type in the startup seed.</summary>
+    /// <param name="id">The stable resource type identifier referenced by protected resources and permissions.</param>
+    /// <param name="name">The resource type display name.</param>
+    /// <param name="description">An optional description.</param>
+    /// <returns>The same builder instance.</returns>
+    /// <exception cref="InvalidOperationException"><paramref name="id"/> or <paramref name="name"/> is empty.</exception>
     public SqlOSFgaSeedBuilder ResourceType(string id, string name, string? description = null)
     {
         var normalizedId = RequireValue(id, nameof(id));
@@ -70,6 +81,14 @@ public sealed class SqlOSFgaSeedBuilder
         return this;
     }
 
+    /// <summary>Adds or replaces a permission with independent identifier and key values.</summary>
+    /// <param name="id">The stable permission identifier.</param>
+    /// <param name="key">The application-facing permission key used in access checks.</param>
+    /// <param name="name">The permission display name.</param>
+    /// <param name="resourceTypeId">The resource type to which the permission applies.</param>
+    /// <param name="description">An optional description.</param>
+    /// <returns>The same builder instance.</returns>
+    /// <exception cref="InvalidOperationException">A required value is empty.</exception>
     public SqlOSFgaSeedBuilder Permission(string id, string key, string name, string resourceTypeId, string? description = null)
     {
         var normalizedId = RequireValue(id, nameof(id));
@@ -93,9 +112,23 @@ public sealed class SqlOSFgaSeedBuilder
         return this;
     }
 
+    /// <summary>Adds or replaces a permission whose identifier and application-facing key are the same.</summary>
+    /// <param name="key">The stable permission identifier and application-facing key.</param>
+    /// <param name="name">The permission display name.</param>
+    /// <param name="resourceTypeId">The resource type to which the permission applies.</param>
+    /// <returns>The same builder instance.</returns>
+    /// <exception cref="InvalidOperationException">A required value is empty.</exception>
     public SqlOSFgaSeedBuilder Permission(string key, string name, string resourceTypeId)
         => Permission(key, key, name, resourceTypeId);
 
+    /// <summary>Adds or replaces a role with independent identifier and key values.</summary>
+    /// <param name="id">The stable role identifier stored on grants.</param>
+    /// <param name="key">The application-facing role key used by grant helpers.</param>
+    /// <param name="name">The role display name.</param>
+    /// <param name="description">An optional description.</param>
+    /// <param name="isVirtual">Whether the role is virtual.</param>
+    /// <returns>The same builder instance.</returns>
+    /// <exception cref="InvalidOperationException">A required value is empty.</exception>
     public SqlOSFgaSeedBuilder Role(string id, string key, string name, string? description = null, bool isVirtual = false)
     {
         var normalizedId = RequireValue(id, nameof(id));
@@ -119,6 +152,14 @@ public sealed class SqlOSFgaSeedBuilder
         return this;
     }
 
+    /// <summary>
+    /// Adds or replaces a role whose identifier and application-facing key are the same, then
+    /// starts a fluent permission assignment for that role.
+    /// </summary>
+    /// <param name="key">The stable role identifier and application-facing key.</param>
+    /// <param name="name">The role display name.</param>
+    /// <returns>A role seed builder for assigning one or more permissions with <see cref="SqlOSFgaRoleSeedBuilder.Can"/>.</returns>
+    /// <exception cref="InvalidOperationException"><paramref name="key"/> or <paramref name="name"/> is empty.</exception>
     public SqlOSFgaRoleSeedBuilder Role(string key, string name)
     {
         var normalizedKey = RequireValue(key, nameof(key));
@@ -126,6 +167,11 @@ public sealed class SqlOSFgaSeedBuilder
         return new SqlOSFgaRoleSeedBuilder(this, normalizedKey);
     }
 
+    /// <summary>Assigns a permission to a role in the startup seed.</summary>
+    /// <param name="roleKey">The application-facing key of a seeded role.</param>
+    /// <param name="permissionKey">The application-facing key of a seeded permission.</param>
+    /// <returns>The same builder instance.</returns>
+    /// <exception cref="InvalidOperationException"><paramref name="roleKey"/> or <paramref name="permissionKey"/> is empty.</exception>
     public SqlOSFgaSeedBuilder RolePermission(string roleKey, string permissionKey)
     {
         var normalizedRoleKey = RequireValue(roleKey, nameof(roleKey));
@@ -195,6 +241,7 @@ public sealed class SqlOSFgaSeedBuilder
         };
 }
 
+/// <summary>Assigns permissions to a role declared through the fluent FGA startup seed API.</summary>
 public sealed class SqlOSFgaRoleSeedBuilder
 {
     private readonly SqlOSFgaSeedBuilder _builder;
@@ -206,6 +253,10 @@ public sealed class SqlOSFgaRoleSeedBuilder
         _roleKey = roleKey;
     }
 
+    /// <summary>Assigns one or more permission keys to the role.</summary>
+    /// <param name="permissionKeys">The seeded permission keys to assign.</param>
+    /// <returns>The parent FGA seed builder so that model declarations can continue.</returns>
+    /// <exception cref="InvalidOperationException">A permission key is empty.</exception>
     public SqlOSFgaSeedBuilder Can(params string[] permissionKeys)
     {
         foreach (var permissionKey in permissionKeys)

--- a/src/SqlOS/Fga/Interfaces/IHasResourceId.cs
+++ b/src/SqlOS/Fga/Interfaces/IHasResourceId.cs
@@ -1,10 +1,14 @@
 namespace SqlOS.Fga.Interfaces;
 
 /// <summary>
-/// Marker interface for entities that have a ResourceId property.
-/// Used by the authorization system to filter entities based on accessible resources.
+/// Exposes the FGA resource identifier used by SqlOS point checks and query filters.
 /// </summary>
+/// <remarks>
+/// Implement <see cref="ISqlOSResourceEntity"/> instead when SqlOS should synchronize the
+/// entity's backing FGA resource during EF Core saves.
+/// </remarks>
 public interface IHasResourceId
 {
+    /// <summary>Gets the stable identifier of the entity's backing FGA resource.</summary>
     string ResourceId { get; }
 }

--- a/src/SqlOS/Fga/Interfaces/ISqlOSFgaAuthService.cs
+++ b/src/SqlOS/Fga/Interfaces/ISqlOSFgaAuthService.cs
@@ -4,32 +4,59 @@ using SqlOS.Fga.Models;
 namespace SqlOS.Fga.Interfaces;
 
 /// <summary>
-/// RBAC Authorization Service for hierarchical resource access.
-/// Uses hierarchical permissions where access granted at a parent resource
-/// is inherited by child resources.
+/// Checks hierarchical SqlOS FGA permissions and creates EF Core authorization filters.
 /// </summary>
+/// <remarks>
+/// Role grants on a parent resource are inherited by its descendants. A subject's group
+/// memberships are included when SqlOS evaluates a decision.
+/// </remarks>
 public interface ISqlOSFgaAuthService
 {
     /// <summary>
-    /// Check if a subject has access to a resource with a specific permission.
-    /// Walks up the resource hierarchy to find grants.
+    /// Checks whether a subject has a permission on a resource or one of its ancestors.
     /// </summary>
+    /// <param name="subjectId">The subject to authorize.</param>
+    /// <param name="permissionKey">The permission key to require.</param>
+    /// <param name="resourceId">The target resource identifier.</param>
+    /// <returns>
+    /// A result containing the allow/deny decision, evaluation trace, and an error description
+    /// when the subject, permission, or resource cannot be resolved.
+    /// </returns>
     Task<SqlOSFgaAccessCheckResult> CheckAccessAsync(string subjectId, string permissionKey, string resourceId);
 
     /// <summary>
-    /// Check if a subject has a specific permission capability at root level.
+    /// Checks whether a subject has a permission on the configured FGA root resource.
     /// </summary>
+    /// <param name="subjectId">The subject to authorize.</param>
+    /// <param name="permissionKey">The permission key to require at the root resource.</param>
+    /// <returns><see langword="true"/> when the root-resource access check succeeds; otherwise, <see langword="false"/>.</returns>
+    /// <remarks>This method does not search descendants for any resource on which the subject has the permission.</remarks>
     Task<bool> HasCapabilityAsync(string subjectId, string permissionKey);
 
     /// <summary>
-    /// Produce a detailed, structured trace of a resource access decision.
+    /// Produces a detailed, structured trace of a hierarchical resource access decision.
     /// </summary>
+    /// <param name="subjectId">The subject to authorize.</param>
+    /// <param name="resourceId">The target resource identifier.</param>
+    /// <param name="permissionKey">The permission key to require.</param>
+    /// <returns>The decision trace, including the resource path, subjects, grants, roles, and denial guidance.</returns>
     Task<SqlOSFgaResourceAccessTrace> TraceResourceAccessAsync(string subjectId, string resourceId, string permissionKey);
 
     /// <summary>
-    /// Get an expression filter for entities with a ResourceId property.
-    /// The filter restricts results to only those resources the subject can access.
+    /// Creates an EF Core-compatible expression that includes only entities whose resources
+    /// the subject can access with a permission.
     /// </summary>
+    /// <typeparam name="T">The entity type exposing the FGA resource identifier.</typeparam>
+    /// <param name="subjectId">The subject whose accessible resources should be included.</param>
+    /// <param name="permissionKey">The permission key required for each resource.</param>
+    /// <returns>
+    /// An expression for use with <see cref="Queryable.Where{TSource}(IQueryable{TSource},Expression{Func{TSource,bool}})"/>.
+    /// The expression always evaluates to <see langword="false"/> when the subject or permission cannot be resolved.
+    /// </returns>
+    /// <remarks>
+    /// Keep the expression in the <see cref="IQueryable{T}"/> pipeline so EF Core can translate
+    /// it to the configured SqlOS authorization table-valued function.
+    /// </remarks>
     Task<Expression<Func<T, bool>>> GetAuthorizationFilterAsync<T>(
         string subjectId,
         string permissionKey) where T : IHasResourceId;

--- a/src/SqlOS/Fga/Interfaces/ISqlOSResourceEntity.cs
+++ b/src/SqlOS/Fga/Interfaces/ISqlOSResourceEntity.cs
@@ -1,13 +1,26 @@
 namespace SqlOS.Fga.Interfaces;
 
 /// <summary>
-/// Implement on application entities that should be mirrored into the SqlOS FGA resource hierarchy.
+/// Describes an application entity whose backing FGA resource should be synchronized during
+/// <c>SqlOSDbContext&lt;TContext&gt;</c> saves.
 /// </summary>
+/// <remarks>
+/// Resource synchronization does not grant access. Provision subjects and create role grants explicitly.
+/// </remarks>
 public interface ISqlOSResourceEntity : IHasResourceId
 {
+    /// <summary>Gets the identifier of the seeded FGA resource type for this entity.</summary>
     string ResourceTypeId { get; }
+
+    /// <summary>Gets the display name stored on the backing FGA resource.</summary>
     string ResourceName { get; }
+
+    /// <summary>Gets the optional parent resource identifier used for inherited access.</summary>
     string? ParentResourceId { get; }
+
+    /// <summary>Gets the optional description stored on the backing FGA resource.</summary>
     string? ResourceDescription { get; }
+
+    /// <summary>Gets whether the backing FGA resource is active.</summary>
     bool ResourceIsActive { get; }
 }

--- a/src/SqlOS/SqlOS.csproj
+++ b/src/SqlOS/SqlOS.csproj
@@ -21,6 +21,11 @@
     <Nullable>enable</Nullable>
     <RootNamespace>SqlOS</RootNamespace>
     <GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <!-- The XML file improves IDE and generated-reference coverage for documented APIs.
+         CS1591 remains suppressed until the intentionally supported surface is fully annotated.
+         CS0419 covers the intentionally overloaded AddSqlOS cref until member docs are generated. -->
+    <NoWarn>$(NoWarn);1591;0419</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SqlOS/SqlOSDbContext.cs
+++ b/src/SqlOS/SqlOSDbContext.cs
@@ -10,6 +10,13 @@ namespace SqlOS;
 /// <summary>
 /// Base DbContext for applications that host SqlOS auth server and FGA in the same EF Core model.
 /// </summary>
+/// <typeparam name="TContext">The concrete application context type.</typeparam>
+/// <param name="options">The EF Core options registered for the concrete application context.</param>
+/// <remarks>
+/// SqlOS registers its auth, email, calendar, and FGA entities before invoking
+/// <see cref="OnApplicationModelCreating"/>. Save operations synchronize tracked
+/// <see cref="ISqlOSResourceEntity"/> instances with their backing FGA resources.
+/// </remarks>
 public abstract class SqlOSDbContext<TContext>(DbContextOptions<TContext> options)
     : DbContext(options), ISqlOSAuthServerDbContext, ISqlOSFgaDbContext
     where TContext : SqlOSDbContext<TContext>
@@ -30,6 +37,7 @@ public abstract class SqlOSDbContext<TContext>(DbContextOptions<TContext> option
     /// <summary>
     /// Configure application-owned EF entities after SqlOS has registered its auth server and FGA model.
     /// </summary>
+    /// <param name="modelBuilder">The builder for the combined application and SqlOS EF Core model.</param>
     protected virtual void OnApplicationModelCreating(ModelBuilder modelBuilder)
     {
     }

--- a/web/content/blog/row-level-security-ef-core-sql-server-tvfs.mdx
+++ b/web/content/blog/row-level-security-ef-core-sql-server-tvfs.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Row-Level Security with EF Core, SQL Server, and Table-Valued Functions"
-description: "How to implement database-level row-level security in .NET using SQL Server TVFs composed into EF Core LINQ queries — no post-load filtering, no external service calls."
+title: "Authorized EF Core Queries with SQL Server Table-Valued Functions"
+description: "How SqlOS composes hierarchical authorization into EF Core queries with a SQL Server TVF — no post-load filtering or per-row service calls."
 date: "2026-03-15"
 author: "Ross Slaney"
 tags: ["Row-Level Security", "EF Core", "SQL Server", "TVF", "FGA", "RBAC", "Authorization"]
@@ -10,9 +10,9 @@ You need certain users to see certain rows. That's the whole problem.
 
 The typical solution is application-level filtering — `.Where(x => x.TenantId == currentTenant)` — scattered across every query in your codebase. It works until someone forgets the filter, adds a new endpoint without it, or builds a report that bypasses the service layer entirely. At that point, unauthorized data leaks.
 
-Database-level row-level security solves this by pushing authorization into the query itself. The database won't return rows the caller can't see, regardless of how the query was constructed.
+SqlOS addresses this by composing an authorization predicate into the EF Core query itself. The database does not return unauthorized rows for queries that apply that predicate.
 
-This guide covers how to implement RLS in .NET using SQL Server Table-Valued Functions (TVFs) composed directly into EF Core LINQ queries — the approach used by SqlOS FGA.
+This guide covers the SQL Server table-valued function (TVF) approach used by SqlOS FGA. It is query-level authorization, not a SQL Server security policy: raw SQL or an EF query that omits the authorization filter is not protected automatically.
 
 ## The Problem with Application-Level Filtering
 
@@ -33,7 +33,7 @@ This has four problems:
 
 SQL Server has a built-in RLS feature using security policies and predicate functions. It works, but it's tightly coupled to database users/roles and doesn't integrate cleanly with application-level identity (JWTs, claims, etc.).
 
-## A Better Approach: TVFs as Authorization Predicates
+## TVFs as Authorization Predicates
 
 A Table-Valued Function (TVF) is a SQL function that returns a table. When it's an *inline* TVF, SQL Server's optimizer doesn't treat it as a black box — it folds the function body directly into the calling query's execution plan.
 
@@ -42,7 +42,7 @@ This means you can write an authorization check as a TVF and use it as a `WHERE 
 Here's the core idea:
 
 ```sql
-CREATE FUNCTION fn_IsResourceAccessible(
+CREATE FUNCTION [dbo].fn_IsResourceAccessible(
     @ResourceId NVARCHAR(128),
     @SubjectIds NVARCHAR(MAX),
     @PermissionId NVARCHAR(128)
@@ -54,19 +54,19 @@ RETURN
     WITH ancestors AS (
         -- Walk up the resource tree from the target to the root
         SELECT Id, ParentId, 0 AS Depth
-        FROM Resources WHERE Id = @ResourceId
+        FROM [dbo].[SqlOSFgaResources] WHERE Id = @ResourceId
 
         UNION ALL
 
         SELECT r.Id, r.ParentId, a.Depth + 1
-        FROM Resources r
+        FROM [dbo].[SqlOSFgaResources] r
         INNER JOIN ancestors a ON r.Id = a.ParentId
         WHERE a.Depth < 10
     )
     SELECT TOP 1 a.Id
     FROM ancestors a
-    INNER JOIN Grants g ON a.Id = g.ResourceId
-    INNER JOIN RolePermissions rp ON g.RoleId = rp.RoleId
+    INNER JOIN [dbo].[SqlOSFgaGrants] g ON a.Id = g.ResourceId
+    INNER JOIN [dbo].[SqlOSFgaRolePermissions] rp ON g.RoleId = rp.RoleId
     WHERE g.SubjectId IN (
         SELECT LTRIM(RTRIM(value)) FROM STRING_SPLIT(@SubjectIds, ',')
     )
@@ -78,34 +78,26 @@ RETURN
 
 What this does for each row:
 
-1. **Walks up** the resource tree from the target resource to the root (recursive CTE, bounded at depth 10)
+1. **Walks up** the resource tree from the target resource to the root (recursive CTE, bounded by `MaxResourceHierarchyDepth`, which defaults to 10)
 2. **Joins** against grants at each ancestor node
 3. **Checks** if any grant matches the caller's principals and the required permission
 4. **Returns** a row if access exists (`TOP 1` — one match is enough)
 
-Because it's an inline TVF, the SQL Server optimizer composes this directly into your query plan. Authorization becomes part of the index seek, not a separate operation.
+Because it is an inline TVF, SQL Server can compose the function into the calling query plan instead of making an application-side permission request per row. Whether a specific plan uses seeks or scans still depends on indexes, predicates, statistics, and data distribution.
 
 ## Mapping It to EF Core
 
-The TVF needs to be callable from LINQ. In EF Core, you register it as a database function on your `DbContext`:
+The TVF needs to be callable from LINQ. The recommended `SqlOSDbContext<TContext>` base class registers it for relational contexts:
 
 ```csharp
-public class AppDbContext : DbContext
-{
-    [DbFunction("fn_IsResourceAccessible", Schema = "sqlos")]
-    public IQueryable<AccessibleResource> IsResourceAccessible(
-        string resourceId,
-        string subjectIds,
-        string permissionId)
-        => FromExpression(() => IsResourceAccessible(
-            resourceId, subjectIds, permissionId));
-}
+public sealed class AppDbContext(DbContextOptions<AppDbContext> options)
+    : SqlOSDbContext<AppDbContext>(options);
 ```
 
 Then you build an authorization filter as an `Expression<Func<T, bool>>` that calls the TVF:
 
 ```csharp
-var filter = await fga.BuildFilterAsync<Document>(
+var filter = await fga.GetAuthorizationFilterAsync<Document>(
     subjectId: currentUserId,
     permissionKey: "documents.read");
 
@@ -135,11 +127,13 @@ With a flat model, a team lead who should see all documents in their team's proj
 With a resource tree, you grant a role at the team level and it inherits downward:
 
 ```csharp
-// Grant "viewer" role to user at the team level
-await fga.GrantRoleAsync(new GrantRequest(
+// The subject, resource, and role must already exist.
+await db.GrantRoleAsync(
     subjectId: userId,
-    roleKey: "viewer",
-    resourceId: "team::engineering"));
+    resourceId: "team::engineering",
+    roleKeyOrId: "viewer",
+    cancellationToken: ct);
+await db.SaveChangesAsync(ct);
 
 // This grant now covers:
 // - team::engineering
@@ -152,13 +146,13 @@ The TVF handles the inheritance automatically — it walks up from each document
 
 ## Performance Characteristics
 
-The TVF approach has predictable, bounded cost:
+The TVF approach has a bounded hierarchy walk. A useful conceptual model is:
 
 **Per-row cost:** O(D) where D is the tree depth. Each row triggers a recursive CTE that walks at most D ancestor hops. With proper indexes, each hop is an index seek.
 
 **Per-page cost:** O(k · D) where k is the page size. Under cursor pagination, the database evaluates rows sequentially until it finds k authorized ones.
 
-**The critical property: cost is independent of total row count.** Whether your table has 10K or 1.5M rows, the per-page latency is the same — because cursor pagination only examines rows forward from the cursor, and the TVF only examines ancestors of each candidate row.
+The benchmark below found stable page-level behavior at the tested scales because cursor pagination examines rows forward from the cursor and the TVF walks a bounded ancestor chain. Treat those measurements as benchmark results, not a universal latency guarantee: indexes, selectivity, grant density, plan quality, and application predicates still matter.
 
 Benchmarked results from the [SHRBAC paper](https://github.com/ross-slaney/sqlos/blob/main/paper/shrbac-compsac-2026.pdf):
 
@@ -177,15 +171,15 @@ A common mistake in RBAC systems is encoding scope into role names: `TeamA_Edito
 With the TVF approach, roles stay generic and reusable:
 
 ```csharp
-// Define roles once
-seed.Role("viewer", "Viewer");
-seed.Role("editor", "Editor");
-seed.Role("admin", "Admin");
+// Define roles once and attach reusable permission keys
+seed.Role("viewer", "Viewer").Can("documents.read");
+seed.Role("editor", "Editor").Can("documents.read", "documents.edit");
 
 // Scope is determined by WHERE the grant is placed
-await fga.GrantRoleAsync("viewer", userId, "org::acme");      // sees everything
-await fga.GrantRoleAsync("editor", userId, "team::eng");       // edits eng subtree
-await fga.GrantRoleAsync("viewer", userId, "doc::42");         // sees one document
+await db.GrantRoleAsync(userId, "org::acme", "viewer");   // sees everything
+await db.GrantRoleAsync(userId, "team::eng", "editor");   // edits eng subtree
+await db.GrantRoleAsync(userId, "doc::42", "viewer");     // sees one document
+await db.SaveChangesAsync(ct);
 ```
 
 Same three roles. Different scope depending on where in the tree the grant lives. No role explosion.
@@ -211,8 +205,8 @@ Reads and writes use the same grants, the same roles, the same resource tree. On
 **Use TVF-based RLS when:**
 - You need row-level visibility filtering in EF Core
 - Your authorization model has hierarchical structure (orgs, teams, projects, etc.)
-- You want authorization enforced at the database level, not just the application level
-- You need predictable query performance that doesn't degrade with dataset size
+- You want authorization composed into the SQL query rather than evaluated after materialization
+- You can index the resource/grant paths and benchmark the expected hierarchy and grant density
 - You want the same model for human users, service accounts, and autonomous agents
 
 **Consider alternatives when:**
@@ -229,20 +223,19 @@ dotnet add package SqlOS
 ```
 
 ```csharp
-builder.AddSqlOS<AppDbContext>(options =>
-{
-    options.Fga.Seed(seed =>
+builder.AddSqlOS<AppDbContext>(
+    db => db.UseSqlServer(connectionString),
+    options =>
     {
-        seed.ResourceType("document", "Document");
-        seed.Permission("documents.read", "Read documents", "document");
-        seed.Permission("documents.edit", "Edit documents", "document");
-        seed.Role("viewer", "Viewer");
-        seed.Role("editor", "Editor");
-        seed.RolePermission("viewer", "documents.read");
-        seed.RolePermission("editor", "documents.read");
-        seed.RolePermission("editor", "documents.edit");
+        options.Fga.Seed(seed =>
+        {
+            seed.ResourceType("document", "Document");
+            seed.Permission("documents.read", "Read documents", "document");
+            seed.Permission("documents.edit", "Edit documents", "document");
+            seed.Role("viewer", "Viewer").Can("documents.read");
+            seed.Role("editor", "Editor").Can("documents.read", "documents.edit");
+        });
     });
-});
 
 var app = builder.Build();
 app.MapSqlOS(); // Maps routes; schema + TVF run on host startup
@@ -250,4 +243,4 @@ app.MapSqlOS(); // Maps routes; schema + TVF run on host startup
 
 The [getting started guide](/docs/getting-started) walks through the full setup. The [SHRBAC paper](https://github.com/ross-slaney/sqlos/blob/main/paper/shrbac-compsac-2026.pdf) covers the formal model and benchmark methodology.
 
-Row-level security isn't a feature you bolt on. It's a property of how your authorization model composes with your data queries. When authorization lives in the database as a TVF, every query is automatically secure — not because every developer remembered to add the filter, but because the filter is the query.
+Authorized row filtering is a property of how the authorization model composes with a data query. With SqlOS, the filter becomes part of the SQL query instead of running after materialization. Apply it directly or use `ISpecificationExecutor` on every protected list path; it does not turn unfiltered EF or raw SQL into an automatically protected query.

--- a/web/content/docs/authserver/dashboard-overview.mdx
+++ b/web/content/docs/authserver/dashboard-overview.mdx
@@ -11,7 +11,16 @@ The dashboard is admin UI inside your app. It covers AuthServer, Audit Logs, com
 
 Default path is `DashboardBasePath` (`/sqlos`). Register SqlOS. Call `app.MapSqlOS()` after `Build()`.
 
-Example: `http://localhost:5062/sqlos/`. Protect it with a password in `appsettings.json` (or env vars).
+Example: `http://localhost:5062/sqlos/`. Protect it by assigning dashboard options in the `AddSqlOS` callback:
+
+```csharp
+options.Dashboard.AuthMode = SqlOSDashboardAuthMode.Password;
+options.Dashboard.Password =
+    builder.Configuration["SqlOS:Dashboard:Password"]
+    ?? throw new InvalidOperationException("SqlOS dashboard password is required.");
+```
+
+The password can come from user secrets, an environment variable, or another configuration provider, but SqlOS does not bind the `SqlOS` configuration section automatically.
 
 ![Dashboard home](/docs/dashboard-home.png)
 

--- a/web/content/docs/authserver/memberships.mdx
+++ b/web/content/docs/authserver/memberships.mdx
@@ -14,12 +14,11 @@ For human onboarding, prefer [Email Invitations](/docs/authserver/invitations) o
 **SDK**:
 
 ```csharp
-var membership = await adminService.CreateMembershipAsync(new CreateMembershipRequest
-{
-    OrganizationId = org.Id,
-    UserId = user.Id,
-    Role = "admin"
-});
+var membership = await adminService.CreateMembershipAsync(
+    org.Id,
+    new SqlOSCreateMembershipRequest(
+        UserId: user.Id,
+        Role: "admin"));
 ```
 
 **Admin API**:

--- a/web/content/docs/authserver/organizations.mdx
+++ b/web/content/docs/authserver/organizations.mdx
@@ -16,12 +16,11 @@ Organizations are tenants in SqlOS. Each organization has its own users (via mem
 **SDK**:
 
 ```csharp
-var org = await adminService.CreateOrganizationAsync(new CreateOrganizationRequest
-{
-    Name = "Acme Corp",
-    Slug = "acme",
-    PrimaryDomain = "acme.com"
-});
+var org = await adminService.CreateOrganizationAsync(
+    new SqlOSCreateOrganizationRequest(
+        Name: "Acme Corp",
+        Slug: "acme",
+        PrimaryDomain: "acme.com"));
 ```
 
 **Admin API**:
@@ -47,12 +46,11 @@ When you set a primary domain, AuthServer uses it for [home realm discovery](/do
 Users join organizations through memberships. Each membership has a role. Public signup does not accept an `organizationId` as permission to join an existing organization; use an invitation, trusted SSO/SCIM provisioning, or an admin-owned workflow to create memberships for existing tenants.
 
 ```csharp
-var membership = await adminService.CreateMembershipAsync(new CreateMembershipRequest
-{
-    OrganizationId = org.Id,
-    UserId = user.Id,
-    Role = "admin"
-});
+var membership = await adminService.CreateMembershipAsync(
+    org.Id,
+    new SqlOSCreateMembershipRequest(
+        UserId: user.Id,
+        Role: "admin"));
 ```
 
 ## Multi-org login
@@ -61,7 +59,7 @@ When a user belongs to multiple organizations and logs in without specifying one
 
 ```csharp
 var result = await authService.LoginWithPasswordAsync(
-    new SqlOSPasswordLoginRequest(email, password, clientId),
+    new SqlOSPasswordLoginRequest(email, password, clientId, OrganizationId: null),
     httpContext, ct);
 
 if (result.RequiresOrganizationSelection)

--- a/web/content/docs/authserver/password-login.mdx
+++ b/web/content/docs/authserver/password-login.mdx
@@ -43,7 +43,7 @@ if (mode === "sso") {
 
 ```csharp
 var result = await authService.LoginWithPasswordAsync(
-    new SqlOSPasswordLoginRequest(email, password, clientId, organizationId: null),
+    new SqlOSPasswordLoginRequest(email, password, clientId, OrganizationId: null),
     httpContext, ct);
 
 if (result.RequiresOrganizationSelection)

--- a/web/content/docs/authserver/refresh-and-logout.mdx
+++ b/web/content/docs/authserver/refresh-and-logout.mdx
@@ -11,7 +11,7 @@ Refresh uses the old refresh token. SqlOS returns a new pair. Idle timeout exten
 
 ```csharp
 var tokens = await authService.RefreshAsync(
-    new SqlOSRefreshRequest(refreshToken, organizationId: null), ct);
+    new SqlOSRefreshRequest(refreshToken, OrganizationId: null), ct);
 ```
 
 **Frontend**:

--- a/web/content/docs/authserver/saml-sso.mdx
+++ b/web/content/docs/authserver/saml-sso.mdx
@@ -19,14 +19,13 @@ You can configure SAML in two ways:
 **SDK**:
 
 ```csharp
-var draft = await adminService.CreateSsoConnectionDraftAsync(new CreateSsoConnectionDraftRequest
-{
-    OrganizationId = org.Id,
-    DisplayName = "Acme Entra SSO",
-    PrimaryDomain = "acme.com",
-    AutoProvisionUsers = true,
-    AutoLinkByEmail = true
-});
+var draft = await adminService.CreateSsoConnectionDraftAsync(
+    new SqlOSCreateSsoConnectionDraftRequest(
+        OrganizationId: org.Id,
+        DisplayName: "Acme Entra SSO",
+        PrimaryDomain: "acme.com",
+        AutoProvisionUsers: true,
+        AutoLinkByEmail: true));
 ```
 
 **Admin API**:

--- a/web/content/docs/authserver/sessions-and-tokens.mdx
+++ b/web/content/docs/authserver/sessions-and-tokens.mdx
@@ -61,7 +61,7 @@ Refresh tokens are opaque and rotated on every use. Each refresh consumes the ol
 
 ```csharp
 var tokens = await authService.RefreshAsync(
-    new SqlOSRefreshRequest(refreshToken, organizationId: null), ct);
+    new SqlOSRefreshRequest(refreshToken, OrganizationId: null), ct);
 ```
 
 **Replay detection**: If a consumed refresh token is reused, SqlOS revokes the entire token family and the session. This protects against token theft.

--- a/web/content/docs/authserver/users-and-credentials.mdx
+++ b/web/content/docs/authserver/users-and-credentials.mdx
@@ -16,12 +16,11 @@ Users are the people who authenticate through SqlOS. Each user has an email, a d
 **SDK**:
 
 ```csharp
-var user = await adminService.CreateUserAsync(new CreateUserRequest
-{
-    DisplayName = "Jane Doe",
-    Email = "jane@acme.com",
-    Password = "securePassword123"
-});
+var user = await adminService.CreateUserAsync(
+    new SqlOSCreateUserRequest(
+        DisplayName: "Jane Doe",
+        Email: "jane@acme.com",
+        Password: "securePassword123"));
 ```
 
 **Admin API**:
@@ -50,9 +49,9 @@ If your app uses organization onboarding, create an [Email Invitation](/docs/aut
 
 ## Email normalization
 
-Emails are normalized on creation (lowercased, trimmed). Use `SqlOSAdminService.NormalizeEmail()` for consistent lookups:
+SqlOS preserves the supplied address for display and stores a separate trimmed, uppercased lookup key. Use `SqlOSAdminService.NormalizeEmail()` when you need to query that normalized key directly:
 
 ```csharp
 var normalized = SqlOSAdminService.NormalizeEmail("Jane@Acme.COM");
-// → "jane@acme.com"
+// → "JANE@ACME.COM"
 ```

--- a/web/content/docs/docs-index.mdx
+++ b/web/content/docs/docs-index.mdx
@@ -1,0 +1,28 @@
+---
+title: "Build B2B SaaS auth on .NET"
+description: "Start with one application and hosted login. Add organizations, SSO, and SQL-backed authorization when your product needs them."
+order: 0
+---
+
+<Callout type="info" title="Current release">
+  These docs target **SqlOS 3.16.0**, **.NET 9**, **EF Core 9**, and **SQL Server**.
+</Callout>
+
+## Get useful proof first
+
+<CardGrid cols={2}>
+  <Card title="Run the Todo sample" description="See hosted login and authorized EF Core queries without changing an app." href="/docs/quickstarts/run-todo" />
+  <Card title="Add SqlOS to one app" description="Embed one hosted auth server with UseSingleApplication." href="/docs/quickstarts/add-to-app" />
+  <Card title="Protect an API" description="Validate a SqlOS bearer token for an exact audience." href="/docs/quickstarts/protect-api" />
+  <Card title="Authorize EF queries" description="Filter rows in SQL with the current FGA APIs." href="/docs/quickstarts/ef-authorization" />
+</CardGrid>
+
+SqlOS has a broad platform surface, but you do not need to adopt it all. The normal path is incremental:
+
+1. Run the sample or embed one application.
+2. Ship hosted login and organizations.
+3. Protect your application API.
+4. Add fine-grained authorization only to data that needs it.
+5. Add social login, SAML SSO, MFA, audit, calendar, or advanced clients as requirements appear.
+
+For a short map of the documentation, continue to [Getting Started](/docs/getting-started).

--- a/web/content/docs/fga/checking-a-permission.mdx
+++ b/web/content/docs/fga/checking-a-permission.mdx
@@ -26,7 +26,7 @@ Use this for:
 
 ## HasCapabilityAsync
 
-Check if a subject has a permission anywhere in the tree:
+Check if a subject has a permission on the configured root resource:
 
 ```csharp
 var canManageWorkspaces = await authService.HasCapabilityAsync(subjectId, "WORKSPACE_MANAGE");
@@ -34,8 +34,10 @@ var canManageWorkspaces = await authService.HasCapabilityAsync(subjectId, "WORKS
 
 Use this for:
 
-- **Global UI toggles** -- show/hide "Create workspace" button.
-- **Broad capability gates** -- "can this user create anything at all?"
+- **Global UI toggles** -- show a create action backed by a root-level grant.
+- **Platform gates** -- enforce capabilities intentionally assigned at the root.
+
+This method calls `CheckAccessAsync` for `RootResourceId`; it does not scan descendant resources to answer whether the subject has that permission somewhere.
 
 ## Access Tester (dashboard)
 

--- a/web/content/docs/fga/has-capability.mdx
+++ b/web/content/docs/fga/has-capability.mdx
@@ -5,7 +5,7 @@ order: 12
 section: fga
 ---
 
-`HasCapabilityAsync` checks whether a subject has a specific permission anywhere in the resource tree. Use it for broad capability gates where you don't have a specific resource ID.
+`HasCapabilityAsync` checks whether a subject has a specific permission on the configured FGA root resource. Use it only for capabilities you deliberately grant at root. It does not search every descendant for any matching grant.
 
 ## Usage
 
@@ -21,11 +21,12 @@ if (!canCreateChains)
 | Scenario | Method |
 | --- | --- |
 | "Can this user edit *this* chain?" | `CheckAccessAsync` with a resource ID |
-| "Can this user edit *any* chain?" | `HasCapabilityAsync` |
+| "Does this user have our global create-chain capability?" | `HasCapabilityAsync`, with a role granted on root |
+| "Can this user edit at least one chain somewhere?" | Query/filter the relevant chain resources; `HasCapabilityAsync` does not answer this |
 | "Show me all chains this user can see" | `GetAuthorizationFilterAsync` |
 
 `HasCapabilityAsync` is useful for:
 
-- **UI toggles** -- show/hide "Create" buttons based on broad permissions
-- **Top-level gates** -- "does this user have any write access at all?"
-- **Feature flags** -- enable/disable features based on capabilities
+- **UI toggles** -- show/hide globally granted "Create" actions
+- **Top-level gates** -- enforce a permission intentionally assigned on the root resource
+- **Global operator roles** -- distinguish a platform-level grant from tenant/resource grants

--- a/web/content/docs/fga/list-filter.mdx
+++ b/web/content/docs/fga/list-filter.mdx
@@ -44,9 +44,9 @@ var result = await executor.ExecuteAsync(
         CreatedAt = chain.CreatedAt
     });
 
-// result.Items     → authorized, searched, sorted, paged
+// result.Data       → authorized, searched, sorted, paged
 // result.NextCursor → cursor for next page
-// result.HasMore   → whether more results exist
+// result.HasNextPage → whether more results exist
 ```
 
 ## Full endpoint example

--- a/web/content/docs/fga/permissions.mdx
+++ b/web/content/docs/fga/permissions.mdx
@@ -52,7 +52,7 @@ var filter = await authService
 var access = await authService
     .CheckAccessAsync(subjectId, "CHAIN_EDIT", resourceId);
 
-// Capability check
+// Root-level capability check
 var canEdit = await authService
     .HasCapabilityAsync(subjectId, "CHAIN_EDIT");
 ```

--- a/web/content/docs/getting-started.mdx
+++ b/web/content/docs/getting-started.mdx
@@ -1,247 +1,109 @@
 ---
 title: "Getting Started"
-description: "Install SqlOS and run the Todo sample in five minutes."
+description: "Choose the shortest SqlOS path for your .NET application."
 order: 0
 ---
 
 <Banner
-  eyebrow="Quick start"
-  title="Install SqlOS, map the routes, and get auth plus FGA in one pass"
-  href="#install"
-  actionLabel="Jump to install"
+  eyebrow="Start here"
+  title="Get one useful SqlOS result before exploring the platform"
+  href="/docs/quickstarts/run-todo"
+  actionLabel="Run the sample"
 >
-  Add the package, register SqlOS on your EF Core context, and call `app.MapSqlOS()`. In a few minutes you will have a dashboard, OAuth endpoints, hosted login, and FGA admin screens on your app origin.
+  Start with a working Todo app or embed one hosted auth server with `UseSingleApplication`. Authentication, API protection, and EF authorization are separate milestones.
 </Banner>
 
-<Callout type="info" title="Prerequisites">
-  - **.NET 8+** (the repo samples target .NET 9)
-  - **SQL Server** with a connection string your EF `DbContext` can use
-  - For the Todo sample: run via Aspire AppHost (starts SQL Server in a container) or point at your own instance
+<Callout type="info" title="Supported stack">
+  - **SqlOS 3.16.0**
+  - **.NET 9** (`net9.0`)
+  - **EF Core 9**
+  - **SQL Server**
 </Callout>
 
-You'll learn how to install SqlOS, wire a minimal host, run the Todo sample, and pick the next doc for your use case.
+## Pick your first result
 
-<InlineToc items='[{"href":"#install","label":"Install"},{"href":"#minimal-host","label":"Minimal host"},{"href":"#set-up-your-dbcontext","label":"DbContext"},{"href":"#map-routes","label":"Map routes"},{"href":"#verify","label":"Verify it works"},{"href":"#run-the-right-sample","label":"Run a sample"},{"href":"#schema-management","label":"Schema"},{"href":"#choose-your-path","label":"Choose your path"}]' />
+<CardGrid cols={2}>
+  <Card title="I want to see it work" description="Run the Todo sample with SQL Server, hosted login, and FGA already wired." href="/docs/quickstarts/run-todo" />
+  <Card title="I want it in my app" description="Install the package and declare one application with UseSingleApplication." href="/docs/quickstarts/add-to-app" />
+</CardGrid>
 
-<Steps>
-  <Step title="Install the package">
-    Add `SqlOS` to your ASP.NET app.
-  </Step>
-  <Step title="Register on your DbContext">
-    Derive from `SqlOSDbContext<TContext>` and call `AddSqlOS` during host setup.
-  </Step>
-  <Step title="Declare protected resources">
-    Make protected entities implement `ISqlOSResourceEntity` so SqlOS can sync FGA resource rows during EF saves.
-  </Step>
-  <Step title="Map routes and verify">
-    Call `MapSqlOS()`, start the app, and open the admin dashboard.
-  </Step>
-</Steps>
+Running the sample is the fastest evaluation. Adding SqlOS to your application is the canonical integration path. Do not begin with SAML, headless auth, FGA modeling, CIMD, or DCR unless one of those is already a product requirement.
 
-## Install
+## The canonical one-app shape
 
-```bash
-dotnet add package SqlOS
-```
+For a typical .NET B2B SaaS product, start with:
 
-## Minimal host
+- one ASP.NET Core host;
+- one EF Core `DbContext` backed by SQL Server;
+- one first-party public PKCE application;
+- the hosted SqlOS login page;
+- the embedded dashboard;
+- no FGA-protected domain entities yet.
 
-A complete minimal `Program.cs` for an owned web app with hosted auth:
+The core registration is intentionally small:
 
 ```csharp
-using Microsoft.EntityFrameworkCore;
-using SqlOS;
-using SqlOS.Extensions;
-
-var builder = WebApplication.CreateBuilder(args);
-
-var connectionString = builder.Configuration.GetConnectionString("DefaultConnection")
-    ?? throw new InvalidOperationException("Connection string 'DefaultConnection' was not configured.");
-
 builder.AddSqlOS<AppDbContext>(
     db => db.UseSqlServer(connectionString),
     options =>
     {
-        options.AuthServer.Issuer = "https://localhost:5001/sqlos/auth";
-        options.AuthServer.PublicOrigin = "https://localhost:5001";
-        options.AuthServer.SeedOwnedWebApp(
-            "web",
-            "My Application",
-            "https://localhost:5001/auth/callback");
+        options.AuthServer.PublicOrigin = publicOrigin;
+        options.AuthServer.Issuer = $"{publicOrigin}/sqlos/auth";
+
+        options.UseSingleApplication("Acme", app =>
+        {
+            app.Origin = publicOrigin;
+            app.Audience = $"{publicOrigin}/api";
+        });
+
+        options.Dashboard.AuthMode = SqlOSDashboardAuthMode.Password;
+        options.Dashboard.Password = dashboardPassword;
     });
-
-var app = builder.Build();
-app.MapSqlOS();
-app.Run();
 ```
 
-## Set up your DbContext
+`UseSingleApplication` creates one first-party PKCE client, a callback at `{Origin}/auth/callback`, standard OpenID scopes, and matching AuthPage branding. Advanced public-client registration and resource indicators remain off until you opt in.
 
-Derive from `SqlOSDbContext<TContext>` to include the SqlOS auth server model, FGA model, and FGA TVF mapping. Add application entities in `OnApplicationModelCreating`:
-
-```csharp
-public sealed class AppDbContext(DbContextOptions<AppDbContext> options)
-    : SqlOSDbContext<AppDbContext>(options)
-{
-    public DbSet<Project> Projects => Set<Project>();
-
-    protected override void OnApplicationModelCreating(ModelBuilder modelBuilder)
-    {
-        modelBuilder.Entity<Project>();
-    }
-}
-```
-
-If you need full EF model control, the lower-level path is still available: implement `ISqlOSAuthServerDbContext` and `ISqlOSFgaDbContext`, expose `IsResourceAccessible`, and call `modelBuilder.UseSqlOS(...)` yourself.
-
-For app data that should participate in FGA, implement `ISqlOSResourceEntity` on the domain entity. `SqlOSDbContext<TContext>` creates, updates, and deletes the matching `SqlOSFgaResource` row when you call `SaveChanges` / `SaveChangesAsync`; role grants remain explicit.
-
-`appsettings.json` needs a SQL Server connection string and optional dashboard password:
-
-```json
-{
-  "ConnectionStrings": {
-    "DefaultConnection": "Server=localhost;Database=SqlOSApp;Trusted_Connection=True;TrustServerCertificate=True"
-  },
-  "SqlOS": {
-    "Dashboard": {
-      "AuthMode": "Password",
-      "Password": "change-me-in-production"
-    }
-  }
-}
-```
-
-## Map routes
-
-```csharp
-var app = builder.Build();
-app.MapSqlOS();
-```
-
-This gives you:
-
-| Path | What it does |
-| --- | --- |
-| `/sqlos` | Admin dashboard |
-| `/sqlos/auth/*` | OAuth 2.0 endpoints, hosted AuthPage, Email OTP, invitations |
-| `/sqlos/admin/auth` | Auth management UI |
-| `/sqlos/admin/fga` | FGA management UI |
-
-## Seed a client
-
-Register your frontend as an OAuth client so users can sign in immediately. Put this inside the `options => { ... }` callback passed to `builder.AddSqlOS`:
-
-```csharp
-options.AuthServer.SeedOwnedWebApp(
-    "my-app",
-    "My Application",
-    "http://localhost:3000/auth/callback");
-```
-
-## Protect an API
-
-For API routes that accept SqlOS access tokens, protect a route group with `RequireSqlOSAccessToken(...)`. It validates the token and populates `HttpContext.User`; your app still resolves the current subject explicitly at the route boundary.
-
-```csharp
-var api = app.MapGroup("/api")
-    .RequireSqlOSAccessToken(options =>
-    {
-        options.ExpectedAudience = "https://localhost:5001/api";
-        options.ResourceMetadataUrl = "https://localhost:5001/.well-known/oauth-protected-resource";
-    });
-
-api.MapGet("/me", (HttpContext http) =>
-{
-    var subjectId = http.User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value;
-    if (string.IsNullOrWhiteSpace(subjectId))
-        return Results.Unauthorized();
-
-    return Results.Ok(new
-    {
-        subjectId,
-        clientId = http.User.FindFirst("client_id")?.Value,
-        audience = http.User.FindFirst(JwtRegisteredClaimNames.Aud)?.Value
-    });
-});
-```
-
-## Verify it works
-
-1. Start your app and open **`/sqlos/admin/auth/`** (or `/sqlos` for the main dashboard).
-2. Sign in with the dashboard password from `appsettings.json` when `AuthMode` is `Password`.
-3. Confirm you can browse organizations, users, and clients.
-
-![SqlOS dashboard home](/docs/dashboard-home.png)
-
-## Run the right sample
-
-<Tabs defaultValue="todo">
-  <TabsList>
-    <TabsTrigger value="todo">Todo sample</TabsTrigger>
-    <TabsTrigger value="example">Example stack</TabsTrigger>
-  </TabsList>
-
-  <TabsContent value="todo">
-    Fastest path — hosted auth, simple FGA, and client onboarding:
-
-    ```bash
-    dotnet run --project examples/SqlOS.Todo.AppHost/SqlOS.Todo.AppHost.csproj
-    ```
-
-    The AppHost starts SQL Server and the Todo API. Open the URL shown in the console, then `/sqlos/admin/auth/`.
-
-    The Todo sample covers:
-
-    - hosted auth first
-    - per-user tenant + todo resource hierarchy
-    - SQL-backed FGA filtering
-    - optional headless, CIMD, and DCR flows
-  </TabsContent>
-
-  <TabsContent value="example">
-    Full stack with API, Next.js, Angular, and Expo:
-
-    ```bash
-    cd examples/SqlOS.Example.Web && npm install
-    cd ../..
-    dotnet run --project examples/SqlOS.Example.AppHost/SqlOS.Example.AppHost.csproj
-    ```
-
-    | URL | App |
-    | --- | --- |
-    | `http://localhost:5062/sqlos/` | Dashboard |
-    | `http://localhost:5062/swagger` | Swagger UI |
-    | `http://localhost:3010/` | Next.js app |
-    | `http://localhost:4200/` | Angular app |
-  </TabsContent>
-</Tabs>
-
-## Schema management
-
-<Callout type="warning" title="SqlOS owns its own tables">
-  SqlOS runs its own SQL scripts on host startup. Your EF migrations do **not** own those tables.
+<Callout type="warning" title="Configuration is explicit">
+  `AddSqlOS` does not automatically bind an `SqlOS` configuration section. Read values from `builder.Configuration`, your secret store, or environment variables and assign them in the options callback as shown above.
 </Callout>
 
-If you migrate **before** the app has started SqlOS once, call `SqlOSBootstrapper.InitializeAsync()` first. The example API shows that pattern when your tables reference SqlOS.
+## Add capabilities in this order
 
-## Choose your path
+<Steps>
+  <Step title="Run or embed SqlOS">
+    Complete [Run the Todo sample](/docs/quickstarts/run-todo) or [Add SqlOS to an app](/docs/quickstarts/add-to-app).
+  </Step>
+  <Step title="Protect application endpoints">
+    Validate bearer tokens for one exact audience with [Protect an API](/docs/quickstarts/protect-api).
+  </Step>
+  <Step title="Authorize application data">
+    When role checks stop being enough, use [EF Core authorization](/docs/quickstarts/ef-authorization).
+  </Step>
+  <Step title="Add production features as needed">
+    Continue into invitations, social login, SAML SSO, MFA, audit logs, or calendar integration.
+  </Step>
+</Steps>
+
+## What starts automatically
+
+When the host starts, SqlOS initializes and upgrades its own tables, signing keys, settings, and startup seeds. Your EF migrations continue to own your application tables. `app.MapSqlOS()` maps the OAuth, hosted login, and admin API routes; the dashboard middleware is registered by `AddSqlOS`.
+
+Default paths:
+
+| Path | Purpose |
+| --- | --- |
+| `/sqlos` | Embedded dashboard |
+| `/sqlos/auth` | OAuth server and hosted login |
+| `/sqlos/admin/auth` | Auth administration |
+| `/sqlos/admin/fga` | Authorization administration |
+
+## Continue by job
 
 <CardGrid cols={2}>
-  <Card title="Hosted auth UI" description="Branded login, dashboard, and OAuth flows out of the box." href="/docs/authserver/overview" />
-  <Card title="Headless / SPA" description="Build your own UI on the same OAuth and session APIs." href="/docs/authserver/headless-auth" />
-  <Card title="FGA basics" description="Model resources, grants, and EF Core query filters." href="/docs/fga/overview" />
-  <Card title="API reference" description="Endpoint and method reference when you need a specific contract." href="/docs/reference/api-reference" />
+  <Card title="Invite organization members" description="Create email-bound, one-time organization invitations." href="/docs/authserver/invitations" />
+  <Card title="Add social login" description="Configure Google, Microsoft, GitHub, Apple, or custom OIDC." href="/docs/guides/social-oidc" />
+  <Card title="Add enterprise SSO" description="Connect an organization to a SAML identity provider." href="/docs/guides/saml-sso" />
+  <Card title="Record audit events" description="Capture application and SqlOS governance events." href="/docs/guides/audit-logs" />
 </CardGrid>
 
-### Deep dives
-
-- [The Developer's Guide to Hierarchical RBAC](/blog/developers-guide-to-hierarchical-rbac)
-- [Headless auth patterns](/blog/headless-auth-server-mode)
-- [Guides](/docs/guides/index) — task-oriented walkthroughs
-
-## Next steps
-
-- [AuthServer Overview](/docs/authserver/overview) — identity, sessions, and auth flows
-- [Todo Sample](/docs/authserver/todo-sample) — hosted auth and FGA in one sample
-- [Configuration](/docs/guides/configuration) — service registration and dashboard setup
+For the complete task directory, see [Guides](/docs/guides/index). Use the reference section after you know which service or endpoint you need.

--- a/web/content/docs/guides/configuration.mdx
+++ b/web/content/docs/guides/configuration.mdx
@@ -12,14 +12,15 @@ section: guides
   actionLabel="Getting Started"
 />
 
-You'll learn the recommended SqlOS SDK setup: host registration, DbContext inheritance, entity-backed FGA resources, explicit role grants, and route mapping.
+You'll learn the recommended SqlOS host setup first, followed by optional FGA, token-validation, and client-onboarding configuration.
 
-## Wire SqlOS in four places
+## Wire SqlOS in three places
 
 1. **Host registration** — `builder.AddSqlOS<AppDbContext>(db => db.UseSqlServer(...), options => ...)`
 2. **EF model** — derive from `SqlOSDbContext<AppDbContext>` and put app entities in `OnApplicationModelCreating`
-3. **Protected resources** — make protected domain entities implement `ISqlOSResourceEntity`
-4. **Routes** — `app.MapSqlOS()` after `Build()`
+3. **Routes** — `app.MapSqlOS()` after `Build()`
+
+Only add `ISqlOSResourceEntity`, FGA seeds, and grants when you are ready to authorize application data.
 
 ## Minimal owned-app setup
 
@@ -30,19 +31,15 @@ builder.AddSqlOS<AppDbContext>(
     {
         options.AuthServer.Issuer = "https://app.example.com/sqlos/auth";
         options.AuthServer.PublicOrigin = "https://app.example.com";
-
-        options.AuthServer.SeedAuthPage(page =>
+        options.UseSingleApplication("Main Web App", app =>
         {
-            page.PageTitle = "Sign in";
-            page.PageSubtitle = "Secure your owned app first.";
+            app.Origin = "https://app.example.com";
+            app.Audience = "https://app.example.com/api";
         });
-
-        options.AuthServer.SeedOwnedWebApp(
-            "web",
-            "Main Web App",
-            "https://app.example.com/auth/callback");
     });
 ```
+
+Single-application mode creates one first-party PKCE client and keeps CIMD, DCR, resource indicators, and multi-application policy out of the starting path.
 
 ## FGA seeding
 
@@ -184,16 +181,16 @@ options.AuthServer.ConfigureEmailOtp(email =>
 
 ## Dashboard password
 
-```json
-{
-  "SqlOS": {
-    "Dashboard": {
-      "AuthMode": "Password",
-      "Password": "your-strong-password"
-    }
-  }
-}
+Read the secret from your normal ASP.NET Core configuration providers and assign it in the `AddSqlOS` callback:
+
+```csharp
+options.Dashboard.AuthMode = SqlOSDashboardAuthMode.Password;
+options.Dashboard.Password =
+    builder.Configuration["SqlOS:Dashboard:Password"]
+    ?? throw new InvalidOperationException("SqlOS dashboard password is required.");
 ```
+
+For local development, `dotnet user-secrets set "SqlOS:Dashboard:Password" "..."` keeps it out of source control. In production, use your platform's secret provider. SqlOS does not automatically bind a `SqlOS` configuration section.
 
 Treat `/sqlos` and `/sqlos/admin` as administrative endpoints — restrict network access in production.
 

--- a/web/content/docs/guides/index.mdx
+++ b/web/content/docs/guides/index.mdx
@@ -1,43 +1,49 @@
 ---
 title: "Guides"
-description: "Task-oriented walkthroughs for auth, SSO, FGA, and operations."
+description: "Production tasks to complete after the SqlOS quickstarts."
 order: 0
 section: guides
 ---
 
 <Banner
   eyebrow="Guides"
-  title="Step-by-step tasks for shipping SqlOS in production"
-  href="../getting-started"
-  actionLabel="Start with Getting Started"
+  title="Add the next capability your product needs"
+  href="/docs/getting-started"
+  actionLabel="Getting Started"
 >
-  Each guide has a clear goal, prerequisites, and next steps. Use these before diving into the full API reference.
+  Quickstarts establish a working application. Guides cover focused authentication, authorization, and operations tasks without requiring you to adopt the rest of the platform.
 </Banner>
 
-You'll learn which guide to pick for your next integration task.
+## Complete a quickstart first
+
+<CardGrid cols={2}>
+  <Card title="Run the Todo sample" description="Fastest runnable proof." href="/docs/quickstarts/run-todo" />
+  <Card title="Add SqlOS to one app" description="Canonical UseSingleApplication setup." href="/docs/quickstarts/add-to-app" />
+  <Card title="Protect an API" description="Audience-aware bearer validation." href="/docs/quickstarts/protect-api" />
+  <Card title="Authorize EF queries" description="SQL-backed row filtering." href="/docs/quickstarts/ef-authorization" />
+</CardGrid>
+
+## Authentication and identity
 
 <CardGrid cols={2}>
   <Card title="Password login" description="Add hosted password auth to an existing ASP.NET app." href="/docs/guides/password-login" />
-  <Card title="Authenticator MFA" description="Enable TOTP, recovery codes, and tenant-required MFA." href="/docs/guides/mfa-totp" />
   <Card title="Social sign-in" description="Configure Google, Microsoft, GitHub, Apple, or custom login." href="/docs/guides/social-oidc" />
-  <Card title="GitHub sign-in" description="Create the GitHub OAuth App and enable the SqlOS provider." href="/docs/guides/github-oidc" />
-  <Card title="SAML SSO for an org" description="Enterprise SSO with Entra or any SAML IdP." href="/docs/guides/saml-sso" />
-  <Card title="Model FGA" description="Design a multi-tenant resource hierarchy." href="/docs/guides/model-fga" />
-  <Card title="Filter EF queries" description="Authorization as a LINQ WHERE clause." href="/docs/guides/ef-query-filters" />
-  <Card title="Audit logs" description="Record application events and review them in the dashboard." href="/docs/guides/audit-logs" />
-  <Card title="Standalone identity server" description="Run one SqlOS auth host for several app surfaces." href="/docs/guides/standalone-identity-server" />
-  <Card title="Configuration" description="Service registration, dashboard, and client modes." href="/docs/guides/configuration" />
-  <Card title="Testing" description="Run unit, integration, and docs checks locally." href="/docs/guides/testing" />
-  <Card title="Troubleshooting" description="Common setup failures and how to fix them." href="/docs/guides/troubleshooting" />
+  <Card title="GitHub sign-in" description="Create the GitHub OAuth App and enable the provider." href="/docs/guides/github-oidc" />
+  <Card title="Authenticator MFA" description="Enable TOTP, recovery codes, and tenant-required MFA." href="/docs/guides/mfa-totp" />
+  <Card title="SAML SSO for an organization" description="Connect Entra or another SAML identity provider." href="/docs/guides/saml-sso" />
+  <Card title="Standalone identity server" description="Run one SqlOS auth host for several application surfaces." href="/docs/guides/standalone-identity-server" />
 </CardGrid>
 
-## Deep dives (blog)
+## Authorization and operations
 
-- [The Developer's Guide to Hierarchical RBAC](/blog/developers-guide-to-hierarchical-rbac)
-- [Headless auth with SqlOS](/blog/headless-auth-server-mode)
-- [MCP and authorization servers](/blog/what-an-authorization-server-needs-for-oauth-powered-mcp-servers)
-- [Single-Application Mode: WorkOS-Style Defaults Without Giving Up SqlOS](/blog/single-application-mode-workos-style-setup)
-- [Application Assignments: The Missing Layer Between Clients and Audiences](/blog/application-assignments-auth-server-control-plane)
-- [MFA Policy: The Auth Server Has to Own the Second Step](/blog/mfa-totp-policy-auth-server)
-- [Audit Logs for Multi-Tenant Products](/blog/audit-logs-for-multi-tenant-products)
-- [Standalone SqlOS Identity Server for Multiple Apps](/blog/standalone-sqlos-identity-server-multi-app)
+<CardGrid cols={2}>
+  <Card title="Model FGA" description="Design a multi-tenant resource hierarchy." href="/docs/guides/model-fga" />
+  <Card title="Filter EF queries" description="Compose authorization into a LINQ WHERE clause." href="/docs/guides/ef-query-filters" />
+  <Card title="Audit logs" description="Record application events and review them in the dashboard." href="/docs/guides/audit-logs" />
+  <Card title="Calendar integration" description="Connect Google Calendar or Microsoft 365." href="/docs/guides/calendar-integration" />
+  <Card title="Configuration" description="Review service registration, dashboard, and client modes." href="/docs/guides/configuration" />
+  <Card title="Testing" description="Run unit, integration, and docs checks locally." href="/docs/guides/testing" />
+  <Card title="Troubleshooting" description="Diagnose common setup, OAuth, SAML, and SQL issues." href="/docs/guides/troubleshooting" />
+</CardGrid>
+
+Use [SDK Reference](/docs/reference/sdk-reference) and [HTTP API Reference](/docs/reference/api-reference) for exact contracts after selecting a task.

--- a/web/content/docs/guides/troubleshooting.mdx
+++ b/web/content/docs/guides/troubleshooting.mdx
@@ -26,7 +26,7 @@ You'll learn how to diagnose connection, OAuth callback, SAML, and migration pro
 
 **Symptom:** EF or raw SQL errors referencing `SqlOS_*` tables.
 
-- Ensure `app.MapSqlOS()` runs and the app has started at least once.
+- Ensure the host has started with `AddSqlOS<TContext>(...)` registered. Schema bootstrap runs from the SqlOS hosted service during startup; `MapSqlOS()` maps HTTP routes but does not create the schema.
 - If your migrations run first, call `SqlOSBootstrapper.InitializeAsync()` before migrating (see [Configuration](/docs/guides/configuration#schema-ownership)).
 
 ## OAuth redirect / callback mismatch
@@ -40,7 +40,7 @@ You'll learn how to diagnose connection, OAuth callback, SAML, and migration pro
 
 **Symptom:** Cannot access `/sqlos/admin/auth/`.
 
-- Check `SqlOS:Dashboard:AuthMode` and `Password` in `appsettings.json`.
+- Check the `options.Dashboard.AuthMode` and `options.Dashboard.Password` values assigned in your `AddSqlOS` callback. SqlOS does not bind the `SqlOS` configuration section automatically.
 - After repeated failures, dashboard throttling may return `429` — wait for the lockout window.
 
 ## SAML

--- a/web/content/docs/quickstarts/add-to-app.mdx
+++ b/web/content/docs/quickstarts/add-to-app.mdx
@@ -1,0 +1,178 @@
+---
+title: "Add SqlOS to one app"
+description: "Embed hosted authentication in an ASP.NET Core app with UseSingleApplication."
+order: 1
+section: quickstarts
+---
+
+<Banner
+  eyebrow="Quickstart"
+  title="Embed one hosted auth server"
+  href="#complete-program"
+  actionLabel="View the code"
+>
+  Install SqlOS 3.16.0, register one SQL Server `DbContext`, declare one application, and map the routes. FGA modeling and advanced client registration can wait.
+</Banner>
+
+## Goal
+
+Start an ASP.NET Core application with:
+
+- SqlOS tables in your existing SQL Server database;
+- one first-party PKCE application;
+- OAuth metadata and hosted login routes;
+- a password-protected embedded dashboard.
+
+## Prerequisites
+
+- .NET 9 SDK;
+- an ASP.NET Core project targeting `net9.0`;
+- EF Core 9;
+- an existing SQL Server database and a login allowed to create tables, indexes, and functions.
+
+SqlOS 3.16.0 targets `net9.0`; it is not compatible with a `net8.0` host.
+
+## Install
+
+```bash
+dotnet add package SqlOS --version 3.16.0
+```
+
+For a new project, store local values with user secrets:
+
+```bash
+dotnet user-secrets init
+dotnet user-secrets set "ConnectionStrings:DefaultConnection" "Server=localhost,1433;Database=Acme;User Id=sa;Password=<your-password>;Encrypt=True;TrustServerCertificate=True"
+dotnet user-secrets set "SqlOS:Dashboard:Password" "<a-long-random-password>"
+```
+
+The database must already exist. SqlOS creates and upgrades its own tables inside it.
+
+## Complete program
+
+Replace `Program.cs` with:
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using SqlOS;
+using SqlOS.Configuration;
+using SqlOS.Extensions;
+
+var builder = WebApplication.CreateBuilder(args);
+
+var connectionString = builder.Configuration.GetConnectionString("DefaultConnection")
+    ?? throw new InvalidOperationException(
+        "Connection string 'DefaultConnection' was not configured.");
+
+const string publicOrigin = "http://localhost:5050";
+var dashboardPassword = builder.Configuration["SqlOS:Dashboard:Password"]
+    ?? throw new InvalidOperationException(
+        "Configure SqlOS:Dashboard:Password with user secrets or your secret store.");
+
+builder.AddSqlOS<AppDbContext>(
+    db => db.UseSqlServer(connectionString),
+    options =>
+    {
+        options.AuthServer.PublicOrigin = publicOrigin;
+        options.AuthServer.Issuer = $"{publicOrigin}/sqlos/auth";
+
+        options.UseSingleApplication("Acme", app =>
+        {
+            app.Origin = publicOrigin;
+            app.ClientId = "acme-web";
+            app.Audience = $"{publicOrigin}/api";
+            app.RedirectPath = "/auth/callback";
+        });
+
+        options.Dashboard.AuthMode = SqlOSDashboardAuthMode.Password;
+        options.Dashboard.Password = dashboardPassword;
+    });
+
+var app = builder.Build();
+
+app.MapSqlOS();
+app.MapGet("/", () => Results.Ok(new { sqlos = "ready" }));
+
+app.Run();
+
+public sealed class AppDbContext(DbContextOptions<AppDbContext> options)
+    : SqlOSDbContext<AppDbContext>(options)
+{
+}
+```
+
+`SqlOSDbContext<TContext>` registers the AuthServer, calendar, email, and FGA EF models. `UseSingleApplication` creates the application seed and AuthPage branding without exposing client-registration terminology in the common path.
+
+<Callout type="warning" title="SqlOS options are not automatically bound">
+  The example explicitly reads the dashboard password from `builder.Configuration` and assigns it to `options.Dashboard.Password`. Merely adding `SqlOS:Dashboard:Password` to configuration does not configure SqlOS unless your callback reads and assigns it.
+</Callout>
+
+## Run
+
+Use the same origin declared in the code:
+
+```bash
+dotnet run --urls http://localhost:5050
+```
+
+On the first start, SqlOS creates or upgrades its schema, creates a signing key, writes default settings, and reconciles the `acme-web` application seed.
+
+## Verify
+
+Check the application:
+
+```bash
+curl http://localhost:5050/
+```
+
+Check OAuth metadata:
+
+```bash
+curl http://localhost:5050/sqlos/auth/.well-known/oauth-authorization-server
+```
+
+Open `http://localhost:5050/sqlos`, enter the configured dashboard password, then confirm:
+
+- the Auth dashboard opens;
+- the Applications or Clients view contains `acme-web`;
+- the redirect URI is `http://localhost:5050/auth/callback`;
+- the audience is `http://localhost:5050/api`.
+
+This host now owns the auth server surfaces. Your browser frontend still needs a standard authorization-code-with-PKCE callback. Run the Todo sample if you want that complete browser exchange before implementing your own frontend.
+
+## Common failures
+
+### `Invalid SqlOS configuration` at startup
+
+`PublicOrigin` must be an absolute origin without a path, query, or fragment. `Issuer` must use the configured auth base path. For the defaults, it is exactly `{PublicOrigin}/sqlos/auth`.
+
+### SQL reports that the database does not exist
+
+SqlOS initializes tables, not the SQL Server database itself. Create the database and grant the application login the required DDL access before starting the host.
+
+### Dashboard password mode has no password
+
+Confirm the configuration key is available to this process and that the options callback assigns it. User secrets apply only to the project in which they were initialized.
+
+### Redirect mismatch
+
+The requested callback must exactly equal the seeded URI, including scheme, host, port, and path. Change `publicOrigin` and `RedirectPath` together.
+
+### Existing application uses the same client ID
+
+Single-application mode will not overwrite an unrelated manual client. Pick a different `ClientId` or remove the conflicting development record deliberately.
+
+## Production notes
+
+- Replace the local origin with the externally reachable HTTPS origin.
+- Read the connection string and dashboard password from your deployment secret store.
+- Restrict `/sqlos` and `/sqlos/admin` at the network or identity-aware proxy layer; the built-in password is a baseline, not the only control for a public admin endpoint.
+- Persist and share ASP.NET Core Data Protection keys across replicas before enabling features that protect durable secrets with Data Protection.
+- Run SqlOS bootstrap before application migrations if your application schema has foreign keys to SqlOS-owned tables.
+
+## Next steps
+
+- [Protect an API](/docs/quickstarts/protect-api)
+- [Authorize EF Core queries](/docs/quickstarts/ef-authorization)
+- [Invite organization members](/docs/authserver/invitations)
+- [Single-application configuration](/docs/authserver/single-application)

--- a/web/content/docs/quickstarts/ef-authorization.mdx
+++ b/web/content/docs/quickstarts/ef-authorization.mdx
@@ -1,0 +1,276 @@
+---
+title: "Authorize EF Core queries"
+description: "Model one protected entity and filter accessible rows in SQL."
+order: 3
+section: quickstarts
+---
+
+<Banner
+  eyebrow="Quickstart"
+  title="Keep row authorization inside the EF query"
+  href="#complete-program"
+  actionLabel="View the code"
+>
+  Implement `ISqlOSResourceEntity`, seed one permission and role, grant that role at creation time, and use `GetAuthorizationFilterAsync` on list queries.
+</Banner>
+
+## Goal
+
+Create projects through an audience-protected API and return only projects the signed-in user may read. The application row and its SqlOS resource are saved through the same `DbContext`.
+
+## Prerequisites
+
+- SqlOS 3.16.0;
+- .NET 9, EF Core 9, and SQL Server;
+- a completed [Protect an API](/docs/quickstarts/protect-api) flow;
+- a valid access token whose `aud` is `http://localhost:5050/api`.
+
+## Complete program
+
+The following `Program.cs` is a complete one-app host with one protected `Project` entity:
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using SqlOS;
+using SqlOS.AuthServer.Extensions;
+using SqlOS.Configuration;
+using SqlOS.Extensions;
+using SqlOS.Fga.Interfaces;
+
+var builder = WebApplication.CreateBuilder(args);
+
+var connectionString = builder.Configuration.GetConnectionString("DefaultConnection")
+    ?? throw new InvalidOperationException(
+        "Connection string 'DefaultConnection' was not configured.");
+
+const string publicOrigin = "http://localhost:5050";
+const string apiAudience = $"{publicOrigin}/api";
+const string projectRead = "project.read";
+const string projectOwner = "project_owner";
+
+var dashboardPassword = builder.Configuration["SqlOS:Dashboard:Password"]
+    ?? throw new InvalidOperationException(
+        "Configure SqlOS:Dashboard:Password with user secrets or your secret store.");
+
+builder.AddSqlOS<AppDbContext>(
+    db => db.UseSqlServer(connectionString),
+    options =>
+    {
+        options.AuthServer.PublicOrigin = publicOrigin;
+        options.AuthServer.Issuer = $"{publicOrigin}/sqlos/auth";
+
+        options.UseSingleApplication("Acme", app =>
+        {
+            app.Origin = publicOrigin;
+            app.ClientId = "acme-web";
+            app.Audience = apiAudience;
+        });
+
+        options.Dashboard.AuthMode = SqlOSDashboardAuthMode.Password;
+        options.Dashboard.Password = dashboardPassword;
+
+        options.Fga.Seed(seed =>
+        {
+            seed.ResourceType("project", "Project");
+            seed.Permission(projectRead, "Read project", "project");
+            seed.Role(projectOwner, "Project owner").Can(projectRead);
+        });
+    });
+
+var app = builder.Build();
+
+app.MapSqlOS();
+
+var api = app.MapGroup("/api")
+    .RequireSqlOSAccessToken(apiAudience);
+
+api.MapPost("/projects", async (
+    CreateProjectRequest request,
+    HttpContext http,
+    AppDbContext db,
+    CancellationToken cancellationToken) =>
+{
+    var token = http.GetSqlOSValidatedToken();
+    if (string.IsNullOrWhiteSpace(token?.UserId))
+    {
+        return Results.Unauthorized();
+    }
+
+    if (string.IsNullOrWhiteSpace(request.Name))
+    {
+        return Results.BadRequest(new { error = "name is required" });
+    }
+
+    var projectId = Guid.NewGuid();
+    var project = new Project
+    {
+        Id = projectId,
+        ResourceId = $"project::{projectId:D}",
+        Name = request.Name.Trim(),
+        CreatedAt = DateTime.UtcNow
+    };
+
+    db.Projects.Add(project);
+
+    await db.ProvisionUserSubjectAsync(
+        token.UserId,
+        displayName: token.UserId,
+        organizationId: token.OrganizationId,
+        cancellationToken: cancellationToken);
+
+    await db.GrantRoleAsync(
+        token.UserId,
+        project,
+        projectOwner,
+        cancellationToken);
+
+    await db.SaveChangesAsync(cancellationToken);
+
+    return Results.Created($"/api/projects/{project.Id}", new
+    {
+        project.Id,
+        project.ResourceId,
+        project.Name,
+        project.CreatedAt
+    });
+});
+
+api.MapGet("/projects", async (
+    HttpContext http,
+    AppDbContext db,
+    ISqlOSFgaAuthService authorization,
+    CancellationToken cancellationToken) =>
+{
+    var subjectId = http.GetSqlOSValidatedToken()?.UserId;
+    if (string.IsNullOrWhiteSpace(subjectId))
+    {
+        return Results.Unauthorized();
+    }
+
+    var filter = await authorization.GetAuthorizationFilterAsync<Project>(
+        subjectId,
+        projectRead);
+
+    var projects = await db.Projects
+        .AsNoTracking()
+        .Where(filter)
+        .OrderBy(project => project.Name)
+        .Select(project => new
+        {
+            project.Id,
+            project.ResourceId,
+            project.Name,
+            project.CreatedAt
+        })
+        .ToListAsync(cancellationToken);
+
+    return Results.Ok(projects);
+});
+
+app.Run();
+
+public sealed class AppDbContext(DbContextOptions<AppDbContext> options)
+    : SqlOSDbContext<AppDbContext>(options)
+{
+    public DbSet<Project> Projects => Set<Project>();
+
+    protected override void OnApplicationModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Project>(entity =>
+        {
+            entity.ToTable("Projects");
+            entity.HasKey(project => project.Id);
+            entity.Property(project => project.ResourceId).HasMaxLength(200);
+            entity.HasIndex(project => project.ResourceId).IsUnique();
+        });
+    }
+}
+
+public sealed class Project : ISqlOSResourceEntity
+{
+    public Guid Id { get; set; }
+    public string ResourceId { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; }
+
+    public string ResourceTypeId => "project";
+    public string ResourceName => Name;
+    public string? ParentResourceId => null;
+    public string? ResourceDescription => null;
+    public bool ResourceIsActive => true;
+}
+
+public sealed record CreateProjectRequest(string Name);
+```
+
+Create the `Projects` table with your normal EF migration workflow. SqlOS owns its own tables; your application migration owns `Projects`.
+
+## How the write works
+
+1. The API takes the subject from the validated access token.
+2. `ProvisionUserSubjectAsync` ensures that subject exists in FGA.
+3. The new `Project` describes its resource through `ISqlOSResourceEntity`.
+4. `GrantRoleAsync` grants `project_owner` to the pending resource.
+5. `SqlOSDbContext.SaveChangesAsync` synchronizes the backing resource before EF commits.
+
+The grant remains explicit. Implementing `ISqlOSResourceEntity` does not grant access by itself.
+
+## Verify
+
+Start the host and use an access token from the `acme-web` authorization flow:
+
+```bash
+curl -X POST http://localhost:5050/api/projects \
+  -H "Authorization: Bearer <access-token>" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Launch plan"}'
+```
+
+List accessible rows:
+
+```bash
+curl http://localhost:5050/api/projects \
+  -H "Authorization: Bearer <access-token>"
+```
+
+Open `/sqlos/admin/fga/resources` and confirm the project resource exists. Open Grants and confirm the signed-in subject has `project_owner` on that resource.
+
+Sign in as another user and call the list endpoint. It should not return the first user's project until you explicitly grant that subject an appropriate role.
+
+## Common failures
+
+### `FGA resource type 'project' was not found`
+
+Keep the `options.Fga.Seed(...)` block and restart the host so startup seeding creates the resource type, permission, role, and role-permission link.
+
+### `FGA subject ... was not found`
+
+Provision the subject before calling `GrantRoleAsync`. Grants do not create subjects implicitly.
+
+### The application row exists but no resource appears
+
+The context must derive from `SqlOSDbContext<TContext>`, and the tracked entity must implement `ISqlOSResourceEntity`. Saving through another context bypasses resource synchronization.
+
+### The list is empty
+
+Confirm the subject ID comes from the validated token, the role grant targets the entity's exact `ResourceId`, and the permission key matches the seeded key exactly.
+
+### EF cannot translate the filter
+
+Keep `ResourceId` as a mapped string property. Call `Where(filter)` while the query is still `IQueryable`; do not compile the expression or switch to in-memory enumeration first.
+
+## Production notes
+
+- Never accept the acting subject ID from the request body or query string.
+- Use stable, unique resource IDs and index the mapped `ResourceId` property.
+- Model tenant or organization roots when roles should inherit to many child rows.
+- Check write permissions before modifying existing resources; list filtering only protects reads.
+- Keep resource creation, subject provisioning, and the initial grant in one application transaction where possible.
+- Add integration tests proving that ungranted subjects cannot read or mutate protected rows.
+
+## Next steps
+
+- [Model an FGA hierarchy](/docs/guides/model-fga)
+- [Filter EF Core queries](/docs/guides/ef-query-filters)
+- [Check a permission](/docs/fga/checking-a-permission)
+- [Create protected resources](/docs/fga/creating-resources)

--- a/web/content/docs/quickstarts/protect-api.mdx
+++ b/web/content/docs/quickstarts/protect-api.mdx
@@ -1,0 +1,172 @@
+---
+title: "Protect an API"
+description: "Validate SqlOS access tokens for an exact API audience."
+order: 2
+section: quickstarts
+---
+
+<Banner
+  eyebrow="Quickstart"
+  title="Reject the wrong token at the route boundary"
+  href="#complete-program"
+  actionLabel="View the code"
+>
+  Apply `RequireSqlOSAccessToken` to a route group. SqlOS validates signature, lifetime, session state, revocation, and audience before your endpoint runs.
+</Banner>
+
+## Goal
+
+Add `/api/me` to a one-application SqlOS host. Requests without a bearer token receive `401`; a valid SqlOS token minted for the configured API audience exposes its user, organization, client, and audience.
+
+## Prerequisites
+
+- SqlOS 3.16.0;
+- .NET 9 and EF Core 9;
+- the [Add SqlOS to one app](/docs/quickstarts/add-to-app) setup;
+- a browser or other PKCE client that completes the SqlOS authorization-code flow.
+
+## Complete program
+
+This is the complete `Program.cs` from the one-app quickstart with an audience-protected route group added:
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using SqlOS;
+using SqlOS.AuthServer.Extensions;
+using SqlOS.Configuration;
+using SqlOS.Extensions;
+
+var builder = WebApplication.CreateBuilder(args);
+
+var connectionString = builder.Configuration.GetConnectionString("DefaultConnection")
+    ?? throw new InvalidOperationException(
+        "Connection string 'DefaultConnection' was not configured.");
+
+const string publicOrigin = "http://localhost:5050";
+const string apiAudience = $"{publicOrigin}/api";
+var dashboardPassword = builder.Configuration["SqlOS:Dashboard:Password"]
+    ?? throw new InvalidOperationException(
+        "Configure SqlOS:Dashboard:Password with user secrets or your secret store.");
+
+builder.AddSqlOS<AppDbContext>(
+    db => db.UseSqlServer(connectionString),
+    options =>
+    {
+        options.AuthServer.PublicOrigin = publicOrigin;
+        options.AuthServer.Issuer = $"{publicOrigin}/sqlos/auth";
+
+        options.UseSingleApplication("Acme", app =>
+        {
+            app.Origin = publicOrigin;
+            app.ClientId = "acme-web";
+            app.Audience = apiAudience;
+        });
+
+        options.Dashboard.AuthMode = SqlOSDashboardAuthMode.Password;
+        options.Dashboard.Password = dashboardPassword;
+    });
+
+var app = builder.Build();
+
+app.MapSqlOS();
+
+var api = app.MapGroup("/api")
+    .RequireSqlOSAccessToken(options =>
+    {
+        options.ExpectedAudience = apiAudience;
+        options.Realm = "Acme API";
+    });
+
+api.MapGet("/me", (HttpContext http) =>
+{
+    var token = http.GetSqlOSValidatedToken();
+    if (token is null)
+    {
+        return Results.Unauthorized();
+    }
+
+    return Results.Ok(new
+    {
+        token.UserId,
+        token.OrganizationId,
+        token.ClientId,
+        token.Audience
+    });
+});
+
+app.Run();
+
+public sealed class AppDbContext(DbContextOptions<AppDbContext> options)
+    : SqlOSDbContext<AppDbContext>(options)
+{
+}
+```
+
+`RequireSqlOSAccessToken` is an endpoint filter on the route group. After validation it sets `HttpContext.User` and stores the typed `SqlOSValidatedToken`, available through `GetSqlOSValidatedToken()`.
+
+## Verify
+
+Start the application:
+
+```bash
+dotnet run --urls http://localhost:5050
+```
+
+Without a token:
+
+```bash
+curl -i http://localhost:5050/api/me
+```
+
+Expected result: `401 Unauthorized` with a `WWW-Authenticate: Bearer` challenge.
+
+After completing your `acme-web` authorization-code flow, call the same endpoint with the returned access token:
+
+```bash
+curl http://localhost:5050/api/me \
+  -H "Authorization: Bearer <access-token>"
+```
+
+Expected result:
+
+```json
+{
+  "userId": "usr_...",
+  "organizationId": "org_...",
+  "clientId": "acme-web",
+  "audience": "http://localhost:5050/api"
+}
+```
+
+## Common failures
+
+### Every request returns `401`
+
+Compare the token's `aud` claim with `ExpectedAudience`. Audience matching is exact. A token minted for another API is intentionally rejected even when the issuer and user are valid.
+
+### The bearer token is valid but revoked
+
+Validation also checks the persisted session and client state. Signing out all sessions, revoking the session, disabling the client, or removing application access can invalidate an otherwise well-formed JWT.
+
+### `GetSqlOSValidatedToken()` is null
+
+Confirm the endpoint belongs to the route group returned by `MapGroup(...).RequireSqlOSAccessToken(...)` and import `SqlOS.AuthServer.Extensions`.
+
+### The browser cannot call the API
+
+Bearer validation does not configure CORS. Add an explicit CORS policy for trusted frontend origins; do not use permissive credentials and origins in production.
+
+## Production notes
+
+- Use an HTTPS audience that identifies the deployed resource server.
+- Keep audiences distinct when separate APIs should not accept each other's tokens.
+- Resolve the acting subject from the validated token or `HttpContext.User`; never trust a subject ID supplied in a request body.
+- For MCP or third-party resource discovery, publish protected-resource metadata and set `ResourceMetadataUrl` in the validation options.
+- Use authorization checks in addition to token validation. A valid token identifies the caller; it does not grant access to every application row.
+
+## Next steps
+
+- [Authorize EF Core queries](/docs/quickstarts/ef-authorization)
+- [Token validation guide](/docs/authserver/token-validation)
+- [Sessions and tokens](/docs/authserver/sessions-and-tokens)
+- [Resource indicators and audiences](/docs/authserver/mcp-resource-indicators-and-audience)

--- a/web/content/docs/quickstarts/run-example-stack.mdx
+++ b/web/content/docs/quickstarts/run-example-stack.mdx
@@ -1,0 +1,130 @@
+---
+title: "Run the full example stack"
+description: "Explore the broad SqlOS surface across .NET, Next.js, Angular, and the Todo sample."
+order: 10
+section: quickstarts
+---
+
+<Banner
+  eyebrow="Optional deep dive"
+  title="Use the broad example after the first quickstart"
+  href="/docs/quickstarts/run-todo"
+  actionLabel="Start with Todo"
+>
+  The full Aspire stack is a feature explorer, not the recommended first integration. It runs the .NET API, Next.js and Angular clients, the Todo sample, and two SQL Server databases together.
+</Banner>
+
+## Goal
+
+Compare hosted and headless auth, organization workflows, SSO, sessions, audit logs, and FGA across several clients without assembling the stack yourself.
+
+## Prerequisites
+
+- SqlOS repository checked out at version 3.16.0;
+- .NET 9 SDK;
+- Node.js and npm;
+- Docker running with enough memory for SQL Server;
+- ports `1434`, `3010`, `4200`, `5062`, and `5080` available.
+
+If you only want to see the normal hosted-login path, use [Run the Todo sample](/docs/quickstarts/run-todo). The full stack intentionally contains advanced surfaces.
+
+## Install frontend dependencies
+
+From the repository root:
+
+```bash
+npm install --prefix examples/SqlOS.Example.Web
+npm install --prefix examples/SqlOS.Example.AngularWeb
+```
+
+## Run
+
+```bash
+dotnet run --project examples/SqlOS.Example.AppHost/SqlOS.Example.AppHost.csproj
+```
+
+Wait for SQL Server, `api`, `todo-api`, `web`, and `angular-web` to report healthy.
+
+## Open the stack
+
+| URL | Application |
+| --- | --- |
+| `http://localhost:3010` | Next.js example client |
+| `http://localhost:4200` | Angular example client |
+| `http://localhost:5062/swagger` | Example .NET API |
+| `http://localhost:5062/sqlos` | Example-stack SqlOS dashboard |
+| `http://localhost:5080` | Narrow Todo sample |
+
+The AppHost creates separate `sqlos-example` and `sqlos-todo` databases in one persistent local SQL Server container. The examples do not share identity or authorization rows accidentally.
+
+## Pick one flow
+
+Avoid testing everything at once. Choose the flow that answers your current question:
+
+### Hosted authentication
+
+1. Open the Next.js client.
+2. Start hosted sign-up.
+3. Create a password user and organization.
+4. Complete the PKCE callback.
+5. Inspect the session and claims returned to the client.
+
+### Headless authentication
+
+Use the headless route in the Next.js example to compare app-owned screens with the same SqlOS request, credential, organization-selection, and token state machine.
+
+### Organization administration
+
+Open the dashboard, then inspect users, organizations, memberships, invitations, sessions, applications, and audit events. Create an invitation if email delivery is configured, or copy its acceptance link for a local flow.
+
+### Fine-grained authorization
+
+Use the Retail/workspace surfaces to create protected data, then inspect resources, grants, roles, permissions, and the Access Tester in the FGA dashboard.
+
+### Enterprise identity
+
+Configure social login or a SAML connection only when you have provider credentials. The stack runs without them. The delegated SSO example at `http://localhost:3010/retail/sso` demonstrates how a host application can create a customer-scoped setup session.
+
+## Optional provider secrets
+
+Provider-backed features are disabled until configured. Store local values on the AppHost project rather than committing them:
+
+```bash
+dotnet user-secrets --project examples/SqlOS.Example.AppHost set \
+  "SqlOS:Oidc:Microsoft:ClientId" "<client-id>"
+
+dotnet user-secrets --project examples/SqlOS.Example.AppHost set \
+  "SqlOS:Oidc:Microsoft:ClientSecret" "<client-secret>"
+```
+
+Email OTP, SMS OTP, transactional email, and calendar consent likewise require their documented provider settings. They are optional extensions, not startup requirements.
+
+## Common failures
+
+### A frontend resource exits immediately
+
+Install that frontend's npm dependencies from the repository root, then restart the AppHost. The AppHost runs the existing `dev` scripts; it does not replace `npm install`.
+
+### One of the fixed ports is occupied
+
+Stop the conflicting local process. The seeded issuer and callback URLs use the documented local ports, so changing only one endpoint will cause issuer or redirect mismatches.
+
+### SQL Server starts with old state
+
+The AppHost uses a persistent data volume. Preserve it when the data matters; use a clean development volume when intentionally resetting an obsolete local schema or seed model.
+
+### A provider button is missing
+
+The corresponding OIDC/social connection is enabled only when its credentials are present or it has been configured in the dashboard.
+
+## Production notes
+
+This stack demonstrates integration boundaries; it is not a production topology recommendation. A production app should choose only the required clients, use HTTPS origins, persist secrets and Data Protection keys correctly, restrict admin routes, and test its own organization and authorization rules.
+
+## Next steps
+
+- [Add SqlOS to one app](/docs/quickstarts/add-to-app)
+- [Hosted vs headless auth](/docs/authserver/hosted-vs-headless)
+- [Social sign-in](/docs/guides/social-oidc)
+- [SAML SSO](/docs/guides/saml-sso)
+- [Model authorization](/docs/guides/model-fga)

--- a/web/content/docs/quickstarts/run-todo.mdx
+++ b/web/content/docs/quickstarts/run-todo.mdx
@@ -1,0 +1,111 @@
+---
+title: "Run the Todo sample"
+description: "See SqlOS hosted login and authorized EF Core queries before changing an application."
+order: 0
+section: quickstarts
+---
+
+<Banner
+  eyebrow="Quickstart"
+  title="Get working proof in one command"
+  href="#run"
+  actionLabel="Run the sample"
+>
+  The Todo sample is the fastest way to evaluate SqlOS. Aspire starts SQL Server and the .NET API; the sample already includes hosted auth, a PKCE client, token validation, and FGA-filtered data.
+</Banner>
+
+## Goal
+
+Create an account, receive a SqlOS access token, create Todo rows, and see authorization resources in the embedded dashboard without editing code.
+
+## Prerequisites
+
+- the SqlOS repository checked out locally;
+- .NET 9 SDK;
+- Docker running with enough memory for SQL Server;
+- ports `1435` and `5080` available.
+
+This quickstart uses the source at **SqlOS 3.16.0**. It does not require an external identity provider or email service; password signup is enabled by default.
+
+## Run
+
+From the repository root:
+
+```bash
+dotnet run --project examples/SqlOS.Todo.AppHost/SqlOS.Todo.AppHost.csproj
+```
+
+Wait for the SQL Server resource and `todo-api` to report healthy, then open:
+
+```text
+http://localhost:5080/
+```
+
+The AppHost uses a persistent SQL Server container and passes the database connection string to the API. SqlOS initializes its schema, signing key, OAuth client, and FGA seed data when the API starts.
+
+## Verify
+
+1. Select the hosted sign-up action in the Todo app.
+2. Create a password account.
+3. Complete the redirect back to the Todo app.
+4. Create two Todo items and mark one complete.
+5. Refresh the page. Both rows should remain visible.
+6. Open `http://localhost:5080/sqlos/admin/fga/resources`.
+7. Confirm the resource tree contains a tenant resource for your user and child Todo resources.
+
+Useful endpoints:
+
+| URL | What it proves |
+| --- | --- |
+| `http://localhost:5080/sample/config` | Issuer, audience, client, and enabled sample features |
+| `http://localhost:5080/sqlos/auth/.well-known/oauth-authorization-server` | OAuth server metadata |
+| `http://localhost:5080/.well-known/oauth-protected-resource` | Protected-resource metadata |
+| `http://localhost:5080/swagger` | Sample API endpoints |
+| `http://localhost:5080/sqlos` | Embedded dashboard |
+
+## What the sample demonstrates
+
+The normal flow is intentionally visible:
+
+1. The browser starts an authorization-code flow with PKCE.
+2. SqlOS renders the hosted login and signup pages.
+3. SqlOS redirects to the sample callback with a one-time code.
+4. The sample exchanges the code and calls `/api/todos` with a bearer token.
+5. `RequireSqlOSAccessToken` validates the Todo audience.
+6. `GetAuthorizationFilterAsync<TodoItem>` adds the authorization predicate to the EF Core query.
+
+The sample also contains CLI, CIMD, DCR, Email OTP, and SMS OTP examples. Those are optional paths, not prerequisites for your first application.
+
+## Common failures
+
+### SQL Server never becomes healthy
+
+Confirm Docker is running and port `1435` is free. On Apple silicon, the SQL Server image runs through the platform setting in the AppHost and may take longer on first start.
+
+### Port 5080 is already in use
+
+Stop the process using the port before restarting. The sample OAuth issuer and callback are intentionally fixed to `http://localhost:5080`, so changing only the ASP.NET port will produce redirect or issuer mismatches.
+
+### Old sample data behaves differently
+
+The AppHost uses a persistent data volume. If you previously ran an older schema or FGA model, use a clean development volume before diagnosing current behavior. Do not remove a volume that contains data you need.
+
+### Direct login does not return to Todo
+
+Start sign-in from `http://localhost:5080/`. Opening the hosted login URL directly does not create the Todo app's complete PKCE transaction.
+
+## Production notes
+
+The Todo project is an evaluation sample, not a production deployment template. In production:
+
+- use HTTPS and a stable public origin;
+- protect `/sqlos` with password mode plus a private network, VPN, identity-aware proxy, or equivalent admin control;
+- store database credentials, dashboard credentials, provider secrets, and Data Protection keys outside source control;
+- create application-specific resource types and permission names instead of reusing the Todo model.
+
+## Next steps
+
+- [Add SqlOS to one application](/docs/quickstarts/add-to-app)
+- [Protect an API](/docs/quickstarts/protect-api)
+- [Authorize EF Core queries](/docs/quickstarts/ef-authorization)
+- [Todo sample details](/docs/authserver/todo-sample)

--- a/web/content/docs/reference/api-reference.mdx
+++ b/web/content/docs/reference/api-reference.mdx
@@ -1,363 +1,206 @@
 ---
-title: "API Reference"
-description: "HTTP endpoints for auth, admin, and FGA."
-order: 9
+title: "HTTP Protocol API"
+description: "Consumer-facing OAuth, hosted-auth, headless-auth, OIDC, SAML, and optional registration routes mounted by MapSqlOS."
+order: 12
 section: reference
 ---
 
 <Banner
-  eyebrow="Reference"
-  title="HTTP endpoints mounted by MapSqlOS"
-  href="../getting-started"
-  actionLabel="Getting Started"
+  eyebrow="HTTP reference"
+  title="Routes mounted by MapSqlOS"
+  href="/docs/reference/hosting-api"
+  actionLabel="Hosting API"
 >
-  Use [Guides](/docs/guides/index) for task walkthroughs. This page lists the routes SqlOS exposes on your origin.
+  This page covers consumer-facing protocol and authentication routes from the `SqlOS` package. Dashboard APIs and routes created by example applications have different support boundaries described below.
 </Banner>
 
-For the central governance event model, service APIs, dashboard filters, and CSV export limits, see [Audit Logs Reference](/docs/reference/audit-logs).
+## Base paths
 
-## OAuth Endpoints
+`app.MapSqlOS()` reads the configured paths and maps the package routes.
 
-Call `app.MapSqlOS()` to mount OAuth. Default base: `{DashboardBasePath}/auth` (e.g. `/sqlos/auth`).
-
-| Method | Endpoint | Description |
+| Surface | Default base path | Configuration |
 | --- | --- | --- |
-| GET | `/sqlos/auth/.well-known/oauth-authorization-server` | OAuth metadata |
-| GET | `/sqlos/auth/.well-known/jwks.json` | Public keys for JWT validation |
-| GET | `/sqlos/auth/authorize` | OAuth authorize (PKCE) |
-| POST | `/sqlos/auth/token` | Token exchange (code or refresh) |
-| GET | `/sqlos/auth/login` | Hosted login page |
-| GET | `/sqlos/auth/signup` | Hosted signup page |
-| POST | `/sqlos/auth/mfa/challenge/verify` | Verify TOTP or recovery code for a direct MFA challenge |
-| POST | `/sqlos/auth/mfa/challenge/totp/enroll/start` | Start TOTP enrollment for a direct MFA challenge |
-| POST | `/sqlos/auth/mfa/challenge/totp/enroll/verify` | Verify TOTP enrollment for a direct MFA challenge |
+| OAuth and hosted auth | `/sqlos/auth` | `SqlOSOptions.AuthServer.BasePath` |
+| Auth dashboard | `/sqlos/admin/auth` | Derived from the auth/dashboard base path |
+| FGA dashboard | `/sqlos/admin/fga` | `SqlOSOptions.DashboardBasePath` |
+| Audit dashboard | `/sqlos/admin/audit` | `SqlOSOptions.DashboardBasePath` |
+| Email dashboard | `/sqlos/admin/email` | `SqlOSOptions.DashboardBasePath` |
+| Calendar dashboard | `/sqlos/admin/calendar` | Mapped only when calendar is enabled |
 
-## Headless Auth Endpoints
+Changing `DashboardBasePath` also aligns the default AuthServer base path. `AuthServer.Issuer` must be an absolute URI whose path matches `AuthServer.BasePath`; when `PublicOrigin` is configured, the issuer must be `{PublicOrigin}{BasePath}`.
 
-Base path: `/sqlos/auth/headless`.
+## OAuth discovery and keys
 
-| Method | Endpoint | Description |
+| Method | Route | Request | Response |
+| --- | --- | --- | --- |
+| `GET` | `/sqlos/auth/.well-known/oauth-authorization-server` | None | OAuth authorization-server metadata JSON |
+| `GET` | `/sqlos/auth/.well-known/jwks.json` | None | JWKS containing active and grace-window validation keys |
+
+Discovery is the authoritative source for endpoint URLs and advertised capabilities. Do not synthesize endpoint URLs in portable clients when discovery is available.
+
+## Authorization code and refresh tokens
+
+| Method | Route | Content type | Purpose |
+| --- | --- | --- | --- |
+| `GET` | `/sqlos/auth/authorize` | Query parameters | Start OAuth authorization code + PKCE |
+| `POST` | `/sqlos/auth/token` | `application/x-www-form-urlencoded` | Exchange an authorization code, refresh token, or device code |
+
+The authorization request supports standard OAuth fields including `client_id`, `redirect_uri`, `response_type=code`, `state`, `scope`, `code_challenge`, and `code_challenge_method=S256`. Resource-bound clients can also send `resource` when resource indicators are enabled.
+
+Authorization-code exchange:
+
+```bash
+curl -X POST https://app.example.com/sqlos/auth/token \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  --data-urlencode 'grant_type=authorization_code' \
+  --data-urlencode 'client_id=acme-web' \
+  --data-urlencode 'code=...' \
+  --data-urlencode 'redirect_uri=https://app.example.com/auth/callback' \
+  --data-urlencode 'code_verifier=...'
+```
+
+Refresh:
+
+```bash
+curl -X POST https://app.example.com/sqlos/auth/token \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  --data-urlencode 'grant_type=refresh_token' \
+  --data-urlencode 'client_id=acme-web' \
+  --data-urlencode 'refresh_token=...'
+```
+
+Successful token responses use OAuth-style snake-case JSON fields such as `access_token`, `refresh_token`, `token_type`, and `expires_in`. OAuth errors use an `error` code and may include `error_description`.
+
+## Device authorization
+
+| Method | Route | Purpose |
 | --- | --- | --- |
-| GET | `/requests/{requestId}` | Load the current authorization request view model |
-| POST | `/identify` | Submit email for home realm discovery |
-| POST | `/password/login` | Submit email and password |
-| POST | `/email-otp/start` | Start email OTP sign-in |
-| POST | `/email-otp/verify` | Verify email OTP sign-in |
-| POST | `/signup` | Create a password user and complete authorization |
-| POST | `/signup/email-otp/start` | Start passwordless signup |
-| POST | `/signup/email-otp/verify` | Verify passwordless signup |
-| POST | `/organization/select` | Select an organization after primary login |
-| POST | `/mfa/verify` | Verify TOTP or recovery code |
-| POST | `/mfa/totp/enroll/start` | Start forced TOTP enrollment |
-| POST | `/mfa/totp/enroll/verify` | Verify forced TOTP enrollment and continue authorization |
+| `POST` | `/sqlos/auth/device_authorization` | Start a device authorization request from a client allowed to use device flow |
+| `GET` | `/sqlos/auth/device` | Open the user verification page |
+| `POST` | `/sqlos/auth/device/verify` | Resolve a user code in the hosted UI |
+| `POST` | `/sqlos/auth/device/approve` | Approve the resolved request |
+| `POST` | `/sqlos/auth/device/deny` | Deny the resolved request |
+| `POST` | `/sqlos/auth/token` | Poll with `grant_type=urn:ietf:params:oauth:grant-type:device_code` |
 
-## Auth API (Example)
-
-The sample API exposes REST helpers around SqlOS. Copy the shape you need.
-
-### Discover
+Device authorization start uses form data:
 
 ```bash
-curl -X POST http://localhost:5062/api/v1/auth/discover \
-  -H "Content-Type: application/json" \
-  -d '{"email": "user@acme.com"}'
+curl -X POST https://app.example.com/sqlos/auth/device_authorization \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  --data-urlencode 'client_id=acme-cli' \
+  --data-urlencode 'scope=openid offline_access' \
+  --data-urlencode 'resource=https://app.example.com/api'
 ```
 
-```json
-{"mode": "password", "organizations": []}
-```
+## Hosted AuthPage
 
-### Login
+These browser routes render or process the SqlOS-hosted sign-in experience. Applications normally begin at `/authorize`; they do not call each form handler directly.
 
-```bash
-curl -X POST http://localhost:5062/api/v1/auth/login \
-  -H "Content-Type: application/json" \
-  -d '{"email": "admin@retail.demo", "password": "RetailDemo1!"}'
-```
-
-```json
-{
-  "accessToken": "eyJhbG...",
-  "refreshToken": "rt_...",
-  "sessionId": "ses_...",
-  "organizationId": "org_...",
-  "requiresOrganizationSelection": false
-}
-```
-
-### Select Organization
-
-```bash
-curl -X POST http://localhost:5062/api/v1/auth/select-organization \
-  -H "Content-Type: application/json" \
-  -d '{"pendingAuthToken": "...", "organizationId": "org_..."}'
-```
-
-### Refresh
-
-```bash
-curl -X POST http://localhost:5062/api/v1/auth/refresh \
-  -H "Content-Type: application/json" \
-  -d '{"refreshToken": "rt_...", "organizationId": null}'
-```
-
-### Session
-
-```bash
-curl http://localhost:5062/api/v1/auth/session \
-  -H "Authorization: Bearer eyJhbG..."
-```
-
-```json
-{
-  "userId": "usr_...",
-  "sessionId": "ses_...",
-  "organizationId": "org_...",
-  "email": "admin@retail.demo",
-  "displayName": "Company Admin"
-}
-```
-
-### Logout
-
-```bash
-curl -X POST http://localhost:5062/api/v1/auth/logout \
-  -H "Content-Type: application/json" \
-  -d '{"refreshToken": "rt_..."}'
-```
-
-### OIDC Providers
-
-```bash
-curl http://localhost:5062/api/v1/auth/oidc/providers
-```
-
-```json
-[{"connectionId": "oidc_...", "providerType": "google", "displayName": "Google"}]
-```
-
-### Start SSO
-
-```bash
-curl -X POST http://localhost:5062/api/v1/auth/sso/start \
-  -H "Content-Type: application/json" \
-  -d '{"email": "user@acme.com"}'
-```
-
-### Host-launched SSO Portal Link
-
-The example API demonstrates how a host app can launch the delegated org-admin portal for the current `org_id` instead of exposing the full dashboard admin API to its frontend.
-
-```bash
-curl -X POST http://localhost:5062/api/sso-portal-links \
-  -H "Authorization: Bearer eyJhbG..." \
-  -H "Content-Type: application/json" \
-  -d '{"provider": "microsoft-entra"}'
-```
-
-```json
-{
-  "id": "ssp_...",
-  "organizationId": "org_...",
-  "status": "pending",
-  "setupUrl": "https://localhost/sqlos/admin/auth/sso-portal/start?token=..."
-}
-```
-
----
-
-## Dashboard Admin API
-
-Used by the dashboard UI. Base path: `/sqlos/admin/auth/api`.
-
-### Organizations
-
-```bash
-# List
-curl http://localhost:5062/sqlos/admin/auth/api/organizations
-
-# Create
-curl -X POST http://localhost:5062/sqlos/admin/auth/api/organizations \
-  -d '{"name": "Acme Corp", "slug": "acme", "primaryDomain": "acme.com"}'
-```
-
-### Users
-
-```bash
-# List
-curl http://localhost:5062/sqlos/admin/auth/api/users
-
-# Create
-curl -X POST http://localhost:5062/sqlos/admin/auth/api/users \
-  -d '{"displayName": "Jane Doe", "email": "jane@acme.com", "password": "secret123"}'
-```
-
-### Memberships
-
-```bash
-curl -X POST http://localhost:5062/sqlos/admin/auth/api/memberships \
-  -d '{"organizationId": "org_...", "userId": "usr_...", "role": "admin"}'
-```
-
-### Clients
-
-```bash
-curl -X POST http://localhost:5062/sqlos/admin/auth/api/clients \
-  -d '{"clientId": "my-app", "name": "My App", "audience": "sqlos", "redirectUris": ["http://localhost:3000/callback"]}'
-```
-
-### Security Settings
-
-```bash
-# Get
-curl http://localhost:5062/sqlos/admin/auth/api/settings/security
-
-# Update
-curl -X PUT http://localhost:5062/sqlos/admin/auth/api/settings/security \
-  -d '{"refreshTokenLifetimeMinutes": 10080, "sessionIdleTimeoutMinutes": 1440, "sessionAbsoluteLifetimeMinutes": 43200}'
-```
-
-### MFA Settings
-
-```bash
-# Get global MFA settings
-curl http://localhost:5062/sqlos/admin/auth/api/settings/mfa
-
-# Update global MFA settings
-curl -X PUT http://localhost:5062/sqlos/admin/auth/api/settings/mfa \
-  -H "Content-Type: application/json" \
-  -d '{
-    "enabled": true,
-    "totpEnabled": true,
-    "userSelfEnrollmentEnabled": true,
-    "recoveryCodesEnabled": true,
-    "requireForAllUsers": false,
-    "requireForOwnersAndAdmins": true,
-    "requiredRoles": ["owner", "admin"],
-    "availableFactors": ["totp", "recovery_code"]
-  }'
-
-# Update one organization's MFA policy
-curl -X PUT http://localhost:5062/sqlos/admin/auth/api/organizations/org_123/mfa-policy \
-  -H "Content-Type: application/json" \
-  -d '{
-    "isEnabled": true,
-    "requireMfaForAllUsers": true,
-    "requireMfaForOwnersAndAdmins": false,
-    "userSelfEnrollmentEnabled": true,
-    "recoveryCodesEnabled": true,
-    "requiredRoles": ["owner", "admin"],
-    "availableFactors": ["totp", "recovery_code"]
-  }'
-```
-
-### Sessions
-
-```bash
-curl http://localhost:5062/sqlos/admin/auth/api/sessions
-```
-
-### Delegated SSO Portal Sessions
-
-```bash
-# Create a one-organization setup link
-curl -X POST http://localhost:5062/sqlos/admin/auth/api/sso-portal/sessions \
-  -H "Content-Type: application/json" \
-  -d '{"organizationId": "org_...", "provider": "okta"}'
-
-# List setup links for an organization
-curl http://localhost:5062/sqlos/admin/auth/api/organizations/org_.../sso-portal/sessions
-
-# Revoke a setup link or opened portal session
-curl -X POST http://localhost:5062/sqlos/admin/auth/api/sso-portal/sessions/ssp_.../revoke \
-  -H "Content-Type: application/json" \
-  -d '{"reason": "rotated"}'
-```
-
-The setup URL opens `/sqlos/admin/auth/sso-portal/start?token=...`. The first open consumes the URL token and sets a server-side portal session cookie. Portal APIs under `/sqlos/admin/auth/sso-portal/api` require that cookie and are scoped to the linked organization:
-
-| Method | Endpoint | Description |
+| Method | Route | Purpose |
 | --- | --- | --- |
-| GET | `/state` | Organization, provider guides, SP values, connection status |
-| PUT | `/provider` | Choose `microsoft-entra`, `okta`, `google-workspace`, or `generic-saml` |
-| POST | `/domain` | Create or reuse a pending domain-ownership TXT record |
-| POST | `/domains/{domainId}/confirm` | Verify DNS TXT ownership and activate the domain claim |
-| POST | `/metadata/validate` | Validate pasted or uploaded metadata XML |
-| POST | `/metadata` | Save metadata and hold the connection for activation |
-| POST | `/activate` | Enable the SAML connection after review |
-| POST | `/disable` | Disable the organization SAML connection |
-| POST | `/test` | Validate readiness or create a SAML redirect when `clientId` and `redirectUri` are supplied |
-| POST | `/signout` | Clear the portal session cookie |
+| `GET` | `/sqlos/auth/login` | Hosted sign-in page |
+| `POST` | `/sqlos/auth/login/identify` | Home-realm discovery |
+| `POST` | `/sqlos/auth/login/password` | Password sign-in form |
+| `GET` / `POST` | `/sqlos/auth/login/email-otp` and child routes | Email-code sign-in UI/start/verify |
+| `GET` / `POST` | `/sqlos/auth/login/phone-otp` and child routes | Phone-code sign-in UI/start/verify |
+| `POST` | `/sqlos/auth/login/select-organization` | Complete multi-organization selection |
+| `GET` / `POST` | `/sqlos/auth/signup` and child routes | Password, email-code, phone-code, or invitation signup |
+| `POST` | `/sqlos/auth/mfa/verify` | Verify a hosted MFA challenge |
+| `POST` | `/sqlos/auth/mfa/totp/enroll/verify` | Complete required TOTP enrollment |
+| `GET` | `/sqlos/auth/invitations/accept?token=...` | Open an email invitation |
+| `GET` / `POST` | `/sqlos/auth/logout` | End the current session/token flow |
+| `GET` | `/sqlos/auth/logged-out` | Hosted post-logout page |
 
-The headless setup API defaults to `/sqlos/admin/auth/sso-portal/api/setup`, can be moved with `SsoPortal.HeadlessApiBasePath`, and returns `SqlOSSsoSetupActionResult` records for custom admin UIs:
+Form routes can change with the hosted UI. Integrate through `/authorize`, `/token`, and the documented AuthPage configuration unless you are intentionally building a headless UI.
 
-| Method | Endpoint | Description |
+## Headless AuthPage API
+
+The default headless base is `/sqlos/auth/headless`. It can be moved with `AuthServer.Headless.HeadlessApiBasePath`. These endpoints use JSON and operate on SqlOS authorization-request state.
+
+| Method | Relative route | Purpose |
 | --- | --- | --- |
-| GET | `/` | Current setup view model |
-| PUT | `/provider` | Select provider and advance to the domain step |
-| POST | `/domain` | Start DNS TXT verification |
-| POST | `/domains/{domainId}/confirm` | Confirm ownership |
-| POST | `/metadata/validate` | Validate metadata XML |
-| POST | `/metadata` | Import metadata and advance to activation |
-| POST | `/activate` | Activate if allowed actions permit it |
-| POST | `/disable` | Disable the connection |
-| POST | `/test` | Run or record a readiness test |
-| POST | `/signout` | Close the portal session |
+| `POST` | `/start` | Start/load a headless authorization flow |
+| `GET` | `/requests/{requestId}` | Read the current view model |
+| `POST` | `/identify` | Run home-realm discovery |
+| `POST` | `/password/login` | Password sign-in |
+| `POST` | `/password/forgot` | Request a password reset email |
+| `POST` | `/password/reset` | Complete a password reset |
+| `POST` | `/email-otp/start` | Start email-code sign-in |
+| `POST` | `/email-otp/verify` | Verify email-code sign-in |
+| `POST` | `/phone-otp/start` | Start phone-code sign-in |
+| `POST` | `/phone-otp/verify` | Verify phone-code sign-in |
+| `POST` | `/signup` | Password signup |
+| `POST` | `/signup/email-otp/start` | Start email-code signup |
+| `POST` | `/signup/email-otp/verify` | Verify email-code signup |
+| `POST` | `/signup/phone-otp/start` | Start phone-code signup |
+| `POST` | `/signup/phone-otp/verify` | Verify phone-code signup |
+| `POST` | `/invitations/resolve` | Resolve an invitation for the current flow |
+| `POST` | `/invitations/signup` | Accept an invitation through signup |
+| `POST` | `/organization/select` | Select an organization |
+| `POST` | `/mfa/verify` | Verify TOTP or recovery code |
+| `POST` | `/mfa/totp/enroll/start` | Start required TOTP enrollment |
+| `POST` | `/mfa/totp/enroll/verify` | Verify required TOTP enrollment |
+| `POST` | `/provider/start` | Start a configured social/OIDC provider |
+| `POST` | `/device/resolve` | Resolve a device code request |
+| `POST` | `/device/approve` | Approve a device request |
+| `POST` | `/device/deny` | Deny a device request |
 
-The setup view model includes `domain`, `serviceProvider`, `providers`, `latestTest`, and `allowedActions`. Domain ownership uses a TXT record shaped like `_sqlos-verify.acme.com = sqlos-domain-verification=...` by default. Hosts can customize both prefixes with `SsoPortal.DomainVerificationRecordPrefix` and `SsoPortal.DomainVerificationRecordValuePrefix`.
+For browser clients on a different origin, send credentialed requests so the reusable AuthPage session cookie is preserved. See [Headless Auth](/docs/authserver/headless-auth) for request/response walkthroughs.
 
----
+## Social OIDC and SAML callbacks
 
-## FGA Admin API
+| Method | Route | Purpose |
+| --- | --- | --- |
+| `GET` | `/sqlos/auth/oidc/providers` | List enabled social/OIDC providers |
+| `POST` | `/sqlos/auth/oidc/authorization-url` | Create a provider authorization URL |
+| `GET` / `POST` | `/sqlos/auth/oidc/callback` | Complete the provider callback |
+| `POST` | `/sqlos/auth/oidc/exchange` | Exchange the SqlOS PKCE result |
+| `POST` | `/sqlos/auth/sso/authorization-url` | Create a SAML authorization URL |
+| `GET` | `/sqlos/auth/saml/login/{connectionId}` | Redirect to the organization IdP |
+| `POST` | `/sqlos/auth/saml/acs/{connectionId}` | SAML assertion consumer service |
 
-Base path: `/sqlos/admin/fga/api`.
+Prefer the hosted/headless flow abstractions over invoking callback routes manually.
 
-### Resources
+## Dynamic client registration
 
-```bash
-# List (tree)
-curl http://localhost:5062/sqlos/admin/fga/api/resources
+`POST /sqlos/auth/register` is mapped only when `AuthServer.ClientRegistration.Dcr.Enabled` is `true`. It accepts a `SqlOSDynamicClientRegistrationRequest` JSON document and applies the configured DCR redirect, client-type, rate-limit, and policy constraints.
 
-# Create
-curl -X POST http://localhost:5062/sqlos/admin/fga/api/resources \
-  -d '{"name": "New Chain", "typeId": "chain", "parentId": "retail_root"}'
-```
+CIMD does not add a registration route. When enabled, SqlOS resolves URL-shaped client IDs through client metadata documents subject to its trust configuration. See [Preregistration vs CIMD vs DCR](/docs/authserver/preregistration-vs-cimd-vs-dcr).
 
-### Grants
+## Calendar callback
 
-```bash
-# List
-curl http://localhost:5062/sqlos/admin/fga/api/grants
+When `SqlOSOptions.Calendar.Enabled` is `true`, `MapSqlOS` adds:
 
-# Create
-curl -X POST http://localhost:5062/sqlos/admin/fga/api/grants \
-  -d '{"subjectId": "usr_...", "roleId": "role_...", "resourceId": "org::acme"}'
+| Method | Route | Purpose |
+| --- | --- | --- |
+| `GET` | `/sqlos/auth/calendar/callback` | Complete Google/Microsoft calendar consent and redirect to the request's return URI |
 
-# Revoke
-curl -X DELETE http://localhost:5062/sqlos/admin/fga/api/grants/{id}
-```
+Applications start the flow through `SqlOSCalendarService.StartConnectAsync`; there is no public HTTP start endpoint supplied by the package.
 
-### Access Test
+## Dashboard and operator APIs
 
-```bash
-curl -X POST http://localhost:5062/sqlos/admin/fga/api/access-test \
-  -d '{"subjectId": "usr_...", "resourceId": "chain-1", "permissionKey": "CHAIN_VIEW"}'
-```
+`MapSqlOS` also maps APIs used by the embedded auth, FGA, audit, email, SSO-setup, and optional calendar dashboards. Those routes:
 
-```json
-{"allowed": true}
-```
+- are excluded from endpoint/OpenAPI discovery;
+- are protected by the dashboard authorization/session rules;
+- return `404` when the current environment/request is not authorized;
+- are implementation endpoints for the bundled operator UI, not a stable browser-facing management SDK.
 
-### Roles and Permissions
+For trusted backend administration, inject the corresponding .NET service (`SqlOSAdminService`, `ISqlOSAuditLogService`, `SqlOSEmailAdminService`, or `SqlOSCalendarService`) rather than coupling application code to dashboard JSON shapes. Restrict `/sqlos` and `/sqlos/admin/*` at the network/edge layer in production.
 
-```bash
-curl http://localhost:5062/sqlos/admin/fga/api/roles
-curl http://localhost:5062/sqlos/admin/fga/api/permissions
-curl http://localhost:5062/sqlos/admin/fga/api/subjects
-```
+## Example-application routes are not package APIs
 
----
+Routes such as the following are defined under `examples/` and are not mounted by `MapSqlOS`:
 
-## Swagger
+- `/api/v1/auth/*`
+- `/api/todos`
+- `/api/sso-portal-links`
+- `/sample/config`
+- `/.well-known/oauth-protected-resource`
+- `/swagger` and `/swagger/v1/swagger.json`
 
-Open `http://localhost:5062/swagger` for the interactive API explorer when running the example stack.
+They demonstrate how a consuming application can wrap SqlOS services, publish protected-resource metadata, or expose its own product API. Copy the pattern only after checking the example source against your authorization and trust boundary.
+
+## OpenAPI boundary
+
+The current package protocol and dashboard routes call `ExcludeFromDescription()`, so a consuming app's Swagger/OpenAPI document does not automatically become the canonical SqlOS protocol specification. Use OAuth discovery for machine-readable OAuth endpoint metadata and this source-aligned route reference for the remaining package routes. Swagger shown by the example stack describes the example application's endpoints, not the complete SqlOS package surface.

--- a/web/content/docs/reference/audit-logs.mdx
+++ b/web/content/docs/reference/audit-logs.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Audit Logs Reference"
 description: "Record, query, inspect, and export SqlOS and application audit events."
-order: 12
+order: 13
 section: reference
 ---
 
@@ -36,10 +36,8 @@ Audit events are not debug logs, traces, metrics, or product analytics. Keep the
 `AddSqlOS<TContext>()` registers `ISqlOSAuditLogService`.
 
 ```csharp
-builder.Services.AddSqlOS<ExampleAppDbContext>(options =>
-{
-    options.UseSqlServer(connectionString);
-});
+builder.AddSqlOS<ExampleAppDbContext>(
+    db => db.UseSqlServer(connectionString));
 ```
 
 Inject the service into server-side application code. Frontends should not write audit rows directly.

--- a/web/content/docs/reference/authserver-api.mdx
+++ b/web/content/docs/reference/authserver-api.mdx
@@ -1,6 +1,6 @@
 ---
 title: "AuthServer API Reference"
-description: "Complete method reference for login, signup, SSO, OIDC, token management, and admin operations."
+description: "Application-facing methods for login, signup, OTP, SSO, OIDC, token management, and trusted admin workflows."
 order: 11
 section: reference
 ---
@@ -14,13 +14,14 @@ section: reference
   New to SqlOS? Complete [Getting Started](/docs/getting-started) and the [Guides](/docs/guides/index) first. Use this page when you need the exact signature for a specific service method.
 </Banner>
 
-Complete reference for every public method in the AuthServer module.
+This page documents the AuthServer methods intended for application and trusted backend use. It is not an inventory of every public implementation class in the assembly. Hosting and route-mapping APIs are in [Hosting API](/docs/reference/hosting-api); namespace and adjacent service coverage are in the [.NET SDK Map](/docs/reference/sdk-reference).
 
 ## Common flows
 
 | Task | Start here |
 | --- | --- |
 | Login / signup | `SqlOSAuthService` — password and Email OTP sections below |
+| Phone-code login / signup | `SqlOSAuthService` phone OTP methods and `ConfigurePhoneOtp` |
 | MFA / TOTP | `SqlOSAuthService` MFA methods and `SqlOSSettingsService` MFA policy methods |
 | Token validation | `ValidateAccessTokenAsync` |
 | Admin CRUD | `SqlOSAdminService` |
@@ -246,7 +247,9 @@ return Results.Ok(result.Tokens);
 | `Password` | `string` | User's password. |
 | `OrganizationName` | `string?` | If set, a new organization is created and the user is added. |
 | `ClientId` | `string?` | Client application ID. |
-| `OrganizationId` | `string?` | Join existing org instead of creating one. |
+| `OrganizationId` | `string?` | Must be null for self-service signup. A supplied ID is rejected; it never joins an existing organization. |
+
+The same restriction applies to password, Email OTP, and phone OTP self-service signup. To add a user to an existing organization, use the [invitation flow](/docs/authserver/invitations) or trusted backend provisioning with `CreateUserAsync` followed by `CreateMembershipAsync`.
 
 **Returns**
 
@@ -304,7 +307,94 @@ var result = await authService.VerifyEmailOtpSignupAsync(
     ct);
 ```
 
-Signup verification creates the user, marks the primary email verified, creates the organization or membership, creates a session, and returns `SqlOSLoginResult`.
+Signup verification creates the user, marks the primary email verified, creates a new organization when `OrganizationName` is supplied, creates a session, and returns `SqlOSLoginResult`. `OrganizationId` must be null; existing-organization membership requires an invitation or trusted backend provisioning as described above.
+
+---
+
+### Phone OTP sign-in and signup
+
+Phone OTP uses Twilio Verify through the configured `ISqlOSOtpDeliveryChannel`. Enable and configure it during host registration:
+
+```csharp
+options.AuthServer.ConfigurePhoneOtp(phone =>
+{
+    phone.Enabled = true;
+    phone.TwilioAccountSid = builder.Configuration["SqlOS:PhoneOtp:TwilioAccountSid"];
+    phone.TwilioAuthToken = builder.Configuration["SqlOS:PhoneOtp:TwilioAuthToken"];
+    phone.TwilioVerifyServiceSid = builder.Configuration["SqlOS:PhoneOtp:TwilioVerifyServiceSid"];
+    phone.DefaultRegion = "US";
+});
+```
+
+Sign in with a phone code:
+
+```csharp
+var start = await authService.RequestPhoneOtpAsync(
+    new SqlOSPhoneOtpStartRequest(
+        PhoneNumber: phoneNumber,
+        ClientId: "my-app",
+        OrganizationId: null),
+    httpContext,
+    ct);
+
+var login = await authService.VerifyPhoneOtpAsync(
+    new SqlOSPhoneOtpVerifyRequest(
+        ChallengeToken: start.ChallengeToken,
+        Code: code),
+    httpContext,
+    ct);
+```
+
+Passwordless signup:
+
+```csharp
+var start = await authService.RequestPhoneOtpSignupAsync(
+    new SqlOSPhoneOtpSignupStartRequest(
+        DisplayName: "Jane Doe",
+        PhoneNumber: phoneNumber,
+        ClientId: "my-app",
+        OrganizationName: "Acme",
+        OrganizationId: null,
+        CustomFields: null),
+    httpContext,
+    ct);
+
+var signup = await authService.VerifyPhoneOtpSignupAsync(
+    new SqlOSPhoneOtpSignupVerifyRequest(
+        SignupToken: start.SignupToken,
+        ChallengeToken: start.ChallengeToken,
+        Code: code),
+    httpContext,
+    ct);
+```
+
+**Signatures**
+
+```csharp
+Task<SqlOSPhoneOtpStartResult> RequestPhoneOtpAsync(
+    SqlOSPhoneOtpStartRequest request,
+    HttpContext? httpContext = null,
+    CancellationToken cancellationToken = default);
+
+Task<SqlOSPhoneOtpSignupStartResult> RequestPhoneOtpSignupAsync(
+    SqlOSPhoneOtpSignupStartRequest request,
+    HttpContext? httpContext = null,
+    CancellationToken cancellationToken = default);
+
+Task<SqlOSLoginResult> VerifyPhoneOtpAsync(
+    SqlOSPhoneOtpVerifyRequest request,
+    HttpContext httpContext,
+    CancellationToken cancellationToken = default);
+
+Task<SqlOSLoginResult> VerifyPhoneOtpSignupAsync(
+    SqlOSPhoneOtpSignupVerifyRequest request,
+    HttpContext httpContext,
+    CancellationToken cancellationToken = default);
+```
+
+`SqlOSPhoneOtpStartResult` includes `ChallengeToken`, normalized and masked phone values, a public message, `ExpiresAt`, and `NextAllowedSendAt`. The signup result also includes `SignupToken`.
+
+Configuration or runtime validation can throw `InvalidOperationException` when phone OTP is enabled without a complete Twilio configuration, the client is invalid, or a challenge cannot be started or verified. Rate limits, country allow/deny lists, resend timing, and whether phone OTP satisfies MFA are configured through `SqlOSPhoneOtpOptions`.
 
 ---
 
@@ -785,7 +875,7 @@ var user = await adminService.CreateUserAsync(
 |------|------|-------------|
 | `request.DisplayName` | `string` | Display name. |
 | `request.Email` | `string` | Email address (normalized and deduplicated). |
-| `request.Password` | `string?` | Password. If null, the user can only log in via SSO/OIDC. |
+| `request.Password` | `string?` | Optional local password. If null, the user can use configured passwordless methods (including Email OTP) and linked SSO/OIDC providers. |
 
 **Returns**
 
@@ -878,7 +968,7 @@ await adminService.ImportSsoMetadataAsync(
 
 **Returns**
 
-`Task<SqlOSSsoConnectionDraft>` — the created draft with an ID.
+`Task<SqlOSSsoConnection>` — the disabled connection draft with its generated `Id`.
 
 ---
 
@@ -901,7 +991,7 @@ await adminService.ImportSsoMetadataAsync(
 
 **Returns**
 
-`Task`
+`Task<SqlOSSsoConnection>` — the updated connection. The two-argument overload enables the connection after importing valid metadata; an overload accepts `enableConnection` explicitly.
 
 ---
 
@@ -1023,11 +1113,11 @@ var isMember = await adminService.UserHasMembershipAsync(userId, orgId);
 
 ### NormalizeEmail
 
-Normalize an email address (lowercase, trim).
+Normalize an email lookup key by trimming and applying `ToUpperInvariant()`.
 
 ```csharp
 var email = SqlOSAdminService.NormalizeEmail("  Jane@ACME.com ");
-// "jane@acme.com"
+// "JANE@ACME.COM"
 ```
 
 **Parameters**
@@ -1052,14 +1142,14 @@ Home realm discovery checks active verified organization domains first. If no ve
 
 ### DiscoverAsync
 
-Look up the authentication method for an email address. Returns whether the domain maps to an SSO connection, OIDC provider, or password login.
+Look up the authentication method for an email address. Returns whether the domain maps to an SSO connection or password login.
 
 ```csharp
 var result = await hrdService.DiscoverAsync(
     new SqlOSHomeRealmDiscoveryRequest(Email: request.Email));
 
-// result.Mode: "password" | "sso" | "oidc"
-// result.ConnectionId: SSO/OIDC connection ID (if applicable)
+// result.Mode: "password" | "sso"
+// result.ConnectionId: SSO connection ID (when Mode is "sso")
 // result.OrganizationId: matched org ID
 ```
 
@@ -1075,11 +1165,11 @@ var result = await hrdService.DiscoverAsync(
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `Mode` | `string` | Authentication mode: `"password"`, `"sso"`, or `"oidc"`. |
+| `Mode` | `string` | Authentication mode: `"password"` or `"sso"`. |
 | `OrganizationId` | `string?` | Matched organization. |
 | `OrganizationName` | `string?` | Organization display name. |
 | `PrimaryDomain` | `string?` | The matched domain. |
-| `ConnectionId` | `string?` | SSO or OIDC connection ID to use. |
+| `ConnectionId` | `string?` | SSO connection ID to use when `Mode` is `"sso"`. |
 
 ---
 
@@ -1221,7 +1311,7 @@ var providers = await oidcService.ListEnabledProvidersAsync();
 
 **Returns**
 
-`Task<List<SqlOSOidcProviderInfo>>`
+`Task<IReadOnlyList<SqlOSOidcProviderSummary>>`
 
 ---
 
@@ -1316,7 +1406,7 @@ var tokens = await authService.CreateSessionTokensForUserAsync(
 | `Email` | `string` | User's email from the provider. |
 | `DisplayName` | `string` | User's display name from the provider. |
 | `OrganizationId` | `string?` | Matched organization (if any). |
-| `AuthenticationMethod` | `string` | e.g., `"oidc_google"`. |
+| `AuthenticationMethod` | `string` | Provider method: `"google"`, `"microsoft"`, `"apple"`, `"github"`, or `"oidc"` for a custom OIDC provider. |
 
 ---
 
@@ -1352,11 +1442,14 @@ var settings = await settingsService.GetResolvedSecuritySettingsAsync();
 Update the security settings.
 
 ```csharp
-await settingsService.UpdateSecuritySettingsAsync(
+var settings = await settingsService.UpdateSecuritySettingsAsync(
     new SqlOSUpdateSecuritySettingsRequest(
         RefreshTokenLifetimeMinutes: 1440,
         SessionIdleTimeoutMinutes: 60,
-        SessionAbsoluteLifetimeMinutes: 10080));
+        SessionAbsoluteLifetimeMinutes: 10080,
+        SigningKeyRotationIntervalDays: 90,
+        SigningKeyGraceWindowDays: 7,
+        SigningKeyRetiredCleanupDays: 30));
 ```
 
 **Parameters**
@@ -1366,10 +1459,14 @@ await settingsService.UpdateSecuritySettingsAsync(
 | `request.RefreshTokenLifetimeMinutes` | `int` | Refresh token lifetime in minutes. |
 | `request.SessionIdleTimeoutMinutes` | `int` | Idle timeout in minutes. |
 | `request.SessionAbsoluteLifetimeMinutes` | `int` | Absolute lifetime in minutes. |
+| `request.SigningKeyRotationIntervalDays` | `int` | Signing key rotation interval in days. |
+| `request.SigningKeyGraceWindowDays` | `int` | Grace period for a previous signing key in days; must be shorter than the rotation interval. |
+| `request.SigningKeyRetiredCleanupDays` | `int` | Retention period for retired signing keys in days. |
+| `request.RefreshTokenGraceWindowSeconds` | `int` | Optional refresh-token replay grace window in seconds. Defaults to `30`. |
 
 **Returns**
 
-`Task`
+`Task<SqlOSSecuritySettingsDto>` — the persisted security settings.
 
 ---
 
@@ -1455,6 +1552,32 @@ public sealed record SqlOSLoginResult(
     string? MfaToken = null,
     bool RequiresMfaEnrollment = false,
     IReadOnlyList<string>? MfaMethods = null);
+```
+
+### Phone OTP contracts
+
+```csharp
+public sealed record SqlOSPhoneOtpStartRequest(
+    string PhoneNumber,
+    string ClientId,
+    string? OrganizationId);
+
+public sealed record SqlOSPhoneOtpVerifyRequest(
+    string ChallengeToken,
+    string Code);
+
+public sealed record SqlOSPhoneOtpSignupStartRequest(
+    string DisplayName,
+    string PhoneNumber,
+    string ClientId,
+    string? OrganizationName,
+    string? OrganizationId,
+    JsonObject? CustomFields);
+
+public sealed record SqlOSPhoneOtpSignupVerifyRequest(
+    string SignupToken,
+    string ChallengeToken,
+    string Code);
 ```
 
 ### SqlOSValidatedToken

--- a/web/content/docs/reference/fga-api.mdx
+++ b/web/content/docs/reference/fga-api.mdx
@@ -1,11 +1,11 @@
 ---
 title: "FGA API Reference"
-description: "Complete method reference for access checks, entity-backed resources, grants, and FGA query helpers."
+description: "Application-facing access checks, entity-backed resources, grants, and FGA query helpers."
 order: 10
 section: reference
 ---
 
-Complete reference for the public FGA SDK surface. The recommended application path is `SqlOSDbContext<TContext>` plus `ISqlOSResourceEntity` for protected domain rows, explicit subject provisioning, and explicit role grants.
+This page documents the application-facing FGA surface. The recommended path is `SqlOSDbContext<TContext>` plus `ISqlOSResourceEntity` for protected domain rows, explicit subject provisioning, and explicit role grants. Public schema/bootstrap implementation classes are not intended as normal application extension points.
 
 ## ISqlOSFgaAuthService
 
@@ -45,7 +45,7 @@ if (!access.Allowed)
 
 ### HasCapabilityAsync
 
-Check if a subject has a specific permission at root level — i.e., anywhere in the resource tree. Use for global capability gates.
+Check whether a subject has a permission on the configured FGA root resource. Use it for an intentionally global capability granted at root; it does not scan for the permission on arbitrary descendants.
 
 ```csharp
 var canEdit = await authService.HasCapabilityAsync(subjectId, "CHAIN_EDIT");
@@ -62,7 +62,7 @@ if (!canEdit)
 
 **Returns**
 
-`Task<bool>` — `true` if the subject has any grant with a role that includes the permission.
+`Task<bool>` — the result of `CheckAccessAsync(subjectId, permissionKey, RootResourceId)`.
 
 ---
 
@@ -255,10 +255,19 @@ var spec = PagedSpec.For<Chain>(c => c.Id)
 | `For<T>(idSelector)` | `Expression<Func<T, string>>` | Start builder with the ID/tiebreaker column. |
 | `.RequirePermission(key)` | `string` | Set the FGA permission key for authorization filtering. |
 | `.SortByString(name, selector, isDefault?)` | `string`, `Expression<Func<T, string>>`, `bool` | Register a named string sort column. |
-| `.Search(search, ...fields)` | `string?`, `params Expression<Func<T, string>>[]` | Add text search across the given fields. |
+| `.Search(search, ...fields)` | `string?`, `params Expression<Func<T, string?>>[]` | Add text search across the given fields. |
 | `.Where(predicate)` | `Expression<Func<T, bool>>` | Add a static filter. |
-| `.Configure(action)` | `Action<IQueryable<T>>` | Configure the query (e.g., `.Include()`). |
+| `.Configure(configurator)` | `Func<IQueryable<T>, IQueryable<T>>` | Return a configured query (for example `query => query.Include(...)`). |
 | `.Build(pageSize, cursor, sortBy, sortDir)` | `int`, `string?`, `string?`, `string?` | Build the final `PagedSpecification<T>`. |
+
+The exact query-configuration signature is:
+
+```csharp
+public PagedSpecificationBuilder<T> Configure(
+    Func<IQueryable<T>, IQueryable<T>> configurator)
+```
+
+The function must return the query it configures. An `Action<IQueryable<T>>` is not accepted.
 
 ---
 
@@ -282,9 +291,10 @@ var result = await executor.ExecuteAsync(
         LocationCount = c.Locations.Count
     });
 
-// result.Items     — the page of DTOs
-// result.NextCursor — pass to next request for pagination
-// result.HasMore   — whether more pages exist
+// result.Data        — the page of DTOs
+// result.PageSize    — the clamped page size used
+// result.NextCursor  — pass to the next request
+// result.HasNextPage — whether NextCursor is non-null
 ```
 
 **Parameters**
@@ -305,9 +315,10 @@ var result = await executor.ExecuteAsync(
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `Items` | `List<TDto>` | The current page of results. |
+| `Data` | `List<TDto>` | The current page of results. |
+| `PageSize` | `int` | The page size used by the result. |
 | `NextCursor` | `string?` | Opaque cursor for the next page. `null` if no more pages. |
-| `HasMore` | `bool` | Whether additional pages exist. |
+| `HasNextPage` | `bool` | `true` when `NextCursor` is not `null`. |
 
 ---
 

--- a/web/content/docs/reference/hosting-api.mdx
+++ b/web/content/docs/reference/hosting-api.mdx
@@ -1,0 +1,263 @@
+---
+title: "Hosting API"
+description: "Exact .NET hosting signatures for registering, configuring, mapping, and consuming SqlOS."
+order: 8
+section: reference
+---
+
+<Banner
+  eyebrow=".NET API"
+  title="Host SqlOS in an ASP.NET Core application"
+  href="/docs/getting-started"
+  actionLabel="Getting Started"
+>
+  The recommended path has three integration points: derive your EF context from `SqlOSDbContext<TContext>`, call the combined `AddSqlOS` overload, and call `MapSqlOS` after `Build()`.
+</Banner>
+
+## Package and assembly
+
+| Item | Value |
+| --- | --- |
+| Package | `SqlOS` |
+| Assembly | `SqlOS.dll` |
+| Target framework | `net9.0` |
+
+## SqlOSDbContext&lt;TContext&gt;
+
+**Namespace:** `SqlOS`
+
+**Assembly:** `SqlOS.dll`
+
+```csharp
+public abstract class SqlOSDbContext<TContext> : DbContext,
+    ISqlOSAuthServerDbContext,
+    ISqlOSFgaDbContext
+    where TContext : SqlOSDbContext<TContext>
+```
+
+### Constructor
+
+```csharp
+protected SqlOSDbContext(DbContextOptions<TContext> options)
+```
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `options` | `DbContextOptions<TContext>` | EF Core options registered for the derived application context. |
+
+The base context registers SqlOS auth, email, calendar, and FGA entities in the EF model. Relational contexts also register the `dbo.fn_IsResourceAccessible` table-valued function. Its sealed `OnModelCreating` implementation invokes `OnApplicationModelCreating` for application-owned mappings.
+
+`SaveChanges` and `SaveChangesAsync` synchronize tracked entities that implement `ISqlOSResourceEntity` into the FGA resource table before EF saves the unit of work.
+
+### OnApplicationModelCreating
+
+```csharp
+protected virtual void OnApplicationModelCreating(ModelBuilder modelBuilder)
+```
+
+Override this method instead of `OnModelCreating`:
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using SqlOS;
+
+public sealed class AppDbContext(DbContextOptions<AppDbContext> options)
+    : SqlOSDbContext<AppDbContext>(options)
+{
+    public DbSet<Project> Projects => Set<Project>();
+
+    protected override void OnApplicationModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Project>(entity =>
+        {
+            entity.HasKey(project => project.Id);
+            entity.Property(project => project.Name).HasMaxLength(200).IsRequired();
+        });
+    }
+}
+```
+
+## AddSqlOS&lt;TContext&gt;
+
+**Namespace:** `SqlOS.Extensions`
+
+**Type:** `WebApplicationBuilderExtensions`
+
+### Combined DbContext and SqlOS registration
+
+```csharp
+public static WebApplicationBuilder AddSqlOS<TContext>(
+    this WebApplicationBuilder builder,
+    Action<DbContextOptionsBuilder> configureDbContext,
+    Action<SqlOSOptions>? configureSqlOS = null)
+    where TContext : DbContext, ISqlOSAuthServerDbContext, ISqlOSFgaDbContext
+```
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `builder` | `WebApplicationBuilder` | The application host builder. |
+| `configureDbContext` | `Action<DbContextOptionsBuilder>` | Configures the application EF Core context. Use `UseSqlServer(...)` for the supported provider. |
+| `configureSqlOS` | `Action<SqlOSOptions>?` | Optional SqlOS configuration callback. |
+
+**Returns:** the same `WebApplicationBuilder`, for chaining.
+
+This overload calls `AddDbContext<TContext>` and registers the complete SqlOS service graph, hosted bootstrap, signing-key rotation, optional calendar synchronization, and dashboard middleware.
+
+### Existing DbContext registration
+
+```csharp
+public static WebApplicationBuilder AddSqlOS<TContext>(
+    this WebApplicationBuilder builder,
+    Action<SqlOSOptions>? configure = null)
+    where TContext : DbContext, ISqlOSAuthServerDbContext, ISqlOSFgaDbContext
+```
+
+Use this overload only when `TContext` is already registered in DI. It does not register the EF context.
+
+### Exceptions
+
+`AddSqlOS` throws `InvalidOperationException` when option validation fails. Examples include an issuer path that does not match `AuthServer.BasePath`, `PublicOrigin` and issuer mismatch, password dashboard mode without a password, or incomplete email/phone provider configuration.
+
+## UseSingleApplication
+
+**Namespace:** `SqlOS.Configuration`
+
+**Type:** `SqlOSOptions`
+
+```csharp
+public SqlOSOptions UseSingleApplication(
+    string name,
+    Action<SqlOSSingleApplicationOptions>? configure = null)
+```
+
+```csharp
+public SqlOSOptions UseSingleApplication(
+    IConfiguration configuration,
+    string sectionName = "SqlOS:Application")
+```
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `name` | `string` | Product/application display name. A client ID is derived from it unless explicitly configured. |
+| `configure` | `Action<SqlOSSingleApplicationOptions>?` | Overrides origin, client ID, audience, redirect URI, scopes, credentials, and branding defaults. |
+| `configuration` | `IConfiguration` | Configuration containing the single-application section. |
+| `sectionName` | `string` | Section path. Defaults to `SqlOS:Application`. |
+
+**Returns:** the same `SqlOSOptions` instance.
+
+Single-application mode creates one first-party public PKCE client, applies AuthPage/email branding defaults, and disables CIMD and resource indicators. It cannot be combined with explicit startup client seeds.
+
+### Exceptions
+
+- `InvalidOperationException` when `name` is empty.
+- `InvalidOperationException` when the configuration section does not exist.
+- Host bootstrap throws `InvalidOperationException` when neither `Origin` nor an explicit redirect URI is supplied, the origin/redirect is invalid, or explicit client seeds are also configured.
+
+## MapSqlOS
+
+**Namespace:** `SqlOS.Extensions`
+
+**Type:** `WebApplicationExtensions`
+
+```csharp
+public static WebApplication MapSqlOS(this WebApplication app)
+```
+
+**Returns:** the same `WebApplication`.
+
+Maps AuthServer routes, audit-log admin routes, and transactional-email admin routes. Calendar connect/admin routes are also mapped when `SqlOSOptions.Calendar.Enabled` is `true`. Call it once after `builder.Build()`.
+
+## RequireSqlOSAccessToken
+
+**Namespace:** `SqlOS.Extensions`
+
+**Type:** `SqlOSErgonomicsExtensions`
+
+```csharp
+public static RouteGroupBuilder RequireSqlOSAccessToken(
+    this RouteGroupBuilder group,
+    string expectedAudience)
+```
+
+```csharp
+public static RouteGroupBuilder RequireSqlOSAccessToken(
+    this RouteGroupBuilder group,
+    Action<SqlOSAccessTokenValidationOptions> configure)
+```
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `group` | `RouteGroupBuilder` | Minimal API route group to protect. |
+| `expectedAudience` | `string` | Required JWT audience. Validation fails closed when empty. |
+| `configure` | `Action<SqlOSAccessTokenValidationOptions>` | Configures `ExpectedAudience`, optional `Realm`, `ResourceMetadataUrl`, and `ShouldValidate`. |
+
+**Returns:** the same route group.
+
+The endpoint filter validates the bearer token, issuer, lifetime, server-side session state, and exact audience. On success it sets `HttpContext.User` and stores a `SqlOSValidatedToken`. On failure it returns HTTP `401` with a Bearer challenge.
+
+### Exceptions
+
+- `ArgumentNullException` when `group` or `configure` is null.
+- `InvalidOperationException` when `ExpectedAudience` is empty.
+
+## GetSqlOSValidatedToken
+
+**Namespace:** `SqlOS.AuthServer.Extensions`
+
+**Type:** `SqlOSAccessTokenValidationExtensions`
+
+```csharp
+public static SqlOSValidatedToken? GetSqlOSValidatedToken(
+    this HttpContext context)
+```
+
+**Returns:** the validated token stored by `RequireSqlOSAccessToken` or `UseSqlOSAccessTokenValidation`; otherwise `null`.
+
+```csharp
+using SqlOS.AuthServer.Extensions;
+using SqlOS.Extensions;
+
+var api = app.MapGroup("/api")
+    .RequireSqlOSAccessToken("https://app.example.com/api");
+
+api.MapGet("/me", (HttpContext http) =>
+{
+    var token = http.GetSqlOSValidatedToken();
+    return token?.UserId is { } userId
+        ? Results.Ok(new { userId, token.OrganizationId, token.ClientId })
+        : Results.Unauthorized();
+});
+```
+
+## Complete one-application host
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using SqlOS.Extensions;
+
+const string origin = "https://localhost:5001";
+
+var builder = WebApplication.CreateBuilder(args);
+var connectionString = builder.Configuration.GetConnectionString("DefaultConnection")
+    ?? throw new InvalidOperationException(
+        "Connection string 'DefaultConnection' was not configured.");
+
+builder.AddSqlOS<AppDbContext>(
+    db => db.UseSqlServer(connectionString),
+    options =>
+    {
+        options.AuthServer.PublicOrigin = origin;
+        options.AuthServer.Issuer = $"{origin}/sqlos/auth";
+        options.UseSingleApplication("Acme", application =>
+        {
+            application.Origin = origin;
+            application.Audience = $"{origin}/api";
+        });
+    });
+
+var app = builder.Build();
+app.MapSqlOS();
+app.Run();
+```
+
+SqlOS bootstraps its owned schema, signing key, default settings, client seed, and FGA core data when the host starts. Application EF migrations remain responsible only for application-owned tables.

--- a/web/content/docs/reference/index.mdx
+++ b/web/content/docs/reference/index.mdx
@@ -1,0 +1,64 @@
+---
+title: "Reference"
+description: "Source-aligned reference for SqlOS 3.16.0 hosting, authentication, authorization, and integration APIs."
+order: 7
+section: reference
+---
+
+<Banner
+  eyebrow="Reference"
+  title="SqlOS 3.16.0 application API"
+  href="/docs/getting-started"
+  actionLabel="Start with a guide"
+>
+  This section documents the application-facing API shipped by the current `SqlOS` package. Use a guide for a complete workflow; use reference pages when you need an exact namespace, signature, option, return type, or route.
+</Banner>
+
+## Package information
+
+| Item | Value |
+| --- | --- |
+| Package | `SqlOS` |
+| Current source version | `3.16.0` |
+| Assembly | `SqlOS.dll` |
+| Target framework | `net9.0` |
+| EF Core provider | SQL Server, EF Core 9 |
+| ASP.NET Core | Framework reference supplied by the package |
+
+The package now emits and packs `SqlOS.xml` for IDE help and generated-reference tooling. Missing-member warning `CS1591` is temporarily suppressed because XML comments are not yet complete across every public implementation type; overloaded-member `cref` warning `CS0419` is also suppressed until member-level docs are generated. The curated pages below therefore describe the supported application integration surface; they do not claim that every public class in the assembly is a recommended extension point.
+
+## Start here
+
+| Reference | Use it for |
+| --- | --- |
+| [Hosting API](/docs/reference/hosting-api) | `SqlOSDbContext<TContext>`, `AddSqlOS`, `UseSingleApplication`, `MapSqlOS`, and token-protected route groups |
+| [.NET SDK map](/docs/reference/sdk-reference) | DI services, contracts, namespaces, and task-oriented examples |
+| [AuthServer API](/docs/reference/authserver-api) | Exact authentication, invitation, token, MFA, OIDC, and administrative service methods |
+| [FGA API](/docs/reference/fga-api) | Access checks, EF query filters, resource synchronization, grants, and cursor pagination |
+| [HTTP protocol API](/docs/reference/api-reference) | OAuth discovery, authorization, token, hosted, headless, and optional registration routes |
+| [Audit Logs](/docs/reference/audit-logs) | `ISqlOSAuditLogService`, event queries, and CSV export |
+| [Standalone identity host](/docs/reference/standalone-identity-server) | Advanced multi-application deployments |
+
+### SqlOS 3.16 authentication additions
+
+Phone-code authentication is part of the current AuthServer service surface. Configure it with `SqlOSAuthServerOptions.ConfigurePhoneOtp(...)`, then use `RequestPhoneOtpAsync` / `VerifyPhoneOtpAsync` for sign-in or `RequestPhoneOtpSignupAsync` / `VerifyPhoneOtpSignupAsync` for signup. The request/result records are in `SqlOS.AuthServer.Contracts`; see [AuthServer API: Phone OTP](/docs/reference/authserver-api#phone-otp-sign-in-and-signup).
+
+## Integration layers
+
+Choose the highest-level API that fits the application:
+
+1. **One application:** derive from `SqlOSDbContext<TContext>`, call the combined `builder.AddSqlOS<TContext>(...)` overload, configure `UseSingleApplication(...)`, then call `app.MapSqlOS()`.
+2. **Application services:** inject `SqlOSAuthService`, `ISqlOSFgaAuthService`, `ISqlOSAuditLogService`, `ISqlOSTransactionalEmailService`, or `SqlOSCalendarService` for backend workflows.
+3. **Advanced host control:** use explicit client seeds, headless auth, device clients, CIMD/DCR, application assignments, or the lower-level EF/service registration APIs only when the simpler layer cannot express the topology.
+
+## Reference conventions
+
+- Signatures mirror the current C# source.
+- Optional parameters show their source defaults.
+- Exceptions list documented validation failures, not every exception an EF provider, network client, or callback can throw.
+- Dashboard admin routes are operator implementation endpoints. They are not presented as a general-purpose public management API.
+- Routes under `examples/` belong to sample applications and are never part of the `SqlOS` package contract.
+
+## Version drift checks
+
+The docs build verifies the package version, target framework, high-level source symbols, XML documentation setting, known contract names, and common stale example patterns. It complements compilation and tests; it is not a substitute for them.

--- a/web/content/docs/reference/sdk-reference.mdx
+++ b/web/content/docs/reference/sdk-reference.mdx
@@ -1,313 +1,400 @@
 ---
-title: "SDK Reference"
-description: "All SqlOS services, methods, and contracts."
-order: 8
+title: ".NET SDK Map"
+description: "Application-facing SqlOS services, contracts, namespaces, and source-aligned examples."
+order: 9
 section: reference
 ---
 
-## AuthServer Services
+<Banner
+  eyebrow=".NET API"
+  title="Choose the supported application service"
+  href="/docs/reference/hosting-api"
+  actionLabel="Hosting API"
+>
+  This page is a curated map of application-facing services. It does not claim to enumerate every public implementation class in `SqlOS.dll`. Follow the linked method references for exact contracts.
+</Banner>
 
-### SqlOSAuthService
+## Service map
 
-Main auth API. Inject `SqlOSAuthService`.
+All services below are registered by `AddSqlOS<TContext>`.
+
+| Task | Inject | Namespace | Detailed reference |
+| --- | --- | --- | --- |
+| Login, signup, invitations, sessions, tokens, MFA | `SqlOSAuthService` | `SqlOS.AuthServer.Services` | [AuthServer API](/docs/reference/authserver-api) |
+| Administrative identity workflows | `SqlOSAdminService` | `SqlOS.AuthServer.Services` | [AuthServer API](/docs/reference/authserver-api#sqlosadminservice) |
+| Point and query authorization | `ISqlOSFgaAuthService` | `SqlOS.Fga.Interfaces` | [FGA API](/docs/reference/fga-api) |
+| Record and query audit events | `ISqlOSAuditLogService` | `SqlOS.AuditLogs` | [Audit Logs](/docs/reference/audit-logs) |
+| Render and send application email | `ISqlOSTransactionalEmailService` | `SqlOS.Email.Interfaces` | [Transactional email](#transactional-email) |
+| Connect and use Google/Microsoft calendars | `SqlOSCalendarService` | `SqlOS.Calendar.Services` | [Calendar](#calendar) |
+
+Host registration, EF integration, route mapping, and bearer validation are documented separately in [Hosting API](/docs/reference/hosting-api).
+
+## SqlOSAuthService
+
+**Namespace:** `SqlOS.AuthServer.Services`
+
+Use named arguments for positional request records so examples stay readable when several adjacent fields have the same type.
+
+### Password login
 
 ```csharp
-// Password login
-var result = await authService.LoginWithPasswordAsync(
-    new SqlOSPasswordLoginRequest(email, password, clientId, organizationId),
-    httpContext, ct);
+var login = await authService.LoginWithPasswordAsync(
+    new SqlOSPasswordLoginRequest(
+        Email: email,
+        Password: password,
+        ClientId: clientId,
+        OrganizationId: organizationId),
+    httpContext,
+    ct);
+```
 
-// Signup
-var result = await authService.SignUpAsync(
-    new SqlOSSignupRequest(email, password, displayName, clientId),
-    httpContext, ct);
+### Password signup
 
-// Email OTP login
-var otpStart = await authService.RequestEmailOtpAsync(
-    new SqlOSEmailOtpStartRequest(email, clientId, organizationId), httpContext, ct);
-var otpLogin = await authService.VerifyEmailOtpAsync(
-    new SqlOSEmailOtpVerifyRequest(otpStart.ChallengeToken, code), httpContext, ct);
+```csharp
+var signup = await authService.SignUpAsync(
+    new SqlOSSignupRequest(
+        DisplayName: displayName,
+        Email: email,
+        Password: password,
+        OrganizationName: organizationName,
+        ClientId: clientId,
+        OrganizationId: null),
+    httpContext,
+    ct);
+```
 
-// Email OTP signup
-var otpSignupStart = await authService.RequestEmailOtpSignupAsync(
-    new SqlOSEmailOtpSignupStartRequest(displayName, email, clientId, organizationName, null, customFields),
-    httpContext, ct);
-var otpSignup = await authService.VerifyEmailOtpSignupAsync(
-    new SqlOSEmailOtpSignupVerifyRequest(otpSignupStart.SignupToken, otpSignupStart.ChallengeToken, code),
-    httpContext, ct);
+`OrganizationId` is not an invitation to join an existing tenant. Public signup rejects that path; use an invitation, trusted SSO provisioning, or an admin-owned workflow.
 
-// Organization invitations
-var invite = await authService.CreateEmailInvitationAsync(
-    new SqlOSCreateEmailInvitationRequest(organizationId, email, "member"),
-    httpContext, ct);
-var invitedSignup = await authService.AcceptEmailInvitationSignupAsync(
-    new SqlOSAcceptEmailInvitationSignupRequest(invitationToken, displayName, clientId, customFields),
-    httpContext, ct);
-await authService.AcceptEmailInvitationAsync(
-    new SqlOSAcceptEmailInvitationRequest(invitationToken, userId),
-    httpContext, ct);
+### Email OTP
 
-// CLI device OAuth
-var deviceStart = await authService.StartDeviceAuthorizationAsync(
-    new SqlOSDeviceAuthorizationStartRequest(clientId, scope, resource),
-    httpContext, ct);
-var deviceResolved = await authService.ResolveDeviceAuthorizationAsync(
-    deviceStart.UserCode, currentUser, ct);
-await authService.ApproveDeviceAuthorizationAsync(
-    new SqlOSDeviceAuthorizationApprovalRequest(deviceStart.UserCode, organizationId),
-    currentUser, authenticationMethod, httpContext, ct);
-var deviceTokens = await authService.PollDeviceAuthorizationAsync(
-    new SqlOSDeviceTokenPollRequest(clientId, deviceStart.DeviceCode, resource),
-    httpContext, ct);
+```csharp
+var start = await authService.RequestEmailOtpAsync(
+    new SqlOSEmailOtpStartRequest(
+        Email: email,
+        ClientId: clientId,
+        OrganizationId: organizationId),
+    httpContext,
+    ct);
 
-// Organization selection (after multi-org login)
-var tokens = await authService.SelectOrganizationAsync(
-    new SqlOSSelectOrganizationRequest(pendingAuthToken, organizationId),
-    httpContext, ct);
+var login = await authService.VerifyEmailOtpAsync(
+    new SqlOSEmailOtpVerifyRequest(
+        ChallengeToken: start.ChallengeToken,
+        Code: code),
+    httpContext,
+    ct);
+```
 
-// SSO/OIDC code exchange
+### Phone OTP (SqlOS 3.16)
+
+Configure Twilio Verify through the AuthServer options:
+
+```csharp
+options.AuthServer.ConfigurePhoneOtp(phone =>
+{
+    phone.Enabled = true;
+    phone.TwilioAccountSid = builder.Configuration["SqlOS:PhoneOtp:TwilioAccountSid"];
+    phone.TwilioAuthToken = builder.Configuration["SqlOS:PhoneOtp:TwilioAuthToken"];
+    phone.TwilioVerifyServiceSid = builder.Configuration["SqlOS:PhoneOtp:TwilioVerifyServiceSid"];
+    phone.DefaultRegion = "US";
+});
+```
+
+Sign in:
+
+```csharp
+var start = await authService.RequestPhoneOtpAsync(
+    new SqlOSPhoneOtpStartRequest(
+        PhoneNumber: phoneNumber,
+        ClientId: clientId,
+        OrganizationId: organizationId),
+    httpContext,
+    ct);
+
+var login = await authService.VerifyPhoneOtpAsync(
+    new SqlOSPhoneOtpVerifyRequest(
+        ChallengeToken: start.ChallengeToken,
+        Code: code),
+    httpContext,
+    ct);
+```
+
+Passwordless signup uses `SqlOSPhoneOtpSignupStartRequest`, `RequestPhoneOtpSignupAsync`, `SqlOSPhoneOtpSignupVerifyRequest`, and `VerifyPhoneOtpSignupAsync`. See [AuthServer API: Phone OTP](/docs/reference/authserver-api#phone-otp-sign-in-and-signup).
+
+### Invitation
+
+```csharp
+var invitation = await authService.CreateEmailInvitationAsync(
+    new SqlOSCreateEmailInvitationRequest(
+        OrganizationId: organizationId,
+        Email: "teammate@example.com",
+        Role: "member",
+        ClientId: clientId,
+        RedirectUri: redirectUri),
+    httpContext,
+    ct);
+```
+
+### Authorization-code exchange
+
+```csharp
 var tokens = await authService.ExchangeCodeAsync(
-    new SqlOSExchangeCodeRequest(code, state),
-    httpContext, ct);
+    new SqlOSExchangeCodeRequest(
+        Code: code,
+        ClientId: clientId),
+    httpContext,
+    ct);
+```
 
-// Refresh tokens
-var tokens = await authService.RefreshAsync(
-    new SqlOSRefreshRequest(refreshToken, organizationId), ct);
+### Resource-server token validation
 
-// Validate access token for a protected resource server
+```csharp
 var validated = await authService.ValidateAccessTokenAsync(
     rawToken,
     expectedAudience: "https://api.example.com",
     ct);
+```
 
-// Logout
-await authService.LogoutAsync(refreshToken, sessionId, ct);
-await authService.LogoutAllAsync(userId, ct);
+Always pass the expected audience for a protected API. `ValidateAccessTokenWithoutAudienceForIntrospectionOnlyAsync` is obsolete and intended only for diagnostics/introspection.
 
-// Session creation (for custom OIDC flows)
-var tokens = await authService.CreateSessionTokensForUserAsync(
-    user, client, organizationId, "password", userAgent, ipAddress, ct);
+### Password reset and email verification
 
-// Password reset
-await authService.RequestPasswordResetEmailAsync(
-    new SqlOSSendPasswordResetEmailRequest(email, ClientId: clientId), httpContext, ct);
+```csharp
+var reset = await authService.RequestPasswordResetEmailAsync(
+    new SqlOSSendPasswordResetEmailRequest(
+        Email: email,
+        ResetUrlTemplate: "https://app.example.com/reset?token={token}",
+        ClientId: clientId),
+    httpContext,
+    ct);
 
-// Trusted server/admin flows can still request delivery details.
-await authService.SendPasswordResetEmailAsync(
-    new SqlOSSendPasswordResetEmailRequest(email, ClientId: clientId), httpContext, ct);
+var verificationToken = await authService.CreateEmailVerificationTokenAsync(
+    new SqlOSCreateVerificationTokenRequest(Email: email),
+    ct);
 
-// Custom server-side reset-token flows can still generate and deliver the token directly.
-var token = await authService.CreatePasswordResetTokenAsync(
-    new SqlOSForgotPasswordRequest(email), ct);
-await authService.ResetPasswordAsync(
-    new SqlOSResetPasswordRequest(token, newPassword), ct);
-
-// Email verification
-var token = await authService.CreateEmailVerificationTokenAsync(
-    new SqlOSCreateVerificationTokenRequest(userId, email), ct);
 await authService.VerifyEmailAsync(
-    new SqlOSVerifyEmailRequest(token), ct);
+    new SqlOSVerifyEmailRequest(Token: verificationToken),
+    ct);
 ```
 
-### SqlOSAdminService
+## SqlOSAdminService
 
-Administrative operations. Inject via `SqlOSAdminService`.
+**Namespace:** `SqlOS.AuthServer.Services`
+
+This service is for trusted backend/operator workflows. Do not expose it directly to an untrusted browser.
 
 ```csharp
-// Organizations
-var org = await adminService.CreateOrganizationAsync(
-    new CreateOrganizationRequest { Name = "Acme", Slug = "acme", PrimaryDomain = "acme.com" }, ct);
+var organization = await adminService.CreateOrganizationAsync(
+    new SqlOSCreateOrganizationRequest(
+        Name: "Acme",
+        Slug: "acme",
+        PrimaryDomain: "acme.com"),
+    ct);
 
-// Users
 var user = await adminService.CreateUserAsync(
-    new CreateUserRequest { DisplayName = "Jane", Email = "jane@acme.com", Password = "..." }, ct);
+    new SqlOSCreateUserRequest(
+        DisplayName: "Jane Doe",
+        Email: "jane@acme.com",
+        Password: null),
+    ct);
 
-// Memberships
 var membership = await adminService.CreateMembershipAsync(
-    new CreateMembershipRequest { OrganizationId = org.Id, UserId = user.Id, Role = "admin" }, ct);
+    organization.Id,
+    new SqlOSCreateMembershipRequest(
+        UserId: user.Id,
+        Role: "admin"),
+    ct);
 
-// Clients
 var client = await adminService.CreateClientAsync(
-    new CreateClientRequest { ClientId = "my-app", Name = "My App", RedirectUris = ["..."] }, ct);
+    new SqlOSCreateClientRequest(
+        ClientId: "acme-web",
+        Name: "Acme Web",
+        Audience: "https://app.example.com/api",
+        RedirectUris: ["https://app.example.com/auth/callback"]),
+    ct);
+```
 
-// SSO
+### SAML draft and metadata import
+
+```csharp
 var draft = await adminService.CreateSsoConnectionDraftAsync(
-    new CreateSsoConnectionDraftRequest { OrganizationId = org.Id, DisplayName = "Entra SSO", PrimaryDomain = "acme.com" }, ct);
-await adminService.ImportSsoMetadataAsync(draft.ConnectionId, metadataXml, ct);
+    new SqlOSCreateSsoConnectionDraftRequest(
+        OrganizationId: organization.Id,
+        DisplayName: "Acme SSO",
+        PrimaryDomain: "acme.com",
+        AutoProvisionUsers: false,
+        AutoLinkByEmail: true),
+    ct);
 
-// Queries
-var orgs = await adminService.GetUserOrganizationsAsync(userId, ct);
-var isMember = await adminService.UserHasMembershipAsync(userId, organizationId, ct);
-
-// Helpers
-var normalized = SqlOSAdminService.NormalizeEmail(email);
+var connection = await adminService.ImportSsoMetadataAsync(
+    draft.Id,
+    new SqlOSImportSsoMetadataRequest(MetadataXml: metadataXml),
+    ct);
 ```
 
-### SqlOSHomeRealmDiscoveryService
+`SqlOSAdminService.NormalizeEmail(value)` trims and normalizes lookup keys with `ToUpperInvariant()`; it does not return a lowercase display email.
+
+## ISqlOSFgaAuthService
+
+**Namespace:** `SqlOS.Fga.Interfaces`
 
 ```csharp
-var result = await discoveryService.DiscoverAsync(
-    new SqlOSHomeRealmDiscoveryRequest(email), ct);
-// result.Mode → "password" | "sso"
-// result.OrganizationId, result.SsoConnectionId
+var decision = await fga.CheckAccessAsync(
+    subjectId,
+    permissionKey: "WORKSPACE_VIEW",
+    resourceId);
+
+var filter = await fga.GetAuthorizationFilterAsync<Workspace>(
+    subjectId,
+    permissionKey: "WORKSPACE_VIEW");
+
+var visible = await db.Workspaces
+    .Where(filter)
+    .OrderBy(workspace => workspace.Name)
+    .ToListAsync(ct);
 ```
 
-### SqlOSSsoAuthorizationService
+For provisioning, grants, entity synchronization, traces, and pagination, see [FGA API](/docs/reference/fga-api).
+
+## ISqlOSAuditLogService
+
+**Namespace:** `SqlOS.AuditLogs`
 
 ```csharp
-var start = await ssoService.StartAuthorizationAsync(
-    new SqlOSSsoAuthorizationStartRequest { ConnectionId = "...", RedirectUri = "..." }, ct);
-// start.AuthorizationUrl → SAML IdP redirect
-
-var tokens = await ssoService.ExchangeCodeAsync(
-    new SqlOSPkceExchangeRequest { Code = "...", State = "..." },
-    httpContext, ct);
+var recorded = await auditLogs.RecordAsync(
+    new SqlOSAuditLogRecordRequest(
+        Action: "workspace.created",
+        OrganizationId: organizationId,
+        UserId: userId,
+        ApplicationKey: "acme-web",
+        Actor: new SqlOSAuditActor("user", userId),
+        Targets: [new SqlOSAuditTarget("workspace", workspaceId)],
+        Context: SqlOSAuditContext.FromHttpContext(httpContext)),
+    ct);
 ```
 
-### SqlOSOidcAuthService
+See [Audit Logs Reference](/docs/reference/audit-logs) for filtering, idempotency, detail lookup, and CSV export.
+
+## Transactional email
+
+**Interface:** `ISqlOSTransactionalEmailService`
+
+**Namespace:** `SqlOS.Email.Interfaces`
+**Contracts:** `SqlOS.Email.Contracts`
 
 ```csharp
-var start = await oidcService.StartAuthorizationAsync(
-    new SqlOSStartOidcAuthorizationRequest { ConnectionId = "...", RedirectUri = "..." },
-    ipAddress, ct);
-// start.AuthorizationUrl → provider redirect
+Task<SqlOSRenderedEmailPreview> PreviewAsync(
+    string templateKey,
+    IReadOnlyDictionary<string, object?> variables,
+    CancellationToken cancellationToken = default);
 
-var complete = await oidcService.CompleteAuthorizationAsync(
-    new SqlOSCompleteOidcAuthorizationRequest { Code = "...", State = "..." },
-    ipAddress, ct);
-
-var providers = await oidcService.ListEnabledProvidersAsync(ct);
+Task<SqlOSSendEmailResult> SendAsync(
+    SqlOSSendEmailRequest request,
+    CancellationToken cancellationToken = default);
 ```
-
-### SqlOSCryptoService
 
 ```csharp
-var token = cryptoService.GenerateOpaqueToken();
-var id = cryptoService.GenerateId("usr");           // "usr_a1b2c3..."
-var hash = cryptoService.HashToken(token);
-var passwordHash = cryptoService.HashPassword("...");
-var valid = cryptoService.VerifyPassword(hash, "...");
-var challenge = cryptoService.CreatePkceCodeChallenge(verifier);
+var sent = await email.SendAsync(
+    new SqlOSSendEmailRequest(
+        TemplateKey: "app.receipt",
+        To: "buyer@example.com",
+        Variables: new Dictionary<string, object?>
+        {
+            ["orderNumber"] = "A-1234",
+            ["total"] = "$42.00"
+        },
+        IdempotencyKey: "receipt:A-1234"),
+    ct);
 ```
 
-### SqlOSSettingsService
+The example assumes the application has created an active `app.receipt` template with matching variables. Built-in auth templates use the `auth.*` keys and are normally invoked by the corresponding AuthServer workflow.
+
+The configured `ISqlOSEmailSender` performs delivery. Template validation can throw `SqlOSEmailTemplateValidationException` when required variables are missing. See [Transactional Email](/docs/authserver/transactional-email) for configuration and built-in templates.
+
+## Calendar
+
+**Service:** `SqlOSCalendarService`
+
+**Namespace:** `SqlOS.Calendar.Services`
+
+**Contracts:** `SqlOS.Calendar.Contracts`
+
+**Modes and persisted models:** `SqlOS.Calendar.Models`
+
+Calendar support is opt-in with `options.ConfigureCalendar(calendar => calendar.Enabled = true)`. It reuses a configured Google or Microsoft social/OIDC connection for provider client credentials.
 
 ```csharp
-var settings = await settingsService.GetResolvedSecuritySettingsAsync(ct);
-// settings.RefreshTokenLifetime    → TimeSpan
-// settings.SessionIdleTimeout      → TimeSpan
-// settings.SessionAbsoluteLifetime → TimeSpan
+var connect = await calendars.StartConnectAsync(
+    new SqlOSStartCalendarConnectRequest(
+        OidcConnectionId: oidcConnectionId,
+        Mode: SqlOSCalendarIntegrationMode.ConnectionOnly,
+        ReturnUri: "https://app.example.com/settings/calendar/callback",
+        UserId: userId,
+        OrganizationId: null,
+        DisplayName: "Work calendar"),
+    httpContext,
+    ct);
+
+return Results.Redirect(connect.AuthorizationUrl);
 ```
 
----
-
-## FGA Services
-
-### ISqlOSFgaAuthService
+Frequently used methods:
 
 ```csharp
-// Point check
-var result = await authService.CheckAccessAsync(subjectId, "CHAIN_VIEW", resourceId);
-// result.Allowed → bool
+Task<IReadOnlyList<SqlOSCalendarConnectionSummary>> ListConnectionsAsync(
+    string? userId = null,
+    string? organizationId = null,
+    bool includeRevoked = false,
+    CancellationToken cancellationToken = default);
 
-// Root-level capability
-var canEdit = await authService.HasCapabilityAsync(subjectId, "CHAIN_EDIT");
+Task<SqlOSCalendarAccessTokenResult> GetAccessTokenAsync(
+    string calendarConnectionId,
+    string? forUserId = null,
+    string? forOrganizationId = null,
+    CancellationToken cancellationToken = default);
 
-// Query filter
-var filter = await authService.GetAuthorizationFilterAsync<Chain>(subjectId, "CHAIN_VIEW");
-var chains = await dbContext.Chains.Where(filter).ToListAsync();
+Task<IReadOnlyList<SqlOSCalendarSummary>> ListProviderCalendarsAsync(
+    string calendarConnectionId,
+    string? forUserId = null,
+    string? forOrganizationId = null,
+    CancellationToken cancellationToken = default);
 
-// Trace (for debugging)
-var trace = await authService.TraceResourceAccessAsync(subjectId, resourceId, "CHAIN_VIEW");
+Task<IReadOnlyList<SqlOSCalendarEventSnapshot>> ListEventsAsync(
+    string calendarConnectionId,
+    DateTime fromUtc,
+    DateTime toUtc,
+    string? forUserId = null,
+    string? forOrganizationId = null,
+    CancellationToken cancellationToken = default);
 ```
 
-### Resource Lifecycle
+`ListEventsAsync` is for read-pull/two-way connections. Connection-only mode returns provider tokens through `GetAccessTokenAsync` and does not persist event copies. See [Calendar Integration](/docs/authserver/calendar-integration).
 
-```csharp
-public sealed class Workspace : ISqlOSResourceEntity
-{
-    public string Name { get; set; } = "";
-    public string OrganizationResourceId { get; set; } = "";
-    public string ResourceId { get; set; } = "";
+## Key result types
 
-    public string ResourceTypeId => "workspace";
-    public string ResourceName => Name;
-    public string? ParentResourceId => OrganizationResourceId;
-    public string? ResourceDescription => null;
-    public bool ResourceIsActive => true;
-}
+| Type | Namespace | Key members |
+| --- | --- | --- |
+| `SqlOSLoginResult` | `SqlOS.AuthServer.Contracts` | `RequiresOrganizationSelection`, `PendingAuthToken`, `Organizations`, `Tokens`, MFA state |
+| `SqlOSTokenResponse` | `SqlOS.AuthServer.Contracts` | access/refresh token, session, client, organization, expirations |
+| `SqlOSValidatedToken` | `SqlOS.AuthServer.Contracts` | `Principal`, `UserId`, `OrganizationId`, `ClientId`, `Audience` |
+| `SqlOSFgaAccessCheckResult` | `SqlOS.Fga.Models` | `Allowed`, optional trace/error |
+| `PaginatedResult<T>` | `SqlOS.Fga.Specifications` | `Data`, `PageSize`, `NextCursor`, `HasNextPage` |
+| `SqlOSAuditLogListResult` | `SqlOS.AuditLogs` | `Data`, page values, total count/pages |
+| `SqlOSSendEmailResult` | `SqlOS.Email.Contracts` | delivery ID/status, template version, provider/error details |
+| `SqlOSCalendarConnectionSummary` | `SqlOS.Calendar.Contracts` | owner, provider, mode, status, scopes, sync health |
 
-await db.SaveChangesAsync(ct); // syncs the backing SqlOSFgaResource row
-```
+## Namespace map
 
-Manual non-entity resources use `CreateResourceAsync(...)`, `CreateResourceWithIdAsync(...)`, `ProvisionResourceWithIdAsync(...)`, and `DeleteResourceAsync(...)`.
-
-### Subject and Grant Helpers
-
-```csharp
-await db.ProvisionUserSubjectAsync(subjectId, displayName: subjectId, cancellationToken: ct);
-await db.GrantRoleAsync(subjectId, workspace, "workspace_admin", ct);
-await db.RevokeRoleAsync(subjectId, workspace.ResourceId, "workspace_admin", ct);
-```
-
-### AuthorizedDetailAsync Extension
-
-```csharp
-return await authService.AuthorizedDetailAsync(
-    dbContext.Chains, c => c.Id == id,
-    subjectId, "CHAIN_VIEW",
-    chain => new ChainDto { Id = chain.Id, Name = chain.Name });
-```
-
-### PagedSpec Builder
-
-```csharp
-var spec = PagedSpec.For<Chain>(c => c.Id)
-    .RequirePermission("CHAIN_VIEW")
-    .SortByString("name", c => c.Name, isDefault: true)
-    .Search(search, c => c.Name, c => c.Description)
-    .Build(pageSize, cursor, sortBy, sortDir);
-
-var result = await executor.ExecuteAsync(dbContext.Chains, spec, subjectId, chain => new ChainDto { ... });
-// result.Items, result.NextCursor, result.HasMore
-```
-
----
-
-## Key Types
-
-### AuthServer
-
-| Type | Key fields |
+| Namespace | Application-facing contents |
 | --- | --- |
-| `SqlOSLoginResult` | `RequiresOrganizationSelection`, `PendingAuthToken`, `Organizations`, `Tokens` |
-| `SqlOSTokenResponse` | `AccessToken`, `RefreshToken`, `SessionId`, `ClientId`, `OrganizationId` |
-| `SqlOSValidatedToken` | `UserId`, `SessionId`, `ClientId`, `OrganizationId`, `Principal` |
-| `SqlOSHomeRealmDiscoveryResponse` | `Mode`, `Organizations`, `SsoConnectionId` |
-| `SqlOSEmailOtpStartResult` | `ChallengeToken`, `MaskedEmail`, `ExpiresAt`, `NextAllowedSendAt` |
-| `SqlOSEmailOtpSignupStartResult` | `SignupToken`, `ChallengeToken`, `MaskedEmail`, `ExpiresAt`, `NextAllowedSendAt` |
-| `SqlOSEmailInvitationResult` | `InviteUrl`, `Email`, `OrganizationId`, `Role`, `Status`, `ExpiresAt` |
-| `SqlOSInvitationAcceptanceResult` | `MembershipCreated`, `MembershipReactivated`, `EmailVerified` |
-
-### FGA
-
-| Type | Key fields |
-| --- | --- |
-| `SqlOSFgaAccessCheckResult` | `Allowed` |
-| `PagedResult<T>` | `Items`, `NextCursor`, `HasMore` |
-
----
-
-## Namespaces
-
-| Namespace | Contents |
-| --- | --- |
-| `SqlOS` | Bootstrap, options, `SqlOSDbContext<TContext>` |
-| `SqlOS.AuthServer.Services` | Auth service classes |
-| `SqlOS.AuthServer.Contracts` | Request/response types |
-| `SqlOS.AuthServer.Models` | EF Core entities |
-| `SqlOS.Fga.Interfaces` | `ISqlOSFgaAuthService`, `IHasResourceId`, `ISqlOSResourceEntity` |
-| `SqlOS.Extensions` | `ProvisionUserSubjectAsync`, `ProvisionAgentSubjectAsync`, `ProvisionServiceAccountSubjectAsync`, `GrantRoleAsync`, `RevokeRoleAsync`, manual resource APIs |
-| `SqlOS.Fga.Extensions` | Convenience extensions |
-| `SqlOS.Fga.Models` | FGA entities |
-| `SqlOS.Fga.Specifications` | PagedSpec, ISpecificationExecutor |
+| `SqlOS` | `SqlOSDbContext<TContext>` |
+| `SqlOS.Configuration` | root options and dashboard options |
+| `SqlOS.Extensions` | host registration/mapping, bearer validation, resource/subject/grant helpers |
+| `SqlOS.AuthServer.Configuration` | AuthServer, headless, MFA, OTP, client, and token validation options |
+| `SqlOS.AuthServer.Contracts` | authentication, token, client, invitation, OIDC, SAML, and settings records |
+| `SqlOS.AuthServer.Services` | authentication and trusted backend services |
+| `SqlOS.Fga.Interfaces` | authorization services and resource interfaces |
+| `SqlOS.Fga.Specifications` | authorized cursor-pagination specifications/results |
+| `SqlOS.AuditLogs` | audit service and contracts |
+| `SqlOS.Email.Interfaces` / `.Contracts` | transactional email service and requests/results |
+| `SqlOS.Calendar.Services` / `.Contracts` | calendar connection service and requests/results |
+| `SqlOS.Calendar.Models` | provider, mode, status, and persisted calendar model types |

--- a/web/content/docs/reference/standalone-identity-server.mdx
+++ b/web/content/docs/reference/standalone-identity-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Standalone Identity Server Reference"
 description: "Reference tables for using SqlOS as a dedicated identity host for multiple applications."
-order: 13
+order: 14
 section: reference
 ---
 

--- a/web/src/app/docs/page.tsx
+++ b/web/src/app/docs/page.tsx
@@ -1,11 +1,17 @@
-import { redirect } from "next/navigation";
+import { DocsHomePage } from "@emcy/docs";
+import { docsSource } from "@/lib/docs-source";
 
 export const metadata = {
-  title: "Documentation - SqlOS",
+  title: "SqlOS documentation",
   description:
-    "SqlOS documentation for the merged AuthServer and Fga runtime, shared example stack, and SQL-backed test setup.",
+    "Start with one .NET application, then add authentication, organizations, and SQL-backed authorization as your B2B SaaS grows.",
 };
 
 export default function DocsPage() {
-  redirect("/docs/getting-started");
+  return (
+    <DocsHomePage
+      entry={docsSource.getHomeEntry()}
+      navigation={docsSource.getNavigation()}
+    />
+  );
 }

--- a/web/src/lib/docs-source.ts
+++ b/web/src/lib/docs-source.ts
@@ -4,15 +4,15 @@ import { createDocsSource } from "@emcy/docs";
 export const docsSource = createDocsSource({
   contentDir: path.join(process.cwd(), "content/docs"),
   basePath: "/docs",
-  homeRedirect: "getting-started",
   siteTitle: "SqlOS Docs",
   titleSuffix: "SqlOS Docs",
   sectionLabels: {
-    "": "Getting Started",
+    "": "Start here",
+    quickstarts: "Quickstarts",
     guides: "Guides",
     authserver: "AuthServer",
     fga: "Fine-Grained Auth",
     reference: "Reference",
   },
-  sectionOrder: ["", "guides", "authserver", "fga", "reference"],
+  sectionOrder: ["", "quickstarts", "guides", "authserver", "fga", "reference"],
 });


### PR DESCRIPTION
## What changed

- rewrites the README around the SqlOS 3.16 developer path
- adds focused quickstarts for adding SqlOS, protecting APIs, EF authorization, and running the examples
- rebuilds the SDK, hosting, AuthServer, and FGA reference documentation
- adds source-contract, compilable-snippet, build, lint, and link validation to the docs check
- improves the public API ergonomics and XML documentation required by the new guides

## Scope correction

This branch was originally created from a stale pre-#150 base and modified marketing components that #150 had already replaced. The branch has been rebuilt on current `main`.

The marketing homepage, its component architecture, global marketing styles, header, footer, and theme behavior are intentionally unchanged.

## Validation

- `dotnet build SqlOS.sln --no-restore`
- `dotnet test tests/SqlOS.Tests/SqlOS.Tests.csproj --no-build` - 349 passed
- `./scripts/docs-check.sh`
  - source-contract validation
  - compiled documentation snippets
  - ESLint
  - production Next.js build
  - 126 Markdown files with no broken local links
- conflict-free merge-tree check against current `main`
