### PR TITLE
Bound TOTP MFA guessing attempts

### DIFF
--- a/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerModelConfiguration.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerModelConfiguration.cs
@@ -557,6 +557,7 @@ public static class SqlOSAuthServerModelConfiguration
             entity.HasIndex(x => x.TokenHash).IsUnique();
             entity.Property(x => x.Purpose).HasMaxLength(80);
             entity.Property(x => x.ConsumedAt).IsConcurrencyToken();
+            entity.Property(x => x.PayloadJson).IsConcurrencyToken();
         });
 
         modelBuilder.Entity<SqlOSAuditEvent>(entity =>

--- a/src/SqlOS/AuthServer/Configuration/SqlOSMfaOptions.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSMfaOptions.cs
@@ -30,4 +30,8 @@ public sealed class SqlOSTotpMfaOptions
     public int RecoveryCodeCount { get; set; } = 10;
     public TimeSpan EnrollmentTokenLifetime { get; set; } = TimeSpan.FromMinutes(10);
     public TimeSpan ChallengeTokenLifetime { get; set; } = TimeSpan.FromMinutes(10);
+    public int MaxFailedAttemptsPerChallenge { get; set; } = 5;
+    public int MaxFailedAttemptsPerUser { get; set; } = 10;
+    public int MaxFailedAttemptsPerIp { get; set; } = 25;
+    public TimeSpan FailedAttemptWindow { get; set; } = TimeSpan.FromMinutes(10);
 }

--- a/src/SqlOS/AuthServer/Contracts/SqlOSMfaContracts.cs
+++ b/src/SqlOS/AuthServer/Contracts/SqlOSMfaContracts.cs
@@ -109,4 +109,5 @@ internal sealed record SqlOSMfaChallengePayload(
     string? AuthorizationRequestId = null,
     string? Resource = null,
     bool EnrollmentRequired = false,
-    IReadOnlyList<string>? PermittedEnrollmentFactors = null);
+    IReadOnlyList<string>? PermittedEnrollmentFactors = null,
+    int FailedAttempts = 0);

--- a/src/SqlOS/AuthServer/Errors/SqlOSPublicAuthErrorMapper.cs
+++ b/src/SqlOS/AuthServer/Errors/SqlOSPublicAuthErrorMapper.cs
@@ -33,6 +33,7 @@ public static class SqlOSPublicAuthErrorMapper
         "Local password authentication is disabled.",
         "MFA challenge is invalid.",
         "MFA challenge is invalid or expired.",
+        SqlOSAuthService.MfaChallengeFailureMessage,
         "Magic-link sign-in is unavailable.",
         "Only authorization code requests are supported.",
         "Only S256 PKCE is supported.",

