### PR TITLE
Re-evaluate policy during silent SSO

### DIFF
--- a/examples/SqlOS.Example.AngularWeb/src/app/pages/auth-authorize/auth-authorize.component.ts
+++ b/examples/SqlOS.Example.AngularWeb/src/app/pages/auth-authorize/auth-authorize.component.ts
@@ -375,6 +375,7 @@ export class AuthAuthorizeComponent implements OnInit {
     this.email = params.get('email') || '';
 
     const pendingToken = params.get('pendingToken');
+    const mfaToken = params.get('mfaToken');
     const initialDisplayName = params.get('displayName') || '';
     const nextPath = params.get('next') || '/retail';
 
@@ -388,6 +389,7 @@ export class AuthAuthorizeComponent implements OnInit {
         pendingToken,
         this.email || null,
         initialDisplayName || null,
+        mfaToken,
       );
       this.viewModel.set(vm);
       if (vm.view) this.view.set(vm.view);

--- a/examples/SqlOS.Example.AngularWeb/src/app/services/sqlos-headless.service.ts
+++ b/examples/SqlOS.Example.AngularWeb/src/app/services/sqlos-headless.service.ts
@@ -31,6 +31,7 @@ export class SqlosHeadlessService {
     pendingToken?: string | null,
     email?: string | null,
     displayName?: string | null,
+    mfaToken?: string | null,
   ): Promise<HeadlessViewModel> {
     const url = new URL(`${this.headlessBase}/requests/${requestId}`);
     if (view) url.searchParams.set('view', view);
@@ -38,6 +39,7 @@ export class SqlosHeadlessService {
     if (pendingToken) url.searchParams.set('pendingToken', pendingToken);
     if (email) url.searchParams.set('email', email);
     if (displayName) url.searchParams.set('displayName', displayName);
+    if (mfaToken) url.searchParams.set('mfaToken', mfaToken);
 
     const res = await fetch(url.toString(), {
       credentials: 'include',

--- a/examples/SqlOS.Example.Api/Program.cs
+++ b/examples/SqlOS.Example.Api/Program.cs
@@ -189,6 +189,7 @@ builder.AddSqlOS<ExampleAppDbContext>(
                         ["error"] = ctx.Error,
                         ["email"] = ctx.Email,
                         ["pendingToken"] = ctx.PendingToken,
+                        ["mfaToken"] = ctx.MfaToken,
                         ["displayName"] = ctx.DisplayName,
                     };
                     return QueryHelpers.AddQueryString(

--- a/examples/SqlOS.Example.Web/components/sqlos-headless-auth-panel.tsx
+++ b/examples/SqlOS.Example.Web/components/sqlos-headless-auth-panel.tsx
@@ -89,6 +89,7 @@ export function SqlOSHeadlessAuthPanel() {
   const initialError = searchParams.get("error");
   const initialEmail = searchParams.get("email") || "";
   const pendingToken = searchParams.get("pendingToken");
+  const initialMfaToken = searchParams.get("mfaToken");
   const initialDisplayName = searchParams.get("displayName") || "";
   const initialResetToken = searchParams.get("token") || "";
   const nextPath = searchParams.get("next") || "/retail";
@@ -128,6 +129,7 @@ export function SqlOSHeadlessAuthPanel() {
           pendingToken,
           initialEmail,
           initialDisplayName,
+          initialMfaToken,
         );
         setViewModel(vm);
         if (vm.view) setView(vm.view);
@@ -147,7 +149,7 @@ export function SqlOSHeadlessAuthPanel() {
     };
 
     void load();
-  }, [requestId, initialView, initialError, pendingToken, initialEmail, initialDisplayName]);
+  }, [requestId, initialView, initialError, pendingToken, initialEmail, initialDisplayName, initialMfaToken]);
 
   useEffect(() => {
     if (initialResetToken) {

--- a/examples/SqlOS.Example.Web/lib/sqlos-headless.ts
+++ b/examples/SqlOS.Example.Web/lib/sqlos-headless.ts
@@ -110,6 +110,7 @@ export async function getHeadlessRequest(
   pendingToken?: string | null,
   email?: string | null,
   displayName?: string | null,
+  mfaToken?: string | null,
 ): Promise<HeadlessViewModel> {
   const url = new URL(`${headlessBase()}/requests/${requestId}`);
   if (view) url.searchParams.set("view", view);
@@ -117,6 +118,7 @@ export async function getHeadlessRequest(
   if (pendingToken) url.searchParams.set("pendingToken", pendingToken);
   if (email) url.searchParams.set("email", email);
   if (displayName) url.searchParams.set("displayName", displayName);
+  if (mfaToken) url.searchParams.set("mfaToken", mfaToken);
 
   const res = await fetch(url.toString(), {
     credentials: "include",

--- a/examples/SqlOS.Todo.Api/Program.cs
+++ b/examples/SqlOS.Todo.Api/Program.cs
@@ -296,6 +296,7 @@ builder.AddSqlOS<TodoSampleDbContext>(
                         ["error"] = ctx.Error,
                         ["email"] = ctx.Email,
                         ["pendingToken"] = ctx.PendingToken,
+                        ["mfaToken"] = ctx.MfaToken,
                         ["displayName"] = ctx.DisplayName,
                         ["ui_context"] = ctx.UiContext?.ToJsonString()
                     });

--- a/src/SqlOS/AuthServer/Configuration/SqlOSHeadlessAuthOptions.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSHeadlessAuthOptions.cs
@@ -31,7 +31,8 @@ public sealed record SqlOSHeadlessUiRouteContext(
     string? PendingToken,
     string? Email,
     string? DisplayName,
-    JsonObject? UiContext);
+    JsonObject? UiContext,
+    string? MfaToken = null);
 
 public sealed record SqlOSHeadlessSignupHookContext(
     HttpContext HttpContext,

--- a/src/SqlOS/AuthServer/Contracts/SqlOSMfaContracts.cs
+++ b/src/SqlOS/AuthServer/Contracts/SqlOSMfaContracts.cs
@@ -110,3 +110,7 @@ internal sealed record SqlOSMfaChallengePayload(
     string? Resource = null,
     bool EnrollmentRequired = false,
     IReadOnlyList<string>? PermittedEnrollmentFactors = null);
+
+internal sealed record SqlOSAuthorizationMfaChallengeState(
+    bool EnrollmentRequired,
+    IReadOnlyList<string> Methods);

--- a/src/SqlOS/AuthServer/Extensions/EndpointRouteBuilderExtensions.cs
+++ b/src/SqlOS/AuthServer/Extensions/EndpointRouteBuilderExtensions.cs
@@ -174,6 +174,9 @@ public static class EndpointRouteBuilderExtensions
                         if ((completion.RequiresOrganizationSelection || completion.RequiresMfa)
                             && string.Equals(prompt, "none", StringComparison.Ordinal))
                         {
+                            await authorizationServerService.CancelAuthorizationInteractionAsync(
+                                completion,
+                                cancellationToken);
                             return Results.Redirect(await authorizationServerService.BuildAuthorizationErrorRedirectAsync(
                                 authorizationRequest,
                                 "interaction_required",

--- a/src/SqlOS/AuthServer/Extensions/EndpointRouteBuilderExtensions.cs
+++ b/src/SqlOS/AuthServer/Extensions/EndpointRouteBuilderExtensions.cs
@@ -98,6 +98,7 @@ public static class EndpointRouteBuilderExtensions
             HttpContext context,
             SqlOSAuthorizationServerService authorizationServerService,
             SqlOSHeadlessAuthService headlessAuthService,
+            SqlOSAuthService authService,
             SqlOSAuthPageSessionService authPageSessionService,
             SqlOSInvitationService invitationService,
             CancellationToken cancellationToken) =>
@@ -151,14 +152,91 @@ public static class EndpointRouteBuilderExtensions
                 var existingSession = await authPageSessionService.TryGetSessionAsync(context, cancellationToken);
                 if (existingSession != null && !string.Equals(prompt, "login", StringComparison.Ordinal))
                 {
-                    var redirectUrl = await authorizationServerService.IssueAuthorizationRedirectAsync(
-                        authorizationRequest,
-                        existingSession.User,
-                        existingSession.OrganizationId,
-                        existingSession.AuthenticationMethod,
-                        context,
-                        cancellationToken);
-                    return Results.Redirect(redirectUrl);
+                    if (authorizationRequest.ClientApplication?.IsFirstParty != true)
+                    {
+                        if (string.Equals(prompt, "none", StringComparison.Ordinal))
+                        {
+                            return Results.Redirect(await authorizationServerService.BuildAuthorizationErrorRedirectAsync(
+                                authorizationRequest,
+                                "consent_required",
+                                "User interaction is required for this client.",
+                                cancellationToken));
+                        }
+                    }
+                    else
+                    {
+                        var completion = await authorizationServerService.CompleteAuthorizationRequestLoginAsync(
+                            authorizationRequest,
+                            existingSession.User,
+                            existingSession.AuthenticationMethod,
+                            context,
+                            cancellationToken);
+                        if ((completion.RequiresOrganizationSelection || completion.RequiresMfa)
+                            && string.Equals(prompt, "none", StringComparison.Ordinal))
+                        {
+                            return Results.Redirect(await authorizationServerService.BuildAuthorizationErrorRedirectAsync(
+                                authorizationRequest,
+                                "interaction_required",
+                                "Additional user interaction is required.",
+                                cancellationToken));
+                        }
+
+                        if (completion.RequiresOrganizationSelection)
+                        {
+                            if (headlessAuthService.IsBrowserUiEnabled)
+                            {
+                                return Results.Redirect(headlessAuthService.BuildUiUrl(
+                                    context,
+                                    authorizationRequest.Id,
+                                    "organization",
+                                    error: null,
+                                    pendingToken: completion.PendingToken,
+                                    email: existingSession.User.DefaultEmail,
+                                    displayName: null,
+                                    uiContext: SqlOSHeadlessAuthService.ParseUiContext(authorizationRequest.UiContextJson)));
+                            }
+
+                            return Html(await BuildAuthPageViewModelAsync(
+                                "organization",
+                                authorizationRequest.Id,
+                                existingSession.User.DefaultEmail,
+                                error: null,
+                                displayName: null,
+                                pendingToken: completion.PendingToken,
+                                authPrefix,
+                                authorizationServerService,
+                                cancellationToken,
+                                organizationSelection: completion.Organizations));
+                        }
+
+                        if (completion.RequiresMfa)
+                        {
+                            if (headlessAuthService.IsBrowserUiEnabled)
+                            {
+                                return Results.Redirect(headlessAuthService.BuildUiUrl(
+                                    context,
+                                    authorizationRequest.Id,
+                                    completion.RequiresMfaEnrollment ? "mfa-enroll" : "mfa",
+                                    error: null,
+                                    pendingToken: null,
+                                    email: existingSession.User.DefaultEmail,
+                                    displayName: null,
+                                    uiContext: SqlOSHeadlessAuthService.ParseUiContext(authorizationRequest.UiContextJson),
+                                    mfaToken: completion.MfaToken));
+                            }
+
+                            return await RenderMfaChallengeAsync(
+                                completion,
+                                authorizationRequest.Id,
+                                existingSession.User.DefaultEmail,
+                                authPrefix,
+                                authorizationServerService,
+                                authService,
+                                cancellationToken);
+                        }
+
+                        return Results.Redirect(completion.RedirectUrl!);
+                    }
                 }
 
                 if (string.Equals(prompt, "none", StringComparison.Ordinal))
@@ -2634,6 +2712,7 @@ public static class EndpointRouteBuilderExtensions
             string? pendingToken,
             string? email,
             string? displayName,
+            string? mfaToken,
             HttpContext context,
             SqlOSHeadlessAuthService headlessAuthService,
             CancellationToken cancellationToken) =>
@@ -2652,7 +2731,8 @@ public static class EndpointRouteBuilderExtensions
                     pendingToken,
                     email,
                     displayName,
-                    cancellationToken));
+                    cancellationToken,
+                    mfaToken));
             }
             catch (InvalidOperationException ex)
             {

--- a/src/SqlOS/AuthServer/Services/SqlOSAuthService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSAuthService.cs
@@ -1911,6 +1911,40 @@ public sealed class SqlOSAuthService
             _options.Mfa.Totp.ChallengeTokenLifetime,
             cancellationToken);
 
+    internal async Task<SqlOSAuthorizationMfaChallengeState> GetAuthorizationMfaChallengeStateAsync(
+        string mfaToken,
+        string authorizationRequestId,
+        CancellationToken cancellationToken = default)
+    {
+        var token = await RequireTotpMfaService().GetPendingMfaTokenAsync(mfaToken, cancellationToken);
+        if (token.UserId == null)
+        {
+            throw new InvalidOperationException("MFA challenge is invalid or expired.");
+        }
+
+        var payload = _cryptoService.DeserializePayload<SqlOSMfaChallengePayload>(token);
+        if (payload == null
+            || !string.Equals(payload.Flow, "authorization", StringComparison.Ordinal)
+            || !string.Equals(payload.AuthorizationRequestId, authorizationRequestId, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("MFA challenge is invalid or expired.");
+        }
+
+        var evaluation = await RequireMfaPolicyService().EvaluateAsync(
+            token.UserId,
+            token.OrganizationId,
+            payload.AuthenticationMethod,
+            cancellationToken);
+        if (!evaluation.RequiresMfa || evaluation.EnrollmentRequired != payload.EnrollmentRequired)
+        {
+            throw new InvalidOperationException("MFA challenge is invalid or expired.");
+        }
+
+        return new SqlOSAuthorizationMfaChallengeState(
+            payload.EnrollmentRequired,
+            evaluation.AvailableFactors);
+    }
+
     private async Task<SqlOSMfaChallengeVerifyResult> CompleteConsumedMfaChallengeAsync(
         SqlOSTemporaryToken token,
         string factorMethod,
@@ -2649,6 +2683,9 @@ public sealed class SqlOSAuthService
 
     private SqlOSTotpMfaService RequireTotpMfaService()
         => _totpMfaService ?? throw new InvalidOperationException("TOTP MFA service is not registered.");
+
+    private SqlOSMfaPolicyService RequireMfaPolicyService()
+        => _mfaPolicyService ?? throw new InvalidOperationException("MFA policy service is not registered.");
 
     private async Task<SqlOSLoginResult?> TryCreateMfaLoginResultAsync(
         SqlOSUser user,

--- a/src/SqlOS/AuthServer/Services/SqlOSAuthorizationServerService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSAuthorizationServerService.cs
@@ -175,7 +175,8 @@ public sealed class SqlOSAuthorizationServerService
             CodeChallenge = input.CodeChallenge ?? string.Empty,
             CodeChallengeMethod = input.CodeChallengeMethod ?? "S256",
             CreatedAt = DateTime.UtcNow,
-            ExpiresAt = DateTime.UtcNow.AddMinutes(10)
+            ExpiresAt = DateTime.UtcNow.AddMinutes(10),
+            ClientApplication = client
         };
 
         _context.Set<SqlOSAuthorizationRequest>().Add(authorizationRequest);

--- a/src/SqlOS/AuthServer/Services/SqlOSAuthorizationServerService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSAuthorizationServerService.cs
@@ -231,6 +231,27 @@ public sealed class SqlOSAuthorizationServerService
         return QueryHelpers.AddQueryString(authorizationRequest.RedirectUri, query);
     }
 
+    public async Task CancelAuthorizationInteractionAsync(
+        SqlOSAuthorizationRequestLoginResult completion,
+        CancellationToken cancellationToken = default)
+    {
+        if (!string.IsNullOrWhiteSpace(completion.PendingToken))
+        {
+            _ = await _cryptoService.ConsumeTemporaryTokenAsync(
+                "auth_page_pending",
+                completion.PendingToken,
+                cancellationToken);
+        }
+
+        if (!string.IsNullOrWhiteSpace(completion.MfaToken))
+        {
+            _ = await _cryptoService.ConsumeTemporaryTokenAsync(
+                SqlOSAuthService.MfaChallengePurpose,
+                completion.MfaToken,
+                cancellationToken);
+        }
+    }
+
     public async Task<SqlOSPasswordAuthenticationResult> AuthenticatePasswordAsync(
         string email,
         string password,

--- a/src/SqlOS/AuthServer/Services/SqlOSHeadlessAuthService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSHeadlessAuthService.cs
@@ -93,7 +93,8 @@ public sealed class SqlOSHeadlessAuthService
         string? pendingToken,
         string? email,
         string? displayName,
-        JsonObject? uiContext)
+        JsonObject? uiContext,
+        string? mfaToken = null)
     {
         if (!IsBrowserUiEnabled)
         {
@@ -114,7 +115,8 @@ public sealed class SqlOSHeadlessAuthService
                 pendingToken,
                 email,
                 displayName,
-                uiContext));
+                uiContext,
+                mfaToken));
     }
 
     public async Task<string?> TryBuildUiUrlForAuthorizationRequestAsync(
@@ -151,9 +153,42 @@ public sealed class SqlOSHeadlessAuthService
         string? pendingToken,
         string? email,
         string? displayName,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        string? mfaToken = null)
     {
         var authorizationRequest = await _authorizationServerService.GetRequiredAuthorizationRequestAsync(requestId, cancellationToken);
+        if (!string.IsNullOrWhiteSpace(mfaToken))
+        {
+            var state = await RequireAuthService().GetAuthorizationMfaChallengeStateAsync(
+                mfaToken,
+                authorizationRequest.Id,
+                cancellationToken);
+            SqlOSTotpEnrollmentStartResult? enrollment = null;
+            if (state.EnrollmentRequired)
+            {
+                enrollment = await RequireAuthService().StartTotpEnrollmentForAuthorizationChallengeAsync(
+                    mfaToken,
+                    authorizationRequest.Id,
+                    new SqlOSTotpEnrollmentStartRequest(),
+                    cancellationToken);
+            }
+
+            return await BuildViewModelAsync(
+                authorizationRequest,
+                state.EnrollmentRequired ? "mfa-enroll" : "mfa",
+                error,
+                pendingToken: null,
+                email,
+                displayName,
+                fieldErrors: null,
+                organizationSelection: null,
+                mfaToken: mfaToken,
+                requiresMfaEnrollment: state.EnrollmentRequired,
+                mfaMethods: state.Methods,
+                totpEnrollment: enrollment,
+                cancellationToken: cancellationToken);
+        }
+
         return await BuildViewModelAsync(
             authorizationRequest,
             requestedView,

--- a/tests/SqlOS.IntegrationTests/SilentSsoSecurityIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/SilentSsoSecurityIntegrationTests.cs
@@ -81,7 +81,50 @@ public sealed class SilentSsoSecurityIntegrationTests
         var context = verifyScope.ServiceProvider.GetRequiredService<TestSqlOSDbContext>();
         (await context.Set<SqlOSAuthorizationCode>().CountAsync(x => x.UserId == userId)).Should().Be(0);
         (await context.Set<SqlOSTemporaryToken>().CountAsync(x =>
-            x.UserId == userId && x.Purpose == SqlOSAuthService.MfaChallengePurpose && x.ConsumedAt == null)).Should().Be(2);
+            x.UserId == userId && x.Purpose == SqlOSAuthService.MfaChallengePurpose && x.ConsumedAt == null)).Should().Be(1);
+        (await context.Set<SqlOSTemporaryToken>().CountAsync(x =>
+            x.UserId == userId && x.Purpose == SqlOSAuthService.MfaChallengePurpose && x.ConsumedAt != null)).Should().Be(1);
+    }
+
+    [TestMethod]
+    public async Task HostedExistingCookie_ReevaluatesMfaAndRendersChallengeWithoutCode()
+    {
+        await using var server = await SilentSsoServer.CreateAsync(headless: false);
+        string cookie;
+        string userId;
+        await using (var scope = server.App.Services.CreateAsyncScope())
+        {
+            var admin = scope.ServiceProvider.GetRequiredService<SqlOSAdminService>();
+            var auth = scope.ServiceProvider.GetRequiredService<SqlOSAuthService>();
+            var totp = scope.ServiceProvider.GetRequiredService<SqlOSTotpMfaService>();
+            var authPageSession = scope.ServiceProvider.GetRequiredService<SqlOSAuthPageSessionService>();
+            var user = await admin.CreateUserAsync(new SqlOSCreateUserRequest(
+                "Hosted Silent MFA User",
+                $"hosted-silent-mfa-{Guid.NewGuid():N}@example.com",
+                "P@ssword123!"));
+            userId = user.Id;
+            var enrollment = await auth.StartTotpEnrollmentAsync(user.Id, new SqlOSTotpEnrollmentStartRequest());
+            await auth.VerifyTotpEnrollmentAsync(new SqlOSTotpEnrollmentVerifyRequest(
+                enrollment.EnrollmentToken,
+                totp.GenerateCodeForTesting(enrollment.Secret)));
+            cookie = await CreateSessionCookieAsync(authPageSession, user, organizationId: null, "password");
+        }
+
+        using var client = server.App.GetTestClient();
+        client.DefaultRequestHeaders.Add("Cookie", cookie);
+        var authorize = await client.GetAsync(BuildAuthorizeUrl("owned-client", "state-hosted-mfa"));
+
+        authorize.StatusCode.Should().Be(HttpStatusCode.OK);
+        authorize.Content.Headers.ContentType!.MediaType.Should().Be("text/html");
+        var html = await authorize.Content.ReadAsStringAsync();
+        html.Should().Contain("action=\"/sqlos/auth/mfa/verify\"");
+        html.Should().Contain("name=\"mfaToken\"");
+
+        await using var verifyScope = server.App.Services.CreateAsyncScope();
+        var context = verifyScope.ServiceProvider.GetRequiredService<TestSqlOSDbContext>();
+        (await context.Set<SqlOSAuthorizationCode>().CountAsync(x => x.UserId == userId)).Should().Be(0);
+        (await context.Set<SqlOSTemporaryToken>().CountAsync(x =>
+            x.UserId == userId && x.Purpose == SqlOSAuthService.MfaChallengePurpose && x.ConsumedAt == null)).Should().Be(1);
     }
 
     [TestMethod]
@@ -209,7 +252,7 @@ public sealed class SilentSsoSecurityIntegrationTests
     {
         public required WebApplication App { get; init; }
 
-        public static async Task<SilentSsoServer> CreateAsync(bool requireMfa = true)
+        public static async Task<SilentSsoServer> CreateAsync(bool requireMfa = true, bool headless = true)
         {
             await using var bootstrapContext = await AspireFixture.CreateIsolatedAuthContextAsync("SilentSso");
             var connectionString = bootstrapContext.Database.GetConnectionString()!;
@@ -234,20 +277,23 @@ public sealed class SilentSsoSecurityIntegrationTests
                 options.AuthServer.Mfa.RequireForAllUsersByDefault = requireMfa;
                 options.AuthServer.Mfa.AllowUserSelfEnrollmentByDefault = true;
                 options.AuthServer.Mfa.RecoveryCodesEnabledByDefault = true;
-                options.AuthServer.UseHeadlessAuthPage(headless =>
+                if (headless)
                 {
-                    headless.BuildUiUrl = route => Microsoft.AspNetCore.WebUtilities.QueryHelpers.AddQueryString(
-                        "https://app.example.test/authorize",
-                        new Dictionary<string, string?>
-                        {
-                            ["request"] = route.RequestId,
-                            ["view"] = route.View,
-                            ["error"] = route.Error,
-                            ["pendingToken"] = route.PendingToken,
-                            ["email"] = route.Email,
-                            ["mfaToken"] = route.MfaToken
-                        });
-                });
+                    options.AuthServer.UseHeadlessAuthPage(headlessOptions =>
+                    {
+                        headlessOptions.BuildUiUrl = route => Microsoft.AspNetCore.WebUtilities.QueryHelpers.AddQueryString(
+                            "https://app.example.test/authorize",
+                            new Dictionary<string, string?>
+                            {
+                                ["request"] = route.RequestId,
+                                ["view"] = route.View,
+                                ["error"] = route.Error,
+                                ["pendingToken"] = route.PendingToken,
+                                ["email"] = route.Email,
+                                ["mfaToken"] = route.MfaToken
+                            });
+                    });
+                }
             });
             builder.Services.RemoveAll<IHostedService>();
 

