### PR TITLE
Align OIDC integration tests with typed public errors

### DIFF
--- a/examples/SqlOS.Example.IntegrationTests/SqlOSExampleOidcAuthIntegrationTests.cs
+++ b/examples/SqlOS.Example.IntegrationTests/SqlOSExampleOidcAuthIntegrationTests.cs
@@ -184,7 +184,7 @@ public sealed class SqlOSExampleOidcAuthIntegrationTests
 
         callbackResponse.StatusCode.Should().Be(HttpStatusCode.Redirect);
         ExtractQueryValue(callbackResponse.Headers.Location!, "handoff").Should().BeNull();
-        ExtractQueryValue(callbackResponse.Headers.Location!, "error").Should().Be("The social login could not be completed.");
+        ExtractQueryValue(callbackResponse.Headers.Location!, "error").Should().Be("The external sign-in request could not be completed.");
     }
 
     [TestMethod]
@@ -213,7 +213,7 @@ public sealed class SqlOSExampleOidcAuthIntegrationTests
 
         callbackResponse.StatusCode.Should().Be(HttpStatusCode.Redirect);
         ExtractQueryValue(callbackResponse.Headers.Location!, "handoff").Should().BeNull();
-        ExtractQueryValue(callbackResponse.Headers.Location!, "error").Should().Be("The social login could not be completed.");
+        ExtractQueryValue(callbackResponse.Headers.Location!, "error").Should().Be("The external sign-in request could not be completed.");
     }
 
     [TestMethod]

--- a/examples/SqlOS.Todo.IntegrationTests/TodoSampleIntegrationTests.cs
+++ b/examples/SqlOS.Todo.IntegrationTests/TodoSampleIntegrationTests.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SqlOS.AuthServer.Errors;
 using SqlOS.AuthServer.Interfaces;
 using SqlOS.Email.Interfaces;
 using SqlOS.Todo.IntegrationTests.Infrastructure;
@@ -154,7 +155,7 @@ public sealed class TodoSampleIntegrationTests
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         (await response.Content.ReadAsStringAsync())
-            .Should().Contain("State cannot exceed 2048 characters.");
+            .Should().Contain(SqlOSPublicAuthErrorMapper.DefaultAuthorizationRequestMessage);
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary

- update the two protocol-level OIDC failure assertions to the generic typed public error introduced by #117
- update the oversized OAuth state hosted-page assertion so it verifies the generic authorization error instead of internal validation detail
- preserve the existing status and no-handoff security assertions

## Validation

- focused real Example API OIDC integration test passes locally
- focused real Todo hosted authorization integration test passes locally

This is the narrow test follow-up for the stale expectations exposed by the post-merge #117 workflow. Runtime behavior, configuration, dependencies, and public APIs are unchanged.