### PR TITLE
Protect hosted AuthPage forms from login CSRF

### DIFF
--- a/examples/SqlOS.Example.IntegrationTests/SqlOSExampleEmailOtpIntegrationTests.cs
+++ b/examples/SqlOS.Example.IntegrationTests/SqlOSExampleEmailOtpIntegrationTests.cs
@@ -294,11 +294,13 @@ public sealed class SqlOSExampleEmailOtpIntegrationTests
         authorizeResponse.StatusCode.Should().Be(HttpStatusCode.OK);
         var authorizeHtml = await authorizeResponse.Content.ReadAsStringAsync();
         var requestId = ExtractHiddenInput(authorizeHtml, "requestId");
+        var antiforgeryToken = ExtractHiddenInput(authorizeHtml, "__RequestVerificationToken");
 
         var startResponse = await client.PostAsync("/sqlos/auth/login/email-otp/start", new FormUrlEncodedContent(new Dictionary<string, string>
         {
             ["requestId"] = requestId,
-            ["email"] = email
+            ["email"] = email,
+            ["__RequestVerificationToken"] = antiforgeryToken
         }));
         startResponse.EnsureSuccessStatusCode();
         var verifyPageHtml = await startResponse.Content.ReadAsStringAsync();
@@ -309,7 +311,8 @@ public sealed class SqlOSExampleEmailOtpIntegrationTests
             ["requestId"] = requestId,
             ["email"] = email,
             ["challengeToken"] = challengeToken,
-            ["code"] = sender.GetLatestCode(email)
+            ["code"] = sender.GetLatestCode(email),
+            ["__RequestVerificationToken"] = antiforgeryToken
         }));
 
         verifyResponse.StatusCode.Should().Be(HttpStatusCode.Redirect);

--- a/examples/SqlOS.Example.IntegrationTests/SqlOSExampleMagicLinkIntegrationTests.cs
+++ b/examples/SqlOS.Example.IntegrationTests/SqlOSExampleMagicLinkIntegrationTests.cs
@@ -70,7 +70,8 @@ public sealed class SqlOSExampleMagicLinkIntegrationTests
         var userId = await CreateUserAsync(client, email, "Magic Headless User", "P@ssword123!");
         await CreateMembershipAsync(client, organizationId, userId);
         const string verifier = "headless-magic-link-verifier-123456789-rfc7636-secure-value";
-        var requestId = await StartAuthorizationAsync(client, verifier, expectHostedPage: false);
+        var authorization = await StartAuthorizationAsync(client, verifier, expectHostedPage: false);
+        var requestId = authorization.RequestId;
 
         var start = await client.PostAsJsonAsync("/sqlos/auth/headless/magic-link/start", new { requestId, email });
         start.EnsureSuccessStatusCode();
@@ -97,12 +98,15 @@ public sealed class SqlOSExampleMagicLinkIntegrationTests
         var userId = await CreateUserAsync(client, email, "Magic Hosted User", "P@ssword123!");
         await CreateMembershipAsync(client, organizationId, userId);
         const string verifier = "hosted-magic-link-verifier-123456789-rfc7636-secure-value";
-        var requestId = await StartAuthorizationAsync(client, verifier, expectHostedPage: true);
+        var authorization = await StartAuthorizationAsync(client, verifier, expectHostedPage: true);
+        var requestId = authorization.RequestId;
+        var antiforgeryToken = authorization.AntiforgeryToken!;
 
         var start = await client.PostAsync("/sqlos/auth/login/magic-link/start", new FormUrlEncodedContent(new Dictionary<string, string>
         {
             ["requestId"] = requestId,
-            ["email"] = email
+            ["email"] = email,
+            ["__RequestVerificationToken"] = antiforgeryToken
         }));
         start.EnsureSuccessStatusCode();
         var token = ExtractToken(sender.GetLatestMessage(email).TextBody);
@@ -110,7 +114,8 @@ public sealed class SqlOSExampleMagicLinkIntegrationTests
         var complete = await client.PostAsync("/sqlos/auth/login/magic-link/complete", new FormUrlEncodedContent(new Dictionary<string, string>
         {
             ["requestId"] = requestId,
-            ["token"] = token
+            ["token"] = token,
+            ["__RequestVerificationToken"] = antiforgeryToken
         }));
         complete.StatusCode.Should().Be(HttpStatusCode.Redirect);
 
@@ -150,7 +155,7 @@ public sealed class SqlOSExampleMagicLinkIntegrationTests
             });
         });
 
-    private static async Task<string> StartAuthorizationAsync(HttpClient client, string verifier, bool expectHostedPage)
+    private static async Task<AuthorizationStart> StartAuthorizationAsync(HttpClient client, string verifier, bool expectHostedPage)
     {
         var response = await client.GetAsync(QueryHelpers.AddQueryString("/sqlos/auth/authorize", new Dictionary<string, string?>
         {
@@ -166,12 +171,19 @@ public sealed class SqlOSExampleMagicLinkIntegrationTests
         if (expectHostedPage)
         {
             response.StatusCode.Should().Be(HttpStatusCode.OK);
-            return ExtractHiddenInput(await response.Content.ReadAsStringAsync(), "requestId");
+            var html = await response.Content.ReadAsStringAsync();
+            return new AuthorizationStart(
+                ExtractHiddenInput(html, "requestId"),
+                ExtractHiddenInput(html, "__RequestVerificationToken"));
         }
 
         response.StatusCode.Should().Be(HttpStatusCode.Redirect);
-        return QueryHelpers.ParseQuery(response.Headers.Location!.Query)["request"].ToString();
+        return new AuthorizationStart(
+            QueryHelpers.ParseQuery(response.Headers.Location!.Query)["request"].ToString(),
+            null);
     }
+
+    private sealed record AuthorizationStart(string RequestId, string? AntiforgeryToken);
 
     private static async Task AssertMagicLinkSessionAsync(HttpClient client, JsonDocument tokenJson, string organizationId)
     {

--- a/examples/SqlOS.Todo.IntegrationTests/TodoSampleIntegrationTests.cs
+++ b/examples/SqlOS.Todo.IntegrationTests/TodoSampleIntegrationTests.cs
@@ -107,7 +107,8 @@ public sealed class TodoSampleIntegrationTests
                 ["displayName"] = "ASP.NET Core User",
                 ["email"] = $"aspnet-{Guid.NewGuid():N}@example.com",
                 ["password"] = "P@ssword123!",
-                ["organizationName"] = "ASP.NET Core Org"
+                ["organizationName"] = "ASP.NET Core Org",
+                ["__RequestVerificationToken"] = authorize.AntiforgeryToken!
             }));
 
         signupResponse.StatusCode.Should().Be(HttpStatusCode.Redirect);
@@ -190,7 +191,8 @@ public sealed class TodoSampleIntegrationTests
             ["displayName"] = "Password Bypass User",
             ["email"] = $"password-bypass-{Guid.NewGuid():N}@example.com",
             ["password"] = "P@ssword123!",
-            ["organizationName"] = "Password Bypass Org"
+            ["organizationName"] = "Password Bypass Org",
+            ["__RequestVerificationToken"] = authorize.AntiforgeryToken!
         }));
         passwordSignupResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         passwordSignupResponse.Headers.Location.Should().BeNull("password signup is disabled in the Todo email OTP demo");
@@ -200,7 +202,8 @@ public sealed class TodoSampleIntegrationTests
             ["requestId"] = authorize.RequestId,
             ["displayName"] = "OTP Hosted User",
             ["email"] = email,
-            ["organizationName"] = "OTP Hosted Org"
+            ["organizationName"] = "OTP Hosted Org",
+            ["__RequestVerificationToken"] = authorize.AntiforgeryToken!
         }));
 
         startResponse.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -218,7 +221,8 @@ public sealed class TodoSampleIntegrationTests
             ["email"] = email,
             ["challengeToken"] = challengeToken,
             ["signupToken"] = signupToken,
-            ["code"] = code
+            ["code"] = code,
+            ["__RequestVerificationToken"] = authorize.AntiforgeryToken!
         }));
 
         verifyResponse.StatusCode.Should().Be(HttpStatusCode.Redirect);
@@ -266,7 +270,8 @@ public sealed class TodoSampleIntegrationTests
             ["requestId"] = authorize.RequestId,
             ["displayName"] = "SMS Hosted User",
             ["phoneNumber"] = phoneNumber,
-            ["organizationName"] = "SMS Hosted Org"
+            ["organizationName"] = "SMS Hosted Org",
+            ["__RequestVerificationToken"] = authorize.AntiforgeryToken!
         }));
 
         startResponse.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -284,7 +289,8 @@ public sealed class TodoSampleIntegrationTests
             ["phoneNumber"] = phoneNumber,
             ["challengeToken"] = challengeToken,
             ["signupToken"] = signupToken,
-            ["code"] = TestOtpDeliveryChannel.ApprovedCode
+            ["code"] = TestOtpDeliveryChannel.ApprovedCode,
+            ["__RequestVerificationToken"] = authorize.AntiforgeryToken!
         }));
 
         verifyResponse.StatusCode.Should().Be(HttpStatusCode.Redirect);