--- a/src/SqlOS/AuthServer/Extensions/EndpointRouteBuilderExtensions.cs
+++ b/src/SqlOS/AuthServer/Extensions/EndpointRouteBuilderExtensions.cs
@@ -3279,7 +3279,16 @@ public static class EndpointRouteBuilderExtensions
             Results.Ok(await authService.SelectOrganizationForLoginAsync(request, httpContext, cancellationToken)));
 
         auth.MapPost("/mfa/challenge/verify", async (SqlOSMfaChallengeVerifyRequest request, SqlOSAuthService authService, HttpContext httpContext, CancellationToken cancellationToken) =>
-            Results.Ok(await authService.VerifyMfaChallengeAsync(request, httpContext, cancellationToken)));
+        {
+            try
+            {
+                return Results.Ok(await authService.VerifyMfaChallengeAsync(request, httpContext, cancellationToken));
+            }
+            catch (InvalidOperationException ex)
+            {
+                return await PublicAuthJsonErrorAsync(httpContext, ex, SqlOSPublicAuthErrorSurface.HostedPage, cancellationToken);
+            }
+        });
 
         auth.MapPost("/mfa/challenge/totp/enroll/start", async (SqlOSTotpChallengeEnrollmentStartRequest request, SqlOSAuthService authService, CancellationToken cancellationToken) =>
         {

--- a/src/SqlOS/AuthServer/Services/SqlOSAuthService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSAuthService.cs
@@ -19,6 +19,8 @@ namespace SqlOS.AuthServer.Services;
 public sealed class SqlOSAuthService
 {
     public const string MfaChallengePurpose = "mfa_challenge";
+    internal const string MfaChallengeFailureMessage = "MFA code is invalid.";
+    private const string MfaChallengeFailedAuditEvent = "user.mfa.challenge_failed";
     private const string PasswordResetPurpose = "password_reset";
     private const string PasswordResetRequestPurpose = "password_reset_request";
     private const string PasswordResetGenericMessage = "If an account can be reset, you'll receive a password reset email shortly.";
@@ -1879,9 +1881,42 @@ public sealed class SqlOSAuthService
             throw new InvalidOperationException("MFA enrollment must be completed with its challenge-bound enrollment proof.");
         }
 
-        var factorMethod = await RequireTotpMfaService().VerifySecondFactorCodeAsync(token.UserId, request.Code, cancellationToken);
+        var factorMethod = await VerifyMfaChallengeFactorAsync(token, request.Code, httpContext, cancellationToken);
         token.ConsumedAt = DateTime.UtcNow;
         return await CompleteConsumedMfaChallengeAsync(token, factorMethod, httpContext, cancellationToken);
+    }
+
+    internal async Task<string> VerifyMfaChallengeFactorAsync(
+        SqlOSTemporaryToken token,
+        string code,
+        HttpContext? httpContext,
+        CancellationToken cancellationToken)
+    {
+        if (token.UserId == null)
+        {
+            throw new InvalidOperationException("MFA challenge payload is invalid.");
+        }
+
+        await EnsureMfaAttemptAllowedAsync(token, httpContext, cancellationToken);
+        try
+        {
+            return await RequireTotpMfaService().VerifySecondFactorCodeAsync(token.UserId, code, cancellationToken);
+        }
+        catch (InvalidOperationException)
+        {
+            var attemptCount = await RecordMfaChallengeFailureAsync(token, cancellationToken);
+            await TryRecordMfaChallengeAuditAsync(
+                MfaChallengeFailedAuditEvent,
+                token,
+                httpContext,
+                new
+                {
+                    attemptCount,
+                    challengeLocked = attemptCount >= _options.Mfa.Totp.MaxFailedAttemptsPerChallenge
+                },
+                cancellationToken);
+            throw new InvalidOperationException(MfaChallengeFailureMessage);
+        }
     }
 
     internal async Task<string> CreateMfaChallengeAsync(
@@ -1895,7 +1930,21 @@ public sealed class SqlOSAuthService
         string? authorizationRequestId = null,
         string? resource = null,
         CancellationToken cancellationToken = default)
-        => await _cryptoService.CreateTemporaryTokenAsync(
+    {
+        var recentFailures = await CountRecentMfaFailuresAsync(user.Id, null, cancellationToken);
+        if (recentFailures >= _options.Mfa.Totp.MaxFailedAttemptsPerUser)
+        {
+            await TryRecordMfaChallengeAuditAsync(
+                "user.mfa.challenge_issue_rejected",
+                user.Id,
+                organizationId,
+                null,
+                new { recentFailures },
+                cancellationToken);
+            throw new InvalidOperationException(MfaChallengeFailureMessage);
+        }
+
+        return await _cryptoService.CreateTemporaryTokenAsync(
             MfaChallengePurpose,
             user.Id,
             client.Id,
@@ -1910,6 +1959,135 @@ public sealed class SqlOSAuthService
                 permittedEnrollmentFactors),
             _options.Mfa.Totp.ChallengeTokenLifetime,
             cancellationToken);
+    }
+
+    private async Task EnsureMfaAttemptAllowedAsync(
+        SqlOSTemporaryToken token,
+        HttpContext? httpContext,
+        CancellationToken cancellationToken)
+    {
+        var ipAddress = GetIp(httpContext);
+        var recentUserFailures = await CountRecentMfaFailuresAsync(token.UserId!, null, cancellationToken);
+        var recentIpFailures = ipAddress == null
+            ? 0
+            : await CountRecentMfaFailuresAsync(null, ipAddress, cancellationToken);
+        if (recentUserFailures < _options.Mfa.Totp.MaxFailedAttemptsPerUser
+            && recentIpFailures < _options.Mfa.Totp.MaxFailedAttemptsPerIp)
+        {
+            return;
+        }
+
+        token.ConsumedAt = DateTime.UtcNow;
+        try
+        {
+            await _context.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            // Another request has already consumed or updated this challenge.
+        }
+
+        await TryRecordMfaChallengeAuditAsync(
+            "user.mfa.challenge_rate_limited",
+            token,
+            httpContext,
+            new { recentUserFailures, recentIpFailures },
+            cancellationToken);
+        throw new InvalidOperationException(MfaChallengeFailureMessage);
+    }
+
+    private async Task<int> RecordMfaChallengeFailureAsync(
+        SqlOSTemporaryToken token,
+        CancellationToken cancellationToken)
+    {
+        for (var retry = 0; retry < 3; retry++)
+        {
+            var payload = _cryptoService.DeserializePayload<SqlOSMfaChallengePayload>(token)
+                ?? throw new InvalidOperationException("MFA challenge payload is invalid.");
+            if (token.ConsumedAt != null)
+            {
+                return payload.FailedAttempts;
+            }
+
+            var attemptCount = payload.FailedAttempts + 1;
+            token.PayloadJson = JsonSerializer.Serialize(payload with { FailedAttempts = attemptCount });
+            if (attemptCount >= _options.Mfa.Totp.MaxFailedAttemptsPerChallenge)
+            {
+                token.ConsumedAt = DateTime.UtcNow;
+            }
+
+            try
+            {
+                await _context.SaveChangesAsync(cancellationToken);
+                return attemptCount;
+            }
+            catch (DbUpdateConcurrencyException) when (retry < 2 && _context is DbContext dbContext)
+            {
+                dbContext.ChangeTracker.Clear();
+                token = await _context.Set<SqlOSTemporaryToken>()
+                    .FirstOrDefaultAsync(x => x.Id == token.Id, cancellationToken)
+                    ?? throw new InvalidOperationException(MfaChallengeFailureMessage);
+            }
+        }
+
+        throw new InvalidOperationException(MfaChallengeFailureMessage);
+    }
+
+    private async Task<int> CountRecentMfaFailuresAsync(
+        string? userId,
+        string? ipAddress,
+        CancellationToken cancellationToken)
+    {
+        var cutoff = DateTime.UtcNow.Subtract(_options.Mfa.Totp.FailedAttemptWindow);
+        return await _context.Set<SqlOSAuditEvent>()
+            .AsNoTracking()
+            .CountAsync(
+                x => x.Action == MfaChallengeFailedAuditEvent
+                    && x.OccurredAt >= cutoff
+                    && (userId == null || x.UserId == userId)
+                    && (ipAddress == null || x.IpAddress == ipAddress),
+                cancellationToken);
+    }
+
+    private Task TryRecordMfaChallengeAuditAsync(
+        string eventType,
+        SqlOSTemporaryToken token,
+        HttpContext? httpContext,
+        object data,
+        CancellationToken cancellationToken)
+        => TryRecordMfaChallengeAuditAsync(
+            eventType,
+            token.UserId!,
+            token.OrganizationId,
+            GetIp(httpContext),
+            new { challengeId = token.Id, details = data },
+            cancellationToken);
+
+    private async Task TryRecordMfaChallengeAuditAsync(
+        string eventType,
+        string userId,
+        string? organizationId,
+        string? ipAddress,
+        object data,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _adminService.RecordAuditAsync(
+                eventType,
+                "system",
+                null,
+                userId: userId,
+                organizationId: organizationId,
+                ipAddress: ipAddress,
+                data: data,
+                cancellationToken: cancellationToken);
+        }
+        catch (Exception) when (!cancellationToken.IsCancellationRequested)
+        {
+            // The challenge state is already fail-closed; audit availability must not reopen it.
+        }
+    }
 
     private async Task<SqlOSMfaChallengeVerifyResult> CompleteConsumedMfaChallengeAsync(
         SqlOSTemporaryToken token,

--- a/src/SqlOS/AuthServer/Services/SqlOSAuthService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSAuthService.cs
@@ -2000,7 +2000,7 @@ public sealed class SqlOSAuthService
         SqlOSTemporaryToken token,
         CancellationToken cancellationToken)
     {
-        for (var retry = 0; retry < 3; retry++)
+        while (true)
         {
             var payload = _cryptoService.DeserializePayload<SqlOSMfaChallengePayload>(token)
                 ?? throw new InvalidOperationException("MFA challenge payload is invalid.");
@@ -2021,7 +2021,7 @@ public sealed class SqlOSAuthService
                 await _context.SaveChangesAsync(cancellationToken);
                 return attemptCount;
             }
-            catch (DbUpdateConcurrencyException) when (retry < 2 && _context is DbContext dbContext)
+            catch (DbUpdateConcurrencyException) when (_context is DbContext dbContext)
             {
                 dbContext.ChangeTracker.Clear();
                 token = await _context.Set<SqlOSTemporaryToken>()
@@ -2029,8 +2029,6 @@ public sealed class SqlOSAuthService
                     ?? throw new InvalidOperationException(MfaChallengeFailureMessage);
             }
         }
