### PR TITLE
Enforce FGA lifecycle during authorization

### DIFF
--- a/src/SqlOS/Fga/Models/SqlOSFgaUserGroup.cs
+++ b/src/SqlOS/Fga/Models/SqlOSFgaUserGroup.cs
@@ -10,6 +10,7 @@ public class SqlOSFgaUserGroup
     public string? Description { get; set; }
     public string? GroupType { get; set; }
     public string SubjectId { get; set; } = string.Empty;
+    public bool IsActive { get; set; } = true;
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 

--- a/src/SqlOS/Fga/Schema/001_Initial.sql
+++ b/src/SqlOS/Fga/Schema/001_Initial.sql
@@ -141,6 +141,7 @@ BEGIN
         [Description] NVARCHAR(MAX)  NULL,
         [GroupType]   NVARCHAR(MAX)  NULL,
         [SubjectId]   NVARCHAR(450)  NOT NULL,
+        [IsActive]    BIT            NOT NULL DEFAULT 1,
         [CreatedAt]   DATETIME2      NOT NULL,
         [UpdatedAt]   DATETIME2      NOT NULL,
         CONSTRAINT [PK_{UserGroups}] PRIMARY KEY ([Id]),

--- a/src/SqlOS/Fga/Schema/005_AuthorizationLifecycle.sql
+++ b/src/SqlOS/Fga/Schema/005_AuthorizationLifecycle.sql
@@ -1,0 +1,11 @@
+-- SqlOSFga Schema v5: explicit group lifecycle used by authorization enforcement.
+
+IF COL_LENGTH('[{Schema}].[{UserGroups}]', 'IsActive') IS NULL
+BEGIN
+    ALTER TABLE [{Schema}].[{UserGroups}]
+        ADD [IsActive] BIT NOT NULL
+            CONSTRAINT [DF_{UserGroups}_IsActive] DEFAULT 1 WITH VALUES;
+END
+GO
+
+UPDATE [{Schema}].[SqlOSFgaSchema] SET [Version] = 5 WHERE [Version] < 5;

--- a/src/SqlOS/Fga/Services/SqlOSFgaAuthService.cs
+++ b/src/SqlOS/Fga/Services/SqlOSFgaAuthService.cs
@@ -441,6 +441,11 @@ public class SqlOSFgaAuthService : ISqlOSFgaAuthService
 
     private async Task<List<string>> ResolveSubjectIdsAsync(string subjectId)
     {
+        if (!await IsSubjectActiveAsync(subjectId))
+        {
+            return [];
+        }
+
         var subjects = new List<string> { subjectId };
 
         var groupSubjectIds = await _context.Set<SqlOSFgaUserGroupMembership>()
@@ -448,7 +453,9 @@ public class SqlOSFgaAuthService : ISqlOSFgaAuthService
             .Join(_context.Set<SqlOSFgaUserGroup>(),
                 m => m.UserGroupId,
                 g => g.Id,
-                (m, g) => g.SubjectId)
+                (m, g) => g)
+            .Where(g => g.IsActive)
+            .Select(g => g.SubjectId)
             .ToListAsync();
 
         subjects.AddRange(groupSubjectIds);