@@ -664,14 +670,19 @@ public sealed class TodoSampleIntegrationTests
         {
             var redirectUriResult = authorizeResponse.Headers.Location!;
             var requestId = QueryHelpers.ParseQuery(redirectUriResult.Query)["request"].ToString();
-            return new AuthorizationStartResult(requestId, codeVerifier, redirectUriResult, null);
+            return new AuthorizationStartResult(requestId, codeVerifier, redirectUriResult, null, null);
         }
 
         authorizeResponse.EnsureSuccessStatusCode();
         var html = await authorizeResponse.Content.ReadAsStringAsync();
         var requestIdMatch = Regex.Match(html, "name=\"requestId\" value=\"([^\"]+)\"");
         requestIdMatch.Success.Should().BeTrue();
-        return new AuthorizationStartResult(requestIdMatch.Groups[1].Value, codeVerifier, null, html);
+        return new AuthorizationStartResult(
+            requestIdMatch.Groups[1].Value,
+            codeVerifier,
+            null,
+            html,
+            ExtractHiddenInput(html, "__RequestVerificationToken"));
     }
 
     private static async Task<HostedSignupResult> ExecuteHostedSignupAsync(HttpClient client, string clientId, string redirectUri)
@@ -684,7 +695,8 @@ public sealed class TodoSampleIntegrationTests
             ["displayName"] = "Hosted User",
             ["email"] = $"hosted-{Guid.NewGuid():N}@example.com",
             ["password"] = "P@ssword123!",
-            ["organizationName"] = "Hosted Org"
+            ["organizationName"] = "Hosted Org",
+            ["__RequestVerificationToken"] = authorize.AntiforgeryToken!
         }));
 
         signupResponse.StatusCode.Should().Be(HttpStatusCode.Redirect);
@@ -776,7 +788,12 @@ public sealed class TodoSampleIntegrationTests
         return WebUtility.HtmlDecode(match.Groups[1].Value);
     }
 
-    private sealed record AuthorizationStartResult(string RequestId, string CodeVerifier, Uri? HeadlessRedirect, string? Html);
+    private sealed record AuthorizationStartResult(
+        string RequestId,
+        string CodeVerifier,
+        Uri? HeadlessRedirect,
+        string? Html,
+        string? AntiforgeryToken);
     private sealed record HostedSignupResult(string Code, string CodeVerifier);
     private sealed record TokenResult(string AccessToken, string RefreshToken, string ClientId);
 

--- a/src/SqlOS/AuthServer/Extensions/EndpointRouteBuilderExtensions.cs
+++ b/src/SqlOS/AuthServer/Extensions/EndpointRouteBuilderExtensions.cs
@@ -17,6 +17,7 @@ using SqlOS.AuthServer.Errors;
 using SqlOS.AuthServer.Interfaces;
 using SqlOS.AuthServer.Models;
 using SqlOS.AuthServer.Services;
+using SqlOS.AuthServer.Security;
 using SqlOS.Configuration;
 using SqlOS.Dashboard;
 
@@ -37,6 +38,9 @@ public static class EndpointRouteBuilderExtensions
 
         var auth = endpoints.MapGroup(authPrefix);
         auth.ExcludeFromDescription();
+        var hostedForms = auth.MapGroup(string.Empty);
+        hostedForms.WithMetadata(SqlOSHostedFormAntiforgeryMetadata.Instance);
+        hostedForms.AddEndpointFilter<SqlOSHostedFormAntiforgeryFilter>();
 
         var adminRoot = endpoints.MapGroup(adminPrefix);
         adminRoot.ExcludeFromDescription();
@@ -314,7 +318,7 @@ public static class EndpointRouteBuilderExtensions
             return Html(page);
         });
 
-        auth.MapPost("/password/forgot/submit", async (
+        hostedForms.MapPost("/password/forgot/submit", async (
             HttpContext context,
             SqlOSAuthorizationServerService authorizationServerService,
             SqlOSAuthService authService,
@@ -579,7 +583,7 @@ public static class EndpointRouteBuilderExtensions
                 deviceAuthorization: resolved));
         });
 
-        auth.MapPost("/device/verify", async (
+        hostedForms.MapPost("/device/verify", async (
             HttpContext context,
             CancellationToken cancellationToken) =>
         {
@@ -591,7 +595,7 @@ public static class EndpointRouteBuilderExtensions
                 userCode));
         });
 