-
-        throw new InvalidOperationException(MfaChallengeFailureMessage);
     }
 
     private async Task<int> CountRecentMfaFailuresAsync(

--- a/src/SqlOS/AuthServer/Services/SqlOSAuthorizationServerService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSAuthorizationServerService.cs
@@ -681,7 +681,7 @@ public sealed class SqlOSAuthorizationServerService
         }
 
         await GetRequiredAuthorizationRequestAsync(payload.AuthorizationRequestId, cancellationToken);
-        var factorMethod = await RequireTotpMfaService().VerifySecondFactorCodeAsync(token.UserId, code, cancellationToken);
+        var factorMethod = await _authService.VerifyMfaChallengeFactorAsync(token, code, httpContext, cancellationToken);
         token.ConsumedAt = DateTime.UtcNow;
         return await CompleteConsumedMfaChallengeAsync(token, factorMethod, httpContext, cancellationToken);
     }

--- a/src/SqlOS/Configuration/SqlOSOptionsValidator.cs
+++ b/src/SqlOS/Configuration/SqlOSOptionsValidator.cs
@@ -103,6 +103,7 @@ internal static class SqlOSOptionsValidator
         ValidateEmailOptions(options.Email, errors);
         ValidateCalendarOptions(options.Calendar, errors);
         ValidatePasswordLoginAbuseOptions(options.AuthServer.PasswordLogin, errors);
+        ValidateMfaOptions(options.AuthServer.Mfa, errors);
         ValidateAccessTokenValidationOptions(options.AuthServer, errors);
         ValidateClientRegistrationOptions(options.AuthServer, errors);
         ValidateSigningKeyOptions(options.AuthServer, errors);