@@ -458,6 +465,11 @@ public class SqlOSFgaAuthService : ISqlOSFgaAuthService
     private async Task<List<SqlOSFgaSubjectInfo>> ResolveSubjectsWithInfoAsync(string subjectId)
     {
         var result = new List<SqlOSFgaSubjectInfo>();
+
+        if (!await IsSubjectActiveAsync(subjectId))
+        {
+            return result;
+        }
 
         var subject = await _context.Set<SqlOSFgaSubject>().FirstOrDefaultAsync(s => s.Id == subjectId);
         result.Add(new SqlOSFgaSubjectInfo
@@ -474,7 +486,8 @@ public class SqlOSFgaAuthService : ISqlOSFgaAuthService
 
         foreach (var membership in memberships)
         {
-            var group = await _context.Set<SqlOSFgaUserGroup>().FirstOrDefaultAsync(g => g.Id == membership.UserGroupId);
+            var group = await _context.Set<SqlOSFgaUserGroup>()
+                .FirstOrDefaultAsync(g => g.Id == membership.UserGroupId && g.IsActive);
             if (group != null)
             {
                 result.Add(new SqlOSFgaSubjectInfo
@@ -511,13 +524,40 @@ public class SqlOSFgaAuthService : ISqlOSFgaAuthService
             }
 
             var resource = await _context.Set<SqlOSFgaResource>().FirstOrDefaultAsync(r => r.Id == currentId);
-            if (resource == null) break;
+            if (resource == null || !resource.IsActive) break;
             ancestors.Add(resource);
             currentId = resource.ParentId;
             depth++;
         }
 
         return ancestors;
+    }
+
+    private async Task<bool> IsSubjectActiveAsync(string subjectId)
+    {
+        var subjectType = await _context.Set<SqlOSFgaSubject>()
+            .AsNoTracking()
+            .Where(subject => subject.Id == subjectId)
+            .Select(subject => subject.SubjectTypeId)
+            .FirstOrDefaultAsync();
+
+        return subjectType switch
+        {
+            "user" => await _context.Set<SqlOSFgaUser>()
+                .AsNoTracking()
+                .AnyAsync(user => user.SubjectId == subjectId && user.IsActive),
+            "service_account" => await _context.Set<SqlOSFgaServiceAccount>()
+                .AsNoTracking()
+                .AnyAsync(account => account.SubjectId == subjectId
+                    && (account.ExpiresAt == null || account.ExpiresAt > DateTime.UtcNow)),
+            "group" => await _context.Set<SqlOSFgaUserGroup>()
+                .AsNoTracking()
+                .AnyAsync(group => group.SubjectId == subjectId && group.IsActive),
+            "agent" => await _context.Set<SqlOSFgaAgent>()
+                .AsNoTracking()
+                .AnyAsync(agent => agent.SubjectId == subjectId),
+            _ => false
+        };
     }
 
     private async Task<List<SqlOSFgaGrant>> GetActiveGrantsAsync(string subjectId, string resourceId)

--- a/src/SqlOS/Fga/Services/SqlOSFgaAuthService.cs
+++ b/src/SqlOS/Fga/Services/SqlOSFgaAuthService.cs
@@ -1,4 +1,5 @@
 using System.Linq.Expressions;
+using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -387,7 +388,7 @@ public class SqlOSFgaAuthService : ISqlOSFgaAuthService
             return entity => false;
         }
 
-        var subjectIdsStr = string.Join(",", subjectIds);
+        var subjectIdsJson = JsonSerializer.Serialize(subjectIds);
         var permissionId = permission.Id;
 
         // Build the expression using the concrete DbContext type's method
@@ -408,7 +409,7 @@ public class SqlOSFgaAuthService : ISqlOSFgaAuthService
         var entityParam = Expression.Parameter(typeof(T), "entity");
         var resourceIdProp = Expression.Property(entityParam, nameof(IHasResourceId.ResourceId));
         var contextExpr = Expression.Constant(_context, contextType);
-        var filterParameters = new AuthorizationFilterParameters(subjectIdsStr, permissionId);
+        var filterParameters = new AuthorizationFilterParameters(subjectIdsJson, permissionId);
         var filterParametersExpr = Expression.Constant(filterParameters);
         var tvfCall = Expression.Call(contextExpr, tvfMethod,
             resourceIdProp,

--- a/src/SqlOS/Fga/Services/SqlOSFgaFunctionInitializer.cs
+++ b/src/SqlOS/Fga/Services/SqlOSFgaFunctionInitializer.cs
@@ -50,21 +50,28 @@ RETURN
     WITH ancestors AS (
         SELECT Id, ParentId, 0 AS Depth
         FROM [{schema}].[{tables.Resources}]
-        WHERE Id = @ResourceId
+        WHERE Id = @ResourceId AND IsActive = 1
 
         UNION ALL
 
 	        SELECT r.Id, r.ParentId, a.Depth + 1
 	        FROM [{schema}].[{tables.Resources}] r
 	        INNER JOIN ancestors a ON r.Id = a.ParentId
-	        WHERE a.Depth < {maxDepth}
+	        WHERE a.Depth < {maxDepth} AND r.IsActive = 1
 	    )
     SELECT TOP 1 a.Id
     FROM ancestors a
     INNER JOIN [{schema}].[{tables.Grants}] g ON a.Id = g.ResourceId
     INNER JOIN [{schema}].[{tables.RolePermissions}] rp ON g.RoleId = rp.RoleId
+    INNER JOIN [{schema}].[{tables.Subjects}] s ON g.SubjectId = s.Id
+    LEFT JOIN [{schema}].[{tables.Users}] u ON s.Id = u.SubjectId
+    LEFT JOIN [{schema}].[{tables.ServiceAccounts}] sa ON s.Id = sa.SubjectId
+    LEFT JOIN [{schema}].[{tables.UserGroups}] ug ON s.Id = ug.SubjectId
     WHERE g.SubjectId IN (SELECT LTRIM(RTRIM(value)) FROM STRING_SPLIT(@SubjectIds, ','))
       AND rp.PermissionId = @PermissionId
+      AND (s.SubjectTypeId <> 'user' OR u.IsActive = 1)
+      AND (s.SubjectTypeId <> 'service_account' OR (sa.SubjectId IS NOT NULL AND (sa.ExpiresAt IS NULL OR sa.ExpiresAt > GETUTCDATE())))
+      AND (s.SubjectTypeId <> 'group' OR ug.IsActive = 1)
       AND (g.EffectiveFrom IS NULL OR g.EffectiveFrom <= GETUTCDATE())
       AND (g.EffectiveTo IS NULL OR g.EffectiveTo >= GETUTCDATE())
 )";

--- a/src/SqlOS/Fga/Services/SqlOSFgaFunctionInitializer.cs
+++ b/src/SqlOS/Fga/Services/SqlOSFgaFunctionInitializer.cs
@@ -67,11 +67,26 @@ RETURN
     LEFT JOIN [{schema}].[{tables.Users}] u ON s.Id = u.SubjectId
     LEFT JOIN [{schema}].[{tables.ServiceAccounts}] sa ON s.Id = sa.SubjectId
     LEFT JOIN [{schema}].[{tables.UserGroups}] ug ON s.Id = ug.SubjectId
-    WHERE g.SubjectId IN (SELECT LTRIM(RTRIM(value)) FROM STRING_SPLIT(@SubjectIds, ','))
+    LEFT JOIN [{schema}].[{tables.Agents}] ag ON s.Id = ag.SubjectId
+    WHERE g.SubjectId IN (SELECT CONVERT(NVARCHAR(450), [value]) FROM OPENJSON(@SubjectIds))
       AND rp.PermissionId = @PermissionId
       AND (s.SubjectTypeId <> 'user' OR u.IsActive = 1)
       AND (s.SubjectTypeId <> 'service_account' OR (sa.SubjectId IS NOT NULL AND (sa.ExpiresAt IS NULL OR sa.ExpiresAt > GETUTCDATE())))
       AND (s.SubjectTypeId <> 'group' OR ug.IsActive = 1)
+      AND (s.SubjectTypeId <> 'agent' OR ag.SubjectId IS NOT NULL)
+      AND EXISTS (
+          SELECT 1
+          FROM [{schema}].[{tables.Subjects}] caller
+          LEFT JOIN [{schema}].[{tables.Users}] callerUser ON caller.Id = callerUser.SubjectId
+          LEFT JOIN [{schema}].[{tables.ServiceAccounts}] callerSa ON caller.Id = callerSa.SubjectId
+          LEFT JOIN [{schema}].[{tables.UserGroups}] callerGroup ON caller.Id = callerGroup.SubjectId
+          LEFT JOIN [{schema}].[{tables.Agents}] callerAgent ON caller.Id = callerAgent.SubjectId
+          WHERE caller.Id = JSON_VALUE(@SubjectIds, '$[0]')
+            AND (caller.SubjectTypeId <> 'user' OR callerUser.IsActive = 1)
+            AND (caller.SubjectTypeId <> 'service_account' OR (callerSa.SubjectId IS NOT NULL AND (callerSa.ExpiresAt IS NULL OR callerSa.ExpiresAt > GETUTCDATE())))
+            AND (caller.SubjectTypeId <> 'group' OR callerGroup.IsActive = 1)
+            AND (caller.SubjectTypeId <> 'agent' OR callerAgent.SubjectId IS NOT NULL)
+      )
       AND (g.EffectiveFrom IS NULL OR g.EffectiveFrom <= GETUTCDATE())
       AND (g.EffectiveTo IS NULL OR g.EffectiveTo >= GETUTCDATE())
 )";