-        auth.MapPost("/device/approve", async (
+        hostedForms.MapPost("/device/approve", async (
             HttpContext context,
             SqlOSAuthorizationServerService authorizationServerService,
             SqlOSDeviceAuthorizationService deviceAuthorizationService,
@@ -692,7 +696,7 @@ public static class EndpointRouteBuilderExtensions
             }
         });
 
-        auth.MapPost("/device/deny", async (
+        hostedForms.MapPost("/device/deny", async (
             HttpContext context,
             SqlOSAuthorizationServerService authorizationServerService,
             SqlOSDeviceAuthorizationService deviceAuthorizationService,
@@ -726,7 +730,7 @@ public static class EndpointRouteBuilderExtensions
                 deviceUserCode: userCode));
         });
 
-        auth.MapPost("/login/identify", async (
+        hostedForms.MapPost("/login/identify", async (
             HttpContext context,
             SqlOSAuthorizationServerService authorizationServerService,
             SqlOSHomeRealmDiscoveryService discoveryService,
@@ -791,7 +795,7 @@ public static class EndpointRouteBuilderExtensions
             return Html(page);
         });
 
-        auth.MapPost("/login/password", async (
+        hostedForms.MapPost("/login/password", async (
             HttpContext context,
             SqlOSAuthorizationServerService authorizationServerService,
             SqlOSAuthService authService,
@@ -960,7 +964,7 @@ public static class EndpointRouteBuilderExtensions
             return Html(page);
         });
 
-        auth.MapPost("/login/email-otp/start", async (
+        hostedForms.MapPost("/login/email-otp/start", async (
             HttpContext context,
             SqlOSAuthorizationServerService authorizationServerService,
             SqlOSEmailOtpService emailOtpService,
@@ -1037,7 +1041,7 @@ public static class EndpointRouteBuilderExtensions
             }
         });
 
-        auth.MapPost("/login/email-otp/verify", async (
+        hostedForms.MapPost("/login/email-otp/verify", async (
             HttpContext context,
             SqlOSAuthorizationServerService authorizationServerService,
             SqlOSEmailOtpService emailOtpService,
@@ -1202,7 +1206,7 @@ public static class EndpointRouteBuilderExtensions
             return Html(page);
         });
 
-        auth.MapPost("/login/magic-link/start", async (
+        hostedForms.MapPost("/login/magic-link/start", async (
             HttpContext context,
             SqlOSAuthorizationServerService authorizationServerService,
             SqlOSMagicLinkService magicLinkService,
@@ -1317,7 +1321,7 @@ public static class EndpointRouteBuilderExtensions
             return Html(page);
         });
 
-        auth.MapPost("/login/magic-link/complete", async (
+        hostedForms.MapPost("/login/magic-link/complete", async (
             HttpContext context,
             SqlOSAuthorizationServerService authorizationServerService,
             SqlOSMagicLinkService magicLinkService,
@@ -1454,7 +1458,7 @@ public static class EndpointRouteBuilderExtensions
             return Html(page);
         });
 
-        auth.MapPost("/login/phone-otp/start", async (
+        hostedForms.MapPost("/login/phone-otp/start", async (
             HttpContext context,
             SqlOSAuthorizationServerService authorizationServerService,
             SqlOSPhoneOtpService phoneOtpService,
@@ -1508,7 +1512,7 @@ public static class EndpointRouteBuilderExtensions
             }
         });
 
-        auth.MapPost("/login/phone-otp/verify", async (
+        hostedForms.MapPost("/login/phone-otp/verify", async (
             HttpContext context,
             SqlOSAuthorizationServerService authorizationServerService,
             SqlOSPhoneOtpService phoneOtpService,
@@ -1602,7 +1606,7 @@ public static class EndpointRouteBuilderExtensions
             }
         });
 
-        auth.MapPost("/login/select-organization", async (
+        hostedForms.MapPost("/login/select-organization", async (
             HttpContext context,
             SqlOSAuthorizationServerService authorizationServerService,
             SqlOSAuthService authService,
@@ -1632,7 +1636,7 @@ public static class EndpointRouteBuilderExtensions
             return Results.Redirect(completion.RedirectUrl!);
         });
 
-        auth.MapPost("/mfa/verify", async (
+        hostedForms.MapPost("/mfa/verify", async (
             HttpContext context,
             SqlOSAuthorizationServerService authorizationServerService,
             SqlOSAuthService authService,
@@ -1669,7 +1673,7 @@ public static class EndpointRouteBuilderExtensions
             }
         });
 
-        auth.MapPost("/mfa/totp/enroll/verify", async (
+        hostedForms.MapPost("/mfa/totp/enroll/verify", async (
             HttpContext context,
             SqlOSAuthorizationServerService authorizationServerService,
             SqlOSAuthService authService,
@@ -1863,7 +1867,7 @@ public static class EndpointRouteBuilderExtensions
             return Html(page);
         });
 
-        auth.MapPost("/signup/submit", async (
+        hostedForms.MapPost("/signup/submit", async (
             HttpContext context,
             SqlOSAuthorizationServerService authorizationServerService,
             SqlOSAuthPageSessionService authPageSessionService,
@@ -1973,7 +1977,7 @@ public static class EndpointRouteBuilderExtensions
             }
         });
 
-        auth.MapPost("/signup/invitation/submit", async (
+        hostedForms.MapPost("/signup/invitation/submit", async (
             HttpContext context,
             SqlOSAuthorizationServerService authorizationServerService,
             SqlOSAuthPageSessionService authPageSessionService,
@@ -2086,7 +2090,7 @@ public static class EndpointRouteBuilderExtensions
             }
         });
 
-        auth.MapPost("/signup/email-otp/start", async (
+        hostedForms.MapPost("/signup/email-otp/start", async (
             HttpContext context,
             SqlOSAuthorizationServerService authorizationServerService,
             SqlOSEmailOtpService emailOtpService,
@@ -2169,7 +2173,7 @@ public static class EndpointRouteBuilderExtensions
             }
         });
 
-        auth.MapPost("/signup/email-otp/verify", async (
+        hostedForms.MapPost("/signup/email-otp/verify", async (
             HttpContext context,
             SqlOSAuthorizationServerService authorizationServerService,
             SqlOSAuthPageSessionService authPageSessionService,
@@ -2275,7 +2279,7 @@ public static class EndpointRouteBuilderExtensions
             }
         });
 
-        auth.MapPost("/signup/phone-otp/start", async (
+        hostedForms.MapPost("/signup/phone-otp/start", async (
             HttpContext context,
             SqlOSAuthorizationServerService authorizationServerService,
             SqlOSPhoneOtpService phoneOtpService,
@@ -2347,7 +2351,7 @@ public static class EndpointRouteBuilderExtensions
             }
         });
 
-        auth.MapPost("/signup/phone-otp/verify", async (
+        hostedForms.MapPost("/signup/phone-otp/verify", async (
             HttpContext context,
             SqlOSAuthorizationServerService authorizationServerService,
             SqlOSAuthPageSessionService authPageSessionService,
@@ -3332,11 +3336,12 @@ public static class EndpointRouteBuilderExtensions
             Results.Ok(await authService.RequestPasswordResetEmailAsync(request, httpContext, cancellationToken)));
 
         auth.MapGet("/password/reset", (HttpContext context) =>
-            Results.Content(
-                BuildPasswordResetPage(context.Request.Query["token"].ToString(), error: null, success: false),
-                contentType: "text/html"));
+            HostedHtml(BuildPasswordResetPage(
+                context.Request.Query["token"].ToString(),
+                error: null,
+                success: false)));
 
-        auth.MapPost("/password/reset/submit", async (HttpContext context, SqlOSAuthService authService, CancellationToken cancellationToken) =>
+        hostedForms.MapPost("/password/reset/submit", async (HttpContext context, SqlOSAuthService authService, CancellationToken cancellationToken) =>
         {
             var form = await context.Request.ReadFormAsync(cancellationToken);
             var token = form["token"].ToString();
@@ -3351,14 +3356,13 @@ public static class EndpointRouteBuilderExtensions
                 }
 
                 await authService.ResetPasswordAsync(new SqlOSResetPasswordRequest(token, newPassword), cancellationToken);
-                return Results.Content(BuildPasswordResetPage(token: null, error: null, success: true), contentType: "text/html");
+                return HostedHtml(BuildPasswordResetPage(token: null, error: null, success: true));
             }
             catch (InvalidOperationException ex)
             {
-                return Results.Content(
+                return HostedHtml(
                     BuildPasswordResetPage(token, await PublicAuthMessageAsync(context, ex, SqlOSPublicAuthErrorSurface.HostedPage, cancellationToken), success: false),
-                    contentType: "text/html",
-                    statusCode: StatusCodes.Status400BadRequest);
+                    StatusCodes.Status400BadRequest);
             }
         });
 
@@ -5559,7 +5563,10 @@ public static class EndpointRouteBuilderExtensions
     }
 
     private static IResult Html(SqlOSAuthPageViewModel model, int statusCode = StatusCodes.Status200OK)
-        => Results.Content(SqlOSAuthPageRenderer.RenderPage(model), contentType: "text/html", statusCode: statusCode);
+        => HostedHtml(SqlOSAuthPageRenderer.RenderPage(model), statusCode);
+
+    private static IResult HostedHtml(string html, int statusCode = StatusCodes.Status200OK)
+        => new SqlOSHostedHtmlResult(html, statusCode);
 
     private static string BuildPasswordResetPage(string? token, string? error, bool success)
     {

--- a/src/SqlOS/AuthServer/Security/SqlOSHostedFormAntiforgery.cs
+++ b/src/SqlOS/AuthServer/Security/SqlOSHostedFormAntiforgery.cs
@@ -1,9 +1,15 @@
 using System.Net;
+using System.Diagnostics.CodeAnalysis;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
 using System.Text.RegularExpressions;
-using Microsoft.AspNetCore.Antiforgery;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
 using SqlOS.AuthServer.Configuration;
 
 namespace SqlOS.AuthServer.Security;
@@ -17,36 +23,141 @@ internal sealed class SqlOSHostedFormAntiforgeryMetadata
     }
 }
 
-internal sealed class SqlOSHostedFormAntiforgeryFilter(
-    IAntiforgery antiforgery,
-    IOptions<SqlOSAuthServerOptions> options) : IEndpointFilter
+internal sealed class SqlOSHostedFormAntiforgery
 {
-    public async ValueTask<object?> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
+    internal const string FormFieldName = "__RequestVerificationToken";
+    internal static readonly TimeSpan TokenLifetime = TimeSpan.FromMinutes(15);
+    internal static readonly TimeSpan ClockSkew = TimeSpan.FromMinutes(1);
+
+    private readonly SqlOSAuthServerOptions _options;
+    private readonly IDataProtector _protector;
+    private readonly TimeProvider _timeProvider;
+
+    public SqlOSHostedFormAntiforgery(
+        IDataProtectionProvider dataProtectionProvider,
+        IOptions<SqlOSAuthServerOptions> options)
+        : this(dataProtectionProvider, options, TimeProvider.System)
     {
-        var httpContext = context.HttpContext;
-        if (!HasTrustedBrowserSource(httpContext.Request, options.Value))
+    }
+
+    internal SqlOSHostedFormAntiforgery(
+        IDataProtectionProvider dataProtectionProvider,
+        IOptions<SqlOSAuthServerOptions> options,
+        TimeProvider timeProvider)
+    {
+        _options = options.Value;
+        _timeProvider = timeProvider;
+        CookiePath = _options.BasePath.TrimEnd('/');
+        var cookieSuffix = Convert.ToHexString(
+            SHA256.HashData(Encoding.UTF8.GetBytes(CookiePath)))[..16].ToLowerInvariant();
+        CookieName = $"sqlos_auth_page_csrf_{cookieSuffix}";
+        _protector = dataProtectionProvider.CreateProtector(
+            "SqlOS.AuthServer.HostedFormAntiforgery.v1",
+            CookiePath);
+    }
+
+    internal string CookieName { get; }
+    internal string CookiePath { get; }
+
+    internal string IssueRequestToken(HttpContext context)
+    {
+        var cookieSecret = context.Request.Cookies[CookieName];
+        if (!IsValidCookieSecret(cookieSecret))
         {
-            return InvalidRequest();
+            cookieSecret = WebEncoders.Base64UrlEncode(RandomNumberGenerator.GetBytes(32));
+            context.Response.Cookies.Append(CookieName, cookieSecret, new CookieOptions
+            {
+                HttpOnly = true,
+                IsEssential = true,
+                SameSite = SameSiteMode.Strict,
+                Secure = context.Request.IsHttps,
+                Path = CookiePath,
+                MaxAge = TokenLifetime,
+                Expires = _timeProvider.GetUtcNow().Add(TokenLifetime)
+            });
+        }
+
+        var payload = new RequestTokenPayload(
+            _timeProvider.GetUtcNow().ToUnixTimeSeconds(),
+            HashCookie(cookieSecret),
+            WebEncoders.Base64UrlEncode(RandomNumberGenerator.GetBytes(16)));
+        return _protector.Protect(JsonSerializer.Serialize(payload));
+    }
+
+    internal async Task<bool> ValidateRequestAsync(HttpContext context)
+    {
+        if (!HasTrustedBrowserSource(context.Request, _options)
+            || !context.Request.HasFormContentType)
+        {
+            return false;
+        }
+
+        var cookieSecret = context.Request.Cookies[CookieName];
+        if (!IsValidCookieSecret(cookieSecret))
+        {
+            return false;
+        }
+
+        var form = await context.Request.ReadFormAsync(context.RequestAborted);
+        var requestToken = form[FormFieldName].ToString();
+        return ValidateToken(cookieSecret, requestToken);
+    }
+
+    internal bool ValidateToken(string cookieSecret, string requestToken)
+    {
+        if (!IsValidCookieSecret(cookieSecret) || string.IsNullOrWhiteSpace(requestToken))
+        {
+            return false;
+        }
+
+        RequestTokenPayload? payload;
+        try
+        {
+            payload = JsonSerializer.Deserialize<RequestTokenPayload>(_protector.Unprotect(requestToken));
+        }
+        catch (Exception ex) when (ex is CryptographicException or JsonException or FormatException)
+        {
+            return false;
+        }
+
+        if (payload == null || string.IsNullOrWhiteSpace(payload.CookieHash))
+        {
+            return false;
+        }
+
+        var age = _timeProvider.GetUtcNow() - DateTimeOffset.FromUnixTimeSeconds(payload.IssuedAtUnixSeconds);
+        if (age < -ClockSkew || age > TokenLifetime)
+        {
+            return false;
         }
 
         try
         {
-            await antiforgery.ValidateRequestAsync(httpContext);
+            return CryptographicOperations.FixedTimeEquals(
+                WebEncoders.Base64UrlDecode(payload.CookieHash),
+                WebEncoders.Base64UrlDecode(HashCookie(cookieSecret)));
         }
-        catch (AntiforgeryValidationException)
+        catch (FormatException)
         {
-            return InvalidRequest();
+            return false;
         }
-
-        return await next(context);
     }
 
     private static bool HasTrustedBrowserSource(HttpRequest request, SqlOSAuthServerOptions options)
     {
-        var source = request.Headers.Origin.ToString();
+        var source = ReadSingleHeader(request.Headers.Origin);
+        if (source == null && request.Headers.Origin.Count > 0)
+        {
+            return false;
+        }
+
         if (string.IsNullOrWhiteSpace(source))
         {
-            source = request.Headers.Referer.ToString();
+            source = ReadSingleHeader(request.Headers.Referer);
+            if (source == null && request.Headers.Referer.Count > 0)
+            {
+                return false;
+            }
         }
 
         if (string.IsNullOrWhiteSpace(source))
@@ -73,33 +184,50 @@ internal sealed class SqlOSHostedFormAntiforgeryFilter(
             StringComparison.OrdinalIgnoreCase);
     }
 
-    private static IResult InvalidRequest()
-        => Results.Text(
-            "The hosted form could not be validated. Reload the page and try again.",
-            contentType: "text/plain",
-            statusCode: StatusCodes.Status400BadRequest);
-}
+    private static string? ReadSingleHeader(StringValues values)
+        => values.Count switch
+        {
+            0 => string.Empty,
+            1 => values[0],
+            _ => null
+        };
 
-internal sealed class SqlOSAntiforgeryAdditionalDataProvider : IAntiforgeryAdditionalDataProvider
-{
-    internal static readonly TimeSpan TokenLifetime = TimeSpan.FromMinutes(15);
-
-    public string GetAdditionalData(HttpContext context)
-        => DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString(System.Globalization.CultureInfo.InvariantCulture);
-
-    public bool ValidateAdditionalData(HttpContext context, string additionalData)
+    private static bool IsValidCookieSecret([NotNullWhen(true)] string? value)
     {
-        if (!long.TryParse(
-                additionalData,
-                System.Globalization.NumberStyles.None,
-                System.Globalization.CultureInfo.InvariantCulture,
-                out var issuedAtSeconds))
+        if (string.IsNullOrWhiteSpace(value))
         {
             return false;
         }
 
-        var age = DateTimeOffset.UtcNow - DateTimeOffset.FromUnixTimeSeconds(issuedAtSeconds);
-        return age >= TimeSpan.Zero && age <= TokenLifetime;
+        try
+        {
+            return WebEncoders.Base64UrlDecode(value).Length == 32;
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+    }
+
+    private static string HashCookie(string cookieSecret)
+        => WebEncoders.Base64UrlEncode(SHA256.HashData(Encoding.UTF8.GetBytes(cookieSecret)));
+
+    private sealed record RequestTokenPayload(long IssuedAtUnixSeconds, string CookieHash, string Nonce);
+}
+
+internal sealed class SqlOSHostedFormAntiforgeryFilter(SqlOSHostedFormAntiforgery antiforgery) : IEndpointFilter
+{
+    public async ValueTask<object?> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
+    {
+        if (!await antiforgery.ValidateRequestAsync(context.HttpContext))
+        {
+            return Results.Text(
+                "The hosted form could not be validated. Reload the page and try again.",
+                contentType: "text/plain",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        return await next(context);
     }
 }
 
@@ -115,12 +243,9 @@ internal sealed class SqlOSHostedHtmlResult(string html, int statusCode) : IResu
         var responseHtml = html;
         if (PostFormPattern.IsMatch(responseHtml))
         {
-            var antiforgery = httpContext.RequestServices.GetRequiredService<IAntiforgery>();
-            var token = antiforgery.GetAndStoreTokens(httpContext).RequestToken
-                ?? throw new InvalidOperationException("The hosted form antiforgery token could not be created.");
-            var fieldName = httpContext.RequestServices.GetRequiredService<IOptions<AntiforgeryOptions>>()
-                .Value.FormFieldName;
-            var hiddenField = $"<input type=\"hidden\" name=\"{WebUtility.HtmlEncode(fieldName)}\" value=\"{WebUtility.HtmlEncode(token)}\" />";
+            var antiforgery = httpContext.RequestServices.GetRequiredService<SqlOSHostedFormAntiforgery>();
+            var token = antiforgery.IssueRequestToken(httpContext);
+            var hiddenField = $"<input type=\"hidden\" name=\"{FormField()}\" value=\"{WebUtility.HtmlEncode(token)}\" />";
             responseHtml = PostFormPattern.Replace(responseHtml, match => match.Value + hiddenField);
         }
 
@@ -129,4 +254,7 @@ internal sealed class SqlOSHostedHtmlResult(string html, int statusCode) : IResu
         httpContext.Response.Headers.CacheControl = "no-store";
         await httpContext.Response.WriteAsync(responseHtml, httpContext.RequestAborted);
     }
+
+    private static string FormField()
+        => WebUtility.HtmlEncode(SqlOSHostedFormAntiforgery.FormFieldName);
 }

--- a/src/SqlOS/AuthServer/Security/SqlOSHostedFormAntiforgery.cs
+++ b/src/SqlOS/AuthServer/Security/SqlOSHostedFormAntiforgery.cs
@@ -1,0 +1,132 @@
+using System.Net;
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Antiforgery;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using SqlOS.AuthServer.Configuration;
+
+namespace SqlOS.AuthServer.Security;
+
+internal sealed class SqlOSHostedFormAntiforgeryMetadata
+{
+    public static SqlOSHostedFormAntiforgeryMetadata Instance { get; } = new();
+
+    private SqlOSHostedFormAntiforgeryMetadata()
+    {
+    }
+}
+
+internal sealed class SqlOSHostedFormAntiforgeryFilter(
+    IAntiforgery antiforgery,
+    IOptions<SqlOSAuthServerOptions> options) : IEndpointFilter
+{
+    public async ValueTask<object?> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
+    {
+        var httpContext = context.HttpContext;
+        if (!HasTrustedBrowserSource(httpContext.Request, options.Value))
+        {
+            return InvalidRequest();
+        }
+
+        try
+        {
+            await antiforgery.ValidateRequestAsync(httpContext);
+        }
+        catch (AntiforgeryValidationException)
+        {
+            return InvalidRequest();
+        }
+
+        return await next(context);
+    }
+
+    private static bool HasTrustedBrowserSource(HttpRequest request, SqlOSAuthServerOptions options)
+    {
+        var source = request.Headers.Origin.ToString();
+        if (string.IsNullOrWhiteSpace(source))
+        {
+            source = request.Headers.Referer.ToString();
+        }
+
+        if (string.IsNullOrWhiteSpace(source))
+        {
+            return true;
+        }
+
+        if (!Uri.TryCreate(source.Trim(), UriKind.Absolute, out var sourceUri))
+        {
+            return false;
+        }
+
+        var trustedValue = string.IsNullOrWhiteSpace(options.PublicOrigin)
+            ? options.Issuer
+            : options.PublicOrigin;
+        if (!Uri.TryCreate(trustedValue, UriKind.Absolute, out var trustedUri))
+        {
+            return false;
+        }
+
+        return string.Equals(
+            sourceUri.GetLeftPart(UriPartial.Authority).TrimEnd('/'),
+            trustedUri.GetLeftPart(UriPartial.Authority).TrimEnd('/'),
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static IResult InvalidRequest()
+        => Results.Text(
+            "The hosted form could not be validated. Reload the page and try again.",
+            contentType: "text/plain",
+            statusCode: StatusCodes.Status400BadRequest);
+}
+
+internal sealed class SqlOSAntiforgeryAdditionalDataProvider : IAntiforgeryAdditionalDataProvider
+{
+    internal static readonly TimeSpan TokenLifetime = TimeSpan.FromMinutes(15);
+
+    public string GetAdditionalData(HttpContext context)
+        => DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+    public bool ValidateAdditionalData(HttpContext context, string additionalData)
+    {
+        if (!long.TryParse(
+                additionalData,
+                System.Globalization.NumberStyles.None,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out var issuedAtSeconds))
+        {
+            return false;
+        }
+
+        var age = DateTimeOffset.UtcNow - DateTimeOffset.FromUnixTimeSeconds(issuedAtSeconds);
+        return age >= TimeSpan.Zero && age <= TokenLifetime;
+    }
+}
+
+internal sealed class SqlOSHostedHtmlResult(string html, int statusCode) : IResult
+{
+    private static readonly Regex PostFormPattern = new(
+        "(<form\\b[^>]*\\bmethod\\s*=\\s*[\\\"']post[\\\"'][^>]*>)",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant,
+        TimeSpan.FromSeconds(1));
+
+    public async Task ExecuteAsync(HttpContext httpContext)
+    {
+        var responseHtml = html;
+        if (PostFormPattern.IsMatch(responseHtml))
+        {
+            var antiforgery = httpContext.RequestServices.GetRequiredService<IAntiforgery>();
+            var token = antiforgery.GetAndStoreTokens(httpContext).RequestToken
+                ?? throw new InvalidOperationException("The hosted form antiforgery token could not be created.");
+            var fieldName = httpContext.RequestServices.GetRequiredService<IOptions<AntiforgeryOptions>>()
+                .Value.FormFieldName;
+            var hiddenField = $"<input type=\"hidden\" name=\"{WebUtility.HtmlEncode(fieldName)}\" value=\"{WebUtility.HtmlEncode(token)}\" />";
+            responseHtml = PostFormPattern.Replace(responseHtml, match => match.Value + hiddenField);
+        }
+
+        httpContext.Response.StatusCode = statusCode;
+        httpContext.Response.ContentType = "text/html; charset=utf-8";
+        httpContext.Response.Headers.CacheControl = "no-store";
+        await httpContext.Response.WriteAsync(responseHtml, httpContext.RequestAborted);
+    }
+}

--- a/src/SqlOS/Extensions/ServiceCollectionExtensions.cs
+++ b/src/SqlOS/Extensions/ServiceCollectionExtensions.cs
@@ -1,6 +1,5 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.DataProtection;
-using Microsoft.AspNetCore.Antiforgery;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -45,21 +44,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton(Options.Create(options.Email));
         services.AddSingleton(Options.Create(options.Calendar));
         services.AddDataProtection();
-        services.AddAntiforgery(antiforgery =>
-        {
-            var cookieScope = options.AuthServer.BasePath.TrimEnd('/');
-            var cookieSuffix = Convert.ToHexString(
-                System.Security.Cryptography.SHA256.HashData(
-                    System.Text.Encoding.UTF8.GetBytes(cookieScope)))[..16].ToLowerInvariant();
-            antiforgery.Cookie.Name = $"sqlos_auth_page_csrf_{cookieSuffix}";
-            antiforgery.Cookie.Path = cookieScope;
-            antiforgery.Cookie.HttpOnly = true;
-            antiforgery.Cookie.IsEssential = true;
-            antiforgery.Cookie.SameSite = Microsoft.AspNetCore.Http.SameSiteMode.Strict;
-            antiforgery.Cookie.SecurePolicy = Microsoft.AspNetCore.Http.CookieSecurePolicy.SameAsRequest;
-            antiforgery.Cookie.MaxAge = SqlOSAntiforgeryAdditionalDataProvider.TokenLifetime;
-        });
-        services.AddSingleton<IAntiforgeryAdditionalDataProvider, SqlOSAntiforgeryAdditionalDataProvider>();
+        services.AddSingleton<SqlOSHostedFormAntiforgery>();
         services.AddHttpClient();
         services.AddHttpClient(nameof(SqlOSOidcAuthService), client =>
         {

--- a/src/SqlOS/Extensions/ServiceCollectionExtensions.cs
+++ b/src/SqlOS/Extensions/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Antiforgery;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -8,6 +9,7 @@ using SqlOS.Configuration;
 using SqlOS.AuthServer.Configuration;
 using SqlOS.AuthServer.Interfaces;
 using SqlOS.AuthServer.Services;
+using SqlOS.AuthServer.Security;
 using SqlOS.Calendar.Interfaces;
 using SqlOS.Calendar.Services;
 using SqlOS.Dashboard;
@@ -43,6 +45,21 @@ public static class ServiceCollectionExtensions
         services.AddSingleton(Options.Create(options.Email));
         services.AddSingleton(Options.Create(options.Calendar));
         services.AddDataProtection();
+        services.AddAntiforgery(antiforgery =>
+        {
+            var cookieScope = options.AuthServer.BasePath.TrimEnd('/');
+            var cookieSuffix = Convert.ToHexString(
+                System.Security.Cryptography.SHA256.HashData(
+                    System.Text.Encoding.UTF8.GetBytes(cookieScope)))[..16].ToLowerInvariant();
+            antiforgery.Cookie.Name = $"sqlos_auth_page_csrf_{cookieSuffix}";
+            antiforgery.Cookie.Path = cookieScope;
+            antiforgery.Cookie.HttpOnly = true;
+            antiforgery.Cookie.IsEssential = true;
+            antiforgery.Cookie.SameSite = Microsoft.AspNetCore.Http.SameSiteMode.Strict;
+            antiforgery.Cookie.SecurePolicy = Microsoft.AspNetCore.Http.CookieSecurePolicy.SameAsRequest;
+            antiforgery.Cookie.MaxAge = SqlOSAntiforgeryAdditionalDataProvider.TokenLifetime;
+        });
+        services.AddSingleton<IAntiforgeryAdditionalDataProvider, SqlOSAntiforgeryAdditionalDataProvider>();
         services.AddHttpClient();
         services.AddHttpClient(nameof(SqlOSOidcAuthService), client =>
         {

--- a/tests/SqlOS.IntegrationTests/AuthPageCsrfIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/AuthPageCsrfIntegrationTests.cs
@@ -1,0 +1,182 @@
+using System.Net;
+using System.Text.RegularExpressions;
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SqlOS.AuthServer.Contracts;
+using SqlOS.AuthServer.Extensions;
+using SqlOS.AuthServer.Services;
+using SqlOS.Extensions;
+using SqlOS.IntegrationTests.Infrastructure;
+using SqlOS.Services;
+
+namespace SqlOS.IntegrationTests;
+
+[TestClass]
+public sealed class AuthPageCsrfIntegrationTests
+{
+    private const string TrustedOrigin = "https://auth.example.test";
+    private const string AttackerOrigin = "https://attacker.example.test";
+    private const string Password = "P@ssword123!";
+
+    [TestMethod]
+    public async Task HostedPasswordLogin_CrossSitePostWithoutAntiforgery_IsRejectedAndDoesNotSetCookie()
+    {
+        await using var server = await AuthPageCsrfServer.CreateAsync();
+        using var client = server.App.GetTestClient();
+        client.BaseAddress = new Uri(TrustedOrigin);
+
+        using var attack = new HttpRequestMessage(HttpMethod.Post, "/sqlos/auth/login/password")
+        {
+            Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["email"] = server.Email,
+                ["password"] = Password
+            })
+        };
+        attack.Headers.TryAddWithoutValidation("Origin", AttackerOrigin);
+        var rejected = await client.SendAsync(attack);
+
+        rejected.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        rejected.Headers.TryGetValues("Set-Cookie", out var rejectedCookies).Should().BeFalse();
+        (await server.CountAuthPageSessionsAsync()).Should().Be(0);
+
+        var authorize = await client.GetAsync(
+            "/sqlos/auth/authorize?response_type=code&client_id=browser-client"
+            + "&redirect_uri=https%3A%2F%2Fclient.example.test%2Fcallback"
+            + "&scope=openid%20profile%20email&state=victim-state"
+            + "&code_challenge=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA&code_challenge_method=S256");
+        authorize.StatusCode.Should().Be(HttpStatusCode.OK);
+        authorize.Headers.Location.Should().BeNull("the attacker login must not create a reusable AuthPage session");
+        (await authorize.Content.ReadAsStringAsync()).Should().Contain("/sqlos/auth/login/identify");
+    }
+
+    [TestMethod]
+    public async Task HostedStandaloneLogin_ValidAntiforgery_SetsFreshSession()
+    {
+        await using var server = await AuthPageCsrfServer.CreateAsync();
+        using var client = server.App.GetTestClient();
+        client.BaseAddress = new Uri(TrustedOrigin);
+
+        var loginPage = await client.GetAsync("/sqlos/auth/login");
+        loginPage.EnsureSuccessStatusCode();
+        var html = await loginPage.Content.ReadAsStringAsync();
+        var requestToken = ExtractInputValue(html, "__RequestVerificationToken");
+        var antiforgeryCookie = ExtractCookie(loginPage, "sqlos_auth_page_csrf_");
+
+        using var login = new HttpRequestMessage(HttpMethod.Post, "/sqlos/auth/login/password")
+        {
+            Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["email"] = server.Email,
+                ["password"] = Password,
+                ["__RequestVerificationToken"] = requestToken
+            })
+        };
+        login.Headers.TryAddWithoutValidation("Cookie", antiforgeryCookie);
+        login.Headers.TryAddWithoutValidation("Origin", TrustedOrigin);
+        var response = await client.SendAsync(login);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Redirect);
+        response.Headers.Location.Should().Be(new Uri("/sqlos/auth/login?status=signed-in", UriKind.Relative));
+        var authPageCookie = ExtractCookie(response, "sqlos_auth_page=");
+        authPageCookie.Should().NotContain(antiforgeryCookie.Split('=', 2)[1]);
+
+        await using var scope = server.App.Services.CreateAsyncScope();
+        var sessionService = scope.ServiceProvider.GetRequiredService<SqlOSAuthPageSessionService>();
+        var sessionContext = new DefaultHttpContext();
+        sessionContext.Request.Headers.Cookie = authPageCookie;
+        var session = await sessionService.TryGetSessionAsync(sessionContext);
+        session.Should().NotBeNull();
+        session!.User.Id.Should().Be(server.UserId);
+        session.AuthenticationMethod.Should().Be("password");
+    }
+
+    private static string ExtractInputValue(string html, string name)
+    {
+        var match = Regex.Match(
+            html,
+            $@"name=""{Regex.Escape(name)}"" value=""([^""]+)""",
+            RegexOptions.CultureInvariant);
+        match.Success.Should().BeTrue($"the hosted page should contain {name}");
+        return WebUtility.HtmlDecode(match.Groups[1].Value);
+    }
+
+    private static string ExtractCookie(HttpResponseMessage response, string prefix)
+    {
+        response.Headers.TryGetValues("Set-Cookie", out var values).Should().BeTrue();
+        var cookie = values!.Select(value => value.Split(';', 2)[0])
+            .Single(value => value.StartsWith(prefix, StringComparison.Ordinal));
+        return cookie;
+    }
+
+    private sealed class AuthPageCsrfServer : IAsyncDisposable
+    {
+        public required WebApplication App { get; init; }
+        public required string Email { get; init; }
+        public required string UserId { get; init; }
+
+        public static async Task<AuthPageCsrfServer> CreateAsync()
+        {
+            await using var bootstrapContext = await AspireFixture.CreateIsolatedAuthContextAsync("AuthPageCsrf");
+            var connectionString = bootstrapContext.Database.GetConnectionString()!;
+            var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+            {
+                EnvironmentName = Environments.Development
+            });
+            builder.WebHost.UseTestServer();
+            builder.Services.AddDbContext<TestSqlOSDbContext>(database => database.UseSqlServer(connectionString));
+            builder.Services.AddSqlOS<TestSqlOSDbContext>(options =>
+            {
+                options.AuthServer.Issuer = $"{TrustedOrigin}/sqlos/auth";
+                options.AuthServer.BasePath = "/sqlos/auth";
+                options.AuthServer.SeedBrowserClient(
+                    "browser-client",
+                    "Browser Client",
+                    "https://client.example.test/callback");
+            });
+            builder.Services.RemoveAll<IHostedService>();
+
+            var app = builder.Build();
+            app.MapAuthServer("/sqlos/auth");
+            await using var scope = app.Services.CreateAsyncScope();
+            await scope.ServiceProvider.GetRequiredService<SqlOSBootstrapper>().InitializeAsync();
+            var email = $"csrf-{Guid.NewGuid():N}@example.test";
+            var user = await scope.ServiceProvider.GetRequiredService<SqlOSAdminService>()
+                .CreateUserAsync(new SqlOSCreateUserRequest("CSRF Test User", email, Password));
+            await app.StartAsync();
+
+            return new AuthPageCsrfServer
+            {
+                App = app,
+                Email = email,
+                UserId = user.Id
+            };
+        }
+
+        public async Task<int> CountAuthPageSessionsAsync()
+        {
+            await using var scope = App.Services.CreateAsyncScope();
+            return await scope.ServiceProvider.GetRequiredService<TestSqlOSDbContext>()
+                .Set<SqlOS.AuthServer.Models.SqlOSTemporaryToken>()
+                .CountAsync(token => token.Purpose == "auth_page_session" && token.ConsumedAt == null);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await using (var scope = App.Services.CreateAsyncScope())
+            {
+                await scope.ServiceProvider.GetRequiredService<TestSqlOSDbContext>().Database.EnsureDeletedAsync();
+            }
+            await App.StopAsync();
+            await App.DisposeAsync();
+        }
+    }
+}

--- a/tests/SqlOS.IntegrationTests/MfaEnrollmentSecurityIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/MfaEnrollmentSecurityIntegrationTests.cs
@@ -236,6 +236,7 @@ public sealed class MfaEnrollmentSecurityIntegrationTests
         MfaEndpointServer server,
         HttpClient client)
     {
+        var antiforgery = await GetHostedAntiforgeryAsync(client);
         string email;
         string requestA;
         string requestB;
@@ -252,14 +253,16 @@ public sealed class MfaEnrollmentSecurityIntegrationTests
             requestB = (await CreateAuthorizationRequestAsync(authorization, "hosted-b", email, null)).Id;
         }
 
-        var loginResponse = await client.PostAsync(
+        var loginResponse = await PostHostedFormAsync(
+            client,
             "/sqlos/auth/login/password",
-            new FormUrlEncodedContent(new Dictionary<string, string>
+            new Dictionary<string, string>
             {
                 ["requestId"] = requestA,
                 ["email"] = email,
                 ["password"] = "P@ssword123!"
-            }));
+            },
+            antiforgery);
         loginResponse.StatusCode.Should().Be(HttpStatusCode.OK);
         var html = await loginResponse.Content.ReadAsStringAsync();
         var mfaToken = ExtractHtmlValue(html, "mfaToken");
@@ -268,27 +271,31 @@ public sealed class MfaEnrollmentSecurityIntegrationTests
         secret.Should().NotBeNullOrWhiteSpace();
         var code = await GenerateCodeAsync(server, WebUtility.HtmlDecode(secret));
 
-        var rejected = await client.PostAsync(
+        var rejected = await PostHostedFormAsync(
+            client,
             "/sqlos/auth/mfa/totp/enroll/verify",
-            new FormUrlEncodedContent(new Dictionary<string, string>
+            new Dictionary<string, string>
             {
                 ["requestId"] = requestB,
                 ["mfaToken"] = mfaToken,
                 ["enrollmentToken"] = enrollmentToken,
                 ["code"] = code
-            }));
+            },
+            antiforgery);
         rejected.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         await AssertNoAuthorizationArtifactsAsync(server, requestA, requestB);
 
-        var accepted = await client.PostAsync(
+        var accepted = await PostHostedFormAsync(
+            client,
             "/sqlos/auth/mfa/totp/enroll/verify",
-            new FormUrlEncodedContent(new Dictionary<string, string>
+            new Dictionary<string, string>
             {
                 ["requestId"] = requestA,
                 ["mfaToken"] = mfaToken,
                 ["enrollmentToken"] = enrollmentToken,
                 ["code"] = code
-            }));
+            },
+            antiforgery);
         accepted.StatusCode.Should().Be(HttpStatusCode.Redirect);
         await AssertAuthorizationCodeOnlyForAsync(server, requestA, requestB);
     }
@@ -327,6 +334,32 @@ public sealed class MfaEnrollmentSecurityIntegrationTests
             RegexOptions.CultureInvariant);
         match.Success.Should().BeTrue($"hosted MFA HTML should include {inputName}");
         return WebUtility.HtmlDecode(match.Groups[1].Value);
+    }
+
+    private static async Task<(string Token, string Cookie)> GetHostedAntiforgeryAsync(HttpClient client)
+    {
+        var response = await client.GetAsync("/sqlos/auth/password/reset?token=test-only-antiforgery-bootstrap");
+        response.EnsureSuccessStatusCode();
+        var token = ExtractHtmlValue(await response.Content.ReadAsStringAsync(), "__RequestVerificationToken");
+        var cookie = response.Headers.GetValues("Set-Cookie")
+            .Select(value => value.Split(';', 2)[0])
+            .Single(value => value.StartsWith("sqlos_auth_page_csrf_", StringComparison.Ordinal));
+        return (token, cookie);
+    }
+
+    private static async Task<HttpResponseMessage> PostHostedFormAsync(
+        HttpClient client,
+        string path,
+        Dictionary<string, string> fields,
+        (string Token, string Cookie) antiforgery)
+    {
+        fields["__RequestVerificationToken"] = antiforgery.Token;
+        using var request = new HttpRequestMessage(HttpMethod.Post, path)
+        {
+            Content = new FormUrlEncodedContent(fields)
+        };
+        request.Headers.TryAddWithoutValidation("Cookie", antiforgery.Cookie);
+        return await client.SendAsync(request);
     }
 
     private static async Task AssertNoAuthorizationArtifactsAsync(

--- a/tests/SqlOS.Tests/SqlOSHostedFormAntiforgeryTests.cs
+++ b/tests/SqlOS.Tests/SqlOSHostedFormAntiforgeryTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Microsoft.AspNetCore.Antiforgery;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Metadata;
@@ -83,30 +84,62 @@ public sealed class SqlOSHostedFormAntiforgeryTests
     [TestMethod]
     public void AntiforgeryCookies_AreIsolatedByMountedAuthPath()
     {
-        var first = BuildAntiforgeryOptions("/identity-one");
-        var second = BuildAntiforgeryOptions("/identity-two");
+        var first = CreateAntiforgery("/identity-one/auth");
+        var second = CreateAntiforgery("/identity-two/auth");
 
-        first.Cookie.Path.Should().Be("/identity-one/auth");
-        second.Cookie.Path.Should().Be("/identity-two/auth");
-        first.Cookie.Name.Should().NotBe(second.Cookie.Name);
-        first.Cookie.HttpOnly.Should().BeTrue();
-        first.Cookie.SameSite.Should().Be(Microsoft.AspNetCore.Http.SameSiteMode.Strict);
-        first.Cookie.MaxAge.Should().Be(SqlOSAntiforgeryAdditionalDataProvider.TokenLifetime);
+        first.CookiePath.Should().Be("/identity-one/auth");
+        second.CookiePath.Should().Be("/identity-two/auth");
+        first.CookieName.Should().NotBe(second.CookieName);
     }
 
     [TestMethod]
-    public void AntiforgeryAdditionalData_ExpiresAfterDocumentedLifetime()
+    public void AntiforgeryToken_HasShortExpiryAndBoundedClockSkew()
     {
-        var provider = new SqlOSAntiforgeryAdditionalDataProvider();
-        var context = new DefaultHttpContext();
-        var now = DateTimeOffset.UtcNow;
+        var now = new DateTimeOffset(2026, 7, 13, 12, 0, 0, TimeSpan.Zero);
+        var time = new MutableTimeProvider(now);
+        var antiforgery = CreateAntiforgery("/sqlos/auth", time);
 
-        provider.ValidateAdditionalData(
-            context,
-            now.Subtract(TimeSpan.FromMinutes(14)).ToUnixTimeSeconds().ToString()).Should().BeTrue();
-        provider.ValidateAdditionalData(
-            context,
-            now.Subtract(TimeSpan.FromMinutes(16)).ToUnixTimeSeconds().ToString()).Should().BeFalse();
+        var valid = IssueToken(antiforgery);
+        time.UtcNow = now.AddMinutes(14);
+        antiforgery.ValidateToken(valid.CookieSecret, valid.RequestToken).Should().BeTrue();
+        time.UtcNow = now.AddMinutes(16);
+        antiforgery.ValidateToken(valid.CookieSecret, valid.RequestToken).Should().BeFalse();
+
+        time.UtcNow = now.AddSeconds(30);
+        var withinSkew = IssueToken(antiforgery);
+        time.UtcNow = now;
+        antiforgery.ValidateToken(withinSkew.CookieSecret, withinSkew.RequestToken).Should().BeTrue();
+
+        time.UtcNow = now.AddMinutes(2);
+        var beyondSkew = IssueToken(antiforgery);
+        time.UtcNow = now;
+        antiforgery.ValidateToken(beyondSkew.CookieSecret, beyondSkew.RequestToken).Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void AddSqlOS_DoesNotChangeHostAntiforgeryConfigurationOrProvider()
+    {
+        var services = new ServiceCollection();
+        var hostAdditionalData = new HostAntiforgeryAdditionalDataProvider();
+        services.AddAntiforgery(options =>
+        {
+            options.Cookie.Name = "host_app_csrf";
+            options.Cookie.Path = "/";
+            options.FormFieldName = "host_app_token";
+        });
+        services.AddSingleton<IAntiforgeryAdditionalDataProvider>(hostAdditionalData);
+        services.AddDbContext<TestSqlOSInMemoryDbContext>(database =>
+            database.UseInMemoryDatabase($"csrf-host-{Guid.NewGuid():N}"));
+        services.AddSqlOS<TestSqlOSInMemoryDbContext>();
+
+        using var provider = services.BuildServiceProvider();
+        var hostOptions = provider.GetRequiredService<IOptions<AntiforgeryOptions>>().Value;
+        hostOptions.Cookie.Name.Should().Be("host_app_csrf");
+        hostOptions.Cookie.Path.Should().Be("/");
+        hostOptions.FormFieldName.Should().Be("host_app_token");
+        provider.GetRequiredService<IAntiforgeryAdditionalDataProvider>().Should().BeSameAs(hostAdditionalData);
+        provider.GetRequiredService<IAntiforgery>().Should().NotBeNull();
+        provider.GetRequiredService<SqlOSHostedFormAntiforgery>().Should().NotBeNull();
     }
 
     private static async Task<WebApplication> CreateAppAsync()
@@ -131,17 +164,41 @@ public sealed class SqlOSHostedFormAntiforgeryTests
         return app;
     }
 
-    private static AntiforgeryOptions BuildAntiforgeryOptions(string dashboardBasePath)
+    private static SqlOSHostedFormAntiforgery CreateAntiforgery(
+        string authBasePath,
+        TimeProvider? timeProvider = null)
     {
-        var services = new ServiceCollection();
-        services.AddDbContext<TestSqlOSInMemoryDbContext>(database =>
-            database.UseInMemoryDatabase($"csrf-options-{Guid.NewGuid():N}"));
-        services.AddSqlOS<TestSqlOSInMemoryDbContext>(options =>
+        var options = Options.Create(new SqlOS.AuthServer.Configuration.SqlOSAuthServerOptions
         {
-            options.DashboardBasePath = dashboardBasePath;
-            options.AuthServer.Issuer = $"https://localhost{dashboardBasePath}/auth";
+            BasePath = authBasePath,
+            Issuer = $"https://auth.example.test{authBasePath}"
         });
-        using var provider = services.BuildServiceProvider();
-        return provider.GetRequiredService<IOptions<AntiforgeryOptions>>().Value;
+        return new SqlOSHostedFormAntiforgery(
+            new EphemeralDataProtectionProvider(),
+            options,
+            timeProvider ?? TimeProvider.System);
+    }
+
+    private static (string CookieSecret, string RequestToken) IssueToken(SqlOSHostedFormAntiforgery antiforgery)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Scheme = "https";
+        var requestToken = antiforgery.IssueRequestToken(context);
+        var cookie = context.Response.Headers.SetCookie.ToString().Split(';', 2)[0];
+        return (cookie.Split('=', 2)[1], requestToken);
+    }
+
+    private sealed class MutableTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public DateTimeOffset UtcNow { get; set; } = utcNow;
+
+        public override DateTimeOffset GetUtcNow() => UtcNow;
+    }
+
+    private sealed class HostAntiforgeryAdditionalDataProvider : IAntiforgeryAdditionalDataProvider
+    {
+        public string GetAdditionalData(HttpContext context) => "host-app";
+        public bool ValidateAdditionalData(HttpContext context, string additionalData)
+            => additionalData == "host-app";
     }
 }

--- a/tests/SqlOS.Tests/SqlOSHostedFormAntiforgeryTests.cs
+++ b/tests/SqlOS.Tests/SqlOSHostedFormAntiforgeryTests.cs
@@ -1,0 +1,147 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Antiforgery;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SqlOS.AuthServer.Extensions;
+using SqlOS.AuthServer.Security;
+using SqlOS.Extensions;
+using SqlOS.Tests.Infrastructure;
+
+namespace SqlOS.Tests;
+
+[TestClass]
+public sealed class SqlOSHostedFormAntiforgeryTests
+{
+    private static readonly string[] HostedPostRoutes =
+    [
+        "/sqlos/auth/device/approve",
+        "/sqlos/auth/device/deny",
+        "/sqlos/auth/device/verify",
+        "/sqlos/auth/login/email-otp/start",
+        "/sqlos/auth/login/email-otp/verify",
+        "/sqlos/auth/login/identify",
+        "/sqlos/auth/login/magic-link/complete",
+        "/sqlos/auth/login/magic-link/start",
+        "/sqlos/auth/login/password",
+        "/sqlos/auth/login/phone-otp/start",
+        "/sqlos/auth/login/phone-otp/verify",
+        "/sqlos/auth/login/select-organization",
+        "/sqlos/auth/mfa/totp/enroll/verify",
+        "/sqlos/auth/mfa/verify",
+        "/sqlos/auth/password/forgot/submit",
+        "/sqlos/auth/password/reset/submit",
+        "/sqlos/auth/signup/email-otp/start",
+        "/sqlos/auth/signup/email-otp/verify",
+        "/sqlos/auth/signup/invitation/submit",
+        "/sqlos/auth/signup/phone-otp/start",
+        "/sqlos/auth/signup/phone-otp/verify",
+        "/sqlos/auth/signup/submit"
+    ];
+
+    [TestMethod]
+    public async Task HostedStateChangingFormRouteInventory_RequiresAntiforgeryMetadata()
+    {
+        await using var app = await CreateAppAsync();
+
+        var protectedRoutes = app.Services.GetRequiredService<EndpointDataSource>().Endpoints
+            .OfType<RouteEndpoint>()
+            .Where(endpoint => endpoint.Metadata.GetMetadata<IHttpMethodMetadata>()?.HttpMethods.Contains("POST") == true)
+            .Where(endpoint => endpoint.Metadata.GetMetadata<SqlOSHostedFormAntiforgeryMetadata>() != null)
+            .Select(endpoint => endpoint.RoutePattern.RawText)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        protectedRoutes.Should().Equal(HostedPostRoutes.Order(StringComparer.Ordinal));
+    }
+
+    [TestMethod]
+    public async Task HeadlessAndPublicJsonEndpoints_DoNotRequireHostedFormTokens()
+    {
+        await using var app = await CreateAppAsync();
+
+        var endpoints = app.Services.GetRequiredService<EndpointDataSource>().Endpoints
+            .OfType<RouteEndpoint>()
+            .Where(endpoint => endpoint.Metadata.GetMetadata<IHttpMethodMetadata>()?.HttpMethods.Contains("POST") == true)
+            .ToDictionary(endpoint => endpoint.RoutePattern.RawText!, StringComparer.Ordinal);
+
+        endpoints["/sqlos/auth/headless/password/login"].Metadata
+            .GetMetadata<SqlOSHostedFormAntiforgeryMetadata>().Should().BeNull();
+        endpoints["/sqlos/auth/password/login"].Metadata
+            .GetMetadata<SqlOSHostedFormAntiforgeryMetadata>().Should().BeNull();
+    }
+
+    [TestMethod]
+    public void AntiforgeryCookies_AreIsolatedByMountedAuthPath()
+    {
+        var first = BuildAntiforgeryOptions("/identity-one");
+        var second = BuildAntiforgeryOptions("/identity-two");
+
+        first.Cookie.Path.Should().Be("/identity-one/auth");
+        second.Cookie.Path.Should().Be("/identity-two/auth");
+        first.Cookie.Name.Should().NotBe(second.Cookie.Name);
+        first.Cookie.HttpOnly.Should().BeTrue();
+        first.Cookie.SameSite.Should().Be(Microsoft.AspNetCore.Http.SameSiteMode.Strict);
+        first.Cookie.MaxAge.Should().Be(SqlOSAntiforgeryAdditionalDataProvider.TokenLifetime);
+    }
+
+    [TestMethod]
+    public void AntiforgeryAdditionalData_ExpiresAfterDocumentedLifetime()
+    {
+        var provider = new SqlOSAntiforgeryAdditionalDataProvider();
+        var context = new DefaultHttpContext();
+        var now = DateTimeOffset.UtcNow;
+
+        provider.ValidateAdditionalData(
+            context,
+            now.Subtract(TimeSpan.FromMinutes(14)).ToUnixTimeSeconds().ToString()).Should().BeTrue();
+        provider.ValidateAdditionalData(
+            context,
+            now.Subtract(TimeSpan.FromMinutes(16)).ToUnixTimeSeconds().ToString()).Should().BeFalse();
+    }
+
+    private static async Task<WebApplication> CreateAppAsync()
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            EnvironmentName = Environments.Development
+        });
+        builder.WebHost.UseTestServer();
+        builder.Services.AddDbContext<TestSqlOSInMemoryDbContext>(database =>
+            database.UseInMemoryDatabase($"csrf-routes-{Guid.NewGuid():N}"));
+        builder.Services.AddSqlOS<TestSqlOSInMemoryDbContext>(options =>
+        {
+            options.AuthServer.Issuer = "https://auth.example.test/sqlos/auth";
+            options.AuthServer.Headless.EnableApi = true;
+        });
+        builder.Services.RemoveAll<IHostedService>();
+
+        var app = builder.Build();
+        app.MapAuthServer("/sqlos/auth");
+        await app.StartAsync();
+        return app;
+    }
+
+    private static AntiforgeryOptions BuildAntiforgeryOptions(string dashboardBasePath)
+    {
+        var services = new ServiceCollection();
+        services.AddDbContext<TestSqlOSInMemoryDbContext>(database =>
+            database.UseInMemoryDatabase($"csrf-options-{Guid.NewGuid():N}"));
+        services.AddSqlOS<TestSqlOSInMemoryDbContext>(options =>
+        {
+            options.DashboardBasePath = dashboardBasePath;
+            options.AuthServer.Issuer = $"https://localhost{dashboardBasePath}/auth";
+        });
+        using var provider = services.BuildServiceProvider();
+        return provider.GetRequiredService<IOptions<AntiforgeryOptions>>().Value;
+    }
+}

--- a/web/content/docs/authserver/headless-auth.mdx
+++ b/web/content/docs/authserver/headless-auth.mdx
@@ -148,6 +148,8 @@ options.AuthServer.UseHeadlessAuthPage(headless =>
 
 The example repository has complete Next.js and Angular clients. Use [Build your own login and signup UI](/docs/guides/custom-login-ui) for the source-aligned implementation flow, including state and S256 PKCE, credentialed CORS, server-owned view transitions, callback validation, and code exchange.
 
+The headless routes are JSON integration endpoints, not SqlOS-hosted HTML forms, so they do not expect the hosted `__RequestVerificationToken` field. Native clients do not have browser cookie-CSRF exposure. For browser frontends, use an exact credentialed CORS allowlist or a same-origin/backend-for-frontend boundary; never combine credentialed requests with a reflected or wildcard origin. If your own UI host accepts cookie-authenticated form actions, protect those actions with that host's antiforgery mechanism. OAuth `state`, PKCE, and SqlOS request binding remain required but solve different substitution problems.
+
 The core files are:
 
 ```text

--- a/web/content/docs/authserver/hosted-vs-headless.mdx
+++ b/web/content/docs/authserver/hosted-vs-headless.mdx
@@ -29,6 +29,12 @@ The default. SqlOS renders the sign-in, sign-up, invite acceptance, OTP, CLI dev
 
 ![Hosted sign-in page](/docs/auth-signin-page.png)
 
+### Hosted form CSRF protection
+
+Hosted AuthPage forms are protected automatically. Every state-changing form gets a cryptographic ASP.NET Core antiforgery token bound to an `HttpOnly`, auth-path-scoped browser cookie. Tokens expire after 15 minutes, the cookie uses `SameSite=Strict`, and SqlOS also rejects a supplied `Origin` or `Referer` that does not match the configured public origin or issuer. There is no middleware or option for the consuming application to add.
+
+`SameSite` is defense in depth, not the proof by itself: a cross-site form can establish a new login cookie even when no old cookie is sent. The form token is what prevents an attacker from signing a victim's browser into the attacker's account. OAuth `state` and PKCE protect different protocol boundaries and do not replace this hosted-login protection.
+
 ## Headless Auth
 
 SqlOS owns the OAuth protocol. Your app owns the UI.
@@ -61,6 +67,8 @@ builder.AddSqlOS<AppDbContext>(options =>
 ```
 
 Headless uses one switch: `BuildUiUrl`. If that callback exists, `/sqlos/auth/authorize` redirects into your app. [Build the custom UI](/docs/guides/custom-login-ui) or review the [mode details](/docs/authserver/headless-auth#how-sqlos-picks-the-ui).
+
+Headless JSON endpoints deliberately do not require the hosted HTML form token. A native client is not subject to browser cookie CSRF. For a browser-owned headless UI, keep credentialed CORS limited to the exact UI origins, prefer same-origin or backend-for-frontend requests, and apply the UI host's normal CSRF control if it accepts cookie-authenticated actions. Do not copy the hidden hosted-form token into SDK or native-client integrations.
 
 ## Don't rebuild the auth flow
 

--- a/web/content/docs/authserver/hosted-vs-headless.mdx
+++ b/web/content/docs/authserver/hosted-vs-headless.mdx
@@ -31,7 +31,7 @@ The default. SqlOS renders the sign-in, sign-up, invite acceptance, OTP, CLI dev
 
 ### Hosted form CSRF protection
 
-Hosted AuthPage forms are protected automatically. Every state-changing form gets a cryptographic ASP.NET Core antiforgery token bound to an `HttpOnly`, auth-path-scoped browser cookie. Tokens expire after 15 minutes, the cookie uses `SameSite=Strict`, and SqlOS also rejects a supplied `Origin` or `Referer` that does not match the configured public origin or issuer. There is no middleware or option for the consuming application to add.
+Hosted AuthPage forms are protected automatically. Every state-changing form gets a cryptographic ASP.NET Core Data Protection token bound to an `HttpOnly`, auth-path-scoped browser cookie. Tokens expire after 15 minutes, the cookie uses `SameSite=Strict`, and SqlOS also rejects a supplied `Origin` or `Referer` that does not match the configured public origin or issuer. The token service is isolated from the host application's MVC/Razor antiforgery configuration, and there is no middleware or option for the consuming application to add.
 
 `SameSite` is defense in depth, not the proof by itself: a cross-site form can establish a new login cookie even when no old cookie is sent. The form token is what prevents an attacker from signing a victim's browser into the attacker's account. OAuth `state` and PKCE protect different protocol boundaries and do not replace this hosted-login protection.
 

--- a/web/content/docs/reference/api-reference.mdx
+++ b/web/content/docs/reference/api-reference.mdx
@@ -167,6 +167,8 @@ Honor `interval` while polling `/token`. Device errors use the OAuth-style `erro
 
 These browser routes render or process the SqlOS-hosted sign-in experience. Applications normally begin at `/authorize`; they do not call each form handler directly. The form posts use `application/x-www-form-urlencoded` and can change with the bundled UI.
 
+Every hosted `POST` requires the short-lived antiforgery field and matching browser cookie issued by a SqlOS `GET` page. The bundled UI supplies both automatically. Missing, expired, cross-browser, or cross-origin submissions return `400` before credentials or authorization state are processed. This requirement does not apply to the headless or direct JSON APIs.
+
 | Method | Route family | Purpose |
 | --- | --- | --- |
 | `GET` | `/sqlos/auth/login` | Hosted sign-in page |


### PR DESCRIPTION
Closes #160

## Summary
- protect every state-changing hosted AuthPage form with a short-lived cryptographic browser transaction
- enforce the protection inside SqlOS endpoint filters and rendered HTML, with no host middleware or developer configuration required
- use an HttpOnly, `SameSite=Strict`, auth-path-scoped cookie and reject mismatched `Origin`/`Referer` headers as defense in depth
- leave headless/native and direct JSON APIs as separate integration surfaces without HTML form-token requirements
- document why SameSite, OAuth state, and PKCE do not replace login-CSRF protection

## Security and ergonomics
- cross-site valid credentials without a page-issued token cannot create or replace `sqlos_auth_page`
- tokens expire after 15 minutes and are bound to the issuing browser cookie
- cookie names are derived from the mounted auth path so multiple SqlOS apps on one host do not collide
- normal hosted forms receive and submit tokens automatically; application developers do not handle them

## Verification
- Release build: 0 warnings, 0 errors
- unit suites: 544 SqlOS tests + 2 example tests
- SQL-backed integration suites: 133 library + 71 example + 14 Todo tests
- attack regression covers cross-site attacker credentials, confirms no AuthPage session is issued, then proves a normal `/authorize` does not silently issue a code
- same-origin standalone password login proves a fresh valid AuthPage session
- route inventory proves all 22 hosted state-changing handlers carry the protection while headless and public JSON handlers do not
- real hosted password, OTP, magic-link, MFA, signup, invitation, organization, device, and recovery forms are exercised by the full integration suites
- docs/site build passes

An adversarial review and one follow-up iteration will be recorded on this PR before it is marked ready.