### PR TITLE
Harden public security URL generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ var connectionString = builder.Configuration.GetConnectionString("DefaultConnect
     ?? throw new InvalidOperationException(
         "Connection string 'DefaultConnection' was not configured.");
 
-const string publicOrigin = "http://localhost:5050";
+const string appOrigin = "http://localhost:5050";
 var dashboardPassword = builder.Configuration["SqlOS:Dashboard:Password"]
     ?? throw new InvalidOperationException(
         "Configure SqlOS:Dashboard:Password with user secrets or your secret store.");
@@ -62,12 +62,10 @@ builder.AddSqlOS<AppDbContext>(
     db => db.UseSqlServer(connectionString),
     options =>
     {
-        options.AuthServer.PublicOrigin = publicOrigin;
-        options.AuthServer.Issuer = $"{publicOrigin}/sqlos/auth";
         options.UseSingleApplication("Acme", app =>
         {
-            app.Origin = publicOrigin;
-            app.Audience = $"{publicOrigin}/api";
+            app.Origin = appOrigin;
+            app.Audience = $"{appOrigin}/api";
         });
 
         options.Dashboard.AuthMode = SqlOSDashboardAuthMode.Password;

--- a/src/SqlOS/AuthServer/Services/SqlOSAuthorizationServerService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSAuthorizationServerService.cs
@@ -1136,14 +1136,7 @@ public sealed class SqlOSAuthorizationServerService
     }
 
     public string GetPublicOrigin(HttpContext httpContext)
-    {
-        if (!string.IsNullOrWhiteSpace(_options.PublicOrigin))
-        {
-            return _options.PublicOrigin.TrimEnd('/');
-        }
-
-        return $"{httpContext.Request.Scheme}://{httpContext.Request.Host}".TrimEnd('/');
-    }
+        => SqlOSPublicOriginResolver.Resolve(_options);
 
     private static List<string> ParseJsonArray(string json)
         => JsonSerializer.Deserialize<List<string>>(json) ?? new List<string>();

--- a/src/SqlOS/AuthServer/Services/SqlOSDeviceAuthorizationService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSDeviceAuthorizationService.cs
@@ -100,7 +100,7 @@ public sealed class SqlOSDeviceAuthorizationService
             ipAddress: GetIp(httpContext),
             cancellationToken: cancellationToken);
 
-        var origin = GetPublicOrigin(httpContext);
+        var origin = SqlOSPublicOriginResolver.Resolve(_options);
         var basePath = _options.BasePath.TrimEnd('/');
         var verificationUri = $"{origin}{basePath}/device";
         var verificationUriComplete = Microsoft.AspNetCore.WebUtilities.QueryHelpers.AddQueryString(
@@ -604,16 +604,6 @@ public sealed class SqlOSDeviceAuthorizationService
             deviceAuthorization.Status,
             requiresOrganizationSelection,
             organizations);
-
-    private string GetPublicOrigin(HttpContext httpContext)
-    {
-        if (!string.IsNullOrWhiteSpace(_options.PublicOrigin))
-        {
-            return _options.PublicOrigin.TrimEnd('/');
-        }
-
-        return $"{httpContext.Request.Scheme}://{httpContext.Request.Host}".TrimEnd('/');
-    }
 
     private static List<string> NormalizeRequestedScopes(string? scope)
         => string.IsNullOrWhiteSpace(scope)

--- a/src/SqlOS/AuthServer/Services/SqlOSInvitationService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSInvitationService.cs
@@ -692,25 +692,8 @@ public sealed class SqlOSInvitationService
 
     private string BuildAcceptUrl(string rawToken, HttpContext? httpContext)
     {
-        var origin = GetPublicOrigin(httpContext);
+        var origin = SqlOSPublicOriginResolver.Resolve(_options);
         return $"{origin}{_options.BasePath.TrimEnd('/')}/invitations/accept?token={Uri.EscapeDataString(rawToken)}";
-    }
-
-    private string GetPublicOrigin(HttpContext? httpContext)
-    {
-        if (!string.IsNullOrWhiteSpace(_options.PublicOrigin))
-        {
-            return _options.PublicOrigin.TrimEnd('/');
-        }
-
-        if (httpContext != null)
-        {
-            return $"{httpContext.Request.Scheme}://{httpContext.Request.Host}".TrimEnd('/');
-        }
-
-        return _options.Issuer.TrimEnd('/').EndsWith(_options.BasePath.TrimEnd('/'), StringComparison.OrdinalIgnoreCase)
-            ? _options.Issuer.TrimEnd('/')[..^_options.BasePath.TrimEnd('/').Length]
-            : _options.Issuer.TrimEnd('/');
     }
 
     private static void EnsureInvitationPending(SqlOSInvitation invitation)

--- a/src/SqlOS/AuthServer/Services/SqlOSOidcBrowserAuthService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSOidcBrowserAuthService.cs
@@ -414,9 +414,7 @@ public sealed class SqlOSOidcBrowserAuthService
 
     private string GetProviderCallbackUri(HttpContext httpContext)
     {
-        var origin = string.IsNullOrWhiteSpace(_options.PublicOrigin)
-            ? $"{httpContext.Request.Scheme}://{httpContext.Request.Host}".TrimEnd('/')
-            : _options.PublicOrigin!.TrimEnd('/');
+        var origin = SqlOSPublicOriginResolver.Resolve(_options);
 
         return $"{origin}{_options.BasePath.TrimEnd('/')}/oidc/callback";
     }

--- a/src/SqlOS/AuthServer/Services/SqlOSPublicOriginResolver.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSPublicOriginResolver.cs
@@ -1,0 +1,21 @@
+using SqlOS.AuthServer.Configuration;
+
+namespace SqlOS.AuthServer.Services;
+
+internal static class SqlOSPublicOriginResolver
+{
+    public static string Resolve(SqlOSAuthServerOptions options)
+    {
+        var configuredOrigin = options.PublicOrigin?.Trim();
+        if (!string.IsNullOrWhiteSpace(configuredOrigin))
+        {
+            return new Uri(configuredOrigin, UriKind.Absolute)
+                .GetLeftPart(UriPartial.Authority)
+                .TrimEnd('/');
+        }
+
+        return new Uri(options.Issuer, UriKind.Absolute)
+            .GetLeftPart(UriPartial.Authority)
+            .TrimEnd('/');
+    }
+}

--- a/src/SqlOS/AuthServer/Services/SqlOSSsoPortalService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSSsoPortalService.cs
@@ -1038,21 +1038,7 @@ public sealed class SqlOSSsoPortalService
     }
 
     private string GetOrigin(HttpContext? httpContext)
