### PR TITLE
Add transactional email guide

### DIFF
--- a/web/content/docs/authserver/email-branding.mdx
+++ b/web/content/docs/authserver/email-branding.mdx
@@ -9,6 +9,8 @@ Email Branding controls the built-in templates for Email OTP and organization in
 
 Use it when you want a client-ready branded email without owning every HTML template. Use `BuildMessage` delegates when you need a fully custom layout, copy, localization strategy, or provider-specific payload.
 
+For application-owned operational messages, follow [Send transactional email](/docs/guides/transactional-email). Branding supplies shared product identity; Communications templates control each stored message's subject and copy.
+
 ## What is configurable
 
 | Setting | Used for |

--- a/web/content/docs/authserver/transactional-email.mdx
+++ b/web/content/docs/authserver/transactional-email.mdx
@@ -7,6 +7,10 @@ section: authserver
 
 Transactional email is the audited template system for operational messages and built-in AuthServer email. Every SqlOS implementation automatically gets templates for Email OTP, organization invitations, and password reset emails during startup.
 
+<Callout type="tip" title="Build one application email end to end">
+  Follow [Send transactional email](/docs/guides/transactional-email) to create, preview, send, retry, and inspect a real product template. This page remains the compact contract and operations reference.
+</Callout>
+
 ## Configure ACS Email
 
 SqlOS ships an Azure Communication Services sender:
@@ -71,3 +75,8 @@ Email OTP, organization invitations, and password reset emails use the built-in 
 Upgrade behavior is additive for normal AuthServer email configuration. Existing `AuthServer.ConfigureEmailOtp(...)` ACS settings continue to work; configuring `options.Email` is optional unless you want separate transactional email credentials.
 
 Existing custom `BuildMessage` hooks still send through `ISqlOSAuthEmailSender`. Existing custom `ISqlOSAuthEmailSender` implementations also remain usable as the default rendered-template sender when no `options.Email` ACS sender is configured. Hosts that want a separate provider for all transactional templates can register `ISqlOSEmailSender` directly.
+
+## Next steps
+
+- [Send transactional email](/docs/guides/transactional-email)
+- [Email Branding](/docs/authserver/email-branding)

--- a/web/content/docs/authserver/transactional-email.mdx
+++ b/web/content/docs/authserver/transactional-email.mdx
@@ -66,7 +66,7 @@ Open `SqlOS Dashboard > Communications`.
 
 SqlOS stores delivery history with recipient, template key/version, status, timestamps, provider message id, sanitized error, rendered subject, and rendered text preview. It does not persist arbitrary variables JSON by default because variables can contain secrets.
 
-Rendered HTML bodies are not stored unless `options.Email.PersistRenderedHtmlPreview` is enabled. `options.Email.DeliveryRetention` records the host retention policy value; SqlOS does not run a destructive cleanup worker in V0.
+Rendered HTML bodies are not stored unless `options.Email.PersistRenderedHtmlPreview` is enabled. `options.Email.DeliveryRetention` declares and validates the host retention policy value, but the current service does not consume it or run a destructive cleanup worker.
 
 ## Built-in auth email
 

--- a/web/content/docs/guides/index.mdx
+++ b/web/content/docs/guides/index.mdx
@@ -86,6 +86,9 @@ section: guides
   <Card title="Audit logs" description="Record application events and review them in the dashboard." href="/docs/guides/audit-logs">
     <img className="sqlos-guide-card-image" src="/docs/guides-audit-logs.png" alt="Audit Logs dashboard" />
   </Card>
+  <Card title="Transactional email" description="Create, preview, send, retry, and inspect application-owned email." href="/docs/guides/transactional-email">
+    <img className="sqlos-guide-card-image" src="/docs/guides-transactional-email.svg" alt="Retry-safe transactional email workflow" />
+  </Card>
   <Card title="Calendar integration" description="Connect Google Calendar or Microsoft 365." href="/docs/guides/calendar-integration">
     <img className="sqlos-guide-card-image" src="/docs/guides-calendar-integration.png" alt="Calendar Connections dashboard" />
   </Card>