@@ -111,6 +112,29 @@ internal static class SqlOSOptionsValidator
         {
             throw new InvalidOperationException(
                 "Invalid SqlOS configuration:" + Environment.NewLine + string.Join(Environment.NewLine, errors.Select(static error => $"- {error}")));
+        }
+    }
+
+    private static void ValidateMfaOptions(SqlOSMfaOptions options, List<string> errors)
+    {
+        if (options.Totp.MaxFailedAttemptsPerChallenge <= 0)
+        {
+            errors.Add("AuthServer.Mfa.Totp.MaxFailedAttemptsPerChallenge must be greater than zero.");
+        }
+
+        if (options.Totp.MaxFailedAttemptsPerUser < options.Totp.MaxFailedAttemptsPerChallenge)
+        {
+            errors.Add("AuthServer.Mfa.Totp.MaxFailedAttemptsPerUser must be at least MaxFailedAttemptsPerChallenge.");
+        }
+
+        if (options.Totp.MaxFailedAttemptsPerIp < options.Totp.MaxFailedAttemptsPerChallenge)
+        {
+            errors.Add("AuthServer.Mfa.Totp.MaxFailedAttemptsPerIp must be at least MaxFailedAttemptsPerChallenge.");
+        }
+
+        if (options.Totp.FailedAttemptWindow <= TimeSpan.Zero)
+        {
+            errors.Add("AuthServer.Mfa.Totp.FailedAttemptWindow must be greater than zero.");
         }
     }
 

--- a/tests/SqlOS.IntegrationTests/MfaEnrollmentSecurityIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/MfaEnrollmentSecurityIntegrationTests.cs
@@ -110,6 +110,77 @@ public sealed class MfaEnrollmentSecurityIntegrationTests
         await VerifyHostedEndpointBindsAuthorizationRequestAsync(server, client);
     }
 
+    [TestMethod]
+    public async Task RealPublicEndpoint_BoundsMfaGuessingAndRejectsCorrectCodeAfterCap()
+    {
+        await using var server = await MfaEndpointServer.CreateAsync();
+        using var client = server.App.GetTestClient();
+        string email;
+        string userId;
+        string secret;
+        await using (var scope = server.App.Services.CreateAsyncScope())
+        {
+            var admin = scope.ServiceProvider.GetRequiredService<SqlOSAdminService>();
+            var auth = scope.ServiceProvider.GetRequiredService<SqlOSAuthService>();
+            var totp = scope.ServiceProvider.GetRequiredService<SqlOSTotpMfaService>();
+            var user = await admin.CreateUserAsync(new SqlOSCreateUserRequest(
+                "Endpoint Bounded MFA",
+                $"endpoint-bounded-{Guid.NewGuid():N}@example.com",
+                "P@ssword123!"));
+            email = user.DefaultEmail!;
+            userId = user.Id;
+            var enrollment = await auth.StartTotpEnrollmentAsync(user.Id, new SqlOSTotpEnrollmentStartRequest());
+            secret = enrollment.Secret;
+            await auth.VerifyTotpEnrollmentAsync(new SqlOSTotpEnrollmentVerifyRequest(
+                enrollment.EnrollmentToken,
+                totp.GenerateCodeForTesting(secret)));
+        }
+
+        var loginResponse = await client.PostAsJsonAsync("/sqlos/auth/password/login", new
+        {
+            email,
+            password = "P@ssword123!",
+            clientId = "test-client"
+        });
+        loginResponse.EnsureSuccessStatusCode();
+        using var loginJson = JsonDocument.Parse(await loginResponse.Content.ReadAsStringAsync());
+        var mfaToken = loginJson.RootElement.GetProperty("mfaToken").GetString()!;
+
+        for (var attempt = 0; attempt < 5; attempt++)
+        {
+            var rejected = await client.PostAsJsonAsync(
+                "/sqlos/auth/mfa/challenge/verify",
+                new { mfaToken, code = "not-a-valid-code" });
+            rejected.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            (await rejected.Content.ReadAsStringAsync()).Should().Contain("MFA code is invalid");
+        }
+
+        string validCode;
+        await using (var scope = server.App.Services.CreateAsyncScope())
+        {
+            var totp = scope.ServiceProvider.GetRequiredService<SqlOSTotpMfaService>();
+            validCode = totp.GenerateCodeForTesting(
+                secret,
+                DateTimeOffset.UtcNow.AddSeconds(30));
+        }
+
+        var afterCap = await client.PostAsJsonAsync(
+            "/sqlos/auth/mfa/challenge/verify",
+            new { mfaToken, code = validCode });
+        afterCap.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        await using var verifyScope = server.App.Services.CreateAsyncScope();
+        var context = verifyScope.ServiceProvider.GetRequiredService<TestSqlOSDbContext>();
+        var crypto = verifyScope.ServiceProvider.GetRequiredService<SqlOSCryptoService>();
+        var challenge = await context.Set<SqlOSTemporaryToken>()
+            .SingleAsync(x => x.TokenHash == crypto.HashToken(mfaToken));
+        challenge.ConsumedAt.Should().NotBeNull();
+        crypto.DeserializePayload<SqlOSMfaChallengePayload>(challenge)!.FailedAttempts.Should().Be(5);
+        (await context.Set<SqlOSAuditEvent>().CountAsync(x =>
+            x.Action == "user.mfa.challenge_failed" && x.UserId == userId)).Should().Be(5);
+        (await context.Set<SqlOSSession>().CountAsync(x => x.UserId == userId)).Should().Be(0);
+    }
+
     private static async Task VerifyPublicEndpointRejectsFirstFactorEnrollmentAsync(
         MfaEndpointServer server,
         HttpClient client)

