### PR TITLE
Release SqlOS 3.19.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![NuGet](https://img.shields.io/nuget/v/SqlOS)](https://www.nuget.org/packages/SqlOS)
 [![.NET 9](https://img.shields.io/badge/.NET-9.0-purple)](https://dotnet.microsoft.com)
 
-SqlOS 3.18.0 provides a hosted OAuth server, branded login, organizations, sessions, and optional fine-grained authorization to an ASP.NET Core application. It runs in your process and stores its data in your SQL Server database, so you do not need a separate identity or authorization service to get started.
+SqlOS 3.19.0 provides a hosted OAuth server, branded login, organizations, sessions, and optional fine-grained authorization to an ASP.NET Core application. It runs in your process and stores its data in your SQL Server database, so you do not need a separate identity or authorization service to get started.
 
 Start with one application and hosted login. Add SAML SSO, social login, Email OTP, audit logs, calendar connections, or hierarchical authorization when your product needs them.
 
@@ -35,10 +35,10 @@ Requirements:
 Install the package:
 
 ```bash
-dotnet add package SqlOS --version 3.18.0
+dotnet add package SqlOS --version 3.19.0
 ```
 
-> The `main` branch is staged for the 3.18.0 package contract. If NuGet does not list 3.18.0 yet, run the repository examples from source or wait for the package release; do not pair these source docs with 3.16.0.
+> The `main` branch is staged for the 3.19.0 package contract. If NuGet does not list 3.19.0 yet, run the repository examples from source or wait for the package release; do not pair these source docs with 3.16.0.
 
 Use `SqlOSDbContext<TContext>` so SqlOS can register its EF Core model, then declare one application with `UseSingleApplication`:
 

--- a/src/SqlOS/SqlOS.csproj
+++ b/src/SqlOS/SqlOS.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>SqlOS</PackageId>
-    <Version>3.18.0</Version>
+    <Version>3.19.0</Version>
     <Authors>Ross Slaney</Authors>
     <Description>Embedded auth server and fine-grained authorization runtime for .NET + SQL Server + EF Core.</Description>
     <PackageTags>authentication;authorization;fga;saml;jwt;sessions;efcore;sqlserver</PackageTags>

--- a/web/content/blog/sqlos-3-19-safer-oauth-edges-and-magic-links.mdx
+++ b/web/content/blog/sqlos-3-19-safer-oauth-edges-and-magic-links.mdx
@@ -1,0 +1,68 @@
+---
+title: "SqlOS 3.19: Safer OAuth Edges and Opt-In Magic Links"
+description: "SqlOS 3.19 hardens remote OAuth inputs and public failures, improves validation performance, and adds secure magic-link login without changing the password-first local setup."
+date: "2026-07-12"
+author: "Ross Slaney"
+tags: ["AuthServer", "OAuth", "Security", "OIDC", "Magic Link", "SqlOS"]
+---
+
+SqlOS 3.19 continues the security work from 3.18 at the places where an embedded identity server meets untrusted networks and application-owned UI.
+
+The default developer experience stays deliberately quiet. A normal SqlOS application remains password-first, local to the .NET process and SQL Server, and free of required cloud identity or key-management services. The new passwordless and portable-client paths appear only when an application explicitly enables them.
+
+## Remote OAuth inputs now have tighter boundaries
+
+OIDC discovery, JWKS, and UserInfo responses are read as bounded streams. SqlOS rejects an oversized body while reading it instead of buffering an unlimited provider response first.
+
+Client ID Metadata Documents (CIMD) now use a purpose-built HTTP transport. It resolves the metadata host, rejects loopback, private, link-local, documentation, multicast, and mixed public/private answers, connects directly to the validated public address, bypasses ambient proxies, and refuses redirects. Metadata must use a JSON content type and fit the configured byte limit.
+
+CIMD remains disabled until an application asks for portable clients:
+
+```csharp
+builder.AddSqlOS<AppDbContext>(options =>
+{
+    options.AuthServer.EnablePortableMcpClients();
+});
+```
+
+That opt-in works without a host allowlist, which keeps the portable-client use case portable. Closed deployments can add `TrustedHosts` or a parsed-document trust policy as an additional application rule. The network boundary is enforced underneath either configuration.
+
+## Magic-link login is opt-in and origin-safe
+
+Applications can now offer a magic link as a primary credential in both the hosted AuthPage and headless OAuth flows. SqlOS creates, emails, consumes, and audits the short-lived token while the existing authorization request continues through organization selection, MFA, and authorization-code issuance.
+
+Magic links are disabled by default. Enabling them does not replace password login or require an external delivery service when the application already supplies an `ISqlOSAuthEmailSender`:
+
+```csharp
+builder.AddSqlOS<AppDbContext>(options =>
+{
+    options.AuthServer.SeedAuthPage(page =>
+    {
+        page.EnabledCredentialTypes = ["password", "magic_link"];
+    });
+});
+```
+
+Default links come from the configured public origin or issuer, never the request `Host` header. Redemption is atomic and single-use even when two instances race on the same token. Replays and losing concurrent requests receive the same generic public failure without exposing the token or an internal exception.
+
+## Public errors are intentionally less interesting
+
+Hosted and headless authentication endpoints now map failures through one typed public-error boundary. OAuth protocol responses keep stable error codes, browser pages get reviewed messages, and unexpected internal detail stays in diagnostics and audit records. Diagnostic fields are excluded from JSON serialization even if an application serializes the error object itself.
+
+The release also updates protocol-level tests that previously asserted internal exception text. Those tests now verify the public contract and continue to prove that rejected OIDC flows issue no handoff token.
+
+## Validation does less repeated work
+
+Stateful access-token validation now caches safe signing and lifecycle lookups and debounces last-seen writes. Rotation, cleanup, and lifecycle changes invalidate the relevant cache entries. The result is less database work on hot validation paths without extending the security boundary or adding application configuration.
+
+## Tested as real flows
+
+The automated integration suite exercises these changes through the real example hosts and SQL Server, including:
+
+- hosted and headless magic-link authorization-code flows;
+- hostile Host headers, token replay, and concurrent redemption;
+- CIMD metadata fetching, redirects, DNS answers, content types, and bounded streaming;
+- OIDC claim-rejection responses with no handoff token;
+- password, email-code, OIDC, SAML, MFA, refresh, device, DCR, and protected-resource compatibility paths.
+
+SqlOS 3.19 does not include the separate SCIM work under review. This release is narrowly about safer OAuth boundaries, clearer public failures, validation efficiency, and an optional passwordless credential that preserves the existing first-run experience.

--- a/web/content/docs/docs-index.mdx
+++ b/web/content/docs/docs-index.mdx
@@ -5,7 +5,7 @@ order: 0
 ---
 
 <Callout type="info" title="Version contract">
-  These docs target **SqlOS 3.18.0**, **.NET 9**, **EF Core 9**, and **SQL Server**. Use the same package version as the docs: published `3.16.0` predates the ASP.NET Core protected-state schema upgrade and the complete current source/reference contract.
+  These docs target **SqlOS 3.19.0**, **.NET 9**, **EF Core 9**, and **SQL Server**. Use the same package version as the docs: published `3.16.0` predates the ASP.NET Core protected-state schema upgrade and the complete current source/reference contract.
 </Callout>
 
 ## Get useful proof first

--- a/web/content/docs/getting-started.mdx
+++ b/web/content/docs/getting-started.mdx
@@ -14,7 +14,7 @@ order: 0
 </Banner>
 
 <Callout type="info" title="Supported stack">
-  - **SqlOS 3.18.0**
+  - **SqlOS 3.19.0**
   - **.NET 9** (`net9.0`)
   - **EF Core 9**
   - **SQL Server**

--- a/web/content/docs/quickstarts/add-to-app.mdx
+++ b/web/content/docs/quickstarts/add-to-app.mdx
@@ -11,7 +11,7 @@ section: quickstarts
   href="#complete-program"
   actionLabel="View the code"
 >
-  Install SqlOS 3.18.0, register one SQL Server `DbContext`, declare one application, and map the routes. FGA modeling and advanced client registration can wait.
+  Install SqlOS 3.19.0, register one SQL Server `DbContext`, declare one application, and map the routes. FGA modeling and advanced client registration can wait.
 </Banner>
 
 ## Goal
@@ -30,16 +30,16 @@ Start an ASP.NET Core application with:
 - EF Core 9;
 - an existing SQL Server database and a login allowed to create tables, indexes, and functions.
 
-SqlOS 3.18.0 targets `net9.0`; it is not compatible with a `net8.0` host.
+SqlOS 3.19.0 targets `net9.0`; it is not compatible with a `net8.0` host.
 
 ## Install
 
 ```bash
-dotnet add package SqlOS --version 3.18.0
+dotnet add package SqlOS --version 3.19.0
 ```
 
 <Callout type="warning" title="Do not substitute 3.16.0">
-  The `3.18.0` package is the version contract for this guide. If NuGet does not list it yet, run the source examples from this repository or wait for the release; `3.16.0` predates the ASP.NET Core protected-state schema upgrade and other post-tag contracts documented here.
+  The `3.19.0` package is the version contract for this guide. If NuGet does not list it yet, run the source examples from this repository or wait for the release; `3.16.0` predates the ASP.NET Core protected-state schema upgrade and other post-tag contracts documented here.
 </Callout>
 
 For a new project, store local values with user secrets:

--- a/web/content/docs/quickstarts/ef-authorization.mdx
+++ b/web/content/docs/quickstarts/ef-authorization.mdx
@@ -20,7 +20,7 @@ Create projects through an audience-protected API and return only projects the s
 
 ## Prerequisites
 
-- SqlOS 3.18.0;
+- SqlOS 3.19.0;
 - .NET 9, EF Core 9, and SQL Server;
 - a completed [Protect an API](/docs/quickstarts/protect-api) flow;
 - a valid access token whose `aud` is `http://localhost:5050/api`.

--- a/web/content/docs/quickstarts/protect-api.mdx
+++ b/web/content/docs/quickstarts/protect-api.mdx
@@ -20,7 +20,7 @@ Add `/api/me` to a one-application SqlOS host. Requests without a bearer token r
 
 ## Prerequisites
 
-- SqlOS 3.18.0;
+- SqlOS 3.19.0;
 - .NET 9 and EF Core 9;
 - the [Add SqlOS to one app](/docs/quickstarts/add-to-app) setup;
 - the working [.NET hosted-login flow](/docs/quickstarts/aspnet-core-login), adapted so its registered callback matches your handler and its audience is `http://localhost:5050/api`, or another PKCE client that does the same.

--- a/web/content/docs/quickstarts/run-example-stack.mdx
+++ b/web/content/docs/quickstarts/run-example-stack.mdx
@@ -20,7 +20,7 @@ Compare hosted and headless auth, organization workflows, SSO, sessions, audit l
 
 ## Prerequisites
 
-- SqlOS repository checked out at version 3.18.0;
+- SqlOS repository checked out at version 3.19.0;
 - .NET 9 SDK;
 - Node.js and npm;
 - Docker running with enough memory for SQL Server;

--- a/web/content/docs/quickstarts/run-todo.mdx
+++ b/web/content/docs/quickstarts/run-todo.mdx
@@ -25,7 +25,7 @@ Create an account through the SqlOS hosted AuthPage, return to a secure ASP.NET 
 - Docker running with enough memory for SQL Server;
 - ports `1435`, `5080`, `5090`, `18890`, and `18891` available.
 
-This quickstart uses the source at **SqlOS 3.18.0**. Local password authentication is the default, so the first run does not require Azure Communication Services, Twilio, or an OIDC provider.
+This quickstart uses the source at **SqlOS 3.19.0**. Local password authentication is the default, so the first run does not require Azure Communication Services, Twilio, or an OIDC provider.
 
 ## Run
 

--- a/web/content/docs/reference/index.mdx
+++ b/web/content/docs/reference/index.mdx
@@ -1,13 +1,13 @@
 ---
 title: "Reference"
-description: "Source-aligned reference for SqlOS 3.18.0 hosting, authentication, authorization, and integration APIs."
+description: "Source-aligned reference for SqlOS 3.19.0 hosting, authentication, authorization, and integration APIs."
 order: 7
 section: reference
 ---
 
 <Banner
   eyebrow="Reference"
-  title="SqlOS 3.18.0 application API"
+  title="SqlOS 3.19.0 application API"
   href="/docs/getting-started"
   actionLabel="Start with a guide"
 >
@@ -19,7 +19,7 @@ section: reference
 | Item | Value |
 | --- | --- |
 | Package | `SqlOS` |
-| Current source version | `3.18.0` |
+| Current source version | `3.19.0` |
 | Assembly | `SqlOS.dll` |
 | Target framework | `net9.0` |
 | EF Core provider | SQL Server, EF Core 9 |


### PR DESCRIPTION
## Summary

- bump the package and source-aligned documentation contract to 3.19.0
- publish the 3.19 release post covering bounded remote OAuth inputs, CIMD network hardening, typed public errors, validation caching, and opt-in magic links
- keep the release story explicit about password-first local ergonomics and the separate, excluded SCIM work

## Validation

- release build: 0 warnings, 0 errors
- unit suites: 479 library tests + 2 ASP.NET Core example tests passing
- docs/source validation, snippet compilation, lint, static site build, and link check passing

The GitHub Release will be created only after this PR is green and merged. The published release body will include the repository's required compatibility checklist so the publish workflow reruns the full SQL/protocol integration suite before pushing NuGet.
