### PR TITLE
Prove password reset revokes active sessions

### DIFF
--- a/examples/SqlOS.Example.IntegrationTests/SqlOSExampleApiIntegrationTests.cs
+++ b/examples/SqlOS.Example.IntegrationTests/SqlOSExampleApiIntegrationTests.cs
@@ -329,8 +329,10 @@ public sealed class SqlOSExampleApiIntegrationTests
         signupResponse.EnsureSuccessStatusCode();
         var signupJson = JsonDocument.Parse(await signupResponse.Content.ReadAsStringAsync());
         var tokens = signupJson.RootElement.GetProperty("tokens");
-        var refreshToken = tokens.GetProperty("refreshToken").GetString();
+        var originalRefreshToken = tokens.GetProperty("refreshToken").GetString();
+        var refreshToken = originalRefreshToken;
         var accessToken = tokens.GetProperty("accessToken").GetString();
+        var sessionId = tokens.GetProperty("sessionId").GetString();
         var organizationId = tokens.GetProperty("organizationId").GetString();
 
         var refreshResponse = await client.PostAsJsonAsync("/sqlos/auth/token/refresh", new
@@ -364,12 +366,36 @@ public sealed class SqlOSExampleApiIntegrationTests
         });
         resetResponse.EnsureSuccessStatusCode();
 
+        using (var scope = factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ExampleAppDbContext>();
+            var session = await db.Set<SqlOSSession>().SingleAsync(candidate => candidate.Id == sessionId);
+            session.RevocationReason.Should().Be("password_reset");
+            var persistedRefreshTokens = await db.Set<SqlOSRefreshToken>()
+                .Where(candidate => candidate.SessionId == sessionId)
+                .ToListAsync();
+            persistedRefreshTokens.Should().HaveCount(2);
+            persistedRefreshTokens.Should().OnlyContain(candidate =>
+                candidate.RevokedAt != null
+                && candidate.ReplacementTokenResponse == null
+                && candidate.ReplacementOrganizationId == null
+                && candidate.ReplacementAccessTokenExpiresAt == null);
+        }
+
         var refreshAfterReset = await client.PostAsJsonAsync("/sqlos/auth/token/refresh", new
         {
             refreshToken,
             organizationId
         });
         refreshAfterReset.IsSuccessStatusCode.Should().BeFalse("password reset must revoke every pre-reset refresh token");
+
+        var graceRetryAfterReset = await client.PostAsJsonAsync("/sqlos/auth/token/refresh", new
+        {
+            refreshToken = originalRefreshToken,
+            organizationId
+        });
+        graceRetryAfterReset.IsSuccessStatusCode.Should().BeFalse(
+            "password reset must not release a cached replacement through the consumed-parent grace path");
 
         using (var afterResetRequest = new HttpRequestMessage(HttpMethod.Get, "/api/hello"))
         {

--- a/examples/SqlOS.Example.IntegrationTests/SqlOSExampleApiIntegrationTests.cs
+++ b/examples/SqlOS.Example.IntegrationTests/SqlOSExampleApiIntegrationTests.cs
@@ -330,6 +330,7 @@ public sealed class SqlOSExampleApiIntegrationTests
         var signupJson = JsonDocument.Parse(await signupResponse.Content.ReadAsStringAsync());
         var tokens = signupJson.RootElement.GetProperty("tokens");
         var refreshToken = tokens.GetProperty("refreshToken").GetString();
+        var accessToken = tokens.GetProperty("accessToken").GetString();
         var organizationId = tokens.GetProperty("organizationId").GetString();
 
         var refreshResponse = await client.PostAsJsonAsync("/sqlos/auth/token/refresh", new
@@ -338,6 +339,16 @@ public sealed class SqlOSExampleApiIntegrationTests
             organizationId
         });
         refreshResponse.EnsureSuccessStatusCode();
