### PR TITLE
docs: add AuthServer membership to FGA lifecycle guide

### DIFF
--- a/web/content/docs/authserver/memberships.mdx
+++ b/web/content/docs/authserver/memberships.mdx
@@ -56,7 +56,7 @@ var orgs = await adminService.GetUserOrganizationsAsync(userId, ct);
 
 ## Syncing to FGA
 
-When using FGA, membership roles can be mapped to FGA grants. See [Syncing Auth to FGA](/docs/fga/syncing-auth-to-fga) for the pattern.
+When using FGA, membership roles can be mapped to explicit FGA grants. Use [Turn AuthServer memberships into FGA access](/docs/guides/authserver-to-fga) for role upgrade, downgrade, removal, organization switching, and cross-tenant guidance. [Syncing Auth to FGA](/docs/fga/syncing-auth-to-fga) is the shorter API reference.
 
 ## Invite a member
 

--- a/web/content/docs/fga/overview.mdx
+++ b/web/content/docs/fga/overview.mdx
@@ -117,5 +117,6 @@ app.MapSqlOS();
 ## Deep dives
 
 - [Model FGA for multi-tenant apps](/docs/guides/model-fga)
+- [Turn AuthServer memberships into FGA access](/docs/guides/authserver-to-fga)
 - [Filter EF queries with FGA](/docs/guides/ef-query-filters)
 - [The Developer's Guide to Hierarchical RBAC](/blog/developers-guide-to-hierarchical-rbac)

--- a/web/content/docs/fga/syncing-auth-to-fga.mdx
+++ b/web/content/docs/fga/syncing-auth-to-fga.mdx
@@ -5,7 +5,11 @@ order: 14
 section: fga
 ---
 
-When using both AuthServer and FGA, you need to sync authenticated users into the FGA model so they can be authorized. The typical pattern is to sync on login.
+When using both AuthServer and FGA, you need to sync authenticated users into the FGA model so they can be authorized. The typical active-session pattern is to sync on login.
+
+<Callout type="warning" title="Login sync is not the complete lifecycle">
+  The short example below reconciles an active membership and removes the opposite mapped role. Production role changes and offboarding must also reconcile when the membership, user, or organization changes; otherwise an old FGA grant can survive. Follow [Turn AuthServer memberships into FGA access](/docs/guides/authserver-to-fga) for the complete lifecycle, tenant predicates, and the current FGA `IsActive` caveat.
+</Callout>
 
 ## The pattern
 
@@ -16,9 +20,9 @@ public async Task EnsureUserAccessAsync(
     string subjectId, string organizationId, CancellationToken ct)
 {
     var user = await _context.Set<SqlOSUser>()
-        .FirstAsync(x => x.Id == subjectId, ct);
+        .FirstAsync(x => x.Id == subjectId && x.IsActive, ct);
     var organization = await _context.Set<SqlOSOrganization>()
-        .FirstAsync(x => x.Id == organizationId, ct);
+        .FirstAsync(x => x.Id == organizationId && x.IsActive, ct);
     var membership = await _context.Set<SqlOSMembership>()
         .FirstAsync(x => x.UserId == subjectId
             && x.OrganizationId == organizationId
@@ -46,6 +50,11 @@ public async Task EnsureUserAccessAsync(
         ? "org_admin"
         : "org_member";
 
+    await _context.RevokeRoleAsync(
+        subjectId,
+        organizationResourceId,
+        roleKey == "org_admin" ? "org_member" : "org_admin",
+        ct);
     await _context.GrantRoleAsync(subjectId, organizationResourceId, roleKey, ct);
     await _context.SaveChangesAsync(ct);
 }
@@ -57,7 +66,7 @@ public async Task EnsureUserAccessAsync(
 
 **ProvisionResourceWithIdAsync** -- creates or updates the organization resource under root. This is a manual resource because the organization is not represented by an `ISqlOSResourceEntity` in this example.
 
-**GrantRoleAsync** -- creates an idempotent grant linking the subject to a role on the organization resource, mapping the auth membership role to an FGA role:
+**RevokeRoleAsync / GrantRoleAsync** -- remove the stale mapped role and create an idempotent grant linking the subject to the current role on the organization resource:
 
 | Auth role | FGA role |
 | --- | --- |
@@ -77,6 +86,8 @@ if (!string.IsNullOrWhiteSpace(tokens.OrganizationId))
 ```
 
 The example app calls this in the token response helper, so every login automatically ensures the user has the right FGA grants based on their auth membership.
+
+Also reconcile from membership role changes, membership removal/deactivation, and user or organization deactivation. Revoke only the explicit role keys owned by this mapping so unrelated manual grants remain intact. The [complete guide](/docs/guides/authserver-to-fga) includes an offboarding-safe implementation.
 
 ## Why sync instead of query auth directly?
 

--- a/web/content/docs/guides/authserver-to-fga.mdx
+++ b/web/content/docs/guides/authserver-to-fga.mdx
@@ -1,0 +1,404 @@
+---
+title: "Turn AuthServer memberships into FGA access"
+description: "Safely reconcile organization roles into tenant-scoped FGA grants."
+order: 6
+section: guides
+---
+
+<Banner
+  eyebrow="Guide"
+  title="Turn a verified membership into data access"
+  href="/docs/fga/overview"
+  actionLabel="FGA overview"
+>
+  Authenticate the user with AuthServer, reconcile the selected organization membership into explicit FGA grants, and keep tenant ownership in every data query.
+</Banner>
+
+<Callout type="info" title="Prerequisites">
+  - An API route protected with [SqlOS access-token validation](/docs/quickstarts/protect-api)
+  - AuthServer organizations and memberships
+  - An FGA resource hierarchy with organization roots
+  - A `DbContext` derived from `SqlOSDbContext<TContext>` so AuthServer, FGA, and application data share one context
+</Callout>
+
+## The boundary you are building
+
+AuthServer and FGA answer different questions:
+
+| Layer | Question | Source of truth |
+| --- | --- | --- |
+| AuthServer | Who signed in, which organization did they select, and is that membership active? | User, organization, membership, session, and validated token records |
+| FGA | What may this subject do to this application resource? | Subject, resource, role, permission, and grant records |
+
+An AuthServer membership does not automatically create an FGA subject or grant. Likewise, `SqlOSFgaSubject.OrganizationId` is descriptive metadata; it is **not** an enforcement boundary and can hold only one value even when a user belongs to several organizations.
+
+This guide uses an explicit bridge:
+
+![A validated AuthServer membership is reconciled into a tenant-scoped FGA grant before application data is filtered](/docs/guides-authserver-to-fga.svg)
+
+1. Read the subject and organization from validated server state.
+2. Re-read the current user, organization, and membership from the database.
+3. Provision the FGA subject and `org::{organizationId}` resource.
+4. Reconcile the small set of roles owned by the membership mapping.
+5. Apply both the application tenant predicate and the FGA decision.
+
+## 1. Seed the organization authorization model
+
+The example application has organization roots with workspace children. Members may view workspaces; owners and admins may also manage them.
+
+```csharp
+options.Fga.Seed(seed =>
+{
+    seed.ResourceType("organization", "Organization");
+    seed.ResourceType("workspace", "Workspace");
+
+    seed.Permission(
+        "perm_workspace_view",
+        "WORKSPACE_VIEW",
+        "View workspaces",
+        "workspace");
+    seed.Permission(
+        "perm_workspace_manage",
+        "WORKSPACE_MANAGE",
+        "Manage workspaces",
+        "workspace");
+
+    seed.Role("role_org_member", "org_member", "Organization Member");
+    seed.Role("role_org_admin", "org_admin", "Organization Admin");
+    seed.RolePermission("org_member", "WORKSPACE_VIEW");
+    seed.RolePermission("org_admin", "WORKSPACE_VIEW");
+    seed.RolePermission("org_admin", "WORKSPACE_MANAGE");
+});
+```
+
+Every tenant gets a resource directly below the global root. Entity-backed child resources name that organization resource as their parent:
+
+```csharp
+using SqlOS.Fga.Interfaces;
+
+public sealed class Workspace : ISqlOSResourceEntity
+{
+    public string Id { get; set; } = string.Empty;
+    public string ResourceId { get; set; } = string.Empty;
+    public string OrganizationId { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+
+    public string ResourceTypeId => "workspace";
+    public string ResourceName => Name;
+    public string ParentResourceId => $"org::{OrganizationId}";
+    public string? ResourceDescription => null;
+    public bool ResourceIsActive => true;
+}
+```
+
+Assign `ResourceId = $"wrk::{workspace.Id}"` before saving a new workspace. `SqlOSDbContext<TContext>` then synchronizes the entity-backed child beneath its `org::{organizationId}` parent.
+
+```text
+root
+├── org::acme
+│   ├── wrk::planning
+│   └── wrk::support
+└── org::globex
+    └── wrk::operations
+```
+
+Grant organization membership roles on `org::{organizationId}`, never on `root`. A global-root grant would let a tenant-local role inherit into every organization's descendants.
+
+## 2. Reconcile the active membership
+
+Use a dedicated service so login, membership administration, directory sync, and repair jobs all apply the same policy. This version owns exactly two role keys on the organization root: `org_member` and `org_admin`.
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using SqlOS.AuthServer.Models;
+using SqlOS.Extensions;
+using SqlOS.Fga.Models;
+
+public sealed class MembershipFgaSyncService(AppDbContext db)
+{
+    private const string OrganizationResourceType = "organization";
+    private const string OrgMemberRole = "org_member";
+    private const string OrgAdminRole = "org_admin";
+
+    private static readonly string[] MembershipManagedRoles =
+        [OrgMemberRole, OrgAdminRole];
+
+    public async Task<bool> ReconcileAsync(
+        string trustedSubjectId,
+        string trustedOrganizationId,
+        CancellationToken ct = default)
+    {
+        var user = await db.Set<SqlOSUser>()
+            .SingleOrDefaultAsync(x => x.Id == trustedSubjectId, ct);
+        var organization = await db.Set<SqlOSOrganization>()
+            .SingleOrDefaultAsync(x => x.Id == trustedOrganizationId, ct);
+        var membership = await db.Set<SqlOSMembership>()
+            .SingleOrDefaultAsync(
+                x => x.UserId == trustedSubjectId
+                    && x.OrganizationId == trustedOrganizationId,
+                ct);
+
+        var hasActiveMembership = user?.IsActive == true
+            && organization?.IsActive == true
+            && membership?.IsActive == true;
+
+        if (!hasActiveMembership)
+        {
+            await RevokeMembershipRolesIfProvisionedAsync(
+                trustedSubjectId,
+                trustedOrganizationId,
+                ct);
+            await db.SaveChangesAsync(ct);
+            return false;
+        }
+
+        await db.ProvisionUserSubjectAsync(
+            trustedSubjectId,
+            displayName: user!.DisplayName,
+            email: user.DefaultEmail,
+            organizationId: trustedOrganizationId,
+            externalRef: trustedSubjectId,
+            isActive: true,
+            cancellationToken: ct);
+
+        var organizationResourceId = OrganizationResourceId(
+            trustedOrganizationId);
+        await db.ProvisionResourceWithIdAsync(
+            organizationResourceId,
+            resourceTypeId: OrganizationResourceType,
+            name: organization!.Name,
+            parentResourceId: "root",
+            isActive: true,
+            cancellationToken: ct);
+
+        var desiredRole = IsElevated(membership!.Role)
+            ? OrgAdminRole
+            : OrgMemberRole;
+
+        foreach (var mappedRole in MembershipManagedRoles)
+        {
+            if (!mappedRole.Equals(desiredRole, StringComparison.Ordinal))
+            {
+                await db.RevokeRoleAsync(
+                    trustedSubjectId,
+                    organizationResourceId,
+                    mappedRole,
+                    ct);
+            }
+        }
+
+        await db.GrantRoleAsync(
+            trustedSubjectId,
+            organizationResourceId,
+            desiredRole,
+            ct);
+        await db.SaveChangesAsync(ct);
+        return true;
+    }
+
+    private async Task RevokeMembershipRolesIfProvisionedAsync(
+        string subjectId,
+        string organizationId,
+        CancellationToken ct)
+    {
+        var resourceId = OrganizationResourceId(organizationId);
+        var subjectExists = await db.Set<SqlOSFgaSubject>()
+            .AnyAsync(x => x.Id == subjectId, ct);
+        var resourceExists = await db.Set<SqlOSFgaResource>()
+            .AnyAsync(x => x.Id == resourceId, ct);
+
+        if (!subjectExists || !resourceExists)
+        {
+            return;
+        }
+
+        foreach (var mappedRole in MembershipManagedRoles)
+        {
+            await db.RevokeRoleAsync(
+                subjectId,
+                resourceId,
+                mappedRole,
+                ct);
+        }
+    }
+
+    private static string OrganizationResourceId(string organizationId)
+        => $"org::{organizationId}";
+
+    private static bool IsElevated(string role)
+        => role.Equals("owner", StringComparison.OrdinalIgnoreCase)
+            || role.Equals("admin", StringComparison.OrdinalIgnoreCase);
+}
+```
+
+Replace `AppDbContext` with your `SqlOSDbContext<TContext>` subclass. `ProvisionUserSubjectAsync`, `ProvisionResourceWithIdAsync`, `GrantRoleAsync`, and `RevokeRoleAsync` are idempotent, but they only track changes. The final `SaveChangesAsync` is required.
+
+<Callout type="warning" title="Reserve the mapped role keys">
+  The reconciler removes only `org_member` and `org_admin` on this subject's exact organization resource. Reserve those role keys for membership-derived access. Put manual or product-specific access in different role keys or on narrower resources. Do not delete every grant for the subject: that would erase unrelated access in this tenant and other organizations.
+</Callout>
+
+### Why the stale role is revoked first
+
+An add-only sync is unsafe during role changes:
+
+- `member` → `admin`: leaving `org_member` is redundant and makes the effective policy harder to explain.
+- `admin` → `member`: leaving `org_admin` preserves management access after the downgrade.
+- inactive or removed membership: leaving either mapped role keeps authorizing through FGA.
+
+The allowlist makes ownership explicit. An active reconciliation removes only the other mapped role and grants the desired one. An inactive reconciliation removes both mapped roles.
+
+## 3. Use only trusted identity and organization state
+
+Protect the route with the expected audience, then read the typed token saved by SqlOS validation. Do not accept `userId`, `subjectId`, or `organizationId` from the request body as the actor's authority.
+
+```csharp
+using SqlOS.AuthServer.Extensions;
+using SqlOS.Extensions;
+
+var workspaces = app.MapGroup("/api/workspaces")
+    .RequireSqlOSAccessToken("https://api.example.com");
+
+workspaces.MapGet("/", async (
+    HttpContext http,
+    MembershipFgaSyncService membershipSync,
+    CancellationToken ct) =>
+{
+    var token = http.GetSqlOSValidatedToken();
+    if (string.IsNullOrWhiteSpace(token?.UserId)
+        || string.IsNullOrWhiteSpace(token.OrganizationId))
+    {
+        return Results.Unauthorized();
+    }
+
+    var active = await membershipSync.ReconcileAsync(
+        token.UserId,
+        token.OrganizationId,
+        ct);
+    return active ? Results.Ok() : Results.Forbid();
+});
+```
+
+The access token supplies trusted, validated identifiers, but the reconciler still re-reads the database. That prevents a stale request DTO—or an old assumption about the user's role—from selecting the grant.
+
+For an operator workflow, the target IDs may come from an authorized admin action, but the same rule applies: load the current records and derive the grant from the persisted membership rather than accepting an FGA role key from the browser.
+
+## 4. Enforce the tenant boundary and FGA decision
+
+FGA complements the application's tenant predicate; it does not replace it.
+
+### List endpoints
+
+Filter by the validated organization **and** the FGA expression:
+
+```csharp
+var token = http.GetSqlOSValidatedToken()!;
+var organizationId = token.OrganizationId!;
+var subjectId = token.UserId!;
+
+var filter = await fgaAuth.GetAuthorizationFilterAsync<Workspace>(
+    subjectId,
+    "WORKSPACE_VIEW");
+
+var rows = await db.Workspaces
+    .Where(x => x.OrganizationId == organizationId)
+    .Where(filter)
+    .OrderBy(x => x.Name)
+    .ToListAsync(ct);
+```
+
+The tenant predicate prevents rows owned by another organization from entering the candidate set. The FGA filter then applies resource-level authorization inside that tenant.
+
+### Detail and mutation endpoints
+
+Establish tenant ownership before the point check:
+
+```csharp
+var workspace = await db.Workspaces
+    .SingleOrDefaultAsync(
+        x => x.Id == workspaceId
+            && x.OrganizationId == organizationId,
+        ct);
+
+if (workspace is null)
+{
+    return Results.NotFound();
+}
+
+var access = await fgaAuth.CheckAccessAsync(
+    subjectId,
+    "WORKSPACE_MANAGE",
+    workspace.ResourceId);
+
+if (!access.Allowed)
+{
+    return Results.Forbid();
+}
+```
+
+Do the same ownership check before update, delete, sharing, or grant-management operations. Never authorize a resource ID from the request and then load a row without the organization predicate.
+
+## 5. Reconcile every lifecycle transition
+
+Login-time reconciliation keeps the common path fresh, but it is not an offboarding system by itself. Also call the reconciler from trusted workflows that change authorization state:
+
+| Transition | Required reconciliation |
+| --- | --- |
+| Membership created or reactivated | Reconcile that user/organization pair and grant the mapped role |
+| `member` → `admin` or `owner` | Revoke `org_member`; grant `org_admin` |
+| `admin` or `owner` → `member` | Revoke `org_admin`; grant `org_member` |
+| Membership deactivated or removed | Revoke both membership-managed roles on that organization root |
+| User deactivated | Reconcile every organization membership for that user |
+| Organization deactivated | Reconcile every membership in that organization |
+| User switches organizations | Reconcile the selected pair; do not revoke valid grants in the user's other organizations |
+| Membership reactivated | Re-read the current role and grant only its mapping |
+
+<Callout type="danger" title="Do not rely on FGA IsActive for revocation yet">
+  AuthServer rejects inactive users, organizations, and memberships at its session and token boundaries. FGA lifecycle enforcement is tracked separately in open [issue #132](https://github.com/ross-slaney/sqlos/issues/132): current FGA point checks and query filters can still honor an existing grant even when an FGA subject or resource has `IsActive = false`. Remove the mapped grants explicitly during offboarding.
+</Callout>
+
+If one user belongs to several organizations, reconcile each `(subjectId, organizationId)` pair independently. Updating the FGA subject's `OrganizationId` metadata during an organization switch does not revoke, scope, or replace grants in another organization.
+
+## 6. Choose a consistency strategy
+
+When AuthServer, FGA, and application data share one SQL database and `DbContext`, prefer one database transaction around the membership mutation and reconciliation. Commit the membership change and mapped-grant change together.
+
+When the membership source and FGA write cannot share a transaction:
+
+1. write a durable outbox event with the subject and organization IDs;
+2. reconcile from current database state, not from an event-provided role;
+3. retry idempotently until successful;
+4. run a periodic repair job over active and inactive memberships;
+5. alert on reconciliation failures and lag.
+
+Do not treat a best-effort login callback as the only revocation trigger. An offboarded user might never log in again, leaving the old FGA grant untouched.
+
+## 7. Verify upgrades, downgrades, and isolation
+
+Automate these cases with separate users and organizations:
+
+| Test | Proof |
+| --- | --- |
+| First active sync | One mapped grant exists on the selected `org::{id}` resource |
+| Repeat active sync | No duplicate grant is created |
+| Member promoted | `org_member` is gone and `org_admin` is effective |
+| Admin downgraded | `org_admin` is gone before member-level access is evaluated |
+| Membership removed | Both membership-managed roles are gone; unrelated grants remain |
+| User or organization deactivated | Every affected membership pair is reconciled and mapped grants are gone |
+| Organization switch | Each valid tenant keeps its own grant; metadata does not act as policy |
+| Request tampering | Body/query `subjectId` and `organizationId` cannot change the actor or tenant |
+| Cross-tenant list | A token for Acme cannot return Globex rows even if malformed grants exist |
+| Cross-tenant detail/mutation | Tenant ownership is checked before FGA and returns no foreign object |
+
+The runnable example uses this shape in:
+
+- `examples/SqlOS.Example.Api/Services/ExampleFgaService.cs`
+- `examples/SqlOS.Example.Api/Endpoints/ExampleAuthEndpoints.cs`
+- `examples/SqlOS.Example.Api/Endpoints/ExampleEndpoints.cs`
+- `examples/SqlOS.Example.IntegrationTests/SqlOSExampleApiIntegrationTests.cs`
+
+## Next steps
+
+- [Syncing Auth to FGA reference](/docs/fga/syncing-auth-to-fga)
+- [Filter EF queries](/docs/guides/ef-query-filters)
+- [Memberships](/docs/authserver/memberships)
+- [Test your integration](/docs/guides/test-your-integration)

--- a/web/content/docs/guides/authserver-to-fga.mdx
+++ b/web/content/docs/guides/authserver-to-fga.mdx
@@ -152,6 +152,17 @@ public sealed class MembershipFgaSyncService(AppDbContext db)
             return false;
         }
 
+        var desiredRole = MapMembershipRole(membership!.Role);
+        if (desiredRole is null)
+        {
+            await RevokeMembershipRolesIfProvisionedAsync(
+                trustedSubjectId,
+                trustedOrganizationId,
+                ct);
+            await db.SaveChangesAsync(ct);
+            return false;
+        }
+
         await db.ProvisionUserSubjectAsync(
             trustedSubjectId,
             displayName: user!.DisplayName,
@@ -170,10 +181,6 @@ public sealed class MembershipFgaSyncService(AppDbContext db)
             parentResourceId: "root",
             isActive: true,
             cancellationToken: ct);
-
-        var desiredRole = IsElevated(membership!.Role)
-            ? OrgAdminRole
-            : OrgMemberRole;
 
         foreach (var mappedRole in MembershipManagedRoles)
         {
@@ -225,9 +232,13 @@ public sealed class MembershipFgaSyncService(AppDbContext db)
     private static string OrganizationResourceId(string organizationId)
         => $"org::{organizationId}";
 
-    private static bool IsElevated(string role)
-        => role.Equals("owner", StringComparison.OrdinalIgnoreCase)
-            || role.Equals("admin", StringComparison.OrdinalIgnoreCase);
+    private static string? MapMembershipRole(string role)
+        => role.Trim().ToLowerInvariant() switch
+        {
+            "owner" or "admin" => OrgAdminRole,
+            "member" => OrgMemberRole,
+            _ => null
+        };
 }
 ```
 
@@ -246,6 +257,8 @@ An add-only sync is unsafe during role changes:
 - inactive or removed membership: leaving either mapped role keeps authorizing through FGA.
 
 The allowlist makes ownership explicit. An active reconciliation removes only the other mapped role and grants the desired one. An inactive reconciliation removes both mapped roles.
+
+The role-name switch also fails closed. An unexpected active membership role removes the membership-managed grants and returns `false` instead of silently treating an unknown value as `org_member`. Extend the explicit switch when your application defines additional trusted membership roles.
 
 ## 3. Use only trusted identity and organization state
 
@@ -351,6 +364,7 @@ Login-time reconciliation keeps the common path fresh, but it is not an offboard
 | Organization deactivated | Reconcile every membership in that organization |
 | User switches organizations | Reconcile the selected pair; do not revoke valid grants in the user's other organizations |
 | Membership reactivated | Re-read the current role and grant only its mapping |
+| Unexpected/custom role | Remove the mapped grants unless that exact role is deliberately added to the mapping allowlist |
 
 <Callout type="danger" title="Do not rely on FGA IsActive for revocation yet">
   AuthServer rejects inactive users, organizations, and memberships at its session and token boundaries. FGA lifecycle enforcement is tracked separately in open [issue #132](https://github.com/ross-slaney/sqlos/issues/132): current FGA point checks and query filters can still honor an existing grant even when an FGA subject or resource has `IsActive = false`. Remove the mapped grants explicitly during offboarding.
@@ -386,6 +400,7 @@ Automate these cases with separate users and organizations:
 | User or organization deactivated | Every affected membership pair is reconciled and mapped grants are gone |
 | Organization switch | Each valid tenant keeps its own grant; metadata does not act as policy |
 | Request tampering | Body/query `subjectId` and `organizationId` cannot change the actor or tenant |
+| Unknown membership role | Both mapped grants are absent until the role is explicitly supported |
 | Cross-tenant list | A token for Acme cannot return Globex rows even if malformed grants exist |
 | Cross-tenant detail/mutation | Tenant ownership is checked before FGA and returns no foreign object |
 

--- a/web/content/docs/guides/index.mdx
+++ b/web/content/docs/guides/index.mdx
@@ -80,6 +80,9 @@ section: guides
   <Card title="Model FGA" description="Design a multi-tenant resource hierarchy." href="/docs/guides/model-fga">
     <img className="sqlos-guide-card-image" src="/docs/dashboard-fga-resources.png" alt="FGA resource hierarchy dashboard" />
   </Card>
+  <Card title="Connect memberships to FGA" description="Reconcile organization roles into tenant-scoped grants without leaving stale access." href="/docs/guides/authserver-to-fga">
+    <img className="sqlos-guide-card-image" src="/docs/guides-authserver-to-fga.svg" alt="AuthServer membership reconciled into a tenant-scoped FGA grant" />
+  </Card>
   <Card title="Filter EF queries" description="Compose authorization into a LINQ WHERE clause." href="/docs/guides/ef-query-filters">
     <img className="sqlos-guide-card-image" src="/docs/dashboard-access-tester.png" alt="FGA Access Tester" />
   </Card>

--- a/web/content/docs/quickstarts/ef-authorization.mdx
+++ b/web/content/docs/quickstarts/ef-authorization.mdx
@@ -274,6 +274,7 @@ Keep `ResourceId` as a mapped string property. Call `Where(filter)` while the qu
 
 ## Next steps
 
+- [Turn AuthServer memberships into FGA access](/docs/guides/authserver-to-fga)
 - [Model an FGA hierarchy](/docs/guides/model-fga)
 - [Filter EF Core queries](/docs/guides/ef-query-filters)
 - [Check a permission](/docs/fga/checking-a-permission)

--- a/web/content/docs/quickstarts/protect-api.mdx
+++ b/web/content/docs/quickstarts/protect-api.mdx
@@ -175,6 +175,7 @@ Bearer validation does not configure CORS. Add an explicit CORS policy for trust
 ## Next steps
 
 - [Authorize EF Core queries](/docs/quickstarts/ef-authorization)
+- [Turn AuthServer memberships into FGA access](/docs/guides/authserver-to-fga)
 - [Token validation guide](/docs/authserver/token-validation)
 - [Sessions and tokens](/docs/authserver/sessions-and-tokens)
 - [Resource indicators and audiences](/docs/authserver/mcp-resource-indicators-and-audience)

--- a/web/public/docs/guides-authserver-to-fga.svg
+++ b/web/public/docs/guides-authserver-to-fga.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="720" viewBox="0 0 1280 720" role="img" aria-labelledby="title desc">
+  <title id="title">AuthServer membership to FGA reconciliation</title>
+  <desc id="desc">A validated user and organization membership flows through a reconciler that removes stale membership roles, grants the current role on the organization resource, and combines a tenant predicate with FGA authorization.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#eef2ff"/><stop offset="1" stop-color="#ecfdf5"/></linearGradient>
+    <linearGradient id="brand" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#4f46e5"/><stop offset="1" stop-color="#059669"/></linearGradient>
+    <filter id="shadow"><feDropShadow dx="0" dy="10" stdDeviation="15" flood-opacity=".12"/></filter>
+    <style>.eye{font:700 15px system-ui;letter-spacing:2px;fill:#4338ca}.title{font:750 42px system-ui;fill:#111827}.sub{font:400 19px system-ui;fill:#64748b}.h{font:700 19px system-ui;fill:#111827}.p{font:500 15px system-ui;fill:#64748b}.mono{font:700 13px ui-monospace,monospace;fill:#3730a3}.ok{font:700 14px system-ui;fill:#047857}.white{font:700 16px system-ui;fill:#fff}</style>
+  </defs>
+  <rect width="1280" height="720" rx="32" fill="url(#bg)"/>
+  <text x="64" y="76" class="eye">AUTHSERVER → FGA</text>
+  <text x="64" y="124" class="title">Reconcile membership before authorizing data</text>
+  <text x="64" y="159" class="sub">Trusted identity selects the tenant; explicit mapped grants and tenant predicates enforce it.</text>
+  <g filter="url(#shadow)">
+    <rect x="64" y="238" width="260" height="260" rx="26" fill="#fff"/>
+    <rect x="378" y="238" width="260" height="260" rx="26" fill="#fff"/>
+    <rect x="692" y="238" width="260" height="260" rx="26" fill="#fff"/>
+    <rect x="1006" y="238" width="210" height="260" rx="26" fill="#fff"/>
+  </g>
+  <circle cx="105" cy="282" r="23" fill="#e0e7ff"/><path d="M95 282h20m-10-10v20" stroke="#4f46e5" stroke-width="4" stroke-linecap="round"/>
+  <text x="140" y="289" class="h">Validated token</text>
+  <text x="88" y="340" class="p">sub: user_42</text><text x="88" y="368" class="p">org_id: acme</text>
+  <rect x="88" y="408" width="212" height="45" rx="12" fill="#eef2ff"/><text x="194" y="436" text-anchor="middle" class="mono">SERVER-TRUSTED</text>
+  <circle cx="419" cy="282" r="23" fill="url(#brand)"/><path d="M409 282h20m-10-10v20" stroke="#fff" stroke-width="4"/>
+  <text x="454" y="289" class="h">Reconciler</text>
+  <text x="402" y="340" class="p">Re-read active membership</text><text x="402" y="368" class="p">Revoke stale mapped role</text><text x="402" y="396" class="p">Grant current role</text>
+  <rect x="402" y="422" width="212" height="31" rx="10" fill="#dcfce7"/><text x="508" y="443" text-anchor="middle" class="ok">IDEMPOTENT</text>
+  <circle cx="733" cy="282" r="23" fill="#d1fae5"/><path d="M722 291h22v-18h-22z" fill="#059669"/>
+  <text x="768" y="289" class="h">Organization root</text>
+  <text x="716" y="340" class="p">Resource: org::acme</text><text x="716" y="368" class="p">Role: org_admin</text><text x="716" y="396" class="p">Children: workspaces</text>
+  <rect x="716" y="422" width="212" height="31" rx="10" fill="#ecfdf5"/><text x="822" y="443" text-anchor="middle" class="mono">TENANT-SCOPED</text>
+  <circle cx="1047" cy="282" r="23" fill="#e0e7ff"/><path d="M1037 272h20v20h-20z" fill="#4f46e5"/>
+  <text x="1082" y="289" class="h">Data query</text>
+  <text x="1030" y="340" class="p">org predicate</text><text x="1030" y="368" class="p">+ FGA filter</text>
+  <rect x="1030" y="408" width="162" height="45" rx="12" fill="url(#brand)"/><text x="1111" y="436" text-anchor="middle" class="white">ALLOW</text>
+  <path d="M324 368h54M638 368h54M952 368h54" stroke="#818cf8" stroke-width="6" stroke-linecap="round"/>
+  <path d="m362 355 16 13-16 13m314-26 16 13-16 13m314-26 16 13-16 13" fill="none" stroke="#4f46e5" stroke-width="4"/>
+  <rect x="171" y="557" width="938" height="100" rx="24" fill="#fff" stroke="#c7d2fe"/>
+  <text x="640" y="592" text-anchor="middle" class="h">Lifecycle contract</text>
+  <text x="640" y="623" text-anchor="middle" class="p">promote: remove member → grant admin · downgrade: remove admin → grant member · offboard: remove both mapped roles</text>
+</svg>


### PR DESCRIPTION
Closes #173

## Summary

- add a task-oriented guide for reconciling AuthServer memberships into tenant-scoped FGA grants
- document role upgrade, downgrade, offboarding, reactivation, organization switching, and consistency strategies
- require validated subject and organization state plus application tenant predicates for list, detail, and mutation paths
- add an accessible lifecycle diagram, Guides index card, and reciprocal links from membership, FGA, and quickstart docs
- harden the short sync reference so it removes the opposite mapped role and points to the full lifecycle guide

## Validation

- [x] scripts/docs-check.sh
- [x] dotnet test examples/SqlOS.Example.IntegrationTests/SqlOS.Example.IntegrationTests.csproj --filter FullyQualifiedName~Signup_CanCreateAndListWorkspaces --nologo
- [x] compile the new reconciliation sample against the current SqlOS project: 0 warnings, 0 errors
- [x] render and inspect the accessible SVG

## Adversarial review

Reviewed the guidance against current source and open #132 for stale admin access after downgrade, offboarded users retaining FGA grants, request identity or organization tampering, cross-tenant list/detail access, organization switching, idempotency, and accidental removal of unrelated grants.