### PR TITLE
Add customer-managed enterprise SSO guide

### DIFF
--- a/docs/ENTRA_SSO.md
+++ b/docs/ENTRA_SSO.md
@@ -2,6 +2,8 @@
 
 This guide covers the manual end-to-end test flow for a customer organization that uses Microsoft Entra ID as its SAML identity provider.
 
+Start with the public [customer-managed enterprise SSO guide](../web/content/docs/guides/customer-managed-sso.mdx) for the platform/customer trust boundary, one-time setup link, DNS ownership, enrollment policy, and revocation model. This repository supplement focuses on the Entra-specific manual test.
+
 It assumes you are running the shared example stack through the Aspire AppHost and want to validate:
 
 - org-level home realm discovery by email domain

--- a/docs/EXAMPLE_APP.md
+++ b/docs/EXAMPLE_APP.md
@@ -75,6 +75,7 @@ For local-only SSO portal testing without publishing DNS, create the organizatio
 
 For a customer-tenant SAML walkthrough with Microsoft Entra ID, use:
 
+- [Customer-managed enterprise SSO](../web/content/docs/guides/customer-managed-sso.mdx)
 - [Entra SSO Testing](ENTRA_SSO.md)
 
 For OIDC setup, use:

--- a/web/content/docs/authserver/dashboard-overview.mdx
+++ b/web/content/docs/authserver/dashboard-overview.mdx
@@ -100,6 +100,8 @@ For setup details, see [Email OTP](/docs/authserver/email-otp), [Email Invitatio
 
 Open an organization, choose the **SSO** tab, and create a setup link when a customer IT admin should configure SAML themselves. The link is scoped to one organization, can be revoked from the same tab, and opens `/sqlos/admin/auth/sso-portal` instead of the full dashboard.
 
+Follow [Let customer admins set up enterprise SSO](/docs/guides/customer-managed-sso) for the full platform and customer-admin journey, including edge routing, token handling, DNS ownership, enrollment policy, testing, and revocation.
+
 The portal shows Microsoft Entra, Okta, Google Workspace, and generic SAML setup paths. It displays copy-ready SP Entity ID and ACS URL values, verifies the customer email domain through a DNS TXT record, accepts pasted or uploaded metadata XML, validates the IdP entity ID, SSO URL, and signing certificate, then lets the customer activate, disable, replace metadata, and run a SAML test redirect.
 
 Portal launch, open, revoke, provider selection, domain verification, metadata import, activation, disable, and test actions are audit logged with the organization id.

--- a/web/content/docs/authserver/saml-sso.mdx
+++ b/web/content/docs/authserver/saml-sso.mdx
@@ -7,6 +7,8 @@ section: authserver
 
 SqlOS supports SAML 2.0 enterprise SSO. Each organization can have its own connection. Home realm discovery routes a matching email domain only when that connection is complete, enabled, and its enrollment policy applies to the user.
 
+For a complete customer IT administrator journey, use [Let customer admins set up enterprise SSO](/docs/guides/customer-managed-sso). For the platform-team workflow, use [Set up SAML SSO](/docs/guides/saml-sso).
+
 ## Setup
 
 You can configure SAML in two ways:

--- a/web/content/docs/guides/customer-managed-sso.mdx
+++ b/web/content/docs/guides/customer-managed-sso.mdx
@@ -47,6 +47,10 @@ SqlOS stores hashes of both the one-time link token and the continuation token. 
 The defaults enable the hosted portal and setup API, issue links for seven days, expire an idle continuation session after two hours, and require a verified domain for self-serve activation. Choose shorter lifetimes that fit your support workflow and reserve domains owned by your platform:
 
 ```csharp
+options.AuthServer.PublicOrigin =
+    builder.Configuration["SqlOS:PublicOrigin"]
+    ?? throw new InvalidOperationException("SqlOS:PublicOrigin is required.");
+
 options.AuthServer.ConfigureSsoPortal(portal =>
 {
     portal.DefaultLinkLifetime = TimeSpan.FromDays(2);
@@ -56,6 +60,8 @@ options.AuthServer.ConfigureSsoPortal(portal =>
     portal.ReservedDomainRoots.Add("yourapp.com");
 });
 ```
+
+`PublicOrigin` must be the canonical external origin, such as `https://identity.example.com`, with no path, query, or fragment. SqlOS uses it when generating the credential-bearing setup URL. Do not let an untrusted request `Host` value choose the URL you deliver to a customer.
 
 Reserved roots include their subdomains: reserving `yourapp.com` also rejects `login.yourapp.com`. SqlOS also rejects wildcard domains, IP addresses, malformed DNS names, and `localhost` unless `AllowLocalhostDomainVerification` is explicitly enabled.
 
@@ -253,7 +259,7 @@ Start the shared example stack:
 
 ```bash
 cd examples/SqlOS.Example.Web
-npm install
+npm ci
 
 cd /path/to/SqlOS
 dotnet run --project examples/SqlOS.Example.AppHost/SqlOS.Example.AppHost.csproj

--- a/web/content/docs/guides/customer-managed-sso.mdx
+++ b/web/content/docs/guides/customer-managed-sso.mdx
@@ -1,0 +1,280 @@
+---
+title: "Let customer admins set up enterprise SSO"
+description: "Delegate one organization's SAML setup without granting access to the SqlOS operator dashboard."
+order: 4
+section: guides
+---
+
+<Banner
+  eyebrow="Guide"
+  title="Give each customer a one-organization SSO setup portal"
+  href="/docs/guides/saml-sso"
+  actionLabel="Operator-managed SAML"
+>
+  Your platform keeps global control. The customer IT admin receives a one-time link that can configure only their organization's SAML connection.
+</Banner>
+
+<Callout type="info" title="Prerequisites">
+  - An active SqlOS organization
+  - A host authorization rule that decides which customer admins may manage that organization's SSO
+  - A registered browser client with an exact redirect URI for the SAML test
+  - A public HTTPS SqlOS origin and, for self-serve domain verification, access to the customer's public DNS
+</Callout>
+
+This guide uses the bundled hosted portal. If your platform team owns the entire setup, use [Set up SAML SSO](/docs/guides/saml-sso) instead. The [SAML reference](/docs/authserver/saml-sso) documents every route and contract after you choose a setup model.
+
+![A platform operator issues a one-organization setup link that lets a customer IT admin verify DNS and connect an identity provider](/docs/guides-customer-managed-sso.svg)
+
+## Understand the trust boundary
+
+The setup portal is not a customer-facing copy of the global dashboard.
+
+| Actor or credential | What it can do | What it cannot do |
+| --- | --- | --- |
+| Platform operator | Create, list, and revoke setup sessions for an organization; retain normal dashboard/admin authorization | Delegate global operator authority through a setup link |
+| Authorized host backend | Resolve a trusted organization from its authenticated customer-admin context and call `SqlOSSsoPortalService.CreateSessionAsync` | Treat a request-body organization ID as authorization |
+| One-time setup URL | Open exactly one portal session for the organization embedded in the stored setup record | Be reused after its first successful open |
+| Portal continuation cookie | Select a provider, manage enrollment policy, verify a domain, import metadata, activate/disable, test, and optionally revoke matching organization sessions | List users, clients, other organizations, or global dashboard pages |
+
+SqlOS stores hashes of both the one-time link token and the continuation token. The first successful open consumes the link and sets the `sqlos_sso_portal` cookie. The cookie is HttpOnly, `SameSite=Lax`, scoped to `/sqlos/admin/auth/sso-portal`, marked Secure on HTTPS, bounded by the link expiration, and rejected after the configured idle timeout. Revoking the setup session invalidates its continuation cookie too.
+
+<Callout type="warning" title="Treat the setup URL as a credential">
+  Deliver it through your authenticated admin product, a carefully addressed transactional email, or a controlled support channel. Do not put it in application logs, analytics, issue trackers, chat previews, or screenshots. A copied URL is usable until its first open, revocation, or expiration.
+</Callout>
+
+## 1. Configure the portal
+
+The defaults enable the hosted portal and setup API, issue links for seven days, expire an idle continuation session after two hours, and require a verified domain for self-serve activation. Choose shorter lifetimes that fit your support workflow and reserve domains owned by your platform:
+
+```csharp
+options.AuthServer.ConfigureSsoPortal(portal =>
+{
+    portal.DefaultLinkLifetime = TimeSpan.FromDays(2);
+    portal.SessionIdleTimeout = TimeSpan.FromMinutes(30);
+    portal.UseHostedPortal = true;
+    portal.RequireVerifiedDomainForActivation = true;
+    portal.ReservedDomainRoots.Add("yourapp.com");
+});
+```
+
+Reserved roots include their subdomains: reserving `yourapp.com` also rejects `login.yourapp.com`. SqlOS also rejects wildcard domains, IP addresses, malformed DNS names, and `localhost` unless `AllowLocalhostDomainVerification` is explicitly enabled.
+
+### Use your own portal UI
+
+To render the customer experience inside your product, exchange the one-time link as usual, redirect the opened session to your UI, and drive the same state machine through the headless setup API:
+
+```csharp
+options.AuthServer.ConfigureSsoPortal(portal =>
+{
+    portal.UseHostedPortal = false;
+    portal.BuildUiUrl = context =>
+        $"https://admin.example.com/sso/setup" +
+        $"?session_id={context.SessionId}&view={context.View}";
+    portal.HeadlessApiBasePath = "/sqlos/admin/auth/sso-portal/api/setup";
+});
+```
+
+The API still authenticates with the HttpOnly portal cookie. Keep it on the SqlOS origin or configure credentialed browser requests deliberately. `BuildUiUrl` controls browser presentation; it does not widen the organization stored in the portal session.
+
+## 2. Make the narrow production edge exception
+
+Most deployments protect `/sqlos/admin/*` with an operator-only identity proxy or private network. Customers still need to reach the delegated portal, so allow only the portal start, UI, and setup API paths:
+
+```text
+/sqlos/admin/auth/sso-portal*
+```
+
+Keep the dashboard root and all other `/sqlos/admin/*` routes behind the operator boundary. Do not expose `/sqlos/admin/auth/api/*` to make setup links work; link creation, listing, and revocation remain privileged platform operations. If you move `HeadlessApiBasePath`, review that exact path at the edge instead.
+
+See [Production Readiness](/docs/guides/production-readiness#2-protect-the-right-routes) for the complete route policy.
+
+## 3. Create the one-organization setup link
+
+### From the SqlOS dashboard
+
+Open `/sqlos/admin/auth/organizations`, select the organization, open its **SSO** tab, and create a setup link. You can optionally preselect Microsoft Entra, Okta, Google Workspace, or Generic SAML. The organization page lists its setup sessions and lets an operator revoke any pending or opened session.
+
+### From an authorized host backend
+
+Use a host endpoint when setup starts in your own customer-admin product. Authenticate the access token, enforce your customer SSO-admin policy, and derive both the organization and actor from trusted server-owned state:
+
+```csharp
+var customerAdmin = app.MapGroup("/api/customer-admin")
+    .RequireSqlOSAccessToken(apiAudience);
+
+customerAdmin.MapPost("/sso/setup-link", async (
+    CreateSetupLinkRequest request,
+    HttpContext http,
+    ICustomerSsoAuthorization customerSsoAuthorization,
+    SqlOSSsoPortalService portal,
+    CancellationToken ct) =>
+{
+    var token = http.GetSqlOSValidatedToken();
+    if (token?.UserId is not { Length: > 0 } userId ||
+        token.OrganizationId is not { Length: > 0 } organizationId)
+    {
+        return Results.Forbid();
+    }
+
+    if (!await customerSsoAuthorization.CanManageSsoAsync(
+        userId,
+        organizationId,
+        ct))
+    {
+        return Results.Forbid();
+    }
+
+    var session = await portal.CreateSessionAsync(
+        new SqlOSCreateSsoPortalSessionRequest(
+            OrganizationId: organizationId,
+            CreatedByUserId: userId,
+            Provider: request.Provider),
+        http,
+        ct);
+
+    return Results.Ok(new
+    {
+        session.Id,
+        session.SetupUrl,
+        session.ExpiresAt
+    });
+});
+
+public sealed record CreateSetupLinkRequest(string? Provider);
+```
+
+`SqlOSSsoPortalService` performs organization scoping but does not decide whether this caller is one of your customer administrators. Keep that authorization in the host policy. Never accept the effective organization from the request body.
+
+The platform may also create the link through `POST /sqlos/admin/auth/api/sso-portal/sessions`, but that route requires the normal operator session. Deliver only `setupUrl`; do not expose other admin APIs to the customer.
+
+## 4. Have the customer admin configure the IdP
+
+The customer opens the URL once. SqlOS exchanges its token for the continuation cookie and opens the portal on the selected provider. A second open of the same URL returns an already-used error; issue a new link instead of trying to recover the token.
+
+The portal shows the service-provider values using the IdP's own labels:
+
+| Provider | SqlOS SP Entity ID goes in | SqlOS ACS URL goes in | Bring back to SqlOS |
+| --- | --- | --- | --- |
+| Microsoft Entra | **Identifier (Entity ID)** | **Reply URL (ACS URL)** | **Federation Metadata XML** |
+| Okta | **Audience URI (SP Entity ID)** | **Single sign-on URL** | **IdP metadata** |
+| Google Workspace | **Entity ID** | **ACS URL** | **IdP metadata** |
+| Generic SAML | **SP Entity ID** | **ACS URL** | **SAML metadata XML** |
+
+For Okta, set Name ID format to `EmailAddress` and map `email`, `first_name`, and `last_name`. For every provider, the assertion must supply a stable subject and a usable email. Existing-member linking depends on a verified local email; JIT uses the asserted email to create or attach identity, so configure the real tenant identity rather than an unrelated alias. Configure at least one assigned IdP user before testing.
+
+## 5. Choose enrollment policy deliberately
+
+Portal-created connections default to:
+
+- **Require SSO for existing members**: on (`AutoLinkByEmail = true`)
+- **Allow JIT provisioning**: off (`AutoProvisionUsers = false`)
+
+The policy affects both home realm discovery and SAML identity resolution:
+
+| Identity state | Conservative defaults | With JIT provisioning on |
+| --- | --- | --- |
+| Existing active member with a verified matching email | HRD routes to SSO; the first valid assertion links the IdP subject to the existing user without creating another user or membership | Same result |
+| Existing active SqlOS user who is not a member | HRD does not route to this SSO connection, and a connection-directed assertion is denied | A valid assertion may add the missing organization membership |
+| Unknown user | HRD does not route to this SSO connection, and a connection-directed assertion is denied | A valid assertion may create the user, verified email, and membership |
+| Inactive user, organization, or membership | Denied; JIT does not reactivate offboarded access | Still denied until a separate trusted workflow reactivates it |
+
+Turn JIT on only when the customer's IdP assignment is authoritative for tenant membership. Keep it off for invitation- or admin-managed onboarding. Turning **Require SSO for existing members** off leaves existing unlinked members on another configured login method; it does not silently email-link them during SAML sign-in.
+
+## 6. Verify domain ownership
+
+The customer enters a domain such as `acme.com`. SqlOS creates a `pending_ownership` claim and displays an opaque TXT record:
+
+```text
+Type:  TXT
+Name:  _sqlos-verify.acme.com
+Value: sqlos-domain-verification=<opaque-value>
+```
+
+After the customer publishes it, **Check DNS** asks the configured `ISqlOSDomainDnsVerifier` for the exact value. The default verifier uses public DNS-over-HTTPS. A missing or not-yet-propagated record stays `pending_ownership`, records the last check and error, and keeps activation blocked. Retrying is safe after DNS propagation.
+
+An active domain claim cannot be reused by another organization. Hosts with internal DNS or a provider-specific DNS API can replace `ISqlOSDomainDnsVerifier`.
+
+<Callout type="warning" title="PrimaryDomain is a compatibility fallback">
+  Home realm discovery prefers an active verified domain. If no self-serve domain claim exists, an operator-managed `Organization.PrimaryDomain` can satisfy the legacy setup path. Once the customer starts a pending domain claim, that claim must become active before delegated activation; a primary domain does not bypass the pending verification.
+</Callout>
+
+## 7. Validate, import, and activate metadata
+
+Paste or upload the full IdP metadata XML. **Validate metadata** confirms that SqlOS can parse an IdP entity ID, SSO endpoint, and signing certificate. **Save metadata** imports the values but deliberately leaves the connection disabled with status `ready_to_activate`.
+
+Review the parsed IdP entity ID and SSO URL, then select **Activate connection**. Activation requires complete metadata plus the domain condition above. It enables the connection for home realm discovery; it does not sign anyone out.
+
+To rotate IdP metadata later, create a new setup session (or use the operator dashboard), validate and import the replacement XML, review it, and activate again. **Disable connection** stops new SSO routing without deleting the stored configuration.
+
+## 8. Test with fresh state and S256 PKCE
+
+Register the browser client and its exact redirect URI before testing. In the bundled portal, enter the client ID and exact redirect URI; the portal generates fresh state, verifier, and S256 challenge with Web Crypto for each test.
+
+A host-owned portal must send all of these fields to `POST /sqlos/admin/auth/sso-portal/api/setup/test`:
+
+```json
+{
+  "clientId": "acme-web",
+  "redirectUri": "https://app.example.com/auth/callback",
+  "state": "<fresh-high-entropy-state>",
+  "codeChallenge": "<base64url-sha256-of-fresh-verifier>",
+  "codeChallengeMethod": "S256"
+}
+```
+
+Generate a new state and verifier for every attempt. The verifier is 43–128 RFC 7636 unreserved characters; base64url-encoding 32 random bytes produces the recommended 43-character value. The challenge is `BASE64URL(SHA256(ASCII(verifier)))`. `plain`, a missing challenge, or a redirect URI that differs by path, case, port, or trailing slash is rejected. Never reuse state or a verifier across attempts.
+
+The test should redirect to the external IdP. Completing it requires a real IdP application, an assigned IdP user, valid signed metadata, and matching assertion attributes; local metadata can prove portal readiness but cannot emulate an external login.
+
+## 9. Prove home realm discovery
+
+Start the normal hosted or headless login flow and enter an eligible `user@acme.com` address.
+
+1. HRD matches the active verified `acme.com` claim before considering the legacy primary-domain fallback.
+2. The enrollment policy decides whether this email should route to SSO.
+3. AuthServer creates a PKCE-bound SAML authorization request for the registered client and exact redirect URI.
+4. The IdP posts the signed assertion to the connection's ACS URL.
+5. SqlOS validates it and returns an authorization code plus the original state.
+6. The client exchanges the code with the original verifier at `/sqlos/auth/token`.
+
+Check that the resulting session uses SAML authentication and that the user and membership outcome matches the policy table. A non-matching domain should continue to another configured login method.
+
+## 10. Operate and revoke safely
+
+Creating a new setup link does not invalidate earlier links. Revoke obsolete setup sessions from the organization SSO tab, especially after a support handoff or accidental disclosure. Link/session revocation affects only the delegated setup credential; it does not revoke end-user OAuth sessions.
+
+Activation also does not revoke active end-user sessions. If existing matching-domain members must immediately sign in again through SSO, use the separate **Revoke organization sessions** action and confirm it explicitly. It requires an active connection and active verified domain, then revokes matching-domain OAuth/refresh sessions and hosted AuthPage sessions for that organization. It does not revoke users from other domains or organizations.
+
+Portal creation, open, close, revoke, provider selection, enrollment-policy changes, domain verification, metadata import, activation, disable, tests, and organization-session revocation write organization-scoped audit events. Review them in **Governance → Audit Logs**.
+
+## Run the example flow
+
+Start the shared example stack:
+
+```bash
+cd examples/SqlOS.Example.Web
+npm install
+
+cd /path/to/SqlOS
+dotnet run --project examples/SqlOS.Example.AppHost/SqlOS.Example.AppHost.csproj
+```
+
+Sign in at `http://localhost:3010`, then open `http://localhost:3010/retail/sso`. The page calls `POST /api/sso-portal-links` with the signed-in token, derives the organization from `org_id`, creates a link, and opens the bundled portal.
+
+For a local portal-only test, create the organization with a primary domain before opening the portal. That exercises the operator-managed fallback without publishing DNS. To exercise self-serve verification, use a domain whose TXT record you control or replace `ISqlOSDomainDnsVerifier` with a local test implementation. Neither shortcut proves a real SAML login: that still requires an external IdP, matching metadata, an assigned user, and a successful signed callback.
+
+## Expected outcome
+
+- Customer IT admins configure only their organization without global dashboard access.
+- The setup URL is single-use and replaceable through a new, independently revocable session.
+- DNS ownership, metadata readiness, enrollment policy, and PKCE test status are visible before activation.
+- Eligible matching-domain users route through SSO; other users follow the configured fallback policy.
+- Session revocation happens only through the separate confirm-gated action.
+
+## Next steps
+
+- [SAML SSO reference](/docs/authserver/saml-sso)
+- [Home realm discovery](/docs/authserver/home-realm-discovery)
+- [Dashboard and operator API security](/docs/authserver/dashboard-overview)
+- [Production readiness](/docs/guides/production-readiness)
+- [Entra SAML testing supplement](https://github.com/ross-slaney/sqlos/blob/main/docs/ENTRA_SSO.md)

--- a/web/content/docs/guides/index.mdx
+++ b/web/content/docs/guides/index.mdx
@@ -58,6 +58,9 @@ section: guides
   <Card title="SAML SSO for an organization" description="Connect Entra or another SAML identity provider." href="/docs/guides/saml-sso">
     <img className="sqlos-guide-card-image" src="/docs/sso-page.png" alt="Organization SAML SSO configuration" />
   </Card>
+  <Card title="Customer-managed SSO" description="Let each customer IT admin configure one organization's SAML connection." href="/docs/guides/customer-managed-sso">
+    <img className="sqlos-guide-card-image" src="/docs/guides-customer-managed-sso.svg" alt="Delegated one-organization enterprise SSO setup flow" />
+  </Card>
   <Card title="Standalone identity server" description="Run one SqlOS auth host for several application surfaces." href="/docs/guides/standalone-identity-server">
     <img className="sqlos-guide-card-image" src="/docs/guides-standalone-identity-server.svg" alt="Standalone identity server topology" />
   </Card>

--- a/web/content/docs/guides/saml-sso.mdx
+++ b/web/content/docs/guides/saml-sso.mdx
@@ -14,6 +14,10 @@ section: guides
 
 You'll learn how to create a SAML connection, share metadata with your customer’s IdP, and route users by email domain.
 
+<Callout type="info" title="Choose who runs setup">
+  This guide is the **operator-managed** path: your platform team uses the protected SqlOS dashboard. To give a customer IT admin a one-time, one-organization portal instead, follow [Let customer admins set up enterprise SSO](/docs/guides/customer-managed-sso).
+</Callout>
+
 <Callout type="info" title="Prerequisites">
   - An organization in SqlOS with a **primary email domain** set
   - IdP metadata (XML) or manual Entity ID / ACS URL from your customer
@@ -29,7 +33,7 @@ Existing organization members with verified `@acme.com` email automatically use 
 
 1. Open **`/sqlos/admin/auth/`** → SSO / SAML for the target organization.
 2. Create a **draft** SAML connection. Note the **Entity ID** and **ACS URL** SqlOS generates.
-3. Send those values to the customer’s IT admin (or use the [Admin Portal pattern](/docs/authserver/saml-sso) from your product).
+3. Send those values to the customer’s IT admin. If they should complete setup without global dashboard access, switch to the [customer-managed SSO guide](/docs/guides/customer-managed-sso).
 4. Import the IdP **metadata XML** (or paste certificate and endpoints manually).
 5. Review the **Access policy**. The portal default requires SSO for existing members and leaves JIT provisioning off.
 6. Enable the connection and set or verify the org email domain (e.g. `acme.com`).
@@ -43,6 +47,7 @@ Existing organization members with verified `@acme.com` email automatically use 
 
 ## Next steps
 
+- [Let customer admins set up enterprise SSO](/docs/guides/customer-managed-sso)
 - [Organizations](/docs/authserver/organizations)
 - [Entra SSO testing notes](https://github.com/ross-slaney/sqlos/blob/main/docs/ENTRA_SSO.md) (repo supplement)
 - [Troubleshooting SAML errors](/docs/guides/troubleshooting)

--- a/web/content/docs/reference/authserver-api.mdx
+++ b/web/content/docs/reference/authserver-api.mdx
@@ -1306,6 +1306,8 @@ var result = await hrdService.DiscoverAsync(
 
 Manages self-serve organization domain claims for delegated SSO setup. The default verification path is DNS TXT through `ISqlOSDomainDnsVerifier`; hosts can replace that interface without depending on Azure or any specific DNS provider.
 
+Use [Let customer admins set up enterprise SSO](/docs/guides/customer-managed-sso) for the end-to-end trust boundary and customer workflow before calling these lower-level services directly.
+
 ### StartVerificationAsync
 
 Create or reuse a pending domain claim and return the TXT ownership record.

--- a/web/public/docs/guides-customer-managed-sso.svg
+++ b/web/public/docs/guides-customer-managed-sso.svg
@@ -1,0 +1,52 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="720" viewBox="0 0 1280 720" role="img" aria-labelledby="title desc">
+  <title id="title">Customer-managed enterprise SSO setup</title>
+  <desc id="desc">A platform operator creates a one-time organization-scoped link. A customer IT admin uses the delegated SqlOS portal to verify DNS and connect one SAML identity provider, without receiving global dashboard access.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#f5f3ff"/><stop offset="1" stop-color="#eef2ff"/></linearGradient>
+    <linearGradient id="portal" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#7c3aed"/><stop offset="1" stop-color="#4f46e5"/></linearGradient>
+    <filter id="shadow"><feDropShadow dx="0" dy="12" stdDeviation="18" flood-opacity=".14"/></filter>
+    <style>.eye{font:700 15px system-ui,sans-serif;letter-spacing:2px;fill:#6d28d9}.headline{font:750 42px system-ui,sans-serif;fill:#111827}.sub{font:400 19px system-ui,sans-serif;fill:#64748b}.h{font:750 20px system-ui,sans-serif;fill:#111827}.p{font:500 15px system-ui,sans-serif;fill:#64748b}.white{font:750 21px system-ui,sans-serif;fill:#fff}.whiteSub{font:500 14px system-ui,sans-serif;fill:#ede9fe}.chip{font:700 13px system-ui,sans-serif;fill:#5b21b6}.small{font:650 13px system-ui,sans-serif;fill:#475569}</style>
+  </defs>
+  <rect width="1280" height="720" rx="32" fill="url(#bg)"/>
+  <text x="64" y="75" class="eye">DELEGATED ENTERPRISE SSO</text>
+  <text x="64" y="124" class="headline">One customer. One scoped setup session.</text>
+  <text x="64" y="160" class="sub">The platform keeps global control while customer IT connects its own identity provider.</text>
+
+  <g filter="url(#shadow)">
+    <rect x="64" y="242" width="264" height="244" rx="26" fill="#fff"/>
+    <rect x="420" y="216" width="372" height="296" rx="30" fill="url(#portal)"/>
+    <rect x="884" y="242" width="332" height="112" rx="24" fill="#fff"/>
+    <rect x="884" y="390" width="332" height="112" rx="24" fill="#fff"/>
+  </g>
+
+  <circle cx="116" cy="294" r="25" fill="#ede9fe"/><text x="116" y="300" text-anchor="middle" class="chip">1</text>
+  <text x="154" y="291" class="h">Platform operator</text>
+  <text x="96" y="342" class="p">Creates a one-time link</text>
+  <text x="96" y="371" class="p">for organization Acme.</text>
+  <rect x="96" y="407" width="200" height="46" rx="14" fill="#f3e8ff"/>
+  <text x="196" y="435" text-anchor="middle" class="chip">Global dashboard stays private</text>
+
+  <circle cx="474" cy="272" r="25" fill="#fff" fill-opacity=".18"/><text x="474" y="278" text-anchor="middle" class="whiteSub">2</text>
+  <text x="606" y="285" text-anchor="middle" class="white">SqlOS setup portal</text>
+  <text x="606" y="322" text-anchor="middle" class="whiteSub">HttpOnly continuation cookie</text>
+  <rect x="466" y="351" width="280" height="46" rx="14" fill="#fff" fill-opacity=".13"/>
+  <text x="606" y="379" text-anchor="middle" class="whiteSub">organization_id = Acme only</text>
+  <rect x="466" y="414" width="128" height="48" rx="14" fill="#fff" fill-opacity=".13"/>
+  <text x="530" y="443" text-anchor="middle" class="whiteSub">Verify DNS</text>
+  <rect x="618" y="414" width="128" height="48" rx="14" fill="#fff" fill-opacity=".13"/>
+  <text x="682" y="443" text-anchor="middle" class="whiteSub">Import metadata</text>
+
+  <circle cx="932" cy="294" r="25" fill="#ede9fe"/><text x="932" y="300" text-anchor="middle" class="chip">3</text>
+  <text x="970" y="291" class="h">Customer DNS</text>
+  <text x="916" y="325" class="p">_sqlos-verify.acme.com</text>
+  <circle cx="932" cy="442" r="25" fill="#ede9fe"/><text x="932" y="448" text-anchor="middle" class="chip">4</text>
+  <text x="970" y="439" class="h">Customer IdP</text>
+  <text x="916" y="473" class="p">Entra · Okta · Google · SAML</text>
+
+  <path d="M328 364h92M792 298h92M792 446h92" stroke="#a78bfa" stroke-width="7" stroke-linecap="round"/>
+  <path d="m406 352 14 12-14 12m464-90 14 12-14 12m0 124 14 12-14 12" fill="none" stroke="#7c3aed" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <rect x="64" y="574" width="1152" height="78" rx="22" fill="#fff" fill-opacity=".72" stroke="#ddd6fe"/>
+  <text x="640" y="607" text-anchor="middle" class="small">Activation enables home realm discovery. Existing sessions remain active until a separate confirmed revocation.</text>
+  <text x="640" y="634" text-anchor="middle" class="small">Every portal operation is audited and remains scoped to the stored organization.</text>
+</svg>


### PR DESCRIPTION
## Summary

- add a complete customer-admin SSO setup guide covering the platform/customer trust boundary, one-time portal sessions, hosted and headless configuration, narrow edge routing, provider setup, DNS ownership, enrollment policy, metadata activation, PKCE testing, HRD, and revocation
- add an accessible guide visual and make the workflow discoverable from the Guides catalog
- distinguish operator-managed and delegated SAML paths and cross-link the SAML reference, dashboard, API reference, Entra supplement, and example app documentation

## Documentation quality review

- checked one-organization scoping, hashed one-time/continuation tokens, cookie behavior, provider labels, policy defaults/outcomes, pending DNS activation behavior, metadata replacement, PKCE requirements, and separate session revocation against the current runtime and tests
- corrected two review findings so the guide does not overstate assertion-email domain enforcement or claim reused state is rejected by the runtime
- rendered and visually inspected the new 1280x720 SVG; built and served the guide locally with an HTTP 200 response and expected content

## Validation

- `scripts/docs-check.sh`
- `dotnet test tests/SqlOS.Tests/SqlOS.Tests.csproj --filter FullyQualifiedName~SqlOSSsoPortalServiceTests --nologo` (16 passed)
- `dotnet test tests/SqlOS.IntegrationTests/SqlOS.IntegrationTests.csproj --filter FullyQualifiedName~SamlServiceIntegrationTests --nologo` (15 passed)
- `dotnet test examples/SqlOS.Example.IntegrationTests/SqlOS.Example.IntegrationTests.csproj --filter FullyQualifiedName~DelegatedSsoPortal --nologo` (2 passed)

Closes #172