-    {
-        if (!string.IsNullOrWhiteSpace(_options.PublicOrigin))
-        {
-            return _options.PublicOrigin.TrimEnd('/');
-        }
-
-        if (httpContext != null && httpContext.Request.Host.HasValue)
-        {
-            return $"{httpContext.Request.Scheme}://{httpContext.Request.Host}";
-        }
-
-        return Uri.TryCreate(_options.Issuer, UriKind.Absolute, out var issuer)
-            ? issuer.GetLeftPart(UriPartial.Authority).TrimEnd('/')
-            : string.Empty;
-    }
+        => SqlOSPublicOriginResolver.Resolve(_options);
 
     private void SetPortalCookie(HttpContext httpContext, string rawSessionToken, DateTime expiresAt)
         => httpContext.Response.Cookies.Append(GetCookieName(), rawSessionToken, new CookieOptions

--- a/src/SqlOS/Calendar/Services/SqlOSCalendarService.cs
+++ b/src/SqlOS/Calendar/Services/SqlOSCalendarService.cs
@@ -806,11 +806,7 @@ public sealed class SqlOSCalendarService
 
     private string BuildCallbackUri(HttpContext? httpContext)
     {
-        var origin = !string.IsNullOrWhiteSpace(_authOptions.PublicOrigin)
-            ? _authOptions.PublicOrigin!.TrimEnd('/')
-            : httpContext != null
-                ? $"{httpContext.Request.Scheme}://{httpContext.Request.Host}".TrimEnd('/')
-                : throw new InvalidOperationException("Set AuthServer.PublicOrigin (or pass an HttpContext) so the calendar callback URI can be built.");
+        var origin = SqlOSPublicOriginResolver.Resolve(_authOptions);
 
         return $"{origin}{_authOptions.BasePath.TrimEnd('/')}/calendar/callback";
     }

--- a/src/SqlOS/Configuration/SqlOSOptionsValidator.cs
+++ b/src/SqlOS/Configuration/SqlOSOptionsValidator.cs
@@ -605,6 +605,12 @@ internal static class SqlOSOptionsValidator
             return null;
         }
 