--- a/tests/SqlOS.IntegrationTests/Fga/Infrastructure/FgaTestDataSeeder.cs
+++ b/tests/SqlOS.IntegrationTests/Fga/Infrastructure/FgaTestDataSeeder.cs
@@ -104,13 +104,19 @@ public static class FgaTestDataSeeder
         );
 
         // User extension
-        context.Set<SqlOSFgaUser>().Add(new SqlOSFgaUser
-        {
-            Id = TestUserId,
-            SubjectId = TestUserSubjectId,
-            Email = "testuser@example.com",
-            IsActive = true
-        });
+        context.Set<SqlOSFgaUser>().AddRange(
+            new SqlOSFgaUser { Id = "usr_test_sysadmin", SubjectId = SystemAdminSubjectId, IsActive = true },
+            new SqlOSFgaUser { Id = "usr_test_agencyadmin", SubjectId = AgencyAdminSubjectId, IsActive = true },
+            new SqlOSFgaUser { Id = "usr_test_member", SubjectId = AgencyMemberSubjectId, IsActive = true },
+            new SqlOSFgaUser { Id = "usr_test_groupmember", SubjectId = GroupMemberSubjectId, IsActive = true },
+            new SqlOSFgaUser { Id = "usr_test_unauth", SubjectId = UnauthorizedSubjectId, IsActive = true },
+            new SqlOSFgaUser
+            {
+                Id = TestUserId,
+                SubjectId = TestUserSubjectId,
+                Email = "testuser@example.com",
+                IsActive = true
+            });
 
         // Agent extension
         context.Set<SqlOSFgaAgent>().Add(new SqlOSFgaAgent

--- a/tests/SqlOS.IntegrationTests/Fga/SqlOSFgaAuthServiceIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/Fga/SqlOSFgaAuthServiceIntegrationTests.cs
@@ -1,9 +1,12 @@
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SqlOS.Fga.Configuration;
+using SqlOS.Fga.Models;
 using SqlOS.IntegrationTests.Fga.Infrastructure;
 using SqlOS.Fga.Services;
+using SqlOS.IntegrationTests.Infrastructure;
 
 namespace SqlOS.IntegrationTests.Fga;
 
@@ -95,5 +98,143 @@ public class SqlOSFgaAuthServiceIntegrationTests : FgaIntegrationTestBase
         Assert.IsTrue(trace.AccessGranted);
         Assert.IsTrue(trace.PathNodes.Count > 0);
         Assert.IsFalse(string.IsNullOrEmpty(trace.DecisionSummary));
+    }
+
+    [TestMethod]
+    public async Task InactiveUser_IsDeniedByPointCheckAndEfFilterDespiteExistingGrant()
+    {
+        var subjectService = CreateSubjectService();
+        var user = await subjectService.CreateUserAsync("Lifecycle User", $"lifecycle-{Guid.NewGuid():N}@example.com");
+        var resourceId = await CreateProtectedResourceWithGrantAsync(user.SubjectId);
+
+        await AssertPointAndFilterAsync(user.SubjectId, resourceId, expected: true);
+
+        user.IsActive = false;
+        await Context.SaveChangesAsync();
+
+        await AssertPointAndFilterAsync(user.SubjectId, resourceId, expected: false);
+    }
+
+    [TestMethod]
+    public async Task InactiveResourceOrAncestor_IsDeniedByPointCheckAndEfFilter()
+    {
+        var subjectService = CreateSubjectService();
+        var user = await subjectService.CreateUserAsync("Resource Lifecycle User", $"resource-lifecycle-{Guid.NewGuid():N}@example.com");
+        var suffix = Guid.NewGuid().ToString("N");
+        var parent = new SqlOSFgaResource
+        {
+            Id = $"res_lifecycle_parent_{suffix}",
+            ParentId = "root",
+            Name = "Lifecycle Parent",
+            ResourceTypeId = "agency"
+        };
+        var child = new SqlOSFgaResource
+        {
+            Id = $"res_lifecycle_child_{suffix}",
+            ParentId = parent.Id,
+            Name = "Lifecycle Child",
+            ResourceTypeId = "project"
+        };
+        Context.Set<SqlOSFgaResource>().AddRange(parent, child);
+        Context.Set<SqlOSFgaGrant>().Add(new SqlOSFgaGrant
+        {
+            Id = $"grant_lifecycle_{suffix}",
+            SubjectId = user.SubjectId,
+            ResourceId = parent.Id,
+            RoleId = FgaTestDataSeeder.AgencyMemberRoleId
+        });
+        Context.Set<LifecycleProtectedEntity>().Add(new LifecycleProtectedEntity { Id = suffix, ResourceId = child.Id });
+        await Context.SaveChangesAsync();
+
+        await AssertPointAndFilterAsync(user.SubjectId, child.Id, expected: true);
+
+        parent.IsActive = false;
+        await Context.SaveChangesAsync();
+        await AssertPointAndFilterAsync(user.SubjectId, child.Id, expected: false);
+
+        parent.IsActive = true;
+        child.IsActive = false;
+        await Context.SaveChangesAsync();
+        await AssertPointAndFilterAsync(user.SubjectId, child.Id, expected: false);
+    }
+
+    [TestMethod]
+    public async Task ExpiredServiceAccount_IsDeniedByPointCheckAndEfFilter()
+    {
+        var subjectService = CreateSubjectService();
+        var serviceAccount = await subjectService.CreateServiceAccountAsync(
+            "Lifecycle Worker",
+            $"client-{Guid.NewGuid():N}",
+            "test-only-hash",
+            expiresAt: DateTime.UtcNow.AddMinutes(5));
+        var resourceId = await CreateProtectedResourceWithGrantAsync(serviceAccount.SubjectId);
+
+        await AssertPointAndFilterAsync(serviceAccount.SubjectId, resourceId, expected: true);
+
+        serviceAccount.ExpiresAt = DateTime.UtcNow.AddSeconds(-1);
+        await Context.SaveChangesAsync();
+
+        await AssertPointAndFilterAsync(serviceAccount.SubjectId, resourceId, expected: false);
+    }
+
+    [TestMethod]
+    public async Task InactiveGroupGrant_IsDeniedByPointCheckAndEfFilter()
+    {
+        var subjectService = CreateSubjectService();
+        var user = await subjectService.CreateUserAsync("Group Lifecycle User", $"group-lifecycle-{Guid.NewGuid():N}@example.com");
+        var group = await subjectService.CreateGroupAsync("Lifecycle Group");
+        await subjectService.AddToGroupAsync(user.SubjectId, group.Id);
+        var resourceId = await CreateProtectedResourceWithGrantAsync(group.SubjectId);
+
+        await AssertPointAndFilterAsync(user.SubjectId, resourceId, expected: true);
+
+        group.IsActive = false;
+        await Context.SaveChangesAsync();
+
+        await AssertPointAndFilterAsync(user.SubjectId, resourceId, expected: false);
+    }
+
+    private SqlOSFgaSubjectService CreateSubjectService()
+    {
+        var loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
+        return new SqlOSFgaSubjectService(
+            Context,
+            loggerFactory.CreateLogger<SqlOSFgaSubjectService>());
+    }
+
+    private async Task<string> CreateProtectedResourceWithGrantAsync(string grantSubjectId)
+    {
+        var suffix = Guid.NewGuid().ToString("N");
+        var resourceId = $"res_lifecycle_{suffix}";
+        Context.Set<SqlOSFgaResource>().Add(new SqlOSFgaResource
+        {
+            Id = resourceId,
+            ParentId = "root",
+            Name = "Lifecycle Protected Resource",
+            ResourceTypeId = "project"
+        });
+        Context.Set<SqlOSFgaGrant>().Add(new SqlOSFgaGrant
+        {
+            Id = $"grant_lifecycle_{suffix}",
+            SubjectId = grantSubjectId,
+            ResourceId = resourceId,
+            RoleId = FgaTestDataSeeder.AgencyMemberRoleId
+        });
+        Context.Set<LifecycleProtectedEntity>().Add(new LifecycleProtectedEntity { Id = suffix, ResourceId = resourceId });
+        await Context.SaveChangesAsync();
+        return resourceId;
+    }
+
+    private async Task AssertPointAndFilterAsync(string subjectId, string resourceId, bool expected)
+    {
+        var pointCheck = await _authService.CheckAccessAsync(subjectId, "TEST_VIEW", resourceId);
+        Assert.AreEqual(expected, pointCheck.Allowed, "Point authorization result did not match lifecycle policy.");
+
+        var filter = await _authService.GetAuthorizationFilterAsync<LifecycleProtectedEntity>(subjectId, "TEST_VIEW");
+        var listed = await Context.Set<LifecycleProtectedEntity>()
+            .Where(item => item.ResourceId == resourceId)
+            .Where(filter)
+            .AnyAsync();
+        Assert.AreEqual(expected, listed, "EF authorization filter did not match the point authorization result.");
     }
 }