--- a/web/content/docs/guides/transactional-email.mdx
+++ b/web/content/docs/guides/transactional-email.mdx
@@ -1,0 +1,230 @@
+---
+title: "Send transactional email"
+description: "Create, preview, send, retry, and inspect an application-owned email template."
+order: 18
+section: guides
+---
+
+<Banner
+  eyebrow="Guide"
+  title="Send a retry-safe product email"
+  href="/docs/authserver/transactional-email"
+  actionLabel="Transactional email reference"
+>
+  Build an `order-shipped` template, send it from trusted server code, and inspect the persisted delivery record without creating a second email subsystem.
+</Banner>
+
+<Callout type="info" title="Prerequisites">
+  - SqlOS is registered with `AddSqlOS<TContext>()` and mapped with `MapSqlOS()`
+  - The host can open the password-protected SqlOS dashboard
+  - Azure Communication Services Email is configured, or the host has registered its own `ISqlOSEmailSender`
+</Callout>
+
+## Goal
+
+When an order ships, your application should:
+
+1. render one stored template with server-owned order data;
+2. submit the message once even when the operation is retried;
+3. record the template version and provider outcome;
+4. let an operator inspect the result without storing the original variables object.
+
+![An order event rendered through a versioned template into one retry-safe email delivery](/docs/guides-transactional-email.svg)
+
+## 1. Configure delivery
+
+SqlOS includes an Azure Communication Services Email sender. Read its credentials from user secrets in development and a managed secret store in production:
+
+```csharp
+builder.AddSqlOS<AppDbContext>(options =>
+{
+    options.ConfigureEmail(email =>
+    {
+        email.AzureCommunicationServicesConnectionString =
+            builder.Configuration["SqlOS:Email:AzureCommunicationServicesConnectionString"];
+        email.FromAddress =
+            builder.Configuration["SqlOS:Email:FromAddress"];
+
+        email.EnableIdempotency = true;
+        email.PersistRenderedHtmlPreview = false;
+        email.DeliveryRetention = TimeSpan.FromDays(90);
+    });
+});
+```
+
+Never commit the connection string. `scripts/azure/setup-acs-email.sh` can provision the Azure resources and DNS verification records.
+
+If Azure Communication Services is not the right provider, register an application-owned `ISqlOSEmailSender`. The template, validation, idempotency, delivery-history, and dashboard behavior remain the same.
+
+<Callout type="warning" title="Retention is a policy value, not a cleanup job">
+  `DeliveryRetention` records the host's intended retention period. SqlOS does not currently delete old delivery rows automatically. Implement a reviewed cleanup job if the policy must be enforced automatically.
+</Callout>
+
+## 2. Create the template
+
+Open **SqlOS Dashboard > Communications > Email Templates** and create:
+
+| Field | Value |
+| --- | --- |
+| Key | `order-shipped` |
+| Display name | `Order shipped` |
+| Subject | `Order {orderId} has shipped` |
+| HTML | `<p>Order <strong>{orderId}</strong> has shipped.</p><p><a href="{trackingUrl}">Track your order</a></p>` |
+| Text | `Order {orderId} has shipped. Track it at {trackingUrl}` |
+
+Template keys are unique. Content changes increment the stored template version, so each delivery records the exact version it rendered. An inactive template cannot be previewed or sent.
+
+Deleting an unused template removes it. Once a template has delivery history, the dashboard deactivates it instead so past deliveries keep their template relationship.
+
+## 3. Preview with representative values
+
+Use the dashboard preview before sending. You can also make preview part of an internal publishing or smoke-test workflow:
+
+```csharp
+var preview = await email.PreviewAsync(
+    "order-shipped",
+    new Dictionary<string, object?>
+    {
+        ["orderId"] = "A-1042",
+        ["trackingUrl"] = "https://tracking.example.test/A-1042"
+    },
+    ct);
+```
+
+The renderer has deliberately small semantics:
+
+- `{variable}` is the only placeholder syntax;
+- substitutions in HTML are HTML-encoded;
+- subject and text substitutions are plain text;
+- a missing variable fails preview and send;
+- extra variables are ignored.
+
+HTML encoding prevents a value from becoming injected markup. It does **not** decide whether an order exists, whether a recipient may see it, or whether a URL scheme is safe. Generate `trackingUrl` on the trusted server from an allowlisted HTTPS origin.
+
+<Callout type="warning" title="Preview is an operator surface">
+  Do not expose a public endpoint that accepts an arbitrary template key and variables and returns rendered output. Keep preview, template management, and test sends behind the same operator authorization as the dashboard.
+</Callout>
+
+## 4. Send from a trusted business workflow
+
+Inject `ISqlOSTransactionalEmailService` into the application service or endpoint that owns the shipment transition. Resolve the recipient and tracking URL from authorized server-side data rather than accepting them as trusted browser input:
+
+```csharp
+public sealed class ShipmentNotifier(
+    OrdersDbContext db,
+    ISqlOSTransactionalEmailService email)
+{
+    public async Task<SqlOSSendEmailResult> NotifyAsync(
+        string orderId,
+        string organizationId,
+        CancellationToken ct)
+    {
+        var order = await db.Orders.SingleAsync(
+            x => x.Id == orderId && x.OrganizationId == organizationId,
+            ct);
+
+        if (order.ShippedAt is null)
+        {
+            throw new InvalidOperationException("The order has not shipped.");
+        }
+
+        var trustedTrackingUrl =
+            $"https://tracking.example.com/orders/{Uri.EscapeDataString(order.Id)}";
+
+        return await email.SendAsync(new SqlOSSendEmailRequest(
+            TemplateKey: "order-shipped",
+            To: order.CustomerEmail,
+            Variables: new Dictionary<string, object?>
+            {
+                ["orderId"] = order.Id,
+                ["trackingUrl"] = trustedTrackingUrl
+            },
+            IdempotencyKey: $"order:{order.Id}:shipped"),
+            ct);
+    }
+}
+```
+
+The key describes the business event, not the HTTP attempt. Calling `NotifyAsync` again with `order:A-1042:shipped` returns the existing delivery and does not submit a second message. A random GUID on every retry defeats that protection.
+
+Choose the event boundary carefully. If a later reshipment should send another email, give it a distinct stable event identifier such as `order:A-1042:shipment:2`.
+
+<Callout type="warning" title="A transaction still needs application design">
+  Updating the order and calling `SendAsync` are not automatically one atomic operation. If the shipment commit and notification must never diverge, persist an outbox event with the shipment and process it with the same stable idempotency key.
+</Callout>
+
+## 5. Interpret the result correctly
+
+`SendAsync` returns the delivery id, status, template key/version, provider message id, and a sanitized error when submission fails.
+
+| Status | Meaning |
+| --- | --- |
+| `queued` | The configured provider accepted the submission |
+| `failed` | Configuration or provider submission failed; the sanitized outcome was persisted |
+
+`queued` does not prove that the recipient's mail server or inbox accepted the message. SqlOS does not currently process delivery webhooks, bounces, or open events.
+
+Template lookup and rendering happen before a delivery is submitted. A missing or inactive template and a missing required variable raise an error instead of contacting the provider.
+
+## 6. Inspect delivery history
+
+Open **SqlOS Dashboard > Communications > Email Messages**. Filter by status, template key, recipient, or date range.
+
+For each custom-template delivery SqlOS records:
+
+- recipient;
+- template key and version;
+- pending, queued, or failed status and timestamps;
+- provider message id when available;
+- sanitized failure detail;
+- rendered subject and rendered text preview;
+- rendered HTML only when `PersistRenderedHtmlPreview` is enabled.
+
+SqlOS does not store the arbitrary variables dictionary. That does not make variables consequence-free: their substituted values can appear in the stored subject and text preview.
+
+<Callout type="warning" title="Do not render secrets">
+  Never place passwords, access or refresh tokens, API keys, reset tokens, private URLs, or other credentials in a custom template. Keep secret-bearing auth flows on the built-in templates or another purpose-built protected channel.
+</Callout>
+
+Provider errors are sanitized before they are returned, logged as delivery detail, or added to the audit event. Treat sanitized output as operational context, not a complete provider trace.
+
+## 7. Understand built-in auth email
+
+SqlOS seeds three built-in templates:
+
+- `auth.email-otp`
+- `auth.invitation`
+- `auth.password-reset`
+
+You can edit their copy in **Communications > Email Templates**. Their rendered text and HTML are suppressed from delivery history because they contain codes or token-bearing links.
+
+Use [Email Branding](/docs/authserver/email-branding) for shared product identity and colors. Existing `BuildMessage` callbacks and custom `ISqlOSAuthEmailSender` implementations remain the advanced escape hatch for auth-specific layouts or provider behavior.
+
+This subsystem is for operational product email. It does not provide campaigns, subscriber lists, preference management, or marketing-email compliance workflows.
+
+## 8. Verify the integration
+
+Before production, prove each boundary:
+
+- a complete preview renders the expected subject, HTML, and text;
+- omitting `trackingUrl` fails before provider submission;
+- two sends with `order:A-1042:shipped` return one delivery and perform one provider submission;
+- a distinct shipment event produces a new delivery;
+- an inactive template cannot be sent;
+- provider failures store only sanitized detail;
+- the three built-in templates suppress secret-bearing rendered content;
+- the dashboard shows the exact template version used.
+
+The repository's focused regression suite exercises these semantics:
+
+```bash
+dotnet test tests/SqlOS.Tests/SqlOS.Tests.csproj \
+  --filter FullyQualifiedName~SqlOSTransactionalEmailTests
+```
+
+## Next steps
+
+- [Transactional Email reference](/docs/authserver/transactional-email)
+- [Email Branding](/docs/authserver/email-branding)
+- [Audit Logs](/docs/guides/audit-logs)
+- [Production Readiness](/docs/guides/production-readiness)