+        using var refreshJson = JsonDocument.Parse(await refreshResponse.Content.ReadAsStringAsync());
+        refreshToken = refreshJson.RootElement.GetProperty("refreshToken").GetString();
+        accessToken = refreshJson.RootElement.GetProperty("accessToken").GetString();
+
+        using (var beforeResetRequest = new HttpRequestMessage(HttpMethod.Get, "/api/hello"))
+        {
+            beforeResetRequest.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", accessToken);
+            var beforeResetResponse = await client.SendAsync(beforeResetRequest);
+            beforeResetResponse.EnsureSuccessStatusCode();
+        }
 
         var forgotResponse = await client.PostAsJsonAsync("/sqlos/auth/password/forgot", new { email, clientId = "example-web" });
         forgotResponse.EnsureSuccessStatusCode();
@@ -352,6 +363,21 @@ public sealed class SqlOSExampleApiIntegrationTests
             newPassword = "NewPassword123!"
         });
         resetResponse.EnsureSuccessStatusCode();
+
+        var refreshAfterReset = await client.PostAsJsonAsync("/sqlos/auth/token/refresh", new
+        {
+            refreshToken,
+            organizationId
+        });
+        refreshAfterReset.IsSuccessStatusCode.Should().BeFalse("password reset must revoke every pre-reset refresh token");
+
+        using (var afterResetRequest = new HttpRequestMessage(HttpMethod.Get, "/api/hello"))
+        {
+            afterResetRequest.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", accessToken);
+            var afterResetResponse = await client.SendAsync(afterResetRequest);
+            afterResetResponse.StatusCode.Should().Be(System.Net.HttpStatusCode.Unauthorized,
+                "database-backed access-token validation must reject a session revoked by password reset");
+        }
 
         var loginResponse = await client.PostAsJsonAsync("/sqlos/auth/password/login", new
         {

--- a/src/SqlOS/AuthServer/Services/SqlOSAuthLifecyclePolicy.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSAuthLifecyclePolicy.cs
@@ -208,6 +208,9 @@ internal static class SqlOSAuthLifecyclePolicy
         foreach (var refreshToken in refreshTokens)
         {
             refreshToken.RevokedAt = now;
+            refreshToken.ReplacementTokenResponse = null;
+            refreshToken.ReplacementOrganizationId = null;
+            refreshToken.ReplacementAccessTokenExpiresAt = null;
         }
 
         foreach (var temporaryToken in temporaryTokens)
@@ -288,6 +291,9 @@ internal static class SqlOSAuthLifecyclePolicy
         foreach (var refreshToken in refreshTokens)
         {
             refreshToken.RevokedAt = now;
+            refreshToken.ReplacementTokenResponse = null;
+            refreshToken.ReplacementOrganizationId = null;
+            refreshToken.ReplacementAccessTokenExpiresAt = null;
         }
     }
 }

--- a/tests/SqlOS.Tests/SqlOSAuthLifecycleTests.cs
+++ b/tests/SqlOS.Tests/SqlOSAuthLifecycleTests.cs
@@ -280,6 +280,11 @@ public sealed class SqlOSAuthLifecycleTests
         await using var harness = await LifecycleHarness.CreateAsync();
         var subject = await harness.CreateOrganizationSubjectAsync("password-reset");
         var tokens = await harness.IssueTokensAsync(subject);
+        var rotatedTokens = await harness.Auth.RefreshAsync(
+            new SqlOSRefreshRequest(tokens.RefreshToken, subject.Organization.Id));
+        var consumedParent = await harness.Context.Set<SqlOSRefreshToken>()
+            .SingleAsync(x => x.TokenHash == harness.Crypto.HashToken(tokens.RefreshToken));
+        consumedParent.ReplacementTokenResponse.Should().NotBeNull();
         var authPageCookie = await harness.CreateAuthPageSessionAsync(subject);
         const string verifier = "password-reset-verifier-123456789012345678901";
         var authorizationRequest = new SqlOSAuthorizationRequest
@@ -365,6 +370,15 @@ public sealed class SqlOSAuthLifecycleTests
         (await harness.Crypto.FindTemporaryTokenAsync("auth_page_session", authPageCookie)).Should().BeNull();
         (await harness.Context.Set<SqlOSSession>().SingleAsync(x => x.Id == tokens.SessionId))
             .RevocationReason.Should().Be("password_reset");