--- a/tests/SqlOS.IntegrationTests/Fga/SqlOSFgaAuthServiceIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/Fga/SqlOSFgaAuthServiceIntegrationTests.cs
@@ -194,6 +194,44 @@ public class SqlOSFgaAuthServiceIntegrationTests : FgaIntegrationTestBase
         await AssertPointAndFilterAsync(user.SubjectId, resourceId, expected: false);
     }
 
+    [TestMethod]
+    public async Task EfFilter_RechecksDirectGroupMemberLifecycleWhenQueryExecutes()
+    {
+        var subjectService = CreateSubjectService();
+        var user = await subjectService.CreateUserAsync("Racing Lifecycle User", $"racing-lifecycle-{Guid.NewGuid():N}@example.com");
+        var group = await subjectService.CreateGroupAsync("Racing Lifecycle Group");
+        await subjectService.AddToGroupAsync(user.SubjectId, group.Id);
+        var resourceId = await CreateProtectedResourceWithGrantAsync(group.SubjectId);
+        var filter = await _authService.GetAuthorizationFilterAsync<LifecycleProtectedEntity>(user.SubjectId, "TEST_VIEW");
+
+        user.IsActive = false;
+        await Context.SaveChangesAsync();
+
+        var listed = await Context.Set<LifecycleProtectedEntity>()
+            .Where(item => item.ResourceId == resourceId)
+            .Where(filter)
+            .AnyAsync();
+        Assert.IsFalse(listed, "The SQL query must recheck the direct member after the filter has been constructed.");
+    }
+
+    [TestMethod]
+    public async Task CraftedSubjectIdentifier_CannotInjectAnotherGrantSubjectIntoEfFilter()
+    {
+        var suffix = Guid.NewGuid().ToString("N");
+        var victimSubjectId = $"subj_victim_{suffix}";
+        var attackerSubjectId = $"subj_attacker_{suffix},{victimSubjectId}";
+        Context.Set<SqlOSFgaSubject>().AddRange(
+            new SqlOSFgaSubject { Id = victimSubjectId, SubjectTypeId = "user", DisplayName = "Victim" },
+            new SqlOSFgaSubject { Id = attackerSubjectId, SubjectTypeId = "user", DisplayName = "Attacker" });
+        Context.Set<SqlOSFgaUser>().AddRange(
+            new SqlOSFgaUser { Id = $"usr_victim_{suffix}", SubjectId = victimSubjectId, IsActive = true },
+            new SqlOSFgaUser { Id = $"usr_attacker_{suffix}", SubjectId = attackerSubjectId, IsActive = true });
+        await Context.SaveChangesAsync();
+        var resourceId = await CreateProtectedResourceWithGrantAsync(victimSubjectId);
+
+        await AssertPointAndFilterAsync(attackerSubjectId, resourceId, expected: false);
+    }
+
     private SqlOSFgaSubjectService CreateSubjectService()
     {
         var loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());

