### PR TITLE
Add FGA groups guide

### DIFF
--- a/scripts/compile-doc-snippets.mjs
+++ b/scripts/compile-doc-snippets.mjs
@@ -53,6 +53,27 @@ const snippetSpecs = [
     marker: "new SqlOSUpdateSecuritySettingsRequest(",
     wrap: asSecuritySettingsProgram,
   },
+  {
+    name: "FGA group grant",
+    relativePath: "web/content/docs/guides/fga-groups.mdx",
+    heading: "## 4. Grant one role to the group",
+    marker: "await db.GrantRoleAsync(",
+    wrap: asFgaGroupGrantProgram,
+  },
+  {
+    name: "FGA group detail authorization",
+    relativePath: "web/content/docs/guides/fga-groups.mdx",
+    heading: "## 5. Prove inherited detail access",
+    marker: "var workspace = await db.Workspaces",
+    wrap: asFgaGroupDetailProgram,
+  },
+  {
+    name: "FGA group list authorization",
+    relativePath: "web/content/docs/guides/fga-groups.mdx",
+    heading: "## 6. Prove inherited list access",
+    marker: "var filter = await fga.GetAuthorizationFilterAsync<Workspace>",
+    wrap: asFgaGroupListProgram,
+  },
 ];
 
 function extractCsharpBlock({ relativePath, heading, marker }) {
@@ -187,6 +208,79 @@ using SqlOS.AuthServer.Services;
 SqlOSSettingsService settingsService = null!;
 
 ${snippet}
+`;
+}
+
+function asFgaGroupGrantProgram(snippet) {
+  return `using SqlOS.Extensions;
+using SqlOS.Fga.Interfaces;
+using SqlOS.Fga.Models;
+
+ISqlOSFgaDbContext db = null!;
+var support = new SqlOSFgaUserGroup();
+var ct = CancellationToken.None;
+
+${snippet}
+`;
+}
+
+function asFgaGroupDetailProgram(snippet) {
+  return `using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using SqlOS.Fga.Interfaces;
+using SqlOS.Fga.Models;
+
+static async Task<IResult> AuthorizeDetailAsync(
+    ReviewDbContext db,
+    ISqlOSFgaAuthService fga,
+    string workspaceId,
+    string organizationId,
+    string userSubjectId,
+    CancellationToken ct)
+{
+${snippet}
+}
+
+public sealed class ReviewDbContext(DbContextOptions<ReviewDbContext> options) : DbContext(options)
+{
+    public DbSet<Workspace> Workspaces => Set<Workspace>();
+}
+
+public sealed class Workspace : IHasResourceId
+{
+    public string Id { get; set; } = string.Empty;
+    public string OrganizationId { get; set; } = string.Empty;
+    public string ResourceId { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+}
+`;
+}
+
+function asFgaGroupListProgram(snippet) {
+  return `using Microsoft.EntityFrameworkCore;
+using SqlOS.Fga.Interfaces;
+using SqlOS.Fga.Models;
+
+ISqlOSFgaAuthService fga = null!;
+ReviewDbContext db = null!;
+var userSubjectId = "subj_user";
+var organizationId = "org_acme";
+var ct = CancellationToken.None;
+
+${snippet}
+
+public sealed class ReviewDbContext(DbContextOptions<ReviewDbContext> options) : DbContext(options)
+{
+    public DbSet<Workspace> Workspaces => Set<Workspace>();
+}
+
+public sealed class Workspace : IHasResourceId
+{
+    public string Id { get; set; } = string.Empty;
+    public string OrganizationId { get; set; } = string.Empty;
+    public string ResourceId { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+}
 `;
 }
 

--- a/web/content/docs/fga/grants.mdx
+++ b/web/content/docs/fga/grants.mdx
@@ -7,6 +7,8 @@ section: fga
 
 A grant links a subject, a role, and a resource. The subject gains all permissions from the role on that resource and every descendant.
 
+To assign one role to a team and resolve it for every current member, follow [Authorize teams with FGA groups](/docs/guides/fga-groups).
+
 ## Create a grant
 
 **Dashboard**: Fine-Grained Auth > Grants

--- a/web/content/docs/fga/subject-types.mdx
+++ b/web/content/docs/fga/subject-types.mdx
@@ -74,6 +74,8 @@ await subjectService.AddToGroupAsync(subjectId, group.Id, ct);
 
 Groups are subjects with type `group`, but groups cannot be members of other groups.
 
+For the complete membership, grant, inherited-access, and removal workflow, follow [Authorize teams with FGA groups](/docs/guides/fga-groups). That guide also explains why `SqlOSFgaUserGroup.Id` is used for membership while `SubjectId` is used for grants.
+
 ## Authentication by subject type
 
 Authentication is application code. A bearer token, API key, or agent token can map to a user, service account, or agent subject, but FGA receives only the resolved `subjectId`.

--- a/web/content/docs/fga/syncing-auth-to-fga.mdx
+++ b/web/content/docs/fga/syncing-auth-to-fga.mdx
@@ -7,6 +7,8 @@ section: fga
 
 When using both AuthServer and FGA, you need to sync authenticated users into the FGA model so they can be authorized. The typical pattern is to sync on login.
 
+This page maps an AuthServer membership to a direct FGA grant. If the application's source of truth uses teams, follow [Authorize teams with FGA groups](/docs/guides/fga-groups) for group membership, inherited grants, and removal semantics.
+
 ## The pattern
 
 After login, provision the authenticated user as an FGA subject, provision any non-entity organization resource, and map the auth membership to an explicit FGA grant:

--- a/web/content/docs/guides/fga-groups.mdx
+++ b/web/content/docs/guides/fga-groups.mdx
@@ -18,6 +18,7 @@ section: guides
   - Your FGA model already has a workspace resource type
   - `workspace.view` and `workspace.edit` permissions already exist
   - A `workspace_editor` role contains both permissions
+  - A `workspace_reader` role contains only `workspace.view` for the direct-grant coexistence check
   - The target workspace exists in the FGA resource hierarchy
   - The authenticated user has already been provisioned as an FGA subject
 </Callout>
@@ -49,7 +50,7 @@ SqlOS does not automatically copy an AuthServer role or team into an FGA group. 
 
 For an authenticated request, take the acting user and organization from `GetSqlOSValidatedToken()` or another trusted server-side session. Never let a browser body choose the acting `subjectId`, target `groupId`, role, or tenant.
 
-This guide assumes the resolved FGA subject id is `userSubjectId` and the trusted organization id is `organizationId`.
+This guide assumes the resolved FGA subject id is `userSubjectId` and the trusted organization id is `organizationId`. The tenant-owned example also assumes the user subject was provisioned with that `OrganizationId`; if your FGA subjects are global, validate membership through an application-owned user-to-organization table instead.
 
 ## 2. Create the group
 
@@ -76,26 +77,60 @@ The result deliberately has two identifiers:
 
 `CreateGroupAsync` persists both the group subject and group record before returning.
 
-## 3. Add members
-
-Add the user's FGA **subject** id to the group container:
+`CreateGroupAsync` does not accept an organization id, and group authorization does not add a tenant predicate automatically. For a tenant-owned team, keep the group-to-organization relationship in application data or tag the generated group subject before exposing membership management:
 
 ```csharp
+var supportSubject = await db.Set<SqlOSFgaSubject>()
+    .SingleAsync(subject => subject.Id == support.SubjectId, ct);
+
+supportSubject.OrganizationId = organizationId;
+await db.SaveChangesAsync(ct);
+```
+
+`OrganizationId` is metadata your trusted workflow can validate; `CheckAccessAsync` and group resolution do not enforce it for you. A global group may intentionally omit it, but a tenant-owned team needs an equivalent application-owned boundary.
+
+## 3. Add members
+
+Load both sides through the trusted organization boundary, then add the user's FGA **subject** id to the group container:
+
+```csharp
+var memberExists = await db.Set<SqlOSFgaSubject>()
+    .AnyAsync(subject =>
+        subject.Id == userSubjectId &&
+        subject.OrganizationId == organizationId,
+        ct);
+
+var groupExists = await db.Set<SqlOSFgaUserGroup>()
+    .AnyAsync(group =>
+        group.Id == support.Id &&
+        group.Subject != null &&
+        group.Subject.OrganizationId == organizationId,
+        ct);
+
+if (!memberExists || !groupExists)
+{
+    throw new InvalidOperationException("The member and group must belong to the trusted organization.");
+}
+
 await subjectService.AddToGroupAsync(
     userSubjectId,
     support.Id,
     ct);
 ```
 
-Adding the same subject again is a no-op. The service supports subjects of type:
+The package's built-in member types are:
 
 - `user`
 - `agent`
 - `service_account`
 
-Groups cannot contain other groups. Group resolution is intentionally one level deep, so there is no recursive or cyclic membership model to operate.
+Groups cannot contain other groups. `AddToGroupAsync` explicitly rejects a subject whose type is `group`, and group resolution is intentionally one level deep, so there is no recursive or cyclic membership model to operate. The service does not act as a tenant guard or an allowlist for application-defined non-group subject types; if you seed custom subject types, decide their eligibility in the trusted wrapper.
 
 The membership service saves its own changes. You do not need an additional `SaveChangesAsync` after `AddToGroupAsync` or `RemoveFromGroupAsync`.
+
+Sequential retries are idempotent: a later add sees the existing composite membership row, and removing an absent row is a no-op. Two workers racing to add the same new membership can both pass the existence check before one wins the unique insert. Serialize reconciliation per subject/group or treat the duplicate-key loser as convergence after re-reading state.
+
+Group creation, membership changes, and `GrantRoleAsync` do not form one transaction in this workflow: the subject service saves each create/add/remove operation, while the grant is saved separately below. Make reconciliation resumable so partial progress can safely converge.
 
 ## 4. Grant one role to the group
 
@@ -111,7 +146,7 @@ await db.GrantRoleAsync(
 await db.SaveChangesAsync(ct);
 ```
 
-`GrantRoleAsync` is idempotent but does not save automatically. It creates one grant:
+`GrantRoleAsync` is idempotent for a normal replay after the earlier grant is visible, but it does not save automatically. Concurrent first writers can still race on the deterministic grant id, so serialize or handle duplicate-key convergence just as you do for membership. It creates one grant:
 
 ```text
 subject = support.SubjectId
@@ -123,21 +158,35 @@ SqlOS does not copy that grant to each member. When Alice is authorized, the FGA
 
 ## 5. Prove inherited detail access
 
-Authorize the user, not the group:
+Load the application row through the trusted organization before checking its FGA resource. Authorize the user, not the group:
 
 ```csharp
+var workspace = await db.Workspaces
+    .AsNoTracking()
+    .SingleOrDefaultAsync(item =>
+        item.Id == workspaceId &&
+        item.OrganizationId == organizationId,
+        ct);
+
+if (workspace is null)
+{
+    return Results.NotFound();
+}
+
 var result = await fga.CheckAccessAsync(
     userSubjectId,
     permissionKey: "workspace.edit",
-    resourceId: "workspace::acme");
+    resourceId: workspace.ResourceId);
 
 if (!result.Allowed)
 {
     return Results.Forbid();
 }
+
+return Results.Ok(new { workspace.Id, workspace.Name });
 ```
 
-The normal request should never substitute `support.SubjectId` for the authenticated user. Passing the user subject lets SqlOS consider both direct grants and current group memberships.
+The organization predicate prevents an application detail route from revealing or authorizing an object outside the active tenant. The normal request should never substitute `support.SubjectId` for the authenticated user. Passing the user subject lets SqlOS consider both direct grants and current group memberships.
 
 In the FGA dashboard's Access Tester, the trace identifies the group and group-owned grant that produced the allow decision.
 
@@ -159,32 +208,46 @@ var visibleWorkspaces = await db.Workspaces
 
 The first predicate binds the query to the trusted token organization. The FGA expression then limits rows to resources available through the user's direct and group grants. Do not treat a group grant as a replacement for the application's tenant boundary.
 
+Build the filter for each authorization request. `GetAuthorizationFilterAsync` resolves the user's current group subject ids and captures them in the returned expression; caching that expression across membership changes can retain a removed group's id.
+
 ## 7. Remove a member and verify revocation
 
-Remove Alice from the membership container:
+First give Alice an independent read-only grant, then remove her from the membership container:
 
 ```csharp
+await db.GrantRoleAsync(
+    userSubjectId,
+    resourceId: "workspace::acme",
+    roleKeyOrId: "workspace_reader",
+    cancellationToken: ct);
+await db.SaveChangesAsync(ct);
+
 await subjectService.RemoveFromGroupAsync(
     userSubjectId,
     support.Id,
     ct);
 ```
 
-Removal is idempotent and saves immediately. On the next authorization call, SqlOS no longer expands Alice to `support.SubjectId`, so the group's `workspace_editor` grant no longer applies:
+Removal saves immediately. On the next freshly built authorization call, SqlOS no longer expands Alice to `support.SubjectId`, so the group's `workspace_editor` grant no longer applies. Her separate `workspace_reader` grant still does:
 
 ```csharp
-var afterRemoval = await fga.CheckAccessAsync(
+var editAfterRemoval = await fga.CheckAccessAsync(
     userSubjectId,
     "workspace.edit",
     "workspace::acme");
 
-if (afterRemoval.Allowed)
+var viewAfterRemoval = await fga.CheckAccessAsync(
+    userSubjectId,
+    "workspace.view",
+    "workspace::acme");
+
+if (editAfterRemoval.Allowed || !viewAfterRemoval.Allowed)
 {
-    // Inspect other memberships or direct grants before treating this as stale group access.
+    throw new InvalidOperationException("The group removal or direct grant does not match the expected state.");
 }
 ```
 
-Removing membership does not delete the group or its grant. Other Support members retain access. It also does not remove a separate direct grant assigned to Alice, so an allow decision after removal can still be correct.
+Removing membership does not delete the group or its grant. Other Support members retain access. It also does not remove a separate direct grant assigned to Alice: the edit denial proves the group-only permission disappeared, while the view allow proves the direct grant coexists independently.
 
 ## 8. Synchronize the lifecycle
 
@@ -198,7 +261,9 @@ Treat FGA group membership as a projection of an application-owned source of tru
 
 Do not expose `AddToGroupAsync` directly from a public DTO. A valid user subject id, group id, and role name are not proof that the caller may join or manage that team.
 
-For bulk or external directory synchronization, make the operation replay-safe and reconcile both additions and removals. Repeated additions and removals are no-ops, which makes a desired-state loop straightforward.
+For bulk or external directory synchronization, make the operation replay-safe and reconcile both additions and removals. Single-worker replays converge cleanly; coordinate concurrent workers as described above.
+
+Group expansion does not itself enforce an AuthServer user, membership, agent, or service-account active state. Validate the authenticated principal lifecycle before FGA and remove stale memberships during offboarding instead of expecting group resolution to infer deactivation.
 
 ## 9. Inspect and test the result
 

--- a/web/content/docs/guides/fga-groups.mdx
+++ b/web/content/docs/guides/fga-groups.mdx
@@ -1,0 +1,236 @@
+---
+title: "Authorize teams with FGA groups"
+description: "Grant a role once to a team and resolve inherited access for every member."
+order: 17
+section: guides
+---
+
+<Banner
+  eyebrow="Guide"
+  title="Grant resource access to a team"
+  href="/docs/fga/subject-types"
+  actionLabel="Subject types"
+>
+  Create a Support group, grant it one workspace role, prove inherited list and detail access, then remove a member without editing the group grant.
+</Banner>
+
+<Callout type="info" title="Prerequisites">
+  - Your FGA model already has a workspace resource type
+  - `workspace.view` and `workspace.edit` permissions already exist
+  - A `workspace_editor` role contains both permissions
+  - The target workspace exists in the FGA resource hierarchy
+  - The authenticated user has already been provisioned as an FGA subject
+</Callout>
+
+## Goal
+
+Instead of creating one grant per person, represent a team as an FGA group:
+
+```text
+Support team -- workspace_editor --> workspace::acme
+       |
+       +-- user Alice
+       +-- user Bob
+       +-- service account Support Importer
+```
+
+Every request still authorizes Alice, Bob, or the service account by its own subject id. SqlOS expands that subject to its groups at authorization time.
+
+![Users and a service account inherit a workspace role through one FGA group grant](/docs/guides-fga-groups.svg)
+
+## 1. Keep identity and group membership separate
+
+AuthServer organization memberships and FGA group memberships are different application relationships:
+
+- AuthServer membership says a user belongs to an organization and may receive an organization-scoped session.
+- FGA group membership says an already provisioned subject inherits grants assigned to a logical team.
+
+SqlOS does not automatically copy an AuthServer role or team into an FGA group. Synchronize only from a trusted application workflow after validating the actor, organization, and source-of-truth membership.
+
+For an authenticated request, take the acting user and organization from `GetSqlOSValidatedToken()` or another trusted server-side session. Never let a browser body choose the acting `subjectId`, target `groupId`, role, or tenant.
+
+This guide assumes the resolved FGA subject id is `userSubjectId` and the trusted organization id is `organizationId`.
+
+## 2. Create the group
+
+Inject `ISqlOSFgaSubjectService` and create the team:
+
+```csharp
+var support = await subjectService.CreateGroupAsync(
+    name: "Support",
+    description: "People and services that operate the customer support workspace",
+    groupType: "team",
+    cancellationToken: ct);
+```
+
+The result deliberately has two identifiers:
+
+| Identifier | Represents | Use it for |
+| --- | --- | --- |
+| `support.Id` | The membership container | `AddToGroupAsync` and `RemoveFromGroupAsync` |
+| `support.SubjectId` | The group as an authorization principal | `GrantRoleAsync` and access traces |
+
+<Callout type="warning" title="Do not swap the two group identifiers">
+  Pass `support.Id` when changing membership. Pass `support.SubjectId` when granting the group a role. They identify different rows and are not interchangeable.
+</Callout>
+
+`CreateGroupAsync` persists both the group subject and group record before returning.
+
+## 3. Add members
+
+Add the user's FGA **subject** id to the group container:
+
+```csharp
+await subjectService.AddToGroupAsync(
+    userSubjectId,
+    support.Id,
+    ct);
+```
+
+Adding the same subject again is a no-op. The service supports subjects of type:
+
+- `user`
+- `agent`
+- `service_account`
+
+Groups cannot contain other groups. Group resolution is intentionally one level deep, so there is no recursive or cyclic membership model to operate.
+
+The membership service saves its own changes. You do not need an additional `SaveChangesAsync` after `AddToGroupAsync` or `RemoveFromGroupAsync`.
+
+## 4. Grant one role to the group
+
+Grant the role to the group's authorization subject, then save the new grant:
+
+```csharp
+await db.GrantRoleAsync(
+    support.SubjectId,
+    resourceId: "workspace::acme",
+    roleKeyOrId: "workspace_editor",
+    cancellationToken: ct);
+
+await db.SaveChangesAsync(ct);
+```
+
+`GrantRoleAsync` is idempotent but does not save automatically. It creates one grant:
+
+```text
+subject = support.SubjectId
+role = workspace_editor
+resource = workspace::acme
+```
+
+SqlOS does not copy that grant to each member. When Alice is authorized, the FGA service resolves Alice's subject plus any group subject ids and evaluates all applicable grants.
+
+## 5. Prove inherited detail access
+
+Authorize the user, not the group:
+
+```csharp
+var result = await fga.CheckAccessAsync(
+    userSubjectId,
+    permissionKey: "workspace.edit",
+    resourceId: "workspace::acme");
+
+if (!result.Allowed)
+{
+    return Results.Forbid();
+}
+```
+
+The normal request should never substitute `support.SubjectId` for the authenticated user. Passing the user subject lets SqlOS consider both direct grants and current group memberships.
+
+In the FGA dashboard's Access Tester, the trace identifies the group and group-owned grant that produced the allow decision.
+
+## 6. Prove inherited list access
+
+The same expansion happens before SqlOS constructs an EF authorization filter:
+
+```csharp
+var filter = await fga.GetAuthorizationFilterAsync<Workspace>(
+    userSubjectId,
+    "workspace.view");
+
+var visibleWorkspaces = await db.Workspaces
+    .Where(x => x.OrganizationId == organizationId)
+    .Where(filter)
+    .OrderBy(x => x.Name)
+    .ToListAsync(ct);
+```
+
+The first predicate binds the query to the trusted token organization. The FGA expression then limits rows to resources available through the user's direct and group grants. Do not treat a group grant as a replacement for the application's tenant boundary.
+
+## 7. Remove a member and verify revocation
+
+Remove Alice from the membership container:
+
+```csharp
+await subjectService.RemoveFromGroupAsync(
+    userSubjectId,
+    support.Id,
+    ct);
+```
+
+Removal is idempotent and saves immediately. On the next authorization call, SqlOS no longer expands Alice to `support.SubjectId`, so the group's `workspace_editor` grant no longer applies:
+
+```csharp
+var afterRemoval = await fga.CheckAccessAsync(
+    userSubjectId,
+    "workspace.edit",
+    "workspace::acme");
+
+if (afterRemoval.Allowed)
+{
+    // Inspect other memberships or direct grants before treating this as stale group access.
+}
+```
+
+Removing membership does not delete the group or its grant. Other Support members retain access. It also does not remove a separate direct grant assigned to Alice, so an allow decision after removal can still be correct.
+
+## 8. Synchronize the lifecycle
+
+Treat FGA group membership as a projection of an application-owned source of truth:
+
+1. authorize the administrator or trusted synchronization worker;
+2. load the subject and team from the trusted organization;
+3. add missing desired memberships;
+4. remove stale memberships, especially during offboarding;
+5. verify the resulting access decision.
+
+Do not expose `AddToGroupAsync` directly from a public DTO. A valid user subject id, group id, and role name are not proof that the caller may join or manage that team.
+
+For bulk or external directory synchronization, make the operation replay-safe and reconcile both additions and removals. Repeated additions and removals are no-ops, which makes a desired-state loop straightforward.
+
+## 9. Inspect and test the result
+
+Use **Fine-Grained Auth > User Groups** to inspect the group and members. Use **Grants** to inspect the role on `workspace::acme`, then use **Access Tester** with the individual member subject to see the inherited path.
+
+Before production, prove:
+
+- a new member gains detail and list access through the group;
+- a non-member remains denied;
+- repeated add does not duplicate membership;
+- removal makes group-only access disappear;
+- an unrelated direct grant continues to work;
+- an agent or service account can inherit the same group role;
+- adding a group as a member is rejected;
+- a subject and group from another tenant cannot be selected by an unauthorized workflow.
+
+The repository's focused tests cover group lifecycle and subject expansion:
+
+```bash
+dotnet test tests/SqlOS.Tests/SqlOS.Tests.csproj \
+  --filter FullyQualifiedName~SqlOSFgaSubjectServiceTests
+
+dotnet test tests/SqlOS.IntegrationTests/SqlOS.IntegrationTests.csproj \
+  --filter "FullyQualifiedName~SqlOSFgaSubjectTypesIntegrationTests|FullyQualifiedName~SqlOSFgaSubjectResolutionIntegrationTests"
+```
+
+The Retail example's **Walmart Regional Managers** group also demonstrates users and an agent inheriting one group grant.
+
+## Next steps
+
+- [Subject Types](/docs/fga/subject-types)
+- [Grants](/docs/fga/grants)
+- [Access Checks](/docs/fga/checking-a-permission)
+- [List Filtering](/docs/fga/list-filter)
+- [Syncing Auth to FGA](/docs/fga/syncing-auth-to-fga)

--- a/web/content/docs/guides/index.mdx
+++ b/web/content/docs/guides/index.mdx
@@ -71,6 +71,9 @@ section: guides
   <Card title="Background jobs with service accounts" description="Authorize non-user workers with rotated app-owned credentials." href="/docs/guides/service-account-jobs">
     <img className="sqlos-guide-card-image" src="/docs/guides-service-accounts.svg" alt="LedgerOps background worker service-account flow" />
   </Card>
+  <Card title="FGA groups" description="Grant a role once to a team and resolve inherited access for every member." href="/docs/guides/fga-groups">
+    <img className="sqlos-guide-card-image" src="/docs/guides-fga-groups.svg" alt="Team members inheriting workspace access through one FGA group grant" />
+  </Card>
   <Card title="Multi-app access" description="Assign organizations to the clients they are allowed to open." href="/docs/guides/multi-app-access">
     <img className="sqlos-guide-card-image" src="/docs/guides-multi-app-access.svg" alt="Atlas Suite organization access across three applications" />
   </Card>

--- a/web/public/docs/guides-fga-groups.svg
+++ b/web/public/docs/guides-fga-groups.svg
@@ -1,0 +1,62 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675" role="img" aria-labelledby="title desc">
+  <title id="title">Team authorization through an FGA group</title>
+  <desc id="desc">Two users and a service account join a Support group. One workspace editor grant on the group gives each member inherited access to the Acme workspace.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#081424"/>
+      <stop offset="1" stop-color="#16233d"/>
+    </linearGradient>
+    <filter id="shadow" x="-30%" y="-30%" width="160%" height="160%">
+      <feDropShadow dx="0" dy="12" stdDeviation="16" flood-color="#020617" flood-opacity=".45"/>
+    </filter>
+  </defs>
+  <rect width="1200" height="675" rx="28" fill="url(#bg)"/>
+  <circle cx="1070" cy="40" r="190" fill="#8b5cf6" opacity=".10"/>
+  <circle cx="80" cy="650" r="230" fill="#14b8a6" opacity=".08"/>
+  <text x="70" y="78" fill="#a5b4fc" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="21" font-weight="700">FGA USER GROUPS</text>
+  <text x="70" y="126" fill="#f8fafc" font-family="Inter, ui-sans-serif, system-ui" font-size="39" font-weight="750">Grant once. Authorize every member.</text>
+
+  <g filter="url(#shadow)">
+    <rect x="62" y="205" width="270" height="332" rx="22" fill="#101b30" stroke="#334155"/>
+    <text x="90" y="247" fill="#94a3b8" font-family="Inter, ui-sans-serif, system-ui" font-size="16" font-weight="650">MEMBERS</text>
+    <circle cx="110" cy="302" r="26" fill="#0f766e"/>
+    <circle cx="110" cy="302" r="9" fill="#ccfbf1"/>
+    <text x="153" y="309" fill="#f8fafc" font-family="Inter, ui-sans-serif, system-ui" font-size="21" font-weight="700">Alice</text>
+    <text x="153" y="333" fill="#94a3b8" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="14">subj_alice</text>
+    <circle cx="110" cy="393" r="26" fill="#1d4ed8"/>
+    <circle cx="110" cy="393" r="9" fill="#dbeafe"/>
+    <text x="153" y="400" fill="#f8fafc" font-family="Inter, ui-sans-serif, system-ui" font-size="21" font-weight="700">Bob</text>
+    <text x="153" y="424" fill="#94a3b8" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="14">subj_bob</text>
+    <rect x="84" y="463" width="52" height="52" rx="14" fill="#7c3aed"/>
+    <path d="M98 480h24v18H98zm5 18v6m14-6v6" fill="none" stroke="#ede9fe" stroke-width="4" stroke-linejoin="round"/>
+    <text x="153" y="482" fill="#f8fafc" font-family="Inter, ui-sans-serif, system-ui" font-size="18" font-weight="700">Support Importer</text>
+    <text x="153" y="506" fill="#94a3b8" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="14">service_account</text>
+
+    <rect x="457" y="239" width="286" height="238" rx="26" fill="#172554" stroke="#818cf8" stroke-width="2"/>
+    <circle cx="600" cy="305" r="42" fill="#4338ca"/>
+    <circle cx="583" cy="300" r="12" fill="#e0e7ff"/>
+    <circle cx="617" cy="300" r="12" fill="#e0e7ff"/>
+    <path d="M565 339c8-22 28-32 35-32s27 10 35 32" fill="none" stroke="#e0e7ff" stroke-width="7" stroke-linecap="round"/>
+    <text x="540" y="385" fill="#f8fafc" font-family="Inter, ui-sans-serif, system-ui" font-size="27" font-weight="750">Support</text>
+    <text x="512" y="417" fill="#c7d2fe" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="15">Id: grp_support</text>
+    <text x="495" y="445" fill="#c7d2fe" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="15">SubjectId: subj_support</text>
+
+    <rect x="872" y="227" width="266" height="260" rx="24" fill="#101b30" stroke="#334155"/>
+    <rect x="902" y="263" width="206" height="58" rx="14" fill="#14532d"/>
+    <text x="922" y="299" fill="#dcfce7" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="17" font-weight="700">workspace_editor</text>
+    <text x="902" y="368" fill="#f8fafc" font-family="Inter, ui-sans-serif, system-ui" font-size="24" font-weight="750">Acme Workspace</text>
+    <text x="902" y="402" fill="#94a3b8" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="15">workspace::acme</text>
+    <rect x="902" y="432" width="95" height="29" rx="14" fill="#0f766e"/>
+    <text x="922" y="452" fill="#ccfbf1" font-family="Inter, ui-sans-serif, system-ui" font-size="13" font-weight="700">INHERITED</text>
+  </g>
+
+  <path d="M350 357h84" stroke="#818cf8" stroke-width="5" stroke-linecap="round"/>
+  <path d="m419 345 16 12-16 12" fill="none" stroke="#818cf8" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="354" y="337" fill="#94a3b8" font-family="Inter, ui-sans-serif, system-ui" font-size="14">membership</text>
+  <path d="M766 357h82" stroke="#4ade80" stroke-width="5" stroke-linecap="round"/>
+  <path d="m833 345 16 12-16 12" fill="none" stroke="#4ade80" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="785" y="337" fill="#86efac" font-family="Inter, ui-sans-serif, system-ui" font-size="14">one grant</text>
+
+  <rect x="325" y="568" width="550" height="58" rx="17" fill="#0f172a" stroke="#334155"/>
+  <text x="363" y="604" fill="#cbd5e1" font-family="Inter, ui-sans-serif, system-ui" font-size="18">Authorize each request with the member's own subject id</text>
+</svg>


### PR DESCRIPTION
Closes #175

## What changed

- adds a complete team authorization guide covering group creation, the `Id`/`SubjectId` distinction, membership, one group grant, inherited detail/list access, removal, and lifecycle synchronization
- adds an accessible visual and Guides catalog card
- cross-links group workflows from subject, grant, and Auth-to-FGA reference pages

## Validation

- `scripts/docs-check.sh`
- `dotnet test tests/SqlOS.Tests/SqlOS.Tests.csproj --filter FullyQualifiedName~SqlOSFgaSubjectServiceTests` (14 passed)
- `dotnet test tests/SqlOS.IntegrationTests/SqlOS.IntegrationTests.csproj --filter "FullyQualifiedName~SqlOSFgaSubjectTypesIntegrationTests|FullyQualifiedName~SqlOSFgaSubjectResolutionIntegrationTests"` (9 passed)
- `dotnet test examples/SqlOS.Example.IntegrationTests/SqlOS.Example.IntegrationTests.csproj --filter FullyQualifiedName~SqlOSExampleRetailFgaIntegrationTests` (9 passed)

An independent adversarial documentation review will follow before merge.