--- a/tests/SqlOS.IntegrationTests/MfaEnrollmentSecurityIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/MfaEnrollmentSecurityIntegrationTests.cs
@@ -100,6 +100,50 @@ public sealed class MfaEnrollmentSecurityIntegrationTests
     }
 
     [TestMethod]
+    public async Task SqlServer_ConcurrentWrongCodesAllCountTowardChallengeCap()
+    {
+        await using var fixture = await SqlMfaFixture.CreateAsync("MfaGuessRace");
+        var user = await fixture.Admin.CreateUserAsync(new SqlOSCreateUserRequest(
+            "SQL MFA Guess Race",
+            $"sql-mfa-guess-race-{Guid.NewGuid():N}@example.com",
+            "P@ssword123!"));
+        var enrollment = await fixture.Auth.StartTotpEnrollmentAsync(
+            user.Id,
+            new SqlOSTotpEnrollmentStartRequest("Guess race authenticator"));
+        await fixture.Auth.VerifyTotpEnrollmentAsync(new SqlOSTotpEnrollmentVerifyRequest(
+            enrollment.EnrollmentToken,
+            fixture.Totp.GenerateCodeForTesting(enrollment.Secret)));
+        var login = await fixture.Auth.LoginWithPasswordAsync(
+            new SqlOSPasswordLoginRequest(user.DefaultEmail!, "P@ssword123!", "test-client", null),
+            CreateHttpContext());
+        login.RequiresMfa.Should().BeTrue();
+        login.RequiresMfaEnrollment.Should().BeFalse();
+        var connectionString = fixture.Context.Database.GetConnectionString()!;
+
+        await using var instanceA = SqlMfaFixture.CreateForExistingDatabase(connectionString, fixture.Options);
+        await using var instanceB = SqlMfaFixture.CreateForExistingDatabase(connectionString, fixture.Options);
+        await using var instanceC = SqlMfaFixture.CreateForExistingDatabase(connectionString, fixture.Options);
+        await using var instanceD = SqlMfaFixture.CreateForExistingDatabase(connectionString, fixture.Options);
+        await using var instanceE = SqlMfaFixture.CreateForExistingDatabase(connectionString, fixture.Options);
+        var outcomes = await Task.WhenAll(
+            CaptureWrongCodeAsync(instanceA.Auth, login.MfaToken!),
+            CaptureWrongCodeAsync(instanceB.Auth, login.MfaToken!),
+            CaptureWrongCodeAsync(instanceC.Auth, login.MfaToken!),
+            CaptureWrongCodeAsync(instanceD.Auth, login.MfaToken!),
+            CaptureWrongCodeAsync(instanceE.Auth, login.MfaToken!));
+        outcomes.Should().OnlyContain(x => x is InvalidOperationException);
+
+        await using var verify = SqlMfaFixture.CreateForExistingDatabase(connectionString, fixture.Options);
+        var challenge = await verify.Context.Set<SqlOSTemporaryToken>()
+            .SingleAsync(x => x.TokenHash == verify.Crypto.HashToken(login.MfaToken!));
+        challenge.ConsumedAt.Should().NotBeNull();
+        verify.Crypto.DeserializePayload<SqlOSMfaChallengePayload>(challenge)!.FailedAttempts.Should().Be(5);
+        (await verify.Context.Set<SqlOSAuditEvent>().CountAsync(x =>
+            x.Action == "user.mfa.challenge_failed" && x.UserId == user.Id)).Should().Be(5);
+        (await verify.Context.Set<SqlOSSession>().CountAsync(x => x.UserId == user.Id)).Should().Be(0);
+    }
+
+    [TestMethod]
     public async Task RealEndpoints_PublicHeadlessAndHostedRejectChallengeSubstitution()
     {
         await using var server = await MfaEndpointServer.CreateAsync();
@@ -437,6 +481,21 @@ public sealed class MfaEnrollmentSecurityIntegrationTests
         catch (Exception ex)
         {
             return new VerificationOutcome(false, ex);
+        }
+    }
+
+    private static async Task<Exception?> CaptureWrongCodeAsync(SqlOSAuthService auth, string mfaToken)
+    {
+        try
+        {
+            await auth.VerifyMfaChallengeAsync(
+                new SqlOSMfaChallengeVerifyRequest(mfaToken, "not-a-valid-code"),
+                CreateHttpContext());
+            return null;
+        }
+        catch (Exception ex)
+        {
+            return ex;
         }
     }
 

--- a/tests/SqlOS.Tests/SqlOSAuthServiceTests.cs
+++ b/tests/SqlOS.Tests/SqlOSAuthServiceTests.cs
@@ -748,6 +748,110 @@ public sealed class SqlOSAuthServiceTests
     }
 
     [TestMethod]