--- a/tests/SqlOS.IntegrationTests/Fga/SqlOSFgaFunctionInitializerIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/Fga/SqlOSFgaFunctionInitializerIntegrationTests.cs
@@ -52,6 +52,17 @@ public class SqlOSFgaFunctionInitializerIntegrationTests : FgaIntegrationTestBas
         }
     }
 
+    [TestMethod]
+    public async Task EnsureFunctionsExist_EnforcesPrincipalAndResourceLifecycle()
+    {
+        var definition = await GetFunctionDefinitionAsync();
+
+        definition.Should().Contain("IsActive = 1");
+        definition.Should().Contain("u.IsActive = 1");
+        definition.Should().Contain("sa.ExpiresAt > GETUTCDATE()");
+        definition.Should().Contain("ug.IsActive = 1");
+    }
+
     private static async Task<string> GetFunctionDefinitionAsync()
     {
         var connection = Context.Database.GetDbConnection();

--- a/tests/SqlOS.IntegrationTests/Fga/SqlOSFgaFunctionInitializerIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/Fga/SqlOSFgaFunctionInitializerIntegrationTests.cs
@@ -61,6 +61,8 @@ public class SqlOSFgaFunctionInitializerIntegrationTests : FgaIntegrationTestBas
         definition.Should().Contain("u.IsActive = 1");
         definition.Should().Contain("sa.ExpiresAt > GETUTCDATE()");
         definition.Should().Contain("ug.IsActive = 1");
+        definition.Should().Contain("OPENJSON(@SubjectIds)");
+        definition.Should().Contain("JSON_VALUE(@SubjectIds, '$[0]')");
     }
 
     private static async Task<string> GetFunctionDefinitionAsync()