--- a/web/content/docs/guides/transactional-email.mdx
+++ b/web/content/docs/guides/transactional-email.mdx
@@ -57,7 +57,7 @@ Never commit the connection string. `scripts/azure/setup-acs-email.sh` can provi
 If Azure Communication Services is not the right provider, register an application-owned `ISqlOSEmailSender`. The template, validation, idempotency, delivery-history, and dashboard behavior remain the same.
 
 <Callout type="warning" title="Retention is a policy value, not a cleanup job">
-  `DeliveryRetention` records the host's intended retention period. SqlOS does not currently delete old delivery rows automatically. Implement a reviewed cleanup job if the policy must be enforced automatically.
+  `DeliveryRetention` declares the host's intended retention period and is validated at startup, but the current service does not read it to delete old rows. Implement a reviewed cleanup job if the policy must be enforced automatically.
 </Callout>
 
 ## 2. Create the template
@@ -72,9 +72,11 @@ Open **SqlOS Dashboard > Communications > Email Templates** and create:
 | HTML | `<p>Order <strong>{orderId}</strong> has shipped.</p><p><a href="{trackingUrl}">Track your order</a></p>` |
 | Text | `Order {orderId} has shipped. Track it at {trackingUrl}` |
 
-Template keys are unique. Content changes increment the stored template version, so each delivery records the exact version it rendered. An inactive template cannot be previewed or sent.
+Template keys are unique. Content changes increment the stored template version, so each delivery records the exact version it rendered. An inactive template cannot be sent, and `ISqlOSTransactionalEmailService.PreviewAsync` only resolves active templates. The operator dashboard can still preview an inactive stored template for inspection before reactivation.
 
 Deleting an unused template removes it. Once a template has delivery history, the dashboard deactivates it instead so past deliveries keep their template relationship.