--- a/tests/SqlOS.IntegrationTests/SilentSsoSecurityIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/SilentSsoSecurityIntegrationTests.cs
@@ -1,0 +1,280 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SqlOS.AuthServer.Configuration;
+using SqlOS.AuthServer.Contracts;
+using SqlOS.AuthServer.Extensions;
+using SqlOS.AuthServer.Models;
+using SqlOS.AuthServer.Services;
+using SqlOS.Extensions;
+using SqlOS.IntegrationTests.Infrastructure;
+
+namespace SqlOS.IntegrationTests;
+
+[TestClass]
+public sealed class SilentSsoSecurityIntegrationTests
+{
+    private const string CodeChallenge = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+    [TestMethod]
+    public async Task ExistingCookie_ReevaluatesMfaAndHandsChallengeToHeadlessUi()
+    {
+        await using var server = await SilentSsoServer.CreateAsync();
+        string cookie;
+        string userId;
+        await using (var scope = server.App.Services.CreateAsyncScope())
+        {
+            var admin = scope.ServiceProvider.GetRequiredService<SqlOSAdminService>();
+            var auth = scope.ServiceProvider.GetRequiredService<SqlOSAuthService>();
+            var totp = scope.ServiceProvider.GetRequiredService<SqlOSTotpMfaService>();
+            var authPageSession = scope.ServiceProvider.GetRequiredService<SqlOSAuthPageSessionService>();
+            var user = await admin.CreateUserAsync(new SqlOSCreateUserRequest(
+                "Silent MFA User",
+                $"silent-mfa-{Guid.NewGuid():N}@example.com",
+                "P@ssword123!"));
+            userId = user.Id;
+            var enrollment = await auth.StartTotpEnrollmentAsync(user.Id, new SqlOSTotpEnrollmentStartRequest());
+            await auth.VerifyTotpEnrollmentAsync(new SqlOSTotpEnrollmentVerifyRequest(
+                enrollment.EnrollmentToken,
+                totp.GenerateCodeForTesting(enrollment.Secret)));
+            cookie = await CreateSessionCookieAsync(authPageSession, user, organizationId: null, "password");
+        }
+
+        using var client = server.App.GetTestClient();
+        client.DefaultRequestHeaders.Add("Cookie", cookie);
+        var authorize = await client.GetAsync(BuildAuthorizeUrl("owned-client", "state-mfa"));
+        authorize.StatusCode.Should().Be(HttpStatusCode.Redirect);
+        var handoff = authorize.Headers.Location
+            ?? throw new AssertFailedException("Authorize response did not include a headless UI location.");
+        handoff.Host.Should().Be("app.example.test");
+        var query = Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery(handoff.Query);
+        query["view"].ToString().Should().Be("mfa");
+        var requestId = query["request"].ToString();
+        var mfaToken = query["mfaToken"].ToString();
+        mfaToken.Should().NotBeNullOrWhiteSpace();
+
+        var view = await client.GetAsync(
+            $"/sqlos/auth/headless/requests/{Uri.EscapeDataString(requestId)}?view=mfa&mfaToken={Uri.EscapeDataString(mfaToken)}");
+        view.EnsureSuccessStatusCode();
+        using var viewJson = JsonDocument.Parse(await view.Content.ReadAsStringAsync());
+        viewJson.RootElement.GetProperty("view").GetString().Should().Be("mfa");
+        viewJson.RootElement.GetProperty("mfaToken").GetString().Should().Be(mfaToken);
+
+        var silent = await client.GetAsync(BuildAuthorizeUrl("owned-client", "state-mfa-none", "none"));
+        silent.StatusCode.Should().Be(HttpStatusCode.Redirect);
+        silent.Headers.Location!.Host.Should().Be("owned.example.test");
+        var silentQuery = Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery(silent.Headers.Location.Query);
+        silentQuery["error"].ToString().Should().Be("interaction_required");
+        silentQuery["state"].ToString().Should().Be("state-mfa-none");
+
+        await using var verifyScope = server.App.Services.CreateAsyncScope();
+        var context = verifyScope.ServiceProvider.GetRequiredService<TestSqlOSDbContext>();
+        (await context.Set<SqlOSAuthorizationCode>().CountAsync(x => x.UserId == userId)).Should().Be(0);
+        (await context.Set<SqlOSTemporaryToken>().CountAsync(x =>
+            x.UserId == userId && x.Purpose == SqlOSAuthService.MfaChallengePurpose && x.ConsumedAt == null)).Should().Be(2);
+    }
+
+    [TestMethod]
+    public async Task ThirdPartyCookieReuse_RequiresInteractionAndPromptNoneReturnsConsentRequired()
+    {
+        await using var server = await SilentSsoServer.CreateAsync(requireMfa: false);
+        string cookie;
+        await using (var scope = server.App.Services.CreateAsyncScope())
+        {
+            var admin = scope.ServiceProvider.GetRequiredService<SqlOSAdminService>();
+            var authPageSession = scope.ServiceProvider.GetRequiredService<SqlOSAuthPageSessionService>();
+            var user = await admin.CreateUserAsync(new SqlOSCreateUserRequest(
+                "Third Party Session User",
+                $"third-party-session-{Guid.NewGuid():N}@example.com",
+                "P@ssword123!"));
+            cookie = await CreateSessionCookieAsync(authPageSession, user, organizationId: null, "password");
+        }
+
+        using var client = server.App.GetTestClient();
+        client.DefaultRequestHeaders.Add("Cookie", cookie);
+        var interactive = await client.GetAsync(BuildAuthorizeUrl("third-party-client", "state-interactive"));
+        interactive.StatusCode.Should().Be(HttpStatusCode.Redirect);
+        var interactionQuery = Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery(interactive.Headers.Location!.Query);
+        interactionQuery["view"].ToString().Should().Be("login");
+        interactionQuery.ContainsKey("mfaToken").Should().BeFalse();
+
+        var silent = await client.GetAsync(BuildAuthorizeUrl("third-party-client", "state-none", "none"));
+        silent.StatusCode.Should().Be(HttpStatusCode.Redirect);
+        silent.Headers.Location!.Host.Should().Be("third-party.example.test");
+        var errorQuery = Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery(silent.Headers.Location.Query);
+        errorQuery["error"].ToString().Should().Be("consent_required");
+        errorQuery["state"].ToString().Should().Be("state-none");
+
+        await using var verifyScope = server.App.Services.CreateAsyncScope();
+        var context = verifyScope.ServiceProvider.GetRequiredService<TestSqlOSDbContext>();
+        (await context.Set<SqlOSAuthorizationCode>().CountAsync()).Should().Be(0);
+    }
+
+    [TestMethod]
+    public async Task ExistingCookie_UsesAuthorizationRequestOrganizationInsteadOfSessionOrganization()
+    {
+        await using var server = await SilentSsoServer.CreateAsync(requireMfa: false);
+        await using var scope = server.App.Services.CreateAsyncScope();
+        var admin = scope.ServiceProvider.GetRequiredService<SqlOSAdminService>();
+        var authorization = scope.ServiceProvider.GetRequiredService<SqlOSAuthorizationServerService>();
+        var context = scope.ServiceProvider.GetRequiredService<TestSqlOSDbContext>();
+        var user = await admin.CreateUserAsync(new SqlOSCreateUserRequest(
+            "Organization Bound Session",
+            $"organization-bound-{Guid.NewGuid():N}@example.com",
+            "P@ssword123!"));
+        var sessionOrganization = await admin.CreateOrganizationAsync(new SqlOSCreateOrganizationRequest("Session Organization", null));
+        var requestedOrganization = await admin.CreateOrganizationAsync(new SqlOSCreateOrganizationRequest("Requested Organization", null));
+        await admin.CreateMembershipAsync(sessionOrganization.Id, new SqlOSCreateMembershipRequest(user.Id, "member"));
+        await admin.CreateMembershipAsync(requestedOrganization.Id, new SqlOSCreateMembershipRequest(user.Id, "member"));
+        var request = await authorization.CreateAuthorizationRequestAsync(new SqlOSAuthorizeRequestInput(
+            "code",
+            "owned-client",
+            "https://owned.example.test/callback",
+            "state-org",
+            "openid",
+            CodeChallenge,
+            "S256",
+            null,
+            user.DefaultEmail,
+            null,
+            null,
+            "hosted",
+            null));
+        request.OrganizationId = requestedOrganization.Id;
+        await context.SaveChangesAsync();
+
+        var completion = await authorization.CompleteAuthorizationRequestLoginAsync(
+            request,
+            user,
+            "password",
+            CreateHttpContext());
+
+        completion.RedirectUrl.Should().NotBeNull();
+        var code = await context.Set<SqlOSAuthorizationCode>().SingleAsync(x => x.AuthorizationRequestId == request.Id);
+        code.OrganizationId.Should().Be(requestedOrganization.Id);
+        code.OrganizationId.Should().NotBe(sessionOrganization.Id);
+    }
+
+    private static string BuildAuthorizeUrl(string clientId, string state, string? prompt = null)
+    {
+        var redirectUri = clientId == "owned-client"
+            ? "https://owned.example.test/callback"
+            : "https://third-party.example.test/callback";
+        var values = new Dictionary<string, string?>
+        {
+            ["response_type"] = "code",
+            ["client_id"] = clientId,
+            ["redirect_uri"] = redirectUri,
+            ["state"] = state,
+            ["scope"] = "openid profile",
+            ["code_challenge"] = CodeChallenge,
+            ["code_challenge_method"] = "S256",
+            ["prompt"] = prompt
+        };
+        return Microsoft.AspNetCore.WebUtilities.QueryHelpers.AddQueryString("/sqlos/auth/authorize", values);
+    }
+
+    private static async Task<string> CreateSessionCookieAsync(
+        SqlOSAuthPageSessionService sessionService,
+        SqlOSUser user,
+        string? organizationId,
+        string authenticationMethod)
+    {
+        var context = CreateHttpContext();
+        await sessionService.SignInAsync(context, user, organizationId, authenticationMethod);
+        var setCookie = context.Response.Headers.SetCookie.ToString();
+        return setCookie.Split(';', 2)[0];
+    }
+
+    private static DefaultHttpContext CreateHttpContext()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Scheme = "https";
+        context.Request.Host = new HostString("tests");
+        context.Connection.RemoteIpAddress = IPAddress.Parse("203.0.113.250");
+        return context;
+    }
+
+    private sealed class SilentSsoServer : IAsyncDisposable
+    {
+        public required WebApplication App { get; init; }
+
+        public static async Task<SilentSsoServer> CreateAsync(bool requireMfa = true)
+        {
+            await using var bootstrapContext = await AspireFixture.CreateIsolatedAuthContextAsync("SilentSso");
+            var connectionString = bootstrapContext.Database.GetConnectionString()!;
+            var builder = WebApplication.CreateBuilder(new WebApplicationOptions { EnvironmentName = Environments.Development });
+            builder.WebHost.UseTestServer();
+            builder.Services.AddDbContext<TestSqlOSDbContext>(db => db.UseSqlServer(connectionString));
+            builder.Services.AddSqlOS<TestSqlOSDbContext>(options =>
+            {
+                options.AuthServer.Issuer = "https://tests/sqlos/auth";
+                options.AuthServer.BasePath = "/sqlos/auth";
+                options.AuthServer.SeedBrowserClient("owned-client", "Owned Client", "https://owned.example.test/callback");
+                options.AuthServer.SeedClient(client =>
+                {
+                    client.ClientId = "third-party-client";
+                    client.Name = "Third Party Client";
+                    client.RedirectUris = ["https://third-party.example.test/callback"];
+                    client.ClientType = "public_pkce";
+                    client.RequirePkce = true;
+                    client.IsFirstParty = false;
+                });
+                options.AuthServer.Mfa.Enabled = true;
+                options.AuthServer.Mfa.RequireForAllUsersByDefault = requireMfa;
+                options.AuthServer.Mfa.AllowUserSelfEnrollmentByDefault = true;
+                options.AuthServer.Mfa.RecoveryCodesEnabledByDefault = true;
+                options.AuthServer.UseHeadlessAuthPage(headless =>
+                {
+                    headless.BuildUiUrl = route => Microsoft.AspNetCore.WebUtilities.QueryHelpers.AddQueryString(
+                        "https://app.example.test/authorize",
+                        new Dictionary<string, string?>
+                        {
+                            ["request"] = route.RequestId,
+                            ["view"] = route.View,
+                            ["error"] = route.Error,
+                            ["pendingToken"] = route.PendingToken,
+                            ["email"] = route.Email,
+                            ["mfaToken"] = route.MfaToken
+                        });
+                });
+            });
+            builder.Services.RemoveAll<IHostedService>();
+
+            var app = builder.Build();
+            app.MapAuthServer("/sqlos/auth");
+            await app.StartAsync();
+
+            await using var scope = app.Services.CreateAsyncScope();
+            var crypto = scope.ServiceProvider.GetRequiredService<SqlOSCryptoService>();
+            var admin = scope.ServiceProvider.GetRequiredService<SqlOSAdminService>();
+            var settings = scope.ServiceProvider.GetRequiredService<SqlOSSettingsService>();
+            await crypto.EnsureActiveSigningKeyAsync();
+            await admin.UpsertSeededClientsAsync();
+            await settings.UpsertSeededAuthPageSettingsAsync();
+            await settings.UpsertSeededMfaSettingsAsync();
+            return new SilentSsoServer { App = app };
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await using (var scope = App.Services.CreateAsyncScope())
+            {
+                await scope.ServiceProvider.GetRequiredService<TestSqlOSDbContext>().Database.EnsureDeletedAsync();
+            }
+
+            await App.StopAsync();
+            await App.DisposeAsync();
+        }
+    }
+}