--- a/tests/SqlOS.IntegrationTests/Fga/SqlOSFgaSchemaInitializerIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/Fga/SqlOSFgaSchemaInitializerIntegrationTests.cs
@@ -94,6 +94,20 @@ public class SqlOSFgaSchemaInitializerIntegrationTests : FgaIntegrationTestBase
     }
 
     [TestMethod]
+    public async Task EnsureSchema_V5Migration_AddsGroupLifecycleColumn()
+    {
+        var loggerFactory = LoggerFactory.Create(b => b.AddConsole());
+        var initializer = new SqlOSFgaSchemaInitializer(
+            Context,
+            Options.Create(new SqlOSFgaOptions()),
+            loggerFactory.CreateLogger<SqlOSFgaSchemaInitializer>());
+
+        await initializer.EnsureSchemaAsync();
+
+        Assert.IsTrue(await ColumnExistsAsync("SqlOSFgaUserGroups", "IsActive"));
+    }
+
+    [TestMethod]
     public async Task EnsureSchema_SetsCorrectVersion()
     {
         var loggerFactory = LoggerFactory.Create(b => b.AddConsole());
@@ -105,7 +119,7 @@ public class SqlOSFgaSchemaInitializerIntegrationTests : FgaIntegrationTestBase
         await initializer.EnsureSchemaAsync();
 
         var version = await GetSchemaVersionAsync();
-        Assert.IsTrue(version >= 4, $"Schema version should be at least 4, was {version}");
+        Assert.IsTrue(version >= 5, $"Schema version should be at least 5, was {version}");
     }
 
     private async Task<bool> TableExistsAsync(string tableName)