+        if (!string.IsNullOrEmpty(uri.UserInfo))
+        {
+            errors.Add($"{name} cannot include user information.");
+            return null;
+        }
+
         return uri;
     }
 

--- a/src/SqlOS/Configuration/SqlOSPathDefaults.cs
+++ b/src/SqlOS/Configuration/SqlOSPathDefaults.cs
@@ -9,5 +9,12 @@ internal static class SqlOSPathDefaults
     {
         var root = options.DashboardBasePath.TrimEnd('/');
         options.AuthServer.BasePath = $"{root}/auth";
+
+        if (string.Equals(options.AuthServer.Issuer, "https://localhost/sqlos/auth", StringComparison.Ordinal)
+            && string.IsNullOrWhiteSpace(options.AuthServer.PublicOrigin)
+            && Uri.TryCreate(options.AuthServer.SingleApplication?.Origin, UriKind.Absolute, out var applicationOrigin))
+        {
+            options.AuthServer.Issuer = $"{applicationOrigin.GetLeftPart(UriPartial.Authority).TrimEnd('/')}{options.AuthServer.BasePath}";
+        }
     }
 }

--- a/tests/SqlOS.IntegrationTests/PublicOriginSecurityIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/PublicOriginSecurityIntegrationTests.cs
@@ -127,6 +127,25 @@ public sealed class PublicOriginSecurityIntegrationTests
             .Should().Be("https://localhost/sqlos/auth/authorize");
     }
 