+    public async Task MfaChallenge_WrongCodesConsumeChallengeAtConfiguredCap()
+    {
+        var harness = await TestHarness.CreateAsync(configure: options =>
+        {
+            ConfigureRequiredMfa(options);
+            options.Mfa.Totp.MaxFailedAttemptsPerChallenge = 3;
+            options.Mfa.Totp.MaxFailedAttemptsPerUser = 6;
+            options.Mfa.Totp.MaxFailedAttemptsPerIp = 10;
+        });
+        var user = await harness.Admin.CreateUserAsync(new SqlOSCreateUserRequest(
+            "Bounded MFA",
+            $"bounded-mfa-{Guid.NewGuid():N}@example.com",
+            "P@ssword123!"));
+        var enrollment = await harness.Auth.StartTotpEnrollmentAsync(
+            user.Id,
+            new SqlOSTotpEnrollmentStartRequest("Bounded authenticator"));
+        await harness.Auth.VerifyTotpEnrollmentAsync(new SqlOSTotpEnrollmentVerifyRequest(
+            enrollment.EnrollmentToken,
+            harness.Totp.GenerateCodeForTesting(enrollment.Secret)));
+        var login = await harness.Auth.LoginWithPasswordAsync(
+            new SqlOSPasswordLoginRequest(user.DefaultEmail!, "P@ssword123!", "test-client", null),
+            CreatePasswordHttpContext("203.0.113.230"));
+        login.RequiresMfa.Should().BeTrue();
+        login.RequiresMfaEnrollment.Should().BeFalse();
+
+        for (var attempt = 0; attempt < 3; attempt++)
+        {
+            var reject = async () => await harness.Auth.VerifyMfaChallengeAsync(
+                new SqlOSMfaChallengeVerifyRequest(login.MfaToken!, "not-a-valid-code"),
+                CreatePasswordHttpContext("203.0.113.230"));
+            await reject.Should().ThrowAsync<InvalidOperationException>()
+                .WithMessage(SqlOSAuthService.MfaChallengeFailureMessage);
+        }
+
+        var persisted = await harness.Context.Set<SqlOSTemporaryToken>()
+            .SingleAsync(x => x.TokenHash == harness.Crypto.HashToken(login.MfaToken!));
+        persisted.ConsumedAt.Should().NotBeNull();
+        harness.Crypto.DeserializePayload<SqlOSMfaChallengePayload>(persisted)!.FailedAttempts.Should().Be(3);
+        (await harness.Context.Set<SqlOSAuditEvent>().CountAsync(x =>
+            x.Action == "user.mfa.challenge_failed" && x.UserId == user.Id)).Should().Be(3);
+
+        var correctAfterCap = async () => await harness.Auth.VerifyMfaChallengeAsync(
+            new SqlOSMfaChallengeVerifyRequest(
+                login.MfaToken!,
+                harness.Totp.GenerateCodeForTesting(
+                    enrollment.Secret,
+                    DateTimeOffset.UtcNow.AddSeconds(harness.Options.Mfa.Totp.PeriodSeconds))),
+            CreatePasswordHttpContext("203.0.113.230"));
+        await correctAfterCap.Should().ThrowAsync<InvalidOperationException>();
+        (await harness.Context.Set<SqlOSSession>().CountAsync(x => x.UserId == user.Id)).Should().Be(0);
+    }
+
+    [TestMethod]
+    public async Task MfaChallenge_ReissuingChallengesCannotBypassUserThrottle()
+    {
+        var harness = await TestHarness.CreateAsync(configure: options =>
+        {
+            ConfigureRequiredMfa(options);
+            options.Mfa.Totp.MaxFailedAttemptsPerChallenge = 2;
+            options.Mfa.Totp.MaxFailedAttemptsPerUser = 3;
+            options.Mfa.Totp.MaxFailedAttemptsPerIp = 20;
+        });
+        var user = await harness.Admin.CreateUserAsync(new SqlOSCreateUserRequest(
+            "Throttled MFA",
+            $"throttled-mfa-{Guid.NewGuid():N}@example.com",
+            "P@ssword123!"));
+        var enrollment = await harness.Auth.StartTotpEnrollmentAsync(
+            user.Id,
+            new SqlOSTotpEnrollmentStartRequest("Throttled authenticator"));
+        await harness.Auth.VerifyTotpEnrollmentAsync(new SqlOSTotpEnrollmentVerifyRequest(
+            enrollment.EnrollmentToken,
+            harness.Totp.GenerateCodeForTesting(enrollment.Secret)));
+
+        var firstLogin = await harness.Auth.LoginWithPasswordAsync(
+            new SqlOSPasswordLoginRequest(user.DefaultEmail!, "P@ssword123!", "test-client", null),
+            CreatePasswordHttpContext("203.0.113.231"));
+        for (var attempt = 0; attempt < 2; attempt++)
+        {
+            var reject = async () => await harness.Auth.VerifyMfaChallengeAsync(
+                new SqlOSMfaChallengeVerifyRequest(firstLogin.MfaToken!, "wrong"),
+                CreatePasswordHttpContext("203.0.113.231"));
+            await reject.Should().ThrowAsync<InvalidOperationException>()
+                .WithMessage(SqlOSAuthService.MfaChallengeFailureMessage);
+        }
+
+        var secondLogin = await harness.Auth.LoginWithPasswordAsync(
+            new SqlOSPasswordLoginRequest(user.DefaultEmail!, "P@ssword123!", "test-client", null),
+            CreatePasswordHttpContext("203.0.113.232"));
+        var finalFailure = async () => await harness.Auth.VerifyMfaChallengeAsync(
+            new SqlOSMfaChallengeVerifyRequest(secondLogin.MfaToken!, "wrong"),
+            CreatePasswordHttpContext("203.0.113.232"));
+        await finalFailure.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage(SqlOSAuthService.MfaChallengeFailureMessage);
+
+        var reissue = async () => await harness.Auth.LoginWithPasswordAsync(
+            new SqlOSPasswordLoginRequest(user.DefaultEmail!, "P@ssword123!", "test-client", null),
+            CreatePasswordHttpContext("203.0.113.233"));
+        await reissue.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage(SqlOSAuthService.MfaChallengeFailureMessage);
+        (await harness.Context.Set<SqlOSTemporaryToken>().CountAsync(x =>
+            x.Purpose == SqlOSAuthService.MfaChallengePurpose && x.UserId == user.Id)).Should().Be(2);
+    }
+
+    [TestMethod]
     public async Task RecoveryCode_CanSatisfyMfaOnlyOnce()
     {
         var harness = await TestHarness.CreateAsync();

--- a/tests/SqlOS.Tests/SqlOSAuthServiceTests.cs
+++ b/tests/SqlOS.Tests/SqlOSAuthServiceTests.cs
@@ -852,6 +852,72 @@ public sealed class SqlOSAuthServiceTests
     }
 
     [TestMethod]