--- a/web/content/docs/authserver/clients.mdx
+++ b/web/content/docs/authserver/clients.mdx
@@ -104,6 +104,31 @@ Clients seeded in startup code are marked as **startup managed**. Their configur
 
 Dashboard-created clients are fully editable and persist across restarts.
 
+## Browser SSO and the first-party boundary
+
+SqlOS can reuse an existing AuthPage browser session without asking the user to
+enter a primary credential again, but only for clients marked as first-party.
+Owned clients created with `SeedOwnedWebApp`, `SeedOwnedNativeApp`, or the
+single-application setup are first-party automatically.
+
+Before issuing a new authorization code, SqlOS always re-evaluates the current
+organization, membership, and MFA policy. A request bound to an organization
+uses that organization rather than the organization remembered by the browser
+session. If organization selection or MFA is required, the user sees that step
+instead of receiving a code. With `prompt=none`, SqlOS returns
+`interaction_required` because the protocol forbids displaying the step.
+
+Dynamically registered, CIMD, and other third-party clients do not receive this
+silent session reuse. They require a user interaction; `prompt=none` returns
+`consent_required`. This prevents a client-controlled authorization URL from
+riding an unrelated signed-in browser session. Do not set `IsFirstParty` for an
+application you do not own and trust.
+
+Custom headless browser UIs should forward both `PendingToken` and `MfaToken`
+from `BuildUiUrl`. The former carries organization selection; the latter carries
+an MFA step-up into the headless request view. The official examples include
+both automatically.
+
 ## Portable clients with CIMD
 
 Use `CIMD` when a public client uses a stable HTTPS `client_id` that points to its own metadata document.

