### PR TITLE
Add authentication branding guide

### DIFF
--- a/web/content/docs/authserver/dashboard-overview.mdx
+++ b/web/content/docs/authserver/dashboard-overview.mdx
@@ -92,9 +92,9 @@ Audit Logs are a top-level governance surface. Filter by organization, applicati
 
 ## Auth emails
 
-The Auth Page settings screen includes email branding for built-in OTP and invitation emails. It stores the application name, logo data URL, primary color, accent color, and background color used by the default templates.
+The Auth Page settings screen includes email branding for built-in OTP, invitation, and password-reset emails. It stores the application name, logo data URL, primary color, accent color, and background color used by the default templates.
 
-For setup details, see [Email OTP](/docs/authserver/email-otp), [Email Invitations](/docs/authserver/invitations), and [Email Branding](/docs/authserver/email-branding).
+For the end-to-end workflow, see [Brand hosted authentication and email](/docs/guides/auth-branding). Exact feature references remain in [Email OTP](/docs/authserver/email-otp), [Email Invitations](/docs/authserver/invitations), and [Email Branding](/docs/authserver/email-branding).
 
 ## Delegated SSO setup
 

--- a/web/content/docs/authserver/email-branding.mdx
+++ b/web/content/docs/authserver/email-branding.mdx
@@ -5,7 +5,9 @@ order: 11
 section: authserver
 ---
 
-Email Branding controls the built-in templates for Email OTP and organization invitations.
+Email Branding controls the built-in templates for Email OTP, organization invitations, and password reset.
+
+For the complete browser-and-email workflow, follow [Brand hosted authentication and email](/docs/guides/auth-branding).
 
 Use it when you want a client-ready branded email without owning every HTML template. Use `BuildMessage` delegates when you need a fully custom layout, copy, localization strategy, or provider-specific payload.
 
@@ -89,11 +91,11 @@ Both contexts include resolved branding so custom templates can reuse the dashbo
 
 ## Runtime behavior
 
-SqlOS resolves branding in this order:
+SqlOS resolves email visual branding in this order:
 
 1. Email-specific settings from the dashboard or `SeedAuthEmails(...)`.
 2. AuthPage logo/colors for visual fallback.
-3. `EmailOtp.ApplicationName`.
-4. `SqlOS`.
+
+The email application name comes from stored email branding. Before one exists, SqlOS initializes it from `Invitations.ApplicationName`, then `EmailOtp.ApplicationName`, then `SqlOS`.
 
 Invitation emails can override the application name with `ConfigureInvitations(invites => invites.ApplicationName = "...")`.

--- a/web/content/docs/authserver/transactional-email.mdx
+++ b/web/content/docs/authserver/transactional-email.mdx
@@ -11,6 +11,8 @@ Transactional email is the audited template system for operational messages and 
   Follow [Send transactional email](/docs/guides/transactional-email) to create, preview, send, retry, and inspect a real product template. This page remains the compact contract and operations reference.
 </Callout>
 
+Use [Brand hosted authentication and email](/docs/guides/auth-branding) when the task is shared product identity across AuthPage and the three built-in auth templates. This page covers template and delivery behavior.
+
 ## Configure ACS Email
 
 SqlOS ships an Azure Communication Services sender:

--- a/web/content/docs/guides/auth-branding.mdx
+++ b/web/content/docs/guides/auth-branding.mdx
@@ -44,9 +44,9 @@ SqlOS supports two durable operating models:
 
 Startup seeds are reconciled into the database whenever the host starts. If a seed remains configured, a dashboard edit to the same settings is temporary and will be replaced on restart. The dashboard displays a **Startup managed** callout when that applies.
 