+    [TestMethod]
+    public async Task ExplicitPublicOrigin_RemainsAuthoritativeUnderHostileHost()
+    {
+        const string proxyOrigin = "https://proxy.example.test";
+        await using var server = await PublicOriginServer.CreateAsync(
+            issuer: $"{proxyOrigin}/sqlos/auth",
+            trustedOrigin: proxyOrigin,
+            publicOrigin: proxyOrigin);
+        using var client = server.App.GetTestClient();
+
+        var response = await SendWithHostAsync(client, HttpMethod.Get, "/sqlos/auth/.well-known/oauth-authorization-server");
+        response.EnsureSuccessStatusCode();
+        using var metadata = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        metadata.RootElement.GetProperty("authorization_endpoint").GetString()
+            .Should().Be($"{proxyOrigin}/sqlos/auth/authorize");
+        metadata.RootElement.GetProperty("token_endpoint").GetString()
+            .Should().Be($"{proxyOrigin}/sqlos/auth/token");
+    }
+
     private static async Task<HttpResponseMessage> SendWithHostAsync(
         HttpClient client,
         HttpMethod method,
@@ -154,7 +173,8 @@ public sealed class PublicOriginSecurityIntegrationTests
 
         public static async Task<PublicOriginServer> CreateAsync(
             string issuer = $"{TrustedOrigin}/sqlos/auth",
-            string trustedOrigin = TrustedOrigin)
+            string trustedOrigin = TrustedOrigin,
+            string? publicOrigin = null)
         {
             await using var bootstrapContext = await AspireFixture.CreateIsolatedAuthContextAsync("PublicOrigin");
             var connectionString = bootstrapContext.Database.GetConnectionString()!;
@@ -166,6 +186,7 @@ public sealed class PublicOriginSecurityIntegrationTests
             {
                 options.AuthServer.Issuer = issuer;
                 options.AuthServer.BasePath = "/sqlos/auth";
+                options.AuthServer.PublicOrigin = publicOrigin;
                 options.AuthServer.DeviceAuthorization.Enabled = true;
                 options.AuthServer.SeedBrowserClient("browser-client", "Browser Client", "https://client.example.test/callback");
                 options.AuthServer.SeedCliClient("device-client", "Device Client", "openid");

--- a/tests/SqlOS.IntegrationTests/PublicOriginSecurityIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/PublicOriginSecurityIntegrationTests.cs
@@ -1,0 +1,212 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SqlOS.AuthServer.Configuration;
+using SqlOS.AuthServer.Contracts;
+using SqlOS.AuthServer.Extensions;
+using SqlOS.AuthServer.Interfaces;
+using SqlOS.AuthServer.Models;
+using SqlOS.AuthServer.Services;
+using SqlOS.Email.Interfaces;
+using SqlOS.Extensions;
+using SqlOS.IntegrationTests.Infrastructure;
+using SqlOS.Services;
+
+namespace SqlOS.IntegrationTests;
+
+[TestClass]
+public sealed class PublicOriginSecurityIntegrationTests
+{
+    private const string TrustedOrigin = "https://auth.example.test";
+    private const string AttackerHost = "attacker.example.test";
+    private const string CodeChallenge = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+    [TestMethod]
+    public async Task HostileHost_CannotPoisonInvitationOidcDeviceMetadataOrPortalUrls()
+    {
+        await using var server = await PublicOriginServer.CreateAsync();
+        using var client = server.App.GetTestClient();
+
+        var metadataResponse = await SendWithHostAsync(client, HttpMethod.Get, "/sqlos/auth/.well-known/oauth-authorization-server");
+        metadataResponse.EnsureSuccessStatusCode();
+        using var metadata = JsonDocument.Parse(await metadataResponse.Content.ReadAsStringAsync());
+        metadata.RootElement.GetProperty("authorization_endpoint").GetString()
+            .Should().Be($"{TrustedOrigin}/sqlos/auth/authorize");
+        metadata.RootElement.GetProperty("token_endpoint").GetString()
+            .Should().Be($"{TrustedOrigin}/sqlos/auth/token");
+
+        var deviceResponse = await SendWithHostAsync(
+            client,
+            HttpMethod.Post,
+            "/sqlos/auth/device_authorization",
+            new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["client_id"] = "device-client",
+                ["scope"] = "openid"
+            }));
+        deviceResponse.EnsureSuccessStatusCode();
+        using var device = JsonDocument.Parse(await deviceResponse.Content.ReadAsStringAsync());
+        device.RootElement.GetProperty("verification_uri").GetString()
+            .Should().Be($"{TrustedOrigin}/sqlos/auth/device");
+        device.RootElement.GetProperty("verification_uri_complete").GetString()
+            .Should().StartWith($"{TrustedOrigin}/sqlos/auth/device?");
+
+        string connectionId;
+        await using (var scope = server.App.Services.CreateAsyncScope())
+        {
+            connectionId = await scope.ServiceProvider.GetRequiredService<TestSqlOSDbContext>()
+                .Set<SqlOSOidcConnection>()
+                .Where(connection => connection.DisplayName == "Test OIDC")
+                .Select(connection => connection.Id)
+                .SingleAsync();
+        }
+
+        var oidcResponse = await SendWithHostAsync(
+            client,
+            HttpMethod.Post,
+            "/sqlos/auth/oidc/authorization-url",
+            JsonContent.Create(new SqlOSOidcAuthorizationUrlRequest(
+                connectionId,
+                "browser-client",
+                "https://client.example.test/callback",
+                "browser-state",
+                CodeChallenge,
+                "S256",
+                "ada@example.test")));
+        oidcResponse.EnsureSuccessStatusCode();
+        using var oidc = JsonDocument.Parse(await oidcResponse.Content.ReadAsStringAsync());
+        var providerUrl = new Uri(oidc.RootElement.GetProperty("authorizationUrl").GetString()!);
+        var providerQuery = Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery(providerUrl.Query);
+        providerQuery["redirect_uri"].ToString()
+            .Should().Be($"{TrustedOrigin}/sqlos/auth/oidc/callback");
+
+        await using (var scope = server.App.Services.CreateAsyncScope())
+        {
+            var admin = scope.ServiceProvider.GetRequiredService<SqlOSAdminService>();
+            var invitations = scope.ServiceProvider.GetRequiredService<SqlOSInvitationService>();
+            var portal = scope.ServiceProvider.GetRequiredService<SqlOSSsoPortalService>();
+            var organization = await admin.CreateOrganizationAsync(new SqlOSCreateOrganizationRequest("Hostile Host Org", null));
+            var hostileContext = CreateHostileContext();
+            var invitation = await invitations.CreateEmailInvitationAsync(
+                new SqlOSCreateEmailInvitationRequest(
+                    organization.Id,
+                    $"invite-{Guid.NewGuid():N}@example.test",
+                    "member"),
+                hostileContext);
+
+            invitation.InviteUrl.Should().StartWith($"{TrustedOrigin}/sqlos/auth/invitations/accept?token=");
+            invitation.InviteUrl.Should().NotContain(AttackerHost);
+            server.EmailSender.Messages.Should().ContainSingle();
+            server.EmailSender.Messages.Single().HtmlBody.Should().Contain(TrustedOrigin).And.NotContain(AttackerHost);
+            portal.BuildPortalUrl(hostileContext).Should().StartWith(TrustedOrigin).And.NotContain(AttackerHost);
+        }
+    }
+
+    [TestMethod]
+    public async Task DefaultLocalhostIssuer_RemainsZeroConfigurationAndHostIndependent()
+    {
+        await using var server = await PublicOriginServer.CreateAsync(
+            issuer: "https://localhost/sqlos/auth",
+            trustedOrigin: "https://localhost");
+        using var client = server.App.GetTestClient();
+
+        var response = await SendWithHostAsync(client, HttpMethod.Get, "/sqlos/auth/.well-known/oauth-authorization-server");
+        response.EnsureSuccessStatusCode();
+        using var metadata = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        metadata.RootElement.GetProperty("authorization_endpoint").GetString()
+            .Should().Be("https://localhost/sqlos/auth/authorize");
+    }
+
+    private static async Task<HttpResponseMessage> SendWithHostAsync(
+        HttpClient client,
+        HttpMethod method,
+        string path,
+        HttpContent? content = null)
+    {
+        using var request = new HttpRequestMessage(method, path) { Content = content };
+        request.Headers.Host = AttackerHost;
+        return await client.SendAsync(request);
+    }
+
+    private static DefaultHttpContext CreateHostileContext()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Scheme = "https";
+        context.Request.Host = new HostString(AttackerHost);
+        context.Connection.RemoteIpAddress = IPAddress.Parse("203.0.113.140");
+        return context;
+    }
+
+    private sealed class PublicOriginServer : IAsyncDisposable
+    {
+        public required WebApplication App { get; init; }
+        public required TestAuthEmailSender EmailSender { get; init; }
+
+        public static async Task<PublicOriginServer> CreateAsync(
+            string issuer = $"{TrustedOrigin}/sqlos/auth",
+            string trustedOrigin = TrustedOrigin)
+        {
+            await using var bootstrapContext = await AspireFixture.CreateIsolatedAuthContextAsync("PublicOrigin");
+            var connectionString = bootstrapContext.Database.GetConnectionString()!;
+            var emailSender = new TestAuthEmailSender { IsConfigured = true };
+            var builder = WebApplication.CreateBuilder(new WebApplicationOptions { EnvironmentName = Environments.Development });
+            builder.WebHost.UseTestServer();
+            builder.Services.AddDbContext<TestSqlOSDbContext>(db => db.UseSqlServer(connectionString));
+            builder.Services.AddSqlOS<TestSqlOSDbContext>(options =>
+            {
+                options.AuthServer.Issuer = issuer;
+                options.AuthServer.BasePath = "/sqlos/auth";
+                options.AuthServer.DeviceAuthorization.Enabled = true;
+                options.AuthServer.SeedBrowserClient("browser-client", "Browser Client", "https://client.example.test/callback");
+                options.AuthServer.SeedCliClient("device-client", "Device Client", "openid");
+                options.AuthServer.SeedOidcConnection(connection =>
+                {
+                    connection.ProviderType = SqlOSOidcProviderType.Custom;
+                    connection.DisplayName = "Test OIDC";
+                    connection.ClientId = "test-provider-client";
+                    connection.ClientSecret = "test-provider-secret";
+                    connection.UseDiscovery = false;
+                    connection.Issuer = "https://provider.example.test";
+                    connection.AuthorizationEndpoint = "https://provider.example.test/authorize";
+                    connection.TokenEndpoint = "https://provider.example.test/token";
+                    connection.JwksUri = "https://provider.example.test/jwks";
+                    connection.AllowedCallbackUris = [$"{trustedOrigin}/sqlos/auth/oidc/callback"];
+                });
+            });
+            builder.Services.RemoveAll<IHostedService>();
+            builder.Services.RemoveAll<ISqlOSAuthEmailSender>();
+            builder.Services.RemoveAll<ISqlOSEmailSender>();
+            builder.Services.AddSingleton<ISqlOSAuthEmailSender>(emailSender);
+            builder.Services.AddSingleton<ISqlOSEmailSender>(emailSender);
+
+            var app = builder.Build();
+            app.MapAuthServer("/sqlos/auth");
+            await using (var scope = app.Services.CreateAsyncScope())
+            {
+                await scope.ServiceProvider.GetRequiredService<SqlOSBootstrapper>().InitializeAsync();
+            }
+            await app.StartAsync();
+            return new PublicOriginServer { App = app, EmailSender = emailSender };
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await using (var scope = App.Services.CreateAsyncScope())
+            {
+                await scope.ServiceProvider.GetRequiredService<TestSqlOSDbContext>().Database.EnsureDeletedAsync();
+            }
+            await App.StopAsync();
+            await App.DisposeAsync();
+        }
+    }
+}