--- a/tests/SqlOS.IntegrationTests/Infrastructure/TestSqlOSDbContext.cs
+++ b/tests/SqlOS.IntegrationTests/Infrastructure/TestSqlOSDbContext.cs
@@ -21,6 +21,17 @@ public sealed class TestSqlOSDbContext : DbContext, ISqlOSAuthServerDbContext, I
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
+        modelBuilder.Entity<LifecycleProtectedEntity>(entity =>
+        {
+            entity.ToTable("LifecycleProtectedEntities");
+            entity.HasKey(item => item.Id);
+        });
         modelBuilder.UseSqlOS(GetType());
     }
+}
+
+public sealed class LifecycleProtectedEntity : IHasResourceId
+{
+    public string Id { get; set; } = string.Empty;
+    public string ResourceId { get; set; } = string.Empty;
 }

--- a/web/content/docs/guides/service-account-jobs.mdx
+++ b/web/content/docs/guides/service-account-jobs.mdx
@@ -180,7 +180,7 @@ app.MapPost("/internal/ledger/{organizationId}/export", async (
 });
 ```
 
-`SqlOSFgaServiceAccount` has no native disabled flag. Replace its hash with a new undistributed secret for a simple emergency revoke, or add a disabled state in an app-owned credential-version table when you need non-destructive suspension.
+FGA authorization also checks `ExpiresAt`, so an expired service account cannot retain access through an old grant even if an API boundary accidentally omits its own expiry check. Keep the boundary check anyway so authentication fails before authorization and returns one generic credential error. `SqlOSFgaServiceAccount` has no separate disabled flag; set `ExpiresAt` to the current time for immediate authorization revocation, then rotate or remove its credential according to your application policy.
 
 `TryReadServiceCredential` can accept an app-owned scheme such as `Authorization: ServiceAccount <clientId>.<secret>`:
 

--- a/web/content/docs/reference/fga-api.mdx
+++ b/web/content/docs/reference/fga-api.mdx
@@ -93,6 +93,12 @@ var chains = await dbContext.Chains
 
 `Task<Expression<Func<T, bool>>>` — an EF Core-compatible expression you pass to `.Where()`.
 
+### Lifecycle enforcement
+
+Point checks, traces, and EF authorization filters apply the same lifecycle rules automatically. Inactive users and groups, expired service accounts, inactive target resources, and resources below an inactive ancestor are denied even when a matching grant remains stored. Applications do not need to revoke every grant when deactivating one of these records, and should not add a separate display-only lifecycle filter around authorization queries.
+
+Provision typed subjects with the SDK helpers rather than inserting only a bare `SqlOSFgaSubject`: authorization fails closed when a `user`, `group`, `agent`, or `service_account` subject is missing its corresponding typed lifecycle row.
+
 ---
 
 ### TraceResourceAccessAsync


### PR DESCRIPTION
Closes #132.

## What changed
- fails closed for inactive users, inactive groups, expired service accounts, and incomplete typed principals
- stops authorization inheritance at inactive targets or ancestors
- applies the same lifecycle rules in point checks, traces, and the SQL TVF used by EF query filters
- adds an idempotent FGA schema migration for group lifecycle state
- documents automatic lifecycle enforcement and service-account expiry behavior

## Developer ergonomics
No new authorization calls, middleware, services, or configuration are required. Existing active subjects and resources work as before. Developers provision typed subjects with the existing helpers, then changing `IsActive` or `ExpiresAt` is enough to revoke authorization without manually deleting every grant.

## Validation
- Release solution build: 0 warnings, 0 errors
- 542 library unit tests + 2 example unit tests
- 137 real-SQL integration tests, including point/EF-filter parity for every lifecycle case
- 71 example integration tests
- 14 Todo integration tests
- schema migration and generated TVF definition tests
- docs reference/image/snippet/link validation
- website lint, TypeScript, and production build
