### PR TITLE
Secure public account-management auth endpoints

### DIFF
--- a/examples/SqlOS.Example.IntegrationTests/SqlOSExampleApiIntegrationTests.cs
+++ b/examples/SqlOS.Example.IntegrationTests/SqlOSExampleApiIntegrationTests.cs
@@ -127,6 +127,165 @@ public sealed class SqlOSExampleApiIntegrationTests
     }
 
     [TestMethod]
+    public async Task AccountManagementEndpoints_DeriveSessionOwnershipFromRefreshToken()
+    {
+        using var factory = ExampleApiFixture.CreateFactory();
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+        var email = $"account-security-{Guid.NewGuid():N}@example.com";
+        var signupResponse = await client.PostAsJsonAsync("/sqlos/auth/signup", new
+        {
+            displayName = "Account Security User",
+            email,
+            password = "P@ssword123!",
+            clientId = "example-web"
+        });
+        signupResponse.EnsureSuccessStatusCode();
+        using var signupJson = JsonDocument.Parse(await signupResponse.Content.ReadAsStringAsync());
+        var signupTokens = signupJson.RootElement.GetProperty("tokens");
+        var sessionId = signupTokens.GetProperty("sessionId").GetString();
+        var refreshToken = signupTokens.GetProperty("refreshToken").GetString();
+
+        var sessionIdLogout = await client.PostAsJsonAsync("/sqlos/auth/logout", new { sessionId });
+        sessionIdLogout.StatusCode.Should().Be(System.Net.HttpStatusCode.NoContent);
+
+        var refreshAfterSessionIdAttack = await client.PostAsJsonAsync("/sqlos/auth/token/refresh", new { refreshToken });
+        refreshAfterSessionIdAttack.IsSuccessStatusCode.Should().BeTrue("an anonymous session id must not authorize logout");
+        using var refreshedJson = JsonDocument.Parse(await refreshAfterSessionIdAttack.Content.ReadAsStringAsync());
+        refreshToken = refreshedJson.RootElement.GetProperty("refreshToken").GetString();
+
+        var userId = await GetUserIdByEmailAsync(factory.Services, email);
+        var userIdLogoutAll = await client.PostAsJsonAsync("/sqlos/auth/logout-all", new { userId });
+        userIdLogoutAll.StatusCode.Should().Be(System.Net.HttpStatusCode.Unauthorized);
+
+        var refreshAfterUserIdAttack = await client.PostAsJsonAsync("/sqlos/auth/token/refresh", new { refreshToken });
+        refreshAfterUserIdAttack.IsSuccessStatusCode.Should().BeTrue("a caller-supplied user id must not authorize logout-all");
+        using var secondRefreshJson = JsonDocument.Parse(await refreshAfterUserIdAttack.Content.ReadAsStringAsync());
+        refreshToken = secondRefreshJson.RootElement.GetProperty("refreshToken").GetString();
+
+        var selfLogoutAll = await client.PostAsJsonAsync("/sqlos/auth/logout-all", new { refreshToken });
+        selfLogoutAll.StatusCode.Should().Be(System.Net.HttpStatusCode.NoContent);
+
+        var refreshAfterSelfLogoutAll = await client.PostAsJsonAsync("/sqlos/auth/token/refresh", new { refreshToken });
+        refreshAfterSelfLogoutAll.IsSuccessStatusCode.Should().BeFalse("logout-all must revoke the authenticated user's token family");
+    }
+
+    [TestMethod]
+    public async Task EmailVerificationRequest_DeliversTrustedLinkWithoutDisclosingOrEnumerating()
+    {
+        using var factory = ExampleApiFixture.CreateFactory(builder =>
+        {
+            builder.UseSetting("SqlOS:Issuer", "https://auth.example.test/sqlos/auth");
+            builder.UseSetting("SqlOS:PublicOrigin", "https://auth.example.test");
+            builder.ConfigureServices(services =>
+            {
+                services.RemoveAll<ISqlOSEmailSender>();
+                services.AddSingleton<CapturingTransactionalEmailSender>();
+                services.AddSingleton<ISqlOSEmailSender>(sp => sp.GetRequiredService<CapturingTransactionalEmailSender>());
+            });
+        });
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+        var sender = factory.Services.GetRequiredService<CapturingTransactionalEmailSender>();
+        var email = $"verify-{Guid.NewGuid():N}@example.com";
+        var signupResponse = await client.PostAsJsonAsync("/sqlos/auth/signup", new
+        {
+            displayName = "Verification User",
+            email,
+            password = "P@ssword123!",
+            clientId = "example-web"
+        });
+        signupResponse.EnsureSuccessStatusCode();
+
+        using var knownRequest = new HttpRequestMessage(HttpMethod.Post, "/sqlos/auth/email/verification-token")
+        {
+            Content = JsonContent.Create(new { email })
+        };
+        knownRequest.Headers.Host = "attacker.example";
+        knownRequest.Headers.TryAddWithoutValidation("Forwarded", "host=forwarded-attacker.example;proto=https");
+        knownRequest.Headers.TryAddWithoutValidation("X-Forwarded-Host", "forwarded-attacker.example");
+        var knownResponse = await client.SendAsync(knownRequest);
+        knownResponse.EnsureSuccessStatusCode();
+        var knownBody = await knownResponse.Content.ReadAsStringAsync();
+        using var knownJson = JsonDocument.Parse(knownBody);
+        knownJson.RootElement.GetProperty("message").GetString().Should()
+            .Be("If the email can be verified, you'll receive a verification email shortly.");
+        knownJson.RootElement.TryGetProperty("token", out _).Should().BeFalse();
+
+        sender.Messages.Should().ContainSingle();
+        var delivered = sender.Messages.Single();
+        delivered.TextBody.Should().Contain("https://auth.example.test/sqlos/auth/email/verify?token=");
+        delivered.TextBody.Should().NotContain("attacker.example");
+
+        var secondKnownResponse = await client.PostAsJsonAsync("/sqlos/auth/email/verification-email", new { email });
+        secondKnownResponse.EnsureSuccessStatusCode();
+        sender.Messages.Should().ContainSingle("the resend cooldown should prevent mail bombing");
+
+        var unknownResponse = await client.PostAsJsonAsync(
+            "/sqlos/auth/email/verification-token",
+            new { email = $"missing-{Guid.NewGuid():N}@example.com" });
+        unknownResponse.EnsureSuccessStatusCode();
+        (await unknownResponse.Content.ReadAsStringAsync()).Should().Be(knownBody);
+
+        var userId = await GetUserIdByEmailAsync(factory.Services, email);
+        (await IsEmailVerifiedAsync(factory.Services, userId)).Should().BeFalse();
+
+        var verificationToken = ExtractVerificationToken(delivered.TextBody);
+        var verifyResponse = await client.GetAsync($"/sqlos/auth/email/verify?token={Uri.EscapeDataString(verificationToken)}");
+        verifyResponse.EnsureSuccessStatusCode();
+        (await verifyResponse.Content.ReadAsStringAsync()).Should().Contain("Email verified");
+        (await IsEmailVerifiedAsync(factory.Services, userId)).Should().BeTrue();
+
+        var replayResponse = await client.GetAsync($"/sqlos/auth/email/verify?token={Uri.EscapeDataString(verificationToken)}");
+        replayResponse.StatusCode.Should().Be(System.Net.HttpStatusCode.BadRequest);
+    }
+
+    [TestMethod]
+    public async Task EmailVerificationRequest_DeliveryFailureLeavesNoUsableToken()
+    {
+        using var factory = ExampleApiFixture.CreateFactory(builder =>
+        {
+            builder.UseSetting("SqlOS:Issuer", "https://auth.example.test/sqlos/auth");
+            builder.UseSetting("SqlOS:PublicOrigin", "https://auth.example.test");
+            builder.ConfigureServices(services =>
+            {
+                services.RemoveAll<ISqlOSEmailSender>();
+                services.AddSingleton<CapturingTransactionalEmailSender>();
+                services.AddSingleton<ISqlOSEmailSender>(sp => sp.GetRequiredService<CapturingTransactionalEmailSender>());
+            });
+        });
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+        var sender = factory.Services.GetRequiredService<CapturingTransactionalEmailSender>();
+        var email = $"verify-failure-{Guid.NewGuid():N}@example.com";
+        var signupResponse = await client.PostAsJsonAsync("/sqlos/auth/signup", new
+        {
+            displayName = "Verification Failure User",
+            email,
+            password = "P@ssword123!",
+            clientId = "example-web"
+        });
+        signupResponse.EnsureSuccessStatusCode();
+        sender.FailDelivery = true;
+
+        var knownResponse = await client.PostAsJsonAsync("/sqlos/auth/email/verification-token", new { email });
+        var unknownResponse = await client.PostAsJsonAsync(
+            "/sqlos/auth/email/verification-token",
+            new { email = $"missing-{Guid.NewGuid():N}@example.com" });
+        knownResponse.EnsureSuccessStatusCode();
+        unknownResponse.EnsureSuccessStatusCode();
+        (await knownResponse.Content.ReadAsStringAsync()).Should().Be(await unknownResponse.Content.ReadAsStringAsync());
+
+        var userId = await GetUserIdByEmailAsync(factory.Services, email);
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ExampleAppDbContext>();
+        (await db.Set<SqlOSTemporaryToken>().CountAsync(token =>
+            token.UserId == userId
+            && token.Purpose == "email_verification"
+            && token.ConsumedAt == null)).Should().Be(0);
+        (await db.Set<SqlOSAuditEvent>().CountAsync(audit =>
+            audit.UserId == userId
+            && audit.EventType == "user.email-verification-send-failed")).Should().Be(1);
+    }
+
+    [TestMethod]
     public async Task PasswordResetAndRefresh_Work()
     {
         using var factory = ExampleApiFixture.CreateFactory(builder =>
@@ -1166,6 +1325,35 @@ public sealed class SqlOSExampleApiIntegrationTests
         var match = System.Text.RegularExpressions.Regex.Match(textBody, @"token=([A-Za-z0-9_-]+)");
         match.Success.Should().BeTrue();
         return match.Groups[1].Value;
+    }
+
+    private static string ExtractVerificationToken(string textBody)
+    {
+        var match = System.Text.RegularExpressions.Regex.Match(
+            textBody,
+            @"/email/verify\?token=([A-Za-z0-9_-]+)");
+        match.Success.Should().BeTrue();
+        return match.Groups[1].Value;
+    }
+
+    private static async Task<string> GetUserIdByEmailAsync(IServiceProvider services, string email)
+    {
+        using var scope = services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ExampleAppDbContext>();
+        return await db.Set<SqlOSUserEmail>()
+            .Where(userEmail => userEmail.NormalizedEmail == email.ToUpperInvariant())
+            .Select(userEmail => userEmail.UserId)
+            .SingleAsync();
+    }
+
+    private static async Task<bool> IsEmailVerifiedAsync(IServiceProvider services, string userId)
+    {
+        using var scope = services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ExampleAppDbContext>();
+        return await db.Set<SqlOSUserEmail>()
+            .Where(userEmail => userEmail.UserId == userId)
+            .Select(userEmail => userEmail.IsVerified)
+            .SingleAsync();
     }
 
     private static string BuildSignedSamlResponse(

--- a/examples/SqlOS.Example.IntegrationTests/SqlOSExampleApiIntegrationTests.cs
+++ b/examples/SqlOS.Example.IntegrationTests/SqlOSExampleApiIntegrationTests.cs
@@ -143,7 +143,8 @@ public sealed class SqlOSExampleApiIntegrationTests
         using var signupJson = JsonDocument.Parse(await signupResponse.Content.ReadAsStringAsync());
         var signupTokens = signupJson.RootElement.GetProperty("tokens");
         var sessionId = signupTokens.GetProperty("sessionId").GetString();
-        var refreshToken = signupTokens.GetProperty("refreshToken").GetString();
+        var originalRefreshToken = signupTokens.GetProperty("refreshToken").GetString();
+        var refreshToken = originalRefreshToken;
 
         var sessionIdLogout = await client.PostAsJsonAsync("/sqlos/auth/logout", new { sessionId });
         sessionIdLogout.StatusCode.Should().Be(System.Net.HttpStatusCode.NoContent);
@@ -152,6 +153,13 @@ public sealed class SqlOSExampleApiIntegrationTests
         refreshAfterSessionIdAttack.IsSuccessStatusCode.Should().BeTrue("an anonymous session id must not authorize logout");
         using var refreshedJson = JsonDocument.Parse(await refreshAfterSessionIdAttack.Content.ReadAsStringAsync());
         refreshToken = refreshedJson.RootElement.GetProperty("refreshToken").GetString();
+
+        var historicalTokenLogout = await client.PostAsJsonAsync("/sqlos/auth/logout", new { refreshToken = originalRefreshToken });
+        historicalTokenLogout.StatusCode.Should().Be(System.Net.HttpStatusCode.NoContent);
+        var refreshAfterHistoricalTokenAttack = await client.PostAsJsonAsync("/sqlos/auth/token/refresh", new { refreshToken });
+        refreshAfterHistoricalTokenAttack.IsSuccessStatusCode.Should().BeTrue("a consumed refresh token must not authorize logout");
+        using var postAttackRefreshJson = JsonDocument.Parse(await refreshAfterHistoricalTokenAttack.Content.ReadAsStringAsync());
+        refreshToken = postAttackRefreshJson.RootElement.GetProperty("refreshToken").GetString();
 
         var userId = await GetUserIdByEmailAsync(factory.Services, email);
         var userIdLogoutAll = await client.PostAsJsonAsync("/sqlos/auth/logout-all", new { userId });
@@ -231,6 +239,9 @@ public sealed class SqlOSExampleApiIntegrationTests
         var verificationToken = ExtractVerificationToken(delivered.TextBody);
         var verifyResponse = await client.GetAsync($"/sqlos/auth/email/verify?token={Uri.EscapeDataString(verificationToken)}");
         verifyResponse.EnsureSuccessStatusCode();
+        verifyResponse.Headers.CacheControl!.NoStore.Should().BeTrue();
+        verifyResponse.Headers.GetValues("Referrer-Policy").Should().ContainSingle("no-referrer");
+        verifyResponse.Headers.GetValues("X-Content-Type-Options").Should().ContainSingle("nosniff");
         (await verifyResponse.Content.ReadAsStringAsync()).Should().Contain("Email verified");
         (await IsEmailVerifiedAsync(factory.Services, userId)).Should().BeTrue();
 
@@ -283,6 +294,10 @@ public sealed class SqlOSExampleApiIntegrationTests
         (await db.Set<SqlOSAuditEvent>().CountAsync(audit =>
             audit.UserId == userId
             && audit.EventType == "user.email-verification-send-failed")).Should().Be(1);
+        var tokenCreatedAudit = await db.Set<SqlOSAuditEvent>()
+            .SingleAsync(audit => audit.UserId == userId && audit.EventType == "user.email-verification-token-created");
+        tokenCreatedAudit.ActorType.Should().Be("system");
+        tokenCreatedAudit.ActorId.Should().BeNull();
     }
 
     [TestMethod]

--- a/src/SqlOS/AuthServer/Contracts/SqlOSContracts.cs
+++ b/src/SqlOS/AuthServer/Contracts/SqlOSContracts.cs
@@ -137,6 +137,8 @@ public sealed record SqlOSPasswordResetRequestResult(
 
 public sealed record SqlOSCreateVerificationTokenRequest(string Email);
 
+public sealed record SqlOSEmailVerificationRequestResult(string Message);
+
 public sealed record SqlOSVerifyEmailRequest(string Token);
 
 public sealed record SqlOSCreateOrganizationRequest(string Name, string? Slug, string? PrimaryDomain = null);

--- a/src/SqlOS/AuthServer/Extensions/EndpointRouteBuilderExtensions.cs
+++ b/src/SqlOS/AuthServer/Extensions/EndpointRouteBuilderExtensions.cs
@@ -3314,7 +3314,7 @@ public static class EndpointRouteBuilderExtensions
         auth.MapPost("/logout", async (HttpContext context, SqlOSAuthService authService, CancellationToken cancellationToken) =>
         {
             var request = await context.Request.ReadFromJsonAsync<LogoutRequest>(cancellationToken: cancellationToken) ?? new LogoutRequest(null);
-            await authService.LogoutAsync(request.RefreshToken, sessionId: null, cancellationToken);
+            await authService.LogoutByRefreshTokenAsync(request.RefreshToken, cancellationToken);
             return Results.NoContent();
         });
 
@@ -3376,6 +3376,10 @@ public static class EndpointRouteBuilderExtensions
 
         auth.MapGet("/email/verify", async (HttpContext context, SqlOSAuthService authService, CancellationToken cancellationToken) =>
         {
+            context.Response.Headers.CacheControl = "no-store";
+            context.Response.Headers.Pragma = "no-cache";
+            context.Response.Headers["Referrer-Policy"] = "no-referrer";
+            context.Response.Headers["X-Content-Type-Options"] = "nosniff";
             try
             {
                 await authService.VerifyEmailAsync(
@@ -5592,6 +5596,7 @@ public static class EndpointRouteBuilderExtensions
         <head>
           <meta charset="utf-8" />
           <meta name="viewport" content="width=device-width, initial-scale=1" />
+          <meta name="referrer" content="no-referrer" />
           <title>Reset password</title>
           <style>
             body { margin:0; min-height:100vh; display:grid; place-items:center; background:#f8fafc; color:#0f172a; font-family:Segoe UI,Arial,sans-serif; }

--- a/src/SqlOS/AuthServer/Extensions/EndpointRouteBuilderExtensions.cs
+++ b/src/SqlOS/AuthServer/Extensions/EndpointRouteBuilderExtensions.cs
@@ -3313,15 +3313,16 @@ public static class EndpointRouteBuilderExtensions
 
         auth.MapPost("/logout", async (HttpContext context, SqlOSAuthService authService, CancellationToken cancellationToken) =>
         {
-            var request = await context.Request.ReadFromJsonAsync<LogoutRequest>(cancellationToken: cancellationToken) ?? new LogoutRequest(null, null);
-            await authService.LogoutAsync(request.RefreshToken, request.SessionId, cancellationToken);
+            var request = await context.Request.ReadFromJsonAsync<LogoutRequest>(cancellationToken: cancellationToken) ?? new LogoutRequest(null);
+            await authService.LogoutAsync(request.RefreshToken, sessionId: null, cancellationToken);
             return Results.NoContent();
         });
 
         auth.MapPost("/logout-all", async (LogoutAllRequest request, SqlOSAuthService authService, CancellationToken cancellationToken) =>
         {
-            await authService.LogoutAllAsync(request.UserId, cancellationToken);
-            return Results.NoContent();
+            return await authService.LogoutAllByRefreshTokenAsync(request.RefreshToken, cancellationToken)
+                ? Results.NoContent()
+                : Results.Unauthorized();
         });
 
         auth.MapPost("/password/forgot", async (SqlOSForgotPasswordRequest request, SqlOSAuthService authService, HttpContext httpContext, CancellationToken cancellationToken) =>
@@ -3367,8 +3368,29 @@ public static class EndpointRouteBuilderExtensions
             return Results.NoContent();
         });
 
-        auth.MapPost("/email/verification-token", async (SqlOSCreateVerificationTokenRequest request, SqlOSAuthService authService, CancellationToken cancellationToken) =>
-            Results.Ok(new { token = await authService.CreateEmailVerificationTokenAsync(request, cancellationToken) }));
+        auth.MapPost("/email/verification-token", async (SqlOSCreateVerificationTokenRequest request, SqlOSAuthService authService, HttpContext httpContext, CancellationToken cancellationToken) =>
+            Results.Ok(await authService.RequestEmailVerificationAsync(request, httpContext, cancellationToken)));
+
+        auth.MapPost("/email/verification-email", async (SqlOSCreateVerificationTokenRequest request, SqlOSAuthService authService, HttpContext httpContext, CancellationToken cancellationToken) =>
+            Results.Ok(await authService.RequestEmailVerificationAsync(request, httpContext, cancellationToken)));
+
+        auth.MapGet("/email/verify", async (HttpContext context, SqlOSAuthService authService, CancellationToken cancellationToken) =>
+        {
+            try
+            {
+                await authService.VerifyEmailAsync(
+                    new SqlOSVerifyEmailRequest(context.Request.Query["token"].ToString()),
+                    cancellationToken);
+                return Results.Content(BuildEmailVerificationPage(error: null), contentType: "text/html");
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.Content(
+                    BuildEmailVerificationPage(await PublicAuthMessageAsync(context, ex, SqlOSPublicAuthErrorSurface.HostedPage, cancellationToken)),
+                    contentType: "text/html",
+                    statusCode: StatusCodes.Status400BadRequest);
+            }
+        });
 
         auth.MapPost("/email/verify", async (SqlOSVerifyEmailRequest request, SqlOSAuthService authService, CancellationToken cancellationToken) =>
         {
@@ -5597,6 +5619,43 @@ public static class EndpointRouteBuilderExtensions
         """;
     }
 
+    private static string BuildEmailVerificationPage(string? error)
+    {
+        static string H(string? value) => WebUtility.HtmlEncode(value ?? string.Empty);
+
+        var succeeded = string.IsNullOrWhiteSpace(error);
+        var title = succeeded ? "Email verified" : "Verification failed";
+        var message = succeeded
+            ? "Your email is verified. You can close this tab and continue signing in."
+            : H(error);
+        var stateClass = succeeded ? "success" : "error";
+
+        return $$"""
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+          <meta charset="utf-8" />
+          <meta name="viewport" content="width=device-width, initial-scale=1" />
+          <title>{{title}}</title>
+          <style>
+            body { margin:0; min-height:100vh; display:grid; place-items:center; background:#f8fafc; color:#0f172a; font-family:Segoe UI,Arial,sans-serif; }
+            main { width:min(440px, calc(100vw - 32px)); background:#fff; border:1px solid #e2e8f0; border-radius:20px; padding:28px; box-shadow:0 24px 70px rgba(15,23,42,.10); }
+            h1 { margin:0 0 10px; font-size:28px; line-height:1.1; }
+            p { margin:0; color:#475569; line-height:1.5; }
+            .success { border-left:4px solid #16a34a; padding-left:16px; }
+            .error { border-left:4px solid #dc2626; padding-left:16px; }
+          </style>
+        </head>
+        <body>
+          <main class="{{stateClass}}">
+            <h1>{{title}}</h1>
+            <p>{{message}}</p>
+          </main>
+        </body>
+        </html>
+        """;
+    }
+
     private static async Task<IResult> RenderMfaChallengeAsync(
         SqlOSAuthorizationRequestLoginResult completion,
         string? authorizationRequestId,
@@ -5988,7 +6047,7 @@ public static class EndpointRouteBuilderExtensions
             : null;
     }
 
-    private sealed record LogoutRequest(string? RefreshToken, string? SessionId);
+    private sealed record LogoutRequest(string? RefreshToken);
     private sealed record CreateOrganizationInvitationRequest(
         string Email,
         string Role,
@@ -6001,7 +6060,7 @@ public static class EndpointRouteBuilderExtensions
         string? InvitedByUserId,
         bool? SendEmail);
     private sealed record RevokeInvitationRequest(string? Reason);
-    private sealed record LogoutAllRequest(string UserId);
+    private sealed record LogoutAllRequest(string? RefreshToken);
     private sealed record CreateMembershipRequest(string OrganizationId, string UserId, string Role);
     private static bool TryParseClientAuthMethod(string? value, out SqlOSOidcClientAuthMethod? method)
     {

--- a/src/SqlOS/AuthServer/Services/SqlOSAuthService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSAuthService.cs
@@ -22,6 +22,10 @@ public sealed class SqlOSAuthService
     private const string PasswordResetPurpose = "password_reset";
     private const string PasswordResetRequestPurpose = "password_reset_request";
     private const string PasswordResetGenericMessage = "If an account can be reset, you'll receive a password reset email shortly.";
+    private const string EmailVerificationPurpose = "email_verification";
+    private const string EmailVerificationGenericMessage = "If the email can be verified, you'll receive a verification email shortly.";
+    private static readonly TimeSpan EmailVerificationLifetime = TimeSpan.FromDays(1);
+    private static readonly TimeSpan EmailVerificationResendCooldown = TimeSpan.FromMinutes(1);
 
     private readonly ISqlOSAuthServerDbContext _context;
     private readonly SqlOSAuthServerOptions _options;
@@ -1004,6 +1008,37 @@ public sealed class SqlOSAuthService
         await _adminService.RecordAuditAsync("user.logout-all", "user", userId, userId: userId, cancellationToken: cancellationToken);
     }
 
+    internal async Task<bool> LogoutAllByRefreshTokenAsync(
+        string? refreshToken,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(refreshToken))
+        {
+            return false;
+        }
+
+        var now = DateTime.UtcNow;
+        var hashed = _cryptoService.HashToken(refreshToken);
+        var token = await _context.Set<SqlOSRefreshToken>()
+            .Include(x => x.Session)
+            .FirstOrDefaultAsync(x => x.TokenHash == hashed
+                && x.RevokedAt == null
+                && x.ConsumedAt == null
+                && x.ExpiresAt >= now,
+                cancellationToken);
+        var session = token?.Session;
+        if (session == null
+            || session.RevokedAt != null
+            || session.IdleExpiresAt < now
+            || session.AbsoluteExpiresAt < now)
+        {
+            return false;
+        }
+
+        await LogoutAllAsync(session.UserId, cancellationToken);
+        return true;
+    }
+
     public async Task<string> CreatePasswordResetTokenAsync(SqlOSForgotPasswordRequest request, CancellationToken cancellationToken = default)
     {
         var normalizedEmail = SqlOSAdminService.NormalizeEmail(request.Email);
@@ -1409,21 +1444,135 @@ public sealed class SqlOSAuthService
             ?? throw new InvalidOperationException("Unknown email address.");
 
         var token = await _cryptoService.CreateTemporaryTokenAsync(
-            "email_verification",
+            EmailVerificationPurpose,
             email.UserId,
             null,
             null,
             new EmailVerificationPayload(email.Id),
-            TimeSpan.FromDays(1),
+            EmailVerificationLifetime,
             cancellationToken);
 
         await _adminService.RecordAuditAsync("user.email-verification-token-created", "user", email.UserId, userId: email.UserId, cancellationToken: cancellationToken);
         return token;
     }
 
+    public async Task<SqlOSEmailVerificationRequestResult> RequestEmailVerificationAsync(
+        SqlOSCreateVerificationTokenRequest request,
+        HttpContext? httpContext = null,
+        CancellationToken cancellationToken = default)
+    {
+        var trimmedEmail = NormalizeEmailInput(request.Email);
+        var normalizedEmail = SqlOSAdminService.NormalizeEmail(trimmedEmail);
+        var maskedEmail = MaskEmail(trimmedEmail);
+        var now = DateTime.UtcNow;
+        var email = await _context.Set<SqlOSUserEmail>()
+            .FirstOrDefaultAsync(x => x.NormalizedEmail == normalizedEmail, cancellationToken);
+
+        await _adminService.RecordAuditAsync(
+            "user.email-verification-requested",
+            "system",
+            null,
+            userId: email?.UserId,
+            ipAddress: GetIp(httpContext),
+            data: new { maskedEmail, eligible = email is { IsVerified: false } },
+            cancellationToken: cancellationToken);
+
+        if (email == null || email.IsVerified)
+        {
+            return new SqlOSEmailVerificationRequestResult(EmailVerificationGenericMessage);
+        }
+
+        var recentTokens = await _context.Set<SqlOSTemporaryToken>()
+            .Where(x => x.Purpose == EmailVerificationPurpose
+                && x.UserId == email.UserId
+                && x.ConsumedAt == null
+                && x.ExpiresAt >= now
+                && x.CreatedAt >= now.Subtract(EmailVerificationResendCooldown))
+            .ToListAsync(cancellationToken);
+        if (recentTokens.Any(token =>
+                _cryptoService.DeserializePayload<EmailVerificationPayload>(token)?.EmailId == email.Id))
+        {
+            return new SqlOSEmailVerificationRequestResult(EmailVerificationGenericMessage);
+        }
+
+        string? rawToken = null;
+        try
+        {
+            rawToken = await CreateEmailVerificationTokenAsync(request, cancellationToken);
+            var branding = await _settingsService.GetResolvedAuthEmailBrandingAsync(cancellationToken);
+            var applicationName = string.IsNullOrWhiteSpace(branding.ApplicationName)
+                ? string.IsNullOrWhiteSpace(_options.EmailOtp.ApplicationName)
+                    ? "SqlOS"
+                    : _options.EmailOtp.ApplicationName.Trim()
+                : branding.ApplicationName;
+            var verificationUrl = $"{GetTrustedPublicOrigin()}{_options.BasePath.TrimEnd('/')}/email/verify?token={Uri.EscapeDataString(rawToken)}";
+            var result = await (_transactionalEmailService
+                    ?? throw new InvalidOperationException("Transactional email service is not registered."))
+                .SendAsync(
+                    new SqlOSSendEmailRequest(
+                        SqlOSBuiltInEmailTemplates.AuthEmailVerificationKey,
+                        email.Email,
+                        new Dictionary<string, object?>(StringComparer.Ordinal)
+                        {
+                            ["applicationName"] = applicationName,
+                            ["logoBase64"] = branding.LogoBase64 ?? string.Empty,
+                            ["logoImageDisplay"] = string.IsNullOrWhiteSpace(branding.LogoBase64) ? "none" : "block",
+                            ["logoTextDisplay"] = string.IsNullOrWhiteSpace(branding.LogoBase64) ? "block" : "none",
+                            ["maskedEmail"] = MaskEmail(email.Email),
+                            ["verificationUrl"] = verificationUrl,
+                            ["expiresInHours"] = (int)EmailVerificationLifetime.TotalHours,
+                            ["primaryColor"] = branding.PrimaryColor,
+                            ["accentColor"] = branding.AccentColor,
+                            ["backgroundColor"] = branding.BackgroundColor
+                        },
+                        IdempotencyKey: $"auth-email-verification:{email.Id}:{_cryptoService.HashToken(rawToken)[..32]}"),
+                    cancellationToken);
+
+            if (string.Equals(result.Status, SqlOSEmailDeliveryStatuses.Failed, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(result.SanitizedError ?? "Email verification delivery failed.");
+            }
+
+            await _adminService.RecordAuditAsync(
+                "user.email-verification-sent",
+                "system",
+                null,
+                userId: email.UserId,
+                ipAddress: GetIp(httpContext),
+                data: new { maskedEmail, result.DeliveryId, DeliveryStatus = result.Status, result.ProviderMessageId },
+                cancellationToken: cancellationToken);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            if (rawToken != null)
+            {
+                var token = await _cryptoService.FindTemporaryTokenAsync(
+                    EmailVerificationPurpose,
+                    rawToken,
+                    CancellationToken.None);
+                if (token != null)
+                {
+                    token.ConsumedAt = DateTime.UtcNow;
+                    await _context.SaveChangesAsync(CancellationToken.None);
+                }
+            }
+
+            await _adminService.RecordAuditAsync(
+                "user.email-verification-send-failed",
+                "system",
+                null,
+                userId: email.UserId,
+                ipAddress: GetIp(httpContext),
+                data: new { maskedEmail, error = ex.Message },
+                cancellationToken: CancellationToken.None);
+        }
+
+        return new SqlOSEmailVerificationRequestResult(EmailVerificationGenericMessage);
+    }
+
     public async Task VerifyEmailAsync(SqlOSVerifyEmailRequest request, CancellationToken cancellationToken = default)
     {
-        var token = await _cryptoService.ConsumeTemporaryTokenAsync("email_verification", request.Token, cancellationToken)
+        var token = await _cryptoService.ConsumeTemporaryTokenAsync(EmailVerificationPurpose, request.Token, cancellationToken)
             ?? throw new InvalidOperationException("Email verification token is invalid or expired.");
         var payload = _cryptoService.DeserializePayload<EmailVerificationPayload>(token)
             ?? throw new InvalidOperationException("Email verification token payload is invalid.");

--- a/src/SqlOS/AuthServer/Services/SqlOSAuthService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSAuthService.cs
@@ -980,6 +980,25 @@ public sealed class SqlOSAuthService
             return;
         }
 
+        await RevokeSessionAsync(session, cancellationToken);
+    }
+
+    internal async Task<bool> LogoutByRefreshTokenAsync(
+        string? refreshToken,
+        CancellationToken cancellationToken = default)
+    {
+        var session = await FindActiveSessionByRefreshTokenAsync(refreshToken, cancellationToken);
+        if (session == null)
+        {
+            return false;
+        }
+
+        await RevokeSessionAsync(session, cancellationToken);
+        return true;
+    }
+
+    private async Task RevokeSessionAsync(SqlOSSession session, CancellationToken cancellationToken)
+    {
         session.RevokedAt = DateTime.UtcNow;
         session.RevocationReason = "logout";
         var refreshTokens = await _context.Set<SqlOSRefreshToken>().Where(x => x.SessionId == session.Id && x.RevokedAt == null).ToListAsync(cancellationToken);
@@ -1012,9 +1031,23 @@ public sealed class SqlOSAuthService
         string? refreshToken,
         CancellationToken cancellationToken = default)
     {
-        if (string.IsNullOrWhiteSpace(refreshToken))
+        var session = await FindActiveSessionByRefreshTokenAsync(refreshToken, cancellationToken);
+        if (session == null)
         {
             return false;
+        }
+
+        await LogoutAllAsync(session.UserId, cancellationToken);
+        return true;
+    }
+
+    private async Task<SqlOSSession?> FindActiveSessionByRefreshTokenAsync(
+        string? refreshToken,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(refreshToken))
+        {
+            return null;
         }
 
         var now = DateTime.UtcNow;
@@ -1027,16 +1060,12 @@ public sealed class SqlOSAuthService
                 && x.ExpiresAt >= now,
                 cancellationToken);
         var session = token?.Session;
-        if (session == null
-            || session.RevokedAt != null
-            || session.IdleExpiresAt < now
-            || session.AbsoluteExpiresAt < now)
-        {
-            return false;
-        }
-
-        await LogoutAllAsync(session.UserId, cancellationToken);
-        return true;
+        return session != null
+            && session.RevokedAt == null
+            && session.IdleExpiresAt >= now
+            && session.AbsoluteExpiresAt >= now
+                ? session
+                : null;
     }
 
     public async Task<string> CreatePasswordResetTokenAsync(SqlOSForgotPasswordRequest request, CancellationToken cancellationToken = default)
@@ -1452,7 +1481,7 @@ public sealed class SqlOSAuthService
             EmailVerificationLifetime,
             cancellationToken);
 
-        await _adminService.RecordAuditAsync("user.email-verification-token-created", "user", email.UserId, userId: email.UserId, cancellationToken: cancellationToken);
+        await _adminService.RecordAuditAsync("user.email-verification-token-created", "system", null, userId: email.UserId, cancellationToken: cancellationToken);
         return token;
     }
 

--- a/src/SqlOS/Email/Services/SqlOSBuiltInEmailTemplates.cs
+++ b/src/SqlOS/Email/Services/SqlOSBuiltInEmailTemplates.cs
@@ -6,6 +6,7 @@ public static class SqlOSBuiltInEmailTemplates
     public const string AuthMagicLinkKey = "auth.magic-link";
     public const string AuthInvitationKey = "auth.invitation";
     public const string AuthPasswordResetKey = "auth.password-reset";
+    public const string AuthEmailVerificationKey = "auth.email-verification";
 
     public static IReadOnlyList<SqlOSBuiltInEmailTemplateDefinition> All { get; } =
     [
@@ -98,6 +99,29 @@ public static class SqlOSBuiltInEmailTemplates
             """,
             "Reset your {applicationName} password for {maskedEmail}: {resetUrl}. This link expires in {expiresInMinutes} minute(s).",
             """{"applicationName":"SqlOS","logoBase64":"","logoImageDisplay":"none","logoTextDisplay":"block","maskedEmail":"us***@example.com","resetUrl":"https://app.example.test/sqlos/auth/password/reset?token=sample","expiresInMinutes":"60","primaryColor":"#2563eb","accentColor":"#0f172a","backgroundColor":"#f8fafc"}""",
+            SuppressRenderedContentStorage: true),
+        new(
+            AuthEmailVerificationKey,
+            "Email verification",
+            "Verify your {applicationName} email",
+            """
+            <!DOCTYPE html>
+            <html lang="en">
+            <body style="margin:0;padding:24px;background:{backgroundColor};font-family:Segoe UI,Arial,sans-serif;color:{accentColor};">
+              <div style="max-width:560px;margin:0 auto;background:#ffffff;border:1px solid #e2e8f0;border-radius:20px;padding:32px;">
+                <img src="{logoBase64}" alt="{applicationName}" style="max-height:42px;max-width:180px;display:{logoImageDisplay};margin:0 0 16px;" />
+                <p style="display:{logoTextDisplay};margin:0 0 12px;font-size:14px;color:#475569;font-weight:600;">{applicationName}</p>
+                <h1 style="margin:0 0 12px;font-size:28px;line-height:1.1;color:{accentColor};">Verify your email</h1>
+                <p style="margin:0 0 20px;font-size:15px;line-height:1.6;color:#475569;">Use this link to verify {maskedEmail}. It expires in {expiresInHours} hour(s).</p>
+                <p style="margin:0 0 20px;"><a href="{verificationUrl}" style="display:inline-block;background:{primaryColor};color:#ffffff;text-decoration:none;border-radius:10px;padding:12px 18px;font-weight:600;">Verify email</a></p>
+                <p style="margin:0 0 12px;font-size:13px;line-height:1.6;color:#64748b;">If the button does not work, open this link: {verificationUrl}</p>
+                <p style="margin:0;font-size:13px;line-height:1.6;color:#64748b;">If you did not request this verification, you can ignore this email.</p>
+              </div>
+            </body>
+            </html>
+            """,
+            "Verify your {applicationName} email for {maskedEmail}: {verificationUrl}. This link expires in {expiresInHours} hour(s).",
+            """{"applicationName":"SqlOS","logoBase64":"","logoImageDisplay":"none","logoTextDisplay":"block","maskedEmail":"us***@example.com","verificationUrl":"https://app.example.test/sqlos/auth/email/verify?token=sample","expiresInHours":"24","primaryColor":"#2563eb","accentColor":"#0f172a","backgroundColor":"#f8fafc"}""",
             SuppressRenderedContentStorage: true)
     ];
 

--- a/tests/SqlOS.Tests/SqlOSTransactionalEmailTests.cs
+++ b/tests/SqlOS.Tests/SqlOSTransactionalEmailTests.cs
@@ -322,6 +322,7 @@ public sealed class SqlOSTransactionalEmailTests
             .ToListAsync();
         keys.Should().Contain([
             SqlOSBuiltInEmailTemplates.AuthEmailOtpKey,
+            SqlOSBuiltInEmailTemplates.AuthEmailVerificationKey,
             SqlOSBuiltInEmailTemplates.AuthInvitationKey,
             SqlOSBuiltInEmailTemplates.AuthMagicLinkKey,
             SqlOSBuiltInEmailTemplates.AuthPasswordResetKey

--- a/web/content/docs/reference/api-reference.mdx
+++ b/web/content/docs/reference/api-reference.mdx
@@ -205,24 +205,21 @@ These routes expose the same strongly typed contracts used by `SqlOSAuthService`
 | `POST /sqlos/auth/mfa/challenge/totp/enroll/verify` | `SqlOSTotpEnrollmentVerifyRequest` | `200 SqlOSTotpEnrollmentVerifyResult` |
 | `POST /sqlos/auth/token/exchange` | `SqlOSExchangeCodeRequest` | `200 SqlOSTokenResponse` |
 | `POST /sqlos/auth/token/refresh` | `SqlOSRefreshRequest` | `200 SqlOSTokenResponse` |
-| `POST /sqlos/auth/logout` | `{ refreshToken?, sessionId? }` | `204 No Content` |
+| `POST /sqlos/auth/logout` | `{ refreshToken? }` | `204 No Content`; unknown or missing tokens are idempotent no-ops |
+| `POST /sqlos/auth/logout-all` | `{ refreshToken }` | `204 No Content`; `401` when the refresh token is missing, inactive, expired, or already consumed |
 | `POST /sqlos/auth/password/forgot` | `SqlOSForgotPasswordRequest` | `200 SqlOSPasswordResetRequestResult` |
 | `POST /sqlos/auth/password/reset-email` | `SqlOSSendPasswordResetEmailRequest` | `200 SqlOSPasswordResetRequestResult` |
 | `POST /sqlos/auth/password/reset` | `SqlOSResetPasswordRequest` | `204 No Content` |
+| `POST /sqlos/auth/email/verification-email` | `SqlOSCreateVerificationTokenRequest` | `200 SqlOSEmailVerificationRequestResult`; the same generic response is returned for known and unknown emails |
+| `POST /sqlos/auth/email/verification-token` | `SqlOSCreateVerificationTokenRequest` | Compatibility alias for `/email/verification-email`; it sends email and never returns a token |
+| `GET /sqlos/auth/email/verify?token=...` | Query-string token from the verification email | One-time browser verification page |
 | `POST /sqlos/auth/email/verify` | `SqlOSVerifyEmailRequest` | `204 No Content` |
 
 `POST /token/exchange` consumes the temporary code created by the direct SAML request-token flow. An OAuth authorization-code client must use the form-encoded `POST /token` endpoint, which enforces the OAuth redirect URI, PKCE verifier, and optional resource binding.
 
-### Privileged helpers
+Account-management routes are secure by default without adding a blanket ASP.NET Core authorization policy to `/sqlos/auth`. Logout accepts only refresh-token proof of session ownership; the HTTP route ignores a caller-supplied `sessionId`. Logout-all derives the user from an active, unconsumed refresh token and never accepts a `userId`. Email-verification requests send a one-time link through the configured SqlOS email pipeline, use the trusted `PublicOrigin`/issuer rather than request host headers, suppress rapid resends, and return the same public shape for known, unknown, already verified, and delivery-failure cases.
 
-`MapSqlOS` also maps these JSON handlers:
-
-| Route | Behavior | Required host decision |
-| --- | --- | --- |
-| `POST /sqlos/auth/logout-all` | Accepts `{ userId }` and revokes every session for that user | Expose only behind host-owned authorization; the route does not infer the caller's user ID |
-| `POST /sqlos/auth/email/verification-token` | Accepts `SqlOSCreateVerificationTokenRequest` and returns the raw token | Never expose to an untrusted browser; call `SqlOSAuthService` from a protected backend workflow instead |
-
-The `/sqlos/auth` route group does not attach a blanket ASP.NET Core authorization policy. Flow endpoints validate their credentials, challenge tokens, or request state, but explicit IDs are not self-authorizing. Apply host middleware/edge rules to privileged helpers or wrap the .NET service in your own authorized endpoint.
+Trusted backend code can still call `SqlOSAuthService.LogoutAsync(..., sessionId: ...)`, `LogoutAllAsync(userId)`, or `CreateEmailVerificationTokenAsync(...)` after applying its own ownership/admin policy. Do not expose those service methods by mapping caller-supplied IDs or raw tokens directly into a public route.
 
 ## Headless AuthPage API
 


### PR DESCRIPTION
Closes #130

## Summary
- require active refresh-token proof for public logout-all and derive the user from that token
- make public logout ignore caller-supplied session IDs while preserving refresh-token logout
- replace raw email-verification-token disclosure with enumeration-resistant out-of-band delivery through the built-in email pipeline
- add a trusted-origin, one-time browser verification link and built-in template with resend suppression and failed-delivery token cleanup
- document the secure public contracts while preserving trusted in-process service APIs

## Ergonomics
- no blanket authorization policy, external key service, new dependency, or required configuration
- existing callers that send refreshToken plus sessionId to logout continue to work; the extra sessionId is ignored
- standard signup, login, OAuth, refresh, and hosted auth flows are unchanged
- unsafe userId/sessionId-only public calls intentionally stop working

## Validation
- 3 protocol-level integration tests against the real example host/database and a captured transactional email provider
- 542 unit tests passed
- full solution build passed with zero warnings
- documentation lint, snippet compilation, site build, and link validation passed

A required adversarial review and resolution pass will be recorded on this PR before it is marked ready.