--- a/tests/SqlOS.Tests/SqlOSOptionsValidationTests.cs
+++ b/tests/SqlOS.Tests/SqlOSOptionsValidationTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SqlOS.AuthServer.Configuration;
 using SqlOS.Configuration;
@@ -119,6 +120,21 @@ public sealed class SqlOSOptionsValidationTests
         });
 
         act.Should().NotThrow();
+    }
+
+    [TestMethod]
+    public void AddSqlOS_SingleApplicationOriginDerivesIssuerWithoutPublicOriginSetup()
+    {
+        var services = new ServiceCollection();
+
+        services.AddSqlOS<TestSqlOSInMemoryDbContext>(options =>
+            options.UseSingleApplication("Acme", application =>
+                application.Origin = "http://localhost:5050"));
+
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<SqlOSAuthServerOptions>>().Value;
+        options.PublicOrigin.Should().BeNull();
+        options.Issuer.Should().Be("http://localhost:5050/sqlos/auth");
     }
 
     [TestMethod]

--- a/tests/SqlOS.Tests/SqlOSOptionsValidationTests.cs
+++ b/tests/SqlOS.Tests/SqlOSOptionsValidationTests.cs
@@ -58,6 +58,36 @@ public sealed class SqlOSOptionsValidationTests
     }
 
     [DataTestMethod]
