### PR TITLE
Prepare SqlOS 3.18.0 security release

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![NuGet](https://img.shields.io/nuget/v/SqlOS)](https://www.nuget.org/packages/SqlOS)
 [![.NET 9](https://img.shields.io/badge/.NET-9.0-purple)](https://dotnet.microsoft.com)
 
-SqlOS 3.17.0 provides a hosted OAuth server, branded login, organizations, sessions, and optional fine-grained authorization to an ASP.NET Core application. It runs in your process and stores its data in your SQL Server database, so you do not need a separate identity or authorization service to get started.
+SqlOS 3.18.0 provides a hosted OAuth server, branded login, organizations, sessions, and optional fine-grained authorization to an ASP.NET Core application. It runs in your process and stores its data in your SQL Server database, so you do not need a separate identity or authorization service to get started.
 
 Start with one application and hosted login. Add SAML SSO, social login, Email OTP, audit logs, calendar connections, or hierarchical authorization when your product needs them.
 
@@ -35,10 +35,10 @@ Requirements:
 Install the package:
 
 ```bash
-dotnet add package SqlOS --version 3.17.0
+dotnet add package SqlOS --version 3.18.0
 ```
 
-> The `main` branch is staged for the 3.17.0 package contract. If NuGet does not list 3.17.0 yet, run the repository examples from source or wait for the package release; do not pair these source docs with 3.16.0.
+> The `main` branch is staged for the 3.18.0 package contract. If NuGet does not list 3.18.0 yet, run the repository examples from source or wait for the package release; do not pair these source docs with 3.16.0.
 
 Use `SqlOSDbContext<TContext>` so SqlOS can register its EF Core model, then declare one application with `UseSingleApplication`:
 

--- a/src/SqlOS/SqlOS.csproj
+++ b/src/SqlOS/SqlOS.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>SqlOS</PackageId>
-    <Version>3.17.0</Version>
+    <Version>3.18.0</Version>
     <Authors>Ross Slaney</Authors>
     <Description>Embedded auth server and fine-grained authorization runtime for .NET + SQL Server + EF Core.</Description>
     <PackageTags>authentication;authorization;fga;saml;jwt;sessions;efcore;sqlserver</PackageTags>

--- a/tests/SqlOS.IntegrationTests/MfaEnrollmentSecurityIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/MfaEnrollmentSecurityIntegrationTests.cs
@@ -304,7 +304,7 @@ public sealed class MfaEnrollmentSecurityIntegrationTests
             "https://client.example.test/callback",
             state,
             "openid profile email",
-            $"challenge-{state}-1234567890123456789012345678901234567890123",
+            new string('A', 43),
             "S256",
             null,
             email,

--- a/web/content/blog/sqlos-3-18-oauth-security-hardening.mdx
+++ b/web/content/blog/sqlos-3-18-oauth-security-hardening.mdx
@@ -1,0 +1,76 @@
+---
+title: "SqlOS 3.18: OAuth Security Hardening Without More Infrastructure"
+description: "SqlOS 3.18 hardens signing keys, OIDC, SAML, MFA, password reset, sessions, and refresh rotation while keeping the default .NET setup local and automatic."
+date: "2026-07-12"
+author: "Ross Slaney"
+tags: ["AuthServer", "OAuth", "Security", "OIDC", "SAML", "SqlOS"]
+---
+
+SqlOS 3.18 is a security-focused release for the embedded OAuth and identity server.
+
+The important product constraint was not merely to close protocol gaps. SqlOS should remain the auth server a .NET team can add to its own application and SQL Server without first adopting a cloud key service or operating another identity product.
+
+That remains the default:
+
+```csharp
+builder.AddSqlOS<AppDbContext>(options =>
+{
+    options.AuthServer.Issuer = "https://app.example.com/sqlos/auth";
+    options.AuthServer.SeedBrowserClient(
+        "web",
+        "Web App",
+        "https://app.example.com/signin-oidc");
+});
+```
+
+There is no signing-key provider to select and no external key service to provision. SqlOS registers ASP.NET Core Data Protection, isolates its protected material by application, creates signing keys when needed, and stores only protected signing-key references in SQL Server.
+
+## What changed
+
+### Signing private keys are protected automatically
+
+JWT signing private material is no longer stored as an ordinary database secret. SqlOS generates and uses signing keys behind an internal custody boundary backed by ASP.NET Core Data Protection. A database-only compromise does not provide a usable private signing key.
+
+For one application instance on a durable machine, the default is automatic. Multiple replicas and ephemeral containers should share a durable Data Protection key ring; that is a production-readiness decision, not a requirement for local development.
+
+### Refresh retries keep one lineage
+
+The default 30-second refresh grace window now returns the same protected token response to near-concurrent retries. A retry cannot create a sibling refresh token or fork the family:
+
+```text
+R0 (consumed) -> R1 (only active replacement)
+```
+
+The cached response is purpose-bound, encrypted, and cryptographically time-limited. Reuse outside the grace window still revokes the family and session.
+
+### OIDC claims have one authenticated provenance
+
+SqlOS now requires the standard subject from the signed ID token. When UserInfo is used, its subject must exactly match the ID-token subject. Email and `email_verified` are accepted as a pair from one authenticated source, so a verification flag from one response cannot validate an email taken from another.
+
+Apple's first-login `user` form value is treated only as a bounded display-name hint. It is never identity evidence.
+
+### SAML authorization codes require PKCE
+
+SAML login now finishes through the normal OAuth authorization-code exchange. Every authorization code requires S256 PKCE and the exact registered redirect URI. The hosted SqlOS portal generates PKCE automatically; applications implementing the protocol directly must use an RFC 7636 verifier and challenge.
+
+### MFA enrollment stays bound to the login
+
+A successful first factor can no longer be reused to enroll a replacement authenticator outside the pending login. Required enrollment is bound to the same user, client, organization, authorization request, and challenge before tokens are issued.
+
+### Password-reset links come from trusted server configuration
+
+Default reset links are built from `PublicOrigin` or the configured issuer rather than request host headers. Applications with a custom reset page can opt into a server-side URL builder. Unknown users and delivery failures continue to use the same public response shape.
+
+### Lifecycle state is enforced at authentication boundaries
+
+Inactive users, organizations, and memberships are now rejected consistently during authorization, token creation, refresh, hosted-session reuse, OIDC and SAML callbacks, and stateful access-token validation. Public OAuth failures remain generic; the audit log retains the internal reason.
+
+Stateless JWT validation through JWKS still cannot observe a database revocation before token expiry. Use SqlOS's stateful validator when immediate lifecycle enforcement is required, or choose a short access-token lifetime for independently deployed JWKS-only resource servers.
+
+## Secure defaults remain quiet defaults
+
+Most applications should not add security plumbing for this release. The hosted flows create PKCE, signing-key protection is automatic, refresh retry protection is automatic, and lifecycle enforcement follows the data already managed by SqlOS.
+
+The operational exception is the same one faced by any ASP.NET Core application using Data Protection: replicas and replaceable containers need a durable shared key ring. SqlOS documents that in [Production Readiness](/docs/guides/production-readiness), alongside database backup and restore drills.
+
+The result is a materially stronger OAuth server without turning the first-run experience into an infrastructure project.

--- a/web/content/docs/docs-index.mdx
+++ b/web/content/docs/docs-index.mdx
@@ -5,7 +5,7 @@ order: 0
 ---
 
 <Callout type="info" title="Version contract">
-  These docs target **SqlOS 3.17.0**, **.NET 9**, **EF Core 9**, and **SQL Server**. Use the same package version as the docs: published `3.16.0` predates the ASP.NET Core protected-state schema upgrade and the complete current source/reference contract.
+  These docs target **SqlOS 3.18.0**, **.NET 9**, **EF Core 9**, and **SQL Server**. Use the same package version as the docs: published `3.16.0` predates the ASP.NET Core protected-state schema upgrade and the complete current source/reference contract.
 </Callout>
 
 ## Get useful proof first

--- a/web/content/docs/getting-started.mdx
+++ b/web/content/docs/getting-started.mdx
@@ -14,7 +14,7 @@ order: 0
 </Banner>
 
 <Callout type="info" title="Supported stack">
-  - **SqlOS 3.17.0**
+  - **SqlOS 3.18.0**
   - **.NET 9** (`net9.0`)
   - **EF Core 9**
   - **SQL Server**

--- a/web/content/docs/quickstarts/add-to-app.mdx
+++ b/web/content/docs/quickstarts/add-to-app.mdx
@@ -11,7 +11,7 @@ section: quickstarts
   href="#complete-program"
   actionLabel="View the code"
 >
-  Install SqlOS 3.17.0, register one SQL Server `DbContext`, declare one application, and map the routes. FGA modeling and advanced client registration can wait.
+  Install SqlOS 3.18.0, register one SQL Server `DbContext`, declare one application, and map the routes. FGA modeling and advanced client registration can wait.
 </Banner>
 
 ## Goal
@@ -30,16 +30,16 @@ Start an ASP.NET Core application with:
 - EF Core 9;
 - an existing SQL Server database and a login allowed to create tables, indexes, and functions.
 
-SqlOS 3.17.0 targets `net9.0`; it is not compatible with a `net8.0` host.
+SqlOS 3.18.0 targets `net9.0`; it is not compatible with a `net8.0` host.
 
 ## Install
 
 ```bash
-dotnet add package SqlOS --version 3.17.0
+dotnet add package SqlOS --version 3.18.0
 ```
 
 <Callout type="warning" title="Do not substitute 3.16.0">
-  The `3.17.0` package is the version contract for this guide. If NuGet does not list it yet, run the source examples from this repository or wait for the release; `3.16.0` predates the ASP.NET Core protected-state schema upgrade and other post-tag contracts documented here.
+  The `3.18.0` package is the version contract for this guide. If NuGet does not list it yet, run the source examples from this repository or wait for the release; `3.16.0` predates the ASP.NET Core protected-state schema upgrade and other post-tag contracts documented here.
 </Callout>
 
 For a new project, store local values with user secrets:

--- a/web/content/docs/quickstarts/ef-authorization.mdx
+++ b/web/content/docs/quickstarts/ef-authorization.mdx
@@ -20,7 +20,7 @@ Create projects through an audience-protected API and return only projects the s
 
 ## Prerequisites
 
-- SqlOS 3.17.0;
+- SqlOS 3.18.0;
 - .NET 9, EF Core 9, and SQL Server;
 - a completed [Protect an API](/docs/quickstarts/protect-api) flow;
 - a valid access token whose `aud` is `http://localhost:5050/api`.

--- a/web/content/docs/quickstarts/protect-api.mdx
+++ b/web/content/docs/quickstarts/protect-api.mdx
@@ -20,7 +20,7 @@ Add `/api/me` to a one-application SqlOS host. Requests without a bearer token r
 
 ## Prerequisites
 
-- SqlOS 3.17.0;
+- SqlOS 3.18.0;
 - .NET 9 and EF Core 9;
 - the [Add SqlOS to one app](/docs/quickstarts/add-to-app) setup;
 - the working [.NET hosted-login flow](/docs/quickstarts/aspnet-core-login), adapted so its registered callback matches your handler and its audience is `http://localhost:5050/api`, or another PKCE client that does the same.

--- a/web/content/docs/quickstarts/run-example-stack.mdx
+++ b/web/content/docs/quickstarts/run-example-stack.mdx
@@ -20,7 +20,7 @@ Compare hosted and headless auth, organization workflows, SSO, sessions, audit l
 
 ## Prerequisites
 
-- SqlOS repository checked out at version 3.17.0;
+- SqlOS repository checked out at version 3.18.0;
 - .NET 9 SDK;
 - Node.js and npm;
 - Docker running with enough memory for SQL Server;

--- a/web/content/docs/quickstarts/run-todo.mdx
+++ b/web/content/docs/quickstarts/run-todo.mdx
@@ -25,7 +25,7 @@ Create an account through the SqlOS hosted AuthPage, return to a secure ASP.NET 
 - Docker running with enough memory for SQL Server;
 - ports `1435`, `5080`, `5090`, `18890`, and `18891` available.
 
-This quickstart uses the source at **SqlOS 3.17.0**. Local password authentication is the default, so the first run does not require Azure Communication Services, Twilio, or an OIDC provider.
+This quickstart uses the source at **SqlOS 3.18.0**. Local password authentication is the default, so the first run does not require Azure Communication Services, Twilio, or an OIDC provider.
 
 ## Run
 

--- a/web/content/docs/reference/index.mdx
+++ b/web/content/docs/reference/index.mdx
@@ -1,13 +1,13 @@
 ---
 title: "Reference"
-description: "Source-aligned reference for SqlOS 3.17.0 hosting, authentication, authorization, and integration APIs."
+description: "Source-aligned reference for SqlOS 3.18.0 hosting, authentication, authorization, and integration APIs."
 order: 7
 section: reference
 ---
 
 <Banner
   eyebrow="Reference"
-  title="SqlOS 3.17.0 application API"
+  title="SqlOS 3.18.0 application API"
   href="/docs/getting-started"
   actionLabel="Start with a guide"
 >
@@ -19,7 +19,7 @@ section: reference
 | Item | Value |
 | --- | --- |
 | Package | `SqlOS` |
-| Current source version | `3.17.0` |
+| Current source version | `3.18.0` |
 | Assembly | `SqlOS.dll` |
 | Target framework | `net9.0` |
 | EF Core provider | SQL Server, EF Core 9 |


### PR DESCRIPTION
## Summary

- bump the SqlOS package contract from 3.17.0 to 3.18.0
- align README, quickstart, and reference version markers with the package
- publish a release post explaining the OAuth security hardening and its zero-configuration defaults

## Developer impact

SqlOS continues to require no external signing-key service. ASP.NET Core Data Protection is registered automatically; durable/shared key storage is documented only as a production-readiness concern for replicas and ephemeral containers.

The post covers signing-key custody, linear refresh retry lineage, OIDC claim provenance, SAML PKCE, bound MFA enrollment, trusted password-reset URLs, and lifecycle enforcement.

## Validation

- Release solution build: 0 warnings, 0 errors
- library unit tests: 432/432
- ASP.NET Core example tests: 2/2
- documentation source contract and snippets
- ESLint and Next.js production build (117 static pages)
- 34 documentation images validated
- 146 Markdown files with no broken local links

GitHub CI is the final SQL-backed integration and coverage gate before merge and release.