+
+The **Variables JSON** saved with a template is persisted sample metadata for the editor and preview form. Keep those sample values non-secret. It is different from the per-send `Variables` dictionary, which is not stored as JSON on the delivery.
 
 ## 3. Preview with representative values
 
@@ -139,15 +141,20 @@ public sealed class ShipmentNotifier(
                 ["orderId"] = order.Id,
                 ["trackingUrl"] = trustedTrackingUrl
             },
-            IdempotencyKey: $"order:{order.Id}:shipped"),
+            IdempotencyKey:
+                $"org:{organizationId}:order:{order.Id}:shipped"),
             ct);
     }
 }
 ```
 
-The key describes the business event, not the HTTP attempt. Calling `NotifyAsync` again with `order:A-1042:shipped` returns the existing delivery and does not submit a second message. A random GUID on every retry defeats that protection.
+The key describes the business event, not the HTTP attempt. It is globally unique across the delivery table, so include enough tenant and event identity to prevent two legitimate operations from sharing it. Keep the normalized key at 200 characters or fewer. Calling `NotifyAsync` later with the same persisted key returns the existing delivery and does not submit a second message. A random GUID on every retry defeats that protection.
 
-Choose the event boundary carefully. If a later reshipment should send another email, give it a distinct stable event identifier such as `order:A-1042:shipment:2`.
+Choose the event boundary carefully. If a later reshipment should send another email, give it a distinct stable event identifier such as `org:acme:order:A-1042:shipment:2`.
+
+<Callout type="warning" title="Idempotency returns the first outcome">
+  Reusing a key returns the existing `pending`, `queued`, or `failed` delivery without comparing the new template, recipient, or variables and without calling the provider again. Reusing a failed key is not a provider retry. If policy allows another provider attempt, create a new stable attempt/event key deliberately. Concurrent first calls are protected by the unique database index, but a racing caller can receive a persistence conflict instead of the existing result; serialize one outbox consumer per business event or reload after that conflict.
+</Callout>
 
 <Callout type="warning" title="A transaction still needs application design">
   Updating the order and calling `SendAsync` are not automatically one atomic operation. If the shipment commit and notification must never diverge, persist an outbox event with the shipment and process it with the same stable idempotency key.
@@ -159,12 +166,15 @@ Choose the event boundary carefully. If a later reshipment should send another e
 
 | Status | Meaning |
 | --- | --- |
-| `queued` | The configured provider accepted the submission |
+| `pending` | SqlOS persisted the delivery before calling the sender; an interrupted process or cancellation can leave the provider outcome unknown |
+| `queued` | The sender adapter returned success; the built-in ACS adapter started the Azure send operation |
 | `failed` | Configuration or provider submission failed; the sanitized outcome was persisted |
 
 `queued` does not prove that the recipient's mail server or inbox accepted the message. SqlOS does not currently process delivery webhooks, bounces, or open events.
 
-Template lookup and rendering happen before a delivery is submitted. A missing or inactive template and a missing required variable raise an error instead of contacting the provider.
+A `pending` row is not proof that the provider was never contacted. If cancellation or process failure happens around submission, reconcile the provider operation where possible and keep the same idempotency key while investigating; blindly using a new key can produce a duplicate.
+
+Template lookup and rendering happen before a delivery row is created. A missing or inactive template and a missing required variable raise an error instead of contacting the provider. Those validation failures are exceptions, not `failed` delivery results.
 
 ## 6. Inspect delivery history
 
@@ -183,10 +193,10 @@ For each custom-template delivery SqlOS records:
 SqlOS does not store the arbitrary variables dictionary. That does not make variables consequence-free: their substituted values can appear in the stored subject and text preview.
 
 <Callout type="warning" title="Do not render secrets">
-  Never place passwords, access or refresh tokens, API keys, reset tokens, private URLs, or other credentials in a custom template. Keep secret-bearing auth flows on the built-in templates or another purpose-built protected channel.
+  Never place passwords, access or refresh tokens, API keys, reset tokens, secret-bearing URLs, or other credentials in a custom template. Keep secret-bearing auth flows on the built-in templates or another purpose-built protected channel.
 </Callout>
 
-Provider errors are sanitized before they are returned, logged as delivery detail, or added to the audit event. Treat sanitized output as operational context, not a complete provider trace.
+The returned result, persisted `SanitizedError`, and audit-event error are sanitized. The service also passes the caught provider exception to the host's `ILogger`; apply provider SDK redaction, restrict log access, and do not assume the sanitized delivery field sanitizes every host log sink. Treat the delivery error as operational context, not a complete provider trace.
 
 ## 7. Understand built-in auth email
 
@@ -208,9 +218,10 @@ Before production, prove each boundary:
 
 - a complete preview renders the expected subject, HTML, and text;
 - omitting `trackingUrl` fails before provider submission;
-- two sends with `order:A-1042:shipped` return one delivery and perform one provider submission;
+- a later retry with `org:acme:order:A-1042:shipped` returns the first delivery and performs no second provider submission;
+- a failed or pending delivery remains the returned outcome for that same key;
 - a distinct shipment event produces a new delivery;
-- an inactive template cannot be sent;
+- an inactive template cannot be sent or previewed through `ISqlOSTransactionalEmailService`, while the operator dashboard can still preview it;
 - provider failures store only sanitized detail;
 - the three built-in templates suppress secret-bearing rendered content;
 - the dashboard shows the exact template version used.

--- a/web/public/docs/guides-transactional-email.svg
+++ b/web/public/docs/guides-transactional-email.svg
@@ -1,0 +1,54 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675" role="img" aria-labelledby="title desc">
+  <title id="title">Retry-safe transactional email workflow</title>
+  <desc id="desc">An order shipped event flows through a versioned SqlOS email template to a single queued delivery, while a retry returns the same delivery.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0b1020"/>
+      <stop offset="1" stop-color="#18233f"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="14" stdDeviation="18" flood-color="#020617" flood-opacity=".42"/>
+    </filter>
+  </defs>
+  <rect width="1200" height="675" rx="28" fill="url(#bg)"/>
+  <circle cx="1030" cy="92" r="180" fill="#2563eb" opacity=".12"/>
+  <circle cx="170" cy="620" r="210" fill="#14b8a6" opacity=".09"/>
+  <text x="72" y="82" fill="#93c5fd" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="21" font-weight="700">TRANSACTIONAL EMAIL</text>
+  <text x="72" y="128" fill="#f8fafc" font-family="Inter, ui-sans-serif, system-ui" font-size="38" font-weight="750">One business event. One delivery.</text>
+
+  <g filter="url(#shadow)">
+    <rect x="72" y="207" width="260" height="238" rx="22" fill="#111a30" stroke="#334155"/>
+    <rect x="98" y="235" width="68" height="68" rx="16" fill="#0f766e"/>
+    <path d="M117 270h30m-22-12h14m-21 24h28" stroke="#ccfbf1" stroke-width="5" stroke-linecap="round"/>
+    <text x="98" y="344" fill="#f8fafc" font-family="Inter, ui-sans-serif, system-ui" font-size="25" font-weight="700">Order shipped</text>
+    <text x="98" y="380" fill="#94a3b8" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16">order:A-1042:shipped</text>
+    <text x="98" y="413" fill="#5eead4" font-family="Inter, ui-sans-serif, system-ui" font-size="16">trusted server event</text>
+
+    <rect x="470" y="178" width="276" height="296" rx="22" fill="#111a30" stroke="#3b82f6" stroke-width="2"/>
+    <rect x="496" y="208" width="224" height="39" rx="10" fill="#1e3a8a"/>
+    <text x="514" y="234" fill="#dbeafe" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16">order-shipped · v3</text>
+    <text x="496" y="288" fill="#f8fafc" font-family="Inter, ui-sans-serif, system-ui" font-size="21" font-weight="700">Order A-1042 has shipped</text>
+    <rect x="496" y="315" width="203" height="11" rx="5" fill="#475569"/>
+    <rect x="496" y="342" width="173" height="11" rx="5" fill="#334155"/>
+    <rect x="496" y="383" width="142" height="42" rx="12" fill="#2563eb"/>
+    <text x="522" y="410" fill="#fff" font-family="Inter, ui-sans-serif, system-ui" font-size="16" font-weight="700">Track order</text>
+
+    <rect x="884" y="207" width="244" height="238" rx="22" fill="#111a30" stroke="#334155"/>
+    <circle cx="934" cy="264" r="24" fill="#166534"/>
+    <path d="m922 264 8 8 17-19" fill="none" stroke="#dcfce7" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+    <text x="974" y="272" fill="#86efac" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" font-weight="700">QUEUED</text>
+    <text x="910" y="328" fill="#f8fafc" font-family="Inter, ui-sans-serif, system-ui" font-size="23" font-weight="700">edl_7f2…</text>
+    <text x="910" y="362" fill="#94a3b8" font-family="Inter, ui-sans-serif, system-ui" font-size="16">provider accepted</text>
+    <text x="910" y="394" fill="#64748b" font-family="Inter, ui-sans-serif, system-ui" font-size="15">not inbox proof</text>
+  </g>
+
+  <path d="M349 326h98" stroke="#60a5fa" stroke-width="5" stroke-linecap="round"/>
+  <path d="m432 314 16 12-16 12" fill="none" stroke="#60a5fa" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M764 326h98" stroke="#60a5fa" stroke-width="5" stroke-linecap="round"/>
+  <path d="m847 314 16 12-16 12" fill="none" stroke="#60a5fa" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <rect x="334" y="529" width="532" height="78" rx="18" fill="#0f172a" stroke="#334155"/>
+  <path d="M385 568c24-24 56-24 80 0m0 0-14-2m14 2-3-14" fill="none" stroke="#fbbf24" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="498" y="560" fill="#f8fafc" font-family="Inter, ui-sans-serif, system-ui" font-size="18" font-weight="700">Retry with the same event key</text>
+  <text x="498" y="585" fill="#94a3b8" font-family="Inter, ui-sans-serif, system-ui" font-size="15">returns edl_7f2… · no second provider submit</text>
+</svg>

--- a/web/public/docs/guides-transactional-email.svg
+++ b/web/public/docs/guides-transactional-email.svg
@@ -21,7 +21,7 @@
     <rect x="98" y="235" width="68" height="68" rx="16" fill="#0f766e"/>
     <path d="M117 270h30m-22-12h14m-21 24h28" stroke="#ccfbf1" stroke-width="5" stroke-linecap="round"/>
     <text x="98" y="344" fill="#f8fafc" font-family="Inter, ui-sans-serif, system-ui" font-size="25" font-weight="700">Order shipped</text>
-    <text x="98" y="380" fill="#94a3b8" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16">order:A-1042:shipped</text>
+    <text x="98" y="380" fill="#94a3b8" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="12">org:acme:order:A-1042:shipped</text>
     <text x="98" y="413" fill="#5eead4" font-family="Inter, ui-sans-serif, system-ui" font-size="16">trusted server event</text>
 
     <rect x="470" y="178" width="276" height="296" rx="22" fill="#111a30" stroke="#3b82f6" stroke-width="2"/>


### PR DESCRIPTION
Closes #174

## What changed

- adds a task-oriented `order-shipped` guide covering provider setup, templates, preview, trusted server sends, stable idempotency, status semantics, delivery history, and privacy
- adds an accessible guide illustration and Guides catalog card
- cross-links the compact transactional-email and email-branding references

## Validation

- `scripts/docs-check.sh`
- `dotnet test tests/SqlOS.Tests/SqlOS.Tests.csproj --filter FullyQualifiedName~SqlOSTransactionalEmailTests` (14 passed)

An independent adversarial documentation review will follow before merge.