+    [DataRow("issuer")]
+    [DataRow("public-origin")]
+    [DataRow("single-application")]
+    public void AddSqlOS_Throws_WhenTrustedAuthorityIncludesUserInformation(string source)
+    {
+        var services = new ServiceCollection();
+
+        Action act = () => services.AddSqlOS<TestSqlOSInMemoryDbContext>(options =>
+        {
+            if (source == "issuer")
+            {
+                options.AuthServer.Issuer = "https://trusted.example@attacker.example/sqlos/auth";
+            }
+            else if (source == "public-origin")
+            {
+                options.AuthServer.PublicOrigin = "https://trusted.example@attacker.example";
+                options.AuthServer.Issuer = "https://trusted.example@attacker.example/sqlos/auth";
+            }
+            else
+            {
+                options.UseSingleApplication("Acme", application =>
+                    application.Origin = "https://trusted.example@attacker.example");
+            }
+        });
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*cannot include user information.*");
+    }
+
+    [DataTestMethod]
     [DataRow("/")]
     [DataRow("sqlos/scim/v2")]
     [DataRow("/sqlos/scim/v2?tenant=acme")]

--- a/web/content/docs/getting-started.mdx
+++ b/web/content/docs/getting-started.mdx
@@ -49,8 +49,6 @@ builder.AddSqlOS<AppDbContext>(
     db => db.UseSqlServer(connectionString),
     options =>
     {
-        options.AuthServer.PublicOrigin = publicOrigin;
-        options.AuthServer.Issuer = $"{publicOrigin}/sqlos/auth";
         options.UseSingleApplication("Acme", app =>
         {
             app.Origin = publicOrigin;

--- a/web/content/docs/guides/production-readiness.mdx
+++ b/web/content/docs/guides/production-readiness.mdx
@@ -32,9 +32,11 @@ Use this as the minimum deployment contract:
 | Edge or reverse proxy | TLS, trusted forwarded headers, admin-route access control, rate limiting, request limits |
 | Deployment controller | One-writer schema rollout, readiness gates, compatible replicas, rollback/runbook |
 
-## 1. Make the public URL explicit
+## 1. Make the public URL stable
 
-Production URLs must not depend on the container's internal host name or HTTP scheme. Set both values in the `AddSqlOS` callback:
+SqlOS never uses the incoming request `Host` as the authority for invitation links, provider callbacks, discovery metadata, device verification, or SSO portal links. When `PublicOrigin` is omitted, those URLs use the authority of the validated absolute `Issuer`; the default `https://localhost/sqlos/auth` therefore keeps local development zero-configuration.
+
+For production, set the issuer to the canonical external authorization-server URL. Set `PublicOrigin` as an explicit readiness setting when a reverse proxy or deployment configuration makes the externally reachable origin non-obvious, and keep it aligned with the issuer:
 
 ```csharp
 var publicOrigin = builder.Configuration["SqlOS:PublicOrigin"]
@@ -52,7 +54,7 @@ builder.AddSqlOS<AppDbContext>(
     });
 ```
 
-`PublicOrigin` must be an absolute **origin only**: scheme, host, and optional port, with no path, query, or fragment. With `DashboardBasePath = "/sqlos"`, SqlOS derives the auth base path as `/sqlos/auth`, and `Issuer` must be exactly `{PublicOrigin}/sqlos/auth`.
+`PublicOrigin` is optional when the issuer already contains the correct public authority. When configured, it must be an absolute **origin only**: scheme, host, and optional port, with no path, query, or fragment. With `DashboardBasePath = "/sqlos"`, SqlOS derives the auth base path as `/sqlos/auth`, and `Issuer` must be exactly `{PublicOrigin}/sqlos/auth`.
 
 Examples:
 
@@ -65,7 +67,7 @@ The issuer is a security identifier, not just a link. Resource APIs validate the
 
 ### Reverse proxies and forwarded headers
 
-`PublicOrigin` keeps generated invitation, reset, callback, device, and portal URLs on the external origin. Also configure ASP.NET Core to accept forwarded scheme and host information **only from your known proxy** so the rest of the host sees the original HTTPS request correctly:
+The trusted issuer/`PublicOrigin` keeps generated invitation, reset, callback, device, and portal URLs on the external origin regardless of request headers. Also configure ASP.NET Core to accept forwarded scheme and host information **only from your known proxy** so client-IP policy and the rest of the host see the original request correctly:
 
 ```csharp
 using System.Net;

--- a/web/content/docs/quickstarts/add-to-app.mdx
+++ b/web/content/docs/quickstarts/add-to-app.mdx
@@ -76,8 +76,6 @@ builder.AddSqlOS<AppDbContext>(
     db => db.UseSqlServer(connectionString),
     options =>
     {
-        options.AuthServer.PublicOrigin = publicOrigin;
-        options.AuthServer.Issuer = $"{publicOrigin}/sqlos/auth";
         options.UseSingleApplication("Acme", app =>
         {
             app.Origin = publicOrigin;
@@ -150,7 +148,7 @@ That runnable client uses `/signin-sqlos`, the conventional ASP.NET Core middlew
 
 ### `Invalid SqlOS configuration` at startup
 
-`PublicOrigin` must be an absolute origin without a path, query, or fragment. `Issuer` must use the configured auth base path. For the defaults, it is exactly `{PublicOrigin}/sqlos/auth`.
+In single-application local development, SqlOS derives the issuer from `app.Origin` when the issuer is otherwise left at its default. For production or multi-application deployments, configure one stable issuer; set `PublicOrigin` during production readiness when you need to make that external origin explicit. `PublicOrigin` must be an absolute origin without a path, query, or fragment, and the issuer must be exactly `{PublicOrigin}/sqlos/auth` when it is set.
 
 ### SQL reports that the database does not exist
 


### PR DESCRIPTION
Closes #140

## Summary
- route every security-sensitive absolute URL through one trusted public-origin resolver
- default that resolver to the configured issuer authority, so normal single-app and localhost setups require no new setting
- retain `AuthServer.PublicOrigin` as an optional production-readiness override for reverse-proxy deployments
- remove Host-derived URLs from invitation email, OIDC callback, device verification, metadata, SSO portal, and calendar callback flows
- simplify the basic setup docs so developers do not have to think about public-origin configuration until production readiness

## Security and ergonomics
- hostile `Host` headers cannot affect security URLs
- the default `https://localhost/sqlos/auth` development issuer remains zero-configuration
- a single application origin automatically derives the matching issuer when the developer leaves both issuer and public origin at defaults
- no cloud service or external dependency is introduced

## Verification
- Release build: 0 warnings, 0 errors
- unit suites: 543 SqlOS tests + 2 example tests
- SQL-backed integration suites: 133 library + 71 example + 14 Todo tests
- focused protocol coverage sends an attacker-controlled Host through real metadata, device authorization, OIDC authorization URL, invitation email, and SSO portal paths
- docs/site build passes

An adversarial review and one follow-up iteration will be recorded on this PR before it is marked ready.