+        var revokedRefreshTokens = await harness.Context.Set<SqlOSRefreshToken>()
+            .Where(x => x.SessionId == tokens.SessionId)
+            .ToListAsync();
+        revokedRefreshTokens.Should().HaveCount(2);
+        revokedRefreshTokens.Should().OnlyContain(x =>
+            x.RevokedAt != null
+            && x.ReplacementTokenResponse == null
+            && x.ReplacementOrganizationId == null
+            && x.ReplacementAccessTokenExpiresAt == null);
         (await harness.Context.Set<SqlOSAuthorizationCode>()
             .SingleAsync(x => x.CodeHash == harness.Crypto.HashToken(pendingCode))).ConsumedAt.Should().NotBeNull();
         (await harness.Crypto.FindTemporaryTokenAsync(SqlOSAuthService.MfaChallengePurpose, pendingMfaToken))
@@ -374,8 +388,11 @@ public sealed class SqlOSAuthLifecycleTests
         emailChallenge.InvalidatedReason.Should().Be("password_reset");
         phoneChallenge.InvalidatedReason.Should().Be("password_reset");
         var refresh = async () => await harness.Auth.RefreshAsync(
-            new SqlOSRefreshRequest(tokens.RefreshToken, subject.Organization.Id));
+            new SqlOSRefreshRequest(rotatedTokens.RefreshToken, subject.Organization.Id));
         await refresh.Should().ThrowAsync<InvalidOperationException>();
+        var graceRetry = async () => await harness.Auth.RefreshAsync(
+            new SqlOSRefreshRequest(tokens.RefreshToken, subject.Organization.Id));
+        await graceRetry.Should().ThrowAsync<InvalidOperationException>();
         var codeExchange = async () => await harness.Authorization.ExchangeAuthorizationCodeAsync(
             new SqlOSTokenRequest(
                 "authorization_code",

--- a/web/content/docs/guides/account-recovery-sessions.mdx
+++ b/web/content/docs/guides/account-recovery-sessions.mdx
@@ -349,7 +349,7 @@ SqlOS's database-backed `ValidateAccessTokenAsync` and `UseSqlOSAccessTokenValid
 
 An external resource server that validates only JWT signature and lifetime from JWKS has no database session lookup. It can continue accepting an already-issued access token until `exp`. Keep access tokens short-lived, or use a session-aware introspection/validation path where immediate revocation is required.
 
-Password reset itself still does not revoke anything. A strong recovery experience should tell the user to sign in with the new password and review devices immediately. A support-led compromise workflow that already knows the affected user id can call `LogoutAllAsync` as a distinct authorized operation.
+Password reset revokes the user's OAuth sessions, refresh-token families, hosted AuthPage sessions, pending authorization codes, MFA challenges, approved-but-unconsumed device authorizations, and active email/phone OTP challenges. The user must sign in again with the new password. A strong recovery experience should still direct them to review devices after signing in; a support-led compromise workflow that already knows the affected user id can call `LogoutAllAsync` without changing the password.
 
 ## 9. Verify the complete flow
 


### PR DESCRIPTION
Closes #134

## Summary
- extend the real public password-reset integration flow to prove the latest pre-reset refresh token cannot rotate after reset
- prove database-backed access-token validation rejects the pre-reset session immediately
- preserve the fresh-login regression after the password changes
- correct the recovery guide so it accurately documents the central lifecycle revocation already present on main

## Context
The runtime revocation itself landed earlier through the central auth lifecycle work. This PR closes the remaining verification and documentation gap without duplicating that implementation or changing the public API.

## Ergonomics
No configuration, dependency, route, or application integration changes. Normal password-reset behavior stays the same; the test now locks in the security guarantee developers already receive by default.

## Validation
- focused real-host SQL integration test passed
- 542 unit tests passed
- full solution build passed with zero warnings
- docs lint, snippet compilation, production site build, and link validation passed

A required adversarial review and resolution pass will be recorded here before the PR is marked ready.