--- a/web/content/docs/authserver/headless-auth.mdx
+++ b/web/content/docs/authserver/headless-auth.mdx
@@ -41,6 +41,7 @@ builder.AddSqlOS<AppDbContext>(options =>
                     ["view"] = ctx.View,
                     ["email"] = ctx.Email,
                     ["pendingToken"] = ctx.PendingToken,
+                    ["mfaToken"] = ctx.MfaToken,
                     ["ui_context"] = ctx.UiContext?.ToJsonString()
                 });
     });

--- a/web/content/docs/guides/custom-login-ui.mdx
+++ b/web/content/docs/guides/custom-login-ui.mdx
@@ -86,7 +86,8 @@ builder.AddSqlOS<AppDbContext>(options =>
                 ["error"] = context.Error,
                 ["email"] = context.Email,
                 ["displayName"] = context.DisplayName,
-                ["pendingToken"] = context.PendingToken
+                ["pendingToken"] = context.PendingToken,
+                ["mfaToken"] = context.MfaToken
             });
     });
 });

--- a/web/content/docs/guides/standalone-identity-server.mdx
+++ b/web/content/docs/guides/standalone-identity-server.mdx
@@ -138,6 +138,7 @@ auth.UseHeadlessAuthPage(headless =>
                 ["view"] = ctx.View,
                 ["email"] = ctx.Email,
                 ["pendingToken"] = ctx.PendingToken,
+                ["mfaToken"] = ctx.MfaToken,
                 ["ui_context"] = ctx.UiContext?.ToJsonString()
             });
 });


### PR DESCRIPTION
Closes #131.

## What changed
- treats the AuthPage cookie as first-factor state rather than an authorization decision
- re-evaluates requested organization membership and current MFA policy before issuing a code
- preserves silent SSO for explicitly first-party clients while requiring user interaction for third-party clients
- returns protocol-correct `interaction_required` / `consent_required` errors for `prompt=none`
- carries bound MFA challenges through the supported headless UI contract and official examples
- documents the first-party trust boundary and secure default behavior

## Developer ergonomics
Existing owned-app SSO remains automatic for clients seeded through the browser-client helpers. Applications do not need new services or configuration. Custom headless UIs only relay the newly supplied `mfaToken` when the server asks for MFA; official React, Angular, and API examples demonstrate that path.

## Validation
- `dotnet build SqlOS.sln --no-restore` (0 warnings, 0 errors)
- Release solution build (0 warnings, 0 errors)
- 542 SqlOS unit tests + 2 example unit tests
- 134 real-SQL integration tests, including new silent SSO protocol coverage
- 71 example integration tests
- 14 Todo integration tests
- docs reference/image/snippet/link validation
- website lint, TypeScript, and production build