-Choose one owner per environment. A common rollout is to seed initial values, remove the seeds after the first deployment, and then deliberately hand ownership to dashboard operators. Do not alternate owners unintentionally.
+Choose one owner per environment. A common rollout is to seed initial values, remove the seeds after the first deployment, and then deliberately hand ownership to dashboard operators. If you use `UseSingleApplication`, also disable its implicit branding seeds during that handoff, as shown in [Use the dashboard instead](#5-use-the-dashboard-instead). Do not alternate owners unintentionally.
 
-`UseSingleApplication("Acme", ...)` already seeds the application name and basic AuthPage/email defaults when explicit seeds are absent. Add explicit seeds when you want deliberate colors, layout, copy, or logo values.
+`UseSingleApplication("Acme", ...)` creates startup-managed AuthPage and email seeds by default, even when you do not call `SeedAuthPage` or `SeedAuthEmails`. Add explicit seed configuration when you want deliberate colors, layout, copy, or logo values.
 
 ## 2. Store the logo as a data URL
 
@@ -108,7 +108,7 @@ The visual fields control:
 | `Layout = "split"` | form plus secondary brand panel |
 | `Layout = "stacked"` | compact centered presentation without the secondary panel |
 
-Only `split` and `stacked` are valid layouts. Colors must use supported hex values.
+Only `split` and `stacked` are valid layouts. Use six-digit `#RRGGBB` colors so the values render consistently in both the hosted page and built-in email.
 
 <Callout type="warning" title="Credentials are behavior, not decoration">
   `EnabledCredentialTypes` and `EnablePasswordSignup` change which authentication journeys users may start. Configure and test each provider before adding it to the list. Do not enable Email OTP, phone OTP, or a social button merely to change page appearance.
@@ -137,10 +137,13 @@ This branding is consumed by the built-in templates for:
 - `auth.invitation`;
 - `auth.password-reset`.
 
-AuthPage and email branding are separate settings because browser and email presentation often need different assets or contrast. Email visual values resolve in this order:
+AuthPage and email branding are separate settings because browser and email presentation often need different assets or contrast. The email logo resolves in this order:
 
-1. email-specific logo/colors from the dashboard or `SeedAuthEmails`;
-2. the AuthPage logo/color for any email-specific visual value that is empty.
+1. the email-specific logo from the dashboard or `SeedAuthEmails`;
+2. the AuthPage logo when the email logo is empty;
+3. application-name text in the built-in template when neither logo exists.
+
+The color resolver also falls back to the corresponding AuthPage color when an existing stored email color is missing. Current startup seeds and dashboard forms require email colors and initialize defaults, so configure explicit email colors rather than trying to leave those fields empty.
 
 The email application name resolves from the stored email-branding value. Before one exists, SqlOS initializes it from the invitation application name when configured, then the Email OTP application name, then `SqlOS`.
 
@@ -152,7 +155,19 @@ An invitation-specific application name can still override the name for that inv
 
 ## 5. Use the dashboard instead
 
-When operators own branding, do not keep the corresponding startup seeds configured.
+When operators own branding, do not keep the corresponding startup seeds configured. `UseSingleApplication` enables implicit AuthPage and email seeds by default, so dashboard ownership requires disabling those defaults too:
+
+```csharp
+options.UseSingleApplication("Acme", app =>
+{
+    app.Origin = "https://app.acme.example";
+    app.Audience = "https://app.acme.example/api";
+    app.ConfigureAuthPageBranding = false;
+    app.ConfigureEmailBranding = false;
+});
+```
+
+Disable only the surface an operator owns. For example, keep `ConfigureEmailBranding = true` when email branding should remain startup-managed.
 
 Open:
 
@@ -160,7 +175,7 @@ Open:
 /sqlos/admin/auth/settings
 ```
 
-Use **Auth Page** to edit the hosted title, subtitle, logo, colors, layout, signup, and credential list. Use **Email Branding** to edit the application name and email-specific logo/colors.
+Use **Auth Page** to edit the hosted title, subtitle, logo, colors, layout, signup, and credential list. Use **Email Branding** to edit the application name and email-specific logo/colors. Each **Logo upload** control reads the selected image into the adjacent data-URL field; save the form after choosing the file. Clear the email logo field when email should reuse the AuthPage logo.
 
 Dashboard changes are persisted immediately. They affect newly rendered pages and messages; they do not rewrite email already submitted to a provider.
 
@@ -178,7 +193,7 @@ Use the right surface for each concern:
 | Completely custom auth message layout/provider payload | `BuildMessage` callbacks or custom sender |
 | Custom headless browser/native UI | Your frontend |
 
-Headless Auth uses the same SqlOS OAuth and credential state machine, but your application renders the screens. AuthPage branding does not style that custom UI. Built-in auth email can still use SqlOS email branding independently.
+Headless Auth uses the same SqlOS OAuth and credential state machine, but your application renders the screens. SqlOS includes the resolved AuthPage settings in the headless view model; your frontend may reuse those values, but SqlOS does not apply the layout or styling to custom UI. Built-in auth email can still use SqlOS email branding independently.
 
 ## 7. Verify the full journey
 
@@ -204,7 +219,7 @@ Use a development capture sender or inbox you control. Never paste a live OTP, i
 ### Ownership and restart
 
 - with seeds configured, change one value in the dashboard, restart, and confirm the seed is reapplied;
-- without seeds, change the dashboard value, restart, and confirm the persisted operator value remains;
+- without explicit seeds—and with the applicable `UseSingleApplication` branding flags disabled—change the dashboard value, restart, and confirm the persisted operator value remains;
 - verify preview and production load their intended logo data URL from their own configuration source.
 
 ## 8. Run the relevant regression tests

--- a/web/content/docs/guides/auth-branding.mdx
+++ b/web/content/docs/guides/auth-branding.mdx
@@ -1,0 +1,225 @@
+---
+title: "Brand hosted authentication and email"
+description: "Apply one product identity to hosted login, signup, OTP, invitations, and password reset."
+order: 12
+section: guides
+---
+
+<Banner
+  eyebrow="Guide"
+  title="Make authentication look like your product"
+  href="/docs/authserver/email-branding"
+  actionLabel="Email branding reference"
+>
+  Choose a durable configuration owner, style the hosted AuthPage, brand built-in auth email, and verify the complete user journey.
+</Banner>
+
+<Callout type="info" title="Prerequisites">
+  - Hosted AuthPage login already works
+  - Your product has an approved name, logo data URL, and accessible color palette
+  - At least one email journey is configured if you want to inspect rendered email
+</Callout>
+
+## Goal
+
+Users should experience one coherent product identity across:
+
+- hosted login and signup;
+- Email OTP;
+- organization invitations;
+- password reset.
+
+![A shared product identity applied to the hosted login page and built-in authentication email](/docs/guides-auth-branding.svg)
+
+Branding changes presentation. It does not enable a credential provider, alter OAuth clients, or replace the authorization and tenant checks behind account-management workflows.
+
+## 1. Choose who owns the settings
+
+SqlOS supports two durable operating models:
+
+| Owner | Configure with | Best for |
+| --- | --- | --- |
+| Application startup | `SeedAuthPage(...)` and `SeedAuthEmails(...)` | repeatable local, preview, and production environments controlled by code/configuration |
+| Dashboard operator | **Auth Page** and **Email Branding** | installations where authorized operators own product presentation at runtime |
+
+Startup seeds are reconciled into the database whenever the host starts. If a seed remains configured, a dashboard edit to the same settings is temporary and will be replaced on restart. The dashboard displays a **Startup managed** callout when that applies.
+
+Choose one owner per environment. A common rollout is to seed initial values, remove the seeds after the first deployment, and then deliberately hand ownership to dashboard operators. Do not alternate owners unintentionally.
+
+`UseSingleApplication("Acme", ...)` already seeds the application name and basic AuthPage/email defaults when explicit seeds are absent. Add explicit seeds when you want deliberate colors, layout, copy, or logo values.
+
+## 2. Store the logo as a data URL
+
+`LogoBase64` expects an image data URL, not a filesystem path or public image URL:
+
+```text
+data:image/png;base64,iVBORw0KGgo...
+```
+
+Load it through configuration rather than placing a large or sensitive environment-specific value directly in source:
+
+```bash
+dotnet user-secrets set "SqlOS:Branding:LogoDataUrl" \
+  "data:image/png;base64,..."
+```
+
+Use a compact PNG, JPEG, SVG data URL, or other browser-supported image type. Verify the exact asset in the hosted page and email clients you support.
+
+## 3. Brand the hosted AuthPage
+
+Start with the single-application setup, then provide the explicit visual seed:
+
+```csharp
+var logoDataUrl = builder.Configuration["SqlOS:Branding:LogoDataUrl"];
+
+builder.AddSqlOS<AppDbContext>(options =>
+{
+    options.UseSingleApplication("Acme", app =>
+    {
+        app.Origin = "https://app.acme.example";
+        app.Audience = "https://app.acme.example/api";
+    });
+
+    options.AuthServer.SeedAuthPage(page =>
+    {
+        page.PageTitle = "Sign in to Acme";
+        page.PageSubtitle = "Access your team's workspace";
+        page.LogoBase64 = logoDataUrl;
+        page.PrimaryColor = "#4f46e5";
+        page.AccentColor = "#111827";
+        page.BackgroundColor = "#f5f3ff";
+        page.Layout = "split";
+
+        page.EnablePasswordSignup = true;
+        page.EnabledCredentialTypes = ["password", "email_otp"];
+    });
+});
+```
+
+The visual fields control:
+
+| Field | Hosted effect |
+| --- | --- |
+| `PageTitle` / `PageSubtitle` | primary page copy |
+| `LogoBase64` | product mark |
+| `PrimaryColor` | primary controls and emphasis |
+| `AccentColor` | headings and foreground accents |
+| `BackgroundColor` | surrounding page surface |
+| `Layout = "split"` | form plus secondary brand panel |
+| `Layout = "stacked"` | compact centered presentation without the secondary panel |
+
+Only `split` and `stacked` are valid layouts. Colors must use supported hex values.
+
+<Callout type="warning" title="Credentials are behavior, not decoration">
+  `EnabledCredentialTypes` and `EnablePasswordSignup` change which authentication journeys users may start. Configure and test each provider before adding it to the list. Do not enable Email OTP, phone OTP, or a social button merely to change page appearance.
+</Callout>
+
+![Hosted AuthPage using configured password branding](/docs/guides-password-login.png)
+
+## 4. Brand built-in authentication email
+
+Add a separate email seed:
+
+```csharp
+options.AuthServer.SeedAuthEmails(email =>
+{
+    email.ApplicationName = "Acme";
+    email.LogoBase64 = logoDataUrl;
+    email.PrimaryColor = "#4f46e5";
+    email.AccentColor = "#111827";
+    email.BackgroundColor = "#f5f3ff";
+});
+```
+
+This branding is consumed by the built-in templates for:
+
+- `auth.email-otp`;
+- `auth.invitation`;
+- `auth.password-reset`.
+
+AuthPage and email branding are separate settings because browser and email presentation often need different assets or contrast. Email visual values resolve in this order:
+
+1. email-specific logo/colors from the dashboard or `SeedAuthEmails`;
+2. the AuthPage logo/color for any email-specific visual value that is empty.
+
+The email application name resolves from the stored email-branding value. Before one exists, SqlOS initializes it from the invitation application name when configured, then the Email OTP application name, then `SqlOS`.
+
+An invitation-specific application name can still override the name for that invitation workflow.
+
+<Callout type="tip" title="Test the fallback intentionally">
+  Leave `email.LogoBase64` empty in a preview environment and confirm the AuthPage logo appears in built-in email. Then set an email-specific logo and confirm it takes precedence. Do not assume fallback from one successful client render.
+</Callout>
+
+## 5. Use the dashboard instead
+
+When operators own branding, do not keep the corresponding startup seeds configured.
+
+Open:
+
+```text
+/sqlos/admin/auth/settings
+```
+
+Use **Auth Page** to edit the hosted title, subtitle, logo, colors, layout, signup, and credential list. Use **Email Branding** to edit the application name and email-specific logo/colors.
+
+Dashboard changes are persisted immediately. They affect newly rendered pages and messages; they do not rewrite email already submitted to a provider.
+
+The page also exposes authentication behavior. Apply the same review discipline as code configuration when changing signup or credential types.
+
+## 6. Know what branding does not own
+
+Use the right surface for each concern:
+
+| Concern | Owner |
+| --- | --- |
+| Hosted browser layout, title, logo, and colors | AuthPage branding |
+| Built-in auth email product identity and colors | Email Branding |
+| Stored subject, HTML, and text copy | **Communications > Email Templates** |
+| Completely custom auth message layout/provider payload | `BuildMessage` callbacks or custom sender |
+| Custom headless browser/native UI | Your frontend |
+
+Headless Auth uses the same SqlOS OAuth and credential state machine, but your application renders the screens. AuthPage branding does not style that custom UI. Built-in auth email can still use SqlOS email branding independently.
+
+## 7. Verify the full journey
+
+Do not stop after checking the settings form. Test what a user actually receives.
+
+### Hosted browser
+
+- open login and signup at desktop and narrow mobile widths;
+- test `split` and `stacked` if both are supported by your product;
+- check title wrapping, subtitle length, logo aspect ratio, missing-logo fallback, contrast, focus state, and error text;
+- complete each enabled credential flow rather than only rendering its first button.
+
+### Built-in email
+
+- send an Email OTP and inspect its subject, logo, colors, code legibility, text alternative, and application name;
+- create an organization invitation and inspect its organization context and action link;
+- start password recovery and inspect the reset message;
+- verify email-specific logo/color values override AuthPage fallback;
+- confirm the Communications delivery history suppresses secret-bearing rendered content for all three built-in templates.
+
+Use a development capture sender or inbox you control. Never paste a live OTP, invitation token, or password-reset link into an issue, screenshot, test fixture, or public review.
+
+### Ownership and restart
+
+- with seeds configured, change one value in the dashboard, restart, and confirm the seed is reapplied;
+- without seeds, change the dashboard value, restart, and confirm the persisted operator value remains;
+- verify preview and production load their intended logo data URL from their own configuration source.
+
+## 8. Run the relevant regression tests
+
+```bash
+dotnet test tests/SqlOS.Tests/SqlOS.Tests.csproj \
+  --filter "FullyQualifiedName~SqlOSAuthPageRendererTests|FullyQualifiedName~SqlOSSingleApplicationTests|FullyQualifiedName~SqlOSTransactionalEmailTests"
+```
+
+These tests cover configured hosted rendering, single-application defaults, stored templates, and sensitive built-in delivery behavior. Your product review must still inspect its actual logo, palette, copy, and supported clients.
+
+## Next steps
+
+- [Email Branding reference](/docs/authserver/email-branding)
+- [Dashboard](/docs/authserver/dashboard-overview)
+- [Password login](/docs/guides/password-login)
+- [Transactional Email](/docs/authserver/transactional-email)
+- [Hosted vs Headless](/docs/authserver/hosted-vs-headless)

--- a/web/content/docs/guides/index.mdx
+++ b/web/content/docs/guides/index.mdx
@@ -31,6 +31,9 @@ section: guides
   <Card title="Password login" description="Add hosted password auth to an existing ASP.NET app." href="/docs/guides/password-login">
     <img className="sqlos-guide-card-image" src="/docs/guides-password-login.png" alt="Hosted AuthPage password credential step" />
   </Card>
+  <Card title="Auth branding" description="Apply one product identity to hosted login, signup, and built-in auth email." href="/docs/guides/auth-branding">
+    <img className="sqlos-guide-card-image" src="/docs/guides-auth-branding.svg" alt="Consistent Acme branding across hosted authentication and password reset email" />
+  </Card>
   <Card title="Email-code onboarding" description="Create a passwordless account with a short-lived inbox code." href="/docs/guides/email-otp-onboarding">
     <img className="sqlos-guide-card-image" src="/docs/guides-email-otp-onboarding.svg" alt="ParcelPilot passwordless email-code onboarding screens" />
   </Card>

--- a/web/content/docs/guides/password-login.mdx
+++ b/web/content/docs/guides/password-login.mdx
@@ -66,6 +66,7 @@ app.MapSqlOS();
 
 ## Next steps
 
+- [Auth branding](/docs/guides/auth-branding) for the hosted page and built-in email
 - [Email OTP](/docs/authserver/email-otp) for passwordless sign-in
 - [Social sign-in](/docs/guides/social-oidc)
 - [GitHub sign-in](/docs/guides/github-oidc)

--- a/web/public/docs/guides-auth-branding.svg
+++ b/web/public/docs/guides-auth-branding.svg
@@ -1,0 +1,52 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675" role="img" aria-labelledby="title desc">
+  <title id="title">Consistent branding across hosted authentication and email</title>
+  <desc id="desc">Acme product colors and logo appear on a hosted sign-in page and a password reset email, with startup or dashboard ownership feeding both surfaces.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0d1021"/>
+      <stop offset="1" stop-color="#22164a"/>
+    </linearGradient>
+    <filter id="shadow" x="-25%" y="-25%" width="150%" height="150%">
+      <feDropShadow dx="0" dy="15" stdDeviation="18" flood-color="#020617" flood-opacity=".5"/>
+    </filter>
+  </defs>
+  <rect width="1200" height="675" rx="28" fill="url(#bg)"/>
+  <circle cx="1090" cy="80" r="210" fill="#8b5cf6" opacity=".12"/>
+  <circle cx="30" cy="650" r="230" fill="#4f46e5" opacity=".10"/>
+  <text x="70" y="79" fill="#c4b5fd" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="21" font-weight="700">AUTH BRANDING</text>
+  <text x="70" y="127" fill="#f8fafc" font-family="Inter, ui-sans-serif, system-ui" font-size="39" font-weight="750">One identity across every auth touchpoint</text>
+
+  <g filter="url(#shadow)">
+    <rect x="68" y="192" width="425" height="360" rx="25" fill="#f5f3ff"/>
+    <rect x="68" y="192" width="145" height="360" rx="25" fill="#4f46e5"/>
+    <rect x="183" y="192" width="30" height="360" fill="#4f46e5"/>
+    <rect x="96" y="226" width="88" height="38" rx="12" fill="#fff" opacity=".95"/>
+    <path d="M115 246h15l8-13 8 26 8-13h14" fill="none" stroke="#4f46e5" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    <text x="96" y="310" fill="#fff" font-family="Inter, ui-sans-serif, system-ui" font-size="22" font-weight="750">Acme</text>
+    <text x="96" y="342" fill="#ddd6fe" font-family="Inter, ui-sans-serif, system-ui" font-size="14">Team workspaces,</text>
+    <text x="96" y="364" fill="#ddd6fe" font-family="Inter, ui-sans-serif, system-ui" font-size="14">beautifully secure.</text>
+    <text x="253" y="253" fill="#111827" font-family="Inter, ui-sans-serif, system-ui" font-size="25" font-weight="750">Sign in to Acme</text>
+    <text x="253" y="282" fill="#6b7280" font-family="Inter, ui-sans-serif, system-ui" font-size="14">Access your team's workspace</text>
+    <rect x="253" y="317" width="197" height="51" rx="12" fill="#fff" stroke="#c7d2fe"/>
+    <text x="271" y="348" fill="#6b7280" font-family="Inter, ui-sans-serif, system-ui" font-size="15">you@company.com</text>
+    <rect x="253" y="389" width="197" height="51" rx="12" fill="#4f46e5"/>
+    <text x="310" y="421" fill="#fff" font-family="Inter, ui-sans-serif, system-ui" font-size="16" font-weight="700">Continue</text>
+    <text x="253" y="493" fill="#7c3aed" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="14">HOSTED AUTH PAGE</text>
+
+    <rect x="707" y="192" width="425" height="360" rx="25" fill="#fff"/>
+    <rect x="707" y="192" width="425" height="18" rx="9" fill="#4f46e5"/>
+    <rect x="748" y="239" width="102" height="43" rx="12" fill="#ede9fe"/>
+    <path d="M769 261h15l8-13 8 26 8-13h20" fill="none" stroke="#4f46e5" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    <text x="748" y="331" fill="#111827" font-family="Inter, ui-sans-serif, system-ui" font-size="25" font-weight="750">Reset your password</text>
+    <text x="748" y="368" fill="#6b7280" font-family="Inter, ui-sans-serif, system-ui" font-size="16">A password reset was requested</text>
+    <text x="748" y="392" fill="#6b7280" font-family="Inter, ui-sans-serif, system-ui" font-size="16">for your Acme account.</text>
+    <rect x="748" y="425" width="169" height="47" rx="12" fill="#4f46e5"/>
+    <text x="772" y="455" fill="#fff" font-family="Inter, ui-sans-serif, system-ui" font-size="15" font-weight="700">Reset password</text>
+    <text x="748" y="514" fill="#7c3aed" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="14">BUILT-IN AUTH EMAIL</text>
+  </g>
+
+  <rect x="401" y="583" width="398" height="56" rx="17" fill="#111827" stroke="#4f46e5"/>
+  <circle cx="438" cy="611" r="13" fill="#4f46e5"/>
+  <text x="469" y="617" fill="#e0e7ff" font-family="Inter, ui-sans-serif, system-ui" font-size="17" font-weight="650">Startup seed or dashboard owner</text>
+  <path d="M600 576V556" stroke="#818cf8" stroke-width="4" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
Closes #176

## What changed

- adds an end-to-end guide for startup-owned versus dashboard-owned AuthPage and email branding
- documents layouts, data-URL logos, credential behavior, exact email fallback, hosted/headless ownership, and complete browser/email verification
- corrects password-reset coverage and application-name fallback in the email-branding reference
- adds an accessible visual, Guides card, and contextual cross-links

## Validation

- `scripts/docs-check.sh`
- `dotnet test tests/SqlOS.Tests/SqlOS.Tests.csproj --filter "FullyQualifiedName~SqlOSAuthPageRendererTests|FullyQualifiedName~SqlOSSingleApplicationTests|FullyQualifiedName~SqlOSTransactionalEmailTests"` (33 passed)
- `dotnet test examples/SqlOS.Example.IntegrationTests/SqlOS.Example.IntegrationTests.csproj` (60 passed)

An independent adversarial documentation review will follow before merge.