+    public async Task MfaChallenge_IpThrottleSpansUsersWithoutBlockingAnotherIp()
+    {
+        var harness = await TestHarness.CreateAsync(configure: options =>
+        {
+            ConfigureRequiredMfa(options);
+            options.Mfa.Totp.MaxFailedAttemptsPerChallenge = 2;
+            options.Mfa.Totp.MaxFailedAttemptsPerUser = 10;
+            options.Mfa.Totp.MaxFailedAttemptsPerIp = 2;
+        });
+        var first = await CreateEnrolledMfaUserAsync(harness, "IP throttle first");
+        var second = await CreateEnrolledMfaUserAsync(harness, "IP throttle second");
+        var blocked = await CreateEnrolledMfaUserAsync(harness, "IP throttle blocked");
+        var control = await CreateEnrolledMfaUserAsync(harness, "IP throttle control");
+        var sharedIp = "203.0.113.240";
+
+        var firstLogin = await harness.Auth.LoginWithPasswordAsync(
+            new SqlOSPasswordLoginRequest(first.User.DefaultEmail!, "P@ssword123!", "test-client", null),
+            CreatePasswordHttpContext(sharedIp));
+        var secondLogin = await harness.Auth.LoginWithPasswordAsync(
+            new SqlOSPasswordLoginRequest(second.User.DefaultEmail!, "P@ssword123!", "test-client", null),
+            CreatePasswordHttpContext(sharedIp));
+        var blockedLogin = await harness.Auth.LoginWithPasswordAsync(
+            new SqlOSPasswordLoginRequest(blocked.User.DefaultEmail!, "P@ssword123!", "test-client", null),
+            CreatePasswordHttpContext(sharedIp));
+        var controlLogin = await harness.Auth.LoginWithPasswordAsync(
+            new SqlOSPasswordLoginRequest(control.User.DefaultEmail!, "P@ssword123!", "test-client", null),
+            CreatePasswordHttpContext("203.0.113.241"));
+
+        foreach (var mfaToken in new[] { firstLogin.MfaToken!, secondLogin.MfaToken! })
+        {
+            var reject = async () => await harness.Auth.VerifyMfaChallengeAsync(
+                new SqlOSMfaChallengeVerifyRequest(mfaToken, "wrong"),
+                CreatePasswordHttpContext(sharedIp));
+            await reject.Should().ThrowAsync<InvalidOperationException>()
+                .WithMessage(SqlOSAuthService.MfaChallengeFailureMessage);
+        }
+
+        var blockedCorrect = async () => await harness.Auth.VerifyMfaChallengeAsync(
+            new SqlOSMfaChallengeVerifyRequest(
+                blockedLogin.MfaToken!,
+                harness.Totp.GenerateCodeForTesting(
+                    blocked.Secret,
+                    DateTimeOffset.UtcNow.AddSeconds(harness.Options.Mfa.Totp.PeriodSeconds))),
+            CreatePasswordHttpContext(sharedIp));
+        await blockedCorrect.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage(SqlOSAuthService.MfaChallengeFailureMessage);
+
+        var controlResult = await harness.Auth.VerifyMfaChallengeAsync(
+            new SqlOSMfaChallengeVerifyRequest(
+                controlLogin.MfaToken!,
+                harness.Totp.GenerateCodeForTesting(
+                    control.Secret,
+                    DateTimeOffset.UtcNow.AddSeconds(harness.Options.Mfa.Totp.PeriodSeconds))),
+            CreatePasswordHttpContext("203.0.113.241"));
+        controlResult.Tokens.Should().NotBeNull();
+
+        var blockedChallenge = await harness.Context.Set<SqlOSTemporaryToken>()
+            .SingleAsync(x => x.TokenHash == harness.Crypto.HashToken(blockedLogin.MfaToken!));
+        blockedChallenge.ConsumedAt.Should().NotBeNull();
+        (await harness.Context.Set<SqlOSAuditEvent>().CountAsync(x =>
+            x.Action == "user.mfa.challenge_failed" && x.IpAddress == sharedIp)).Should().Be(2);
+        (await harness.Context.Set<SqlOSSession>().CountAsync(x => x.UserId == blocked.User.Id)).Should().Be(0);
+        (await harness.Context.Set<SqlOSSession>().CountAsync(x => x.UserId == control.User.Id)).Should().Be(1);
+    }
+
+    [TestMethod]
     public async Task RecoveryCode_CanSatisfyMfaOnlyOnce()
     {
         var harness = await TestHarness.CreateAsync();
@@ -2761,6 +2827,23 @@ public sealed class SqlOSAuthServiceTests
         options.Mfa.RequireForAllUsersByDefault = true;
         options.Mfa.AllowUserSelfEnrollmentByDefault = true;
         options.Mfa.RecoveryCodesEnabledByDefault = true;
+    }
+
+    private static async Task<(SqlOSUser User, string Secret)> CreateEnrolledMfaUserAsync(
+        TestHarness harness,
+        string displayName)
+    {
+        var user = await harness.Admin.CreateUserAsync(new SqlOSCreateUserRequest(
+            displayName,
+            $"mfa-{Guid.NewGuid():N}@example.com",
+            "P@ssword123!"));
+        var enrollment = await harness.Auth.StartTotpEnrollmentAsync(
+            user.Id,
+            new SqlOSTotpEnrollmentStartRequest($"{displayName} authenticator"));
+        await harness.Auth.VerifyTotpEnrollmentAsync(new SqlOSTotpEnrollmentVerifyRequest(
+            enrollment.EnrollmentToken,
+            harness.Totp.GenerateCodeForTesting(enrollment.Secret)));
+        return (user, enrollment.Secret);
     }
 
     private static async Task<SqlOSLoginResult> LoginForRequiredMfaAsync(

--- a/web/content/docs/authserver/mfa-totp.mdx
+++ b/web/content/docs/authserver/mfa-totp.mdx
@@ -166,6 +166,40 @@ amr: password
 amr: recovery_code
 ```
 
+## Guessing protection
+
+MFA guessing protection is automatic. You do not need to configure a cache,
+rate-limiting service, or hosted dependency. SqlOS stores the enforcement state
+in the same database as the rest of AuthServer and applies it consistently to
+hosted, headless, and direct API verification.
+
+By default, SqlOS:
+
+- consumes a challenge after 5 failed TOTP or recovery-code attempts;
+- rejects new challenges after 10 recent failures for the same user;
+- rejects verification after 25 recent failures from the same IP address; and
+- counts user and IP failures over a 10-minute window.
+
+Failures remain deliberately generic. A rejected code does not reveal whether
+the factor exists, was previously used, or was blocked by a limit. TOTP codes
+and recovery codes also remain single-use.
+
+The defaults are suitable for most applications. Deployments with a documented
+abuse model can tune them without replacing the built-in enforcement:
+
+```csharp
+builder.AddSqlOS<AppDbContext>(options =>
+{
+    options.AuthServer.ConfigureMfa(mfa =>
+    {
+        mfa.Totp.MaxFailedAttemptsPerChallenge = 5;
+        mfa.Totp.MaxFailedAttemptsPerUser = 10;
+        mfa.Totp.MaxFailedAttemptsPerIp = 25;
+        mfa.Totp.FailedAttemptWindow = TimeSpan.FromMinutes(10);
+    });
+});
+```
+
 ## Headless auth behavior
 
 Headless auth uses the same state machine. Your UI must render the new views.


### PR DESCRIPTION
Closes #141

## Summary
- cap failed TOTP and recovery-code attempts per challenge with atomic, cross-instance challenge state
- throttle recent failures per user and IP, including challenge reissuance, with secure defaults and generic public errors
- apply one enforcement path to direct, headless, and hosted MFA flows
- document zero-setup defaults and optional tuning

## Validation
- dotnet build SqlOS.sln (0 warnings, 0 errors)
- dotnet test tests/SqlOS.Tests/SqlOS.Tests.csproj --no-build --no-restore (544 passed)
- dotnet test tests/SqlOS.IntegrationTests/SqlOS.IntegrationTests.csproj --no-build --no-restore (132 passed)
- bash scripts/docs-check.sh

## Protocol proof
A real TestServer plus isolated SQL Server test drives POST /sqlos/auth/mfa/challenge/verify, confirms five uniform public failures, verifies the challenge is consumed and audited in SQL, and proves a valid code after the cap cannot create a session.

An adversarial review and one iteration will be completed on this draft before it is marked ready.