### PR TITLE
Release SqlOS 3.20.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![NuGet](https://img.shields.io/nuget/v/SqlOS)](https://www.nuget.org/packages/SqlOS)
 [![.NET 9](https://img.shields.io/badge/.NET-9.0-purple)](https://dotnet.microsoft.com)
 
-SqlOS 3.19.0 provides a hosted OAuth server, branded login, organizations, sessions, and optional fine-grained authorization to an ASP.NET Core application. It runs in your process and stores its data in your SQL Server database, so you do not need a separate identity or authorization service to get started.
+SqlOS 3.20.0 provides a hosted OAuth server, branded login, organizations, sessions, and optional fine-grained authorization to an ASP.NET Core application. It runs in your process and stores its data in your SQL Server database, so you do not need a separate identity or authorization service to get started.
 
 Start with one application and hosted login. Add SAML SSO, social login, Email OTP, audit logs, calendar connections, or hierarchical authorization when your product needs them.
 
@@ -35,10 +35,10 @@ Requirements:
 Install the package:
 
 ```bash
-dotnet add package SqlOS --version 3.19.0
+dotnet add package SqlOS --version 3.20.0
 ```
 
-> The `main` branch is staged for the 3.19.0 package contract. If NuGet does not list 3.19.0 yet, run the repository examples from source or wait for the package release; do not pair these source docs with 3.16.0.
+> The `main` branch is staged for the 3.20.0 package contract. If NuGet does not list 3.20.0 yet, run the repository examples from source or wait for the package release; do not pair these source docs with 3.16.0.
 
 Use `SqlOSDbContext<TContext>` so SqlOS can register its EF Core model, then declare one application with `UseSingleApplication`:
 

--- a/src/SqlOS/SqlOS.csproj
+++ b/src/SqlOS/SqlOS.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>SqlOS</PackageId>
-    <Version>3.19.0</Version>
+    <Version>3.20.0</Version>
     <Authors>Ross Slaney</Authors>
     <Description>Embedded auth server and fine-grained authorization runtime for .NET + SQL Server + EF Core.</Description>
     <PackageTags>authentication;authorization;fga;saml;jwt;sessions;efcore;sqlserver</PackageTags>

--- a/web/content/blog/hierarchical-authorization-native-ef-core.mdx
+++ b/web/content/blog/hierarchical-authorization-native-ef-core.mdx
@@ -128,7 +128,7 @@ Create the host and install the same package version used to compile this articl
 ```bash
 dotnet new web --framework net9.0 --name HierarchicalEf
 cd HierarchicalEf
-dotnet add package SqlOS --version 3.19.0
+dotnet add package SqlOS --version 3.20.0
 ```
 
 Replace `Program.cs` with the program below. It assumes SQL Server is running and that callers obtain an audience-bound access token through the [Protect an API quickstart](/docs/quickstarts/protect-api). That keeps the sample focused on upgrading the EF model rather than rebuilding the OAuth client flow in the same file.

--- a/web/content/blog/sqlos-3-20-secure-oauth-without-setup-tax.mdx
+++ b/web/content/blog/sqlos-3-20-secure-oauth-without-setup-tax.mdx
@@ -1,0 +1,81 @@
+---
+title: "SqlOS 3.20: Secure OAuth Without the Setup Tax"
+description: "SqlOS 3.20 closes high-priority session, MFA, silent SSO, authorization, URL-generation, and login-CSRF gaps while keeping the normal embedded .NET setup automatic."
+date: "2026-07-13"
+author: "Ross Slaney"
+tags: ["AuthServer", "OAuth", "Security", "MFA", "FGA", "SqlOS"]
+---
+
+SqlOS 3.20 completes a focused pass over the highest-priority security boundaries in the embedded OAuth server.
+
+The important part for application developers is what did **not** change. A normal SqlOS application still runs inside its existing .NET process, stores identity data in its existing SQL Server database, and needs no separate identity product, cloud key service, or security-specific middleware choreography. The new protections are on by default underneath the hosted and headless flows that already exist.
+
+## Password reset now has an explicit revocation contract
+
+Changing a password invalidates the user's existing sessions, access-token lifecycle state, refresh tokens, and pending authentication artifacts. The release adds real SQL-backed protocol coverage proving that a refresh token captured before reset cannot rotate afterward and that a database-validated access token from the old session stops working immediately.
+
+A fresh login with the new password continues normally. There is no application callback to remember and no second revocation API to call.
+
+## TOTP guessing has bounded, shared enforcement
+
+TOTP and recovery-code verification now share atomic attempt limits across hosted, headless, and direct MFA flows. Limits apply to the individual challenge and to recent failures associated with the user and source address, so issuing a new challenge does not reset the attacker's budget.
+
+The state lives in SQL rather than process memory. Multiple application instances therefore enforce the same limit, while unrelated users behind a shared corporate or mobile-network address do not consume one another's challenge budget. Public failures remain generic.
+
+These limits ship with secure defaults and require no new registration or cache service.
+
+## Silent SSO is a fresh policy decision
+
+An AuthPage cookie is now treated as evidence of the first authentication factor, not as permanent permission to issue authorization codes.
+
+For every silent authorization request, SqlOS re-evaluates:
+
+- whether the client is an explicitly owned first-party application;
+- whether current consent policy permits silent continuation;
+- whether the user still belongs to the requested organization; and
+- whether current MFA policy requires another factor.
+
+Owned applications retain the quiet SSO experience they had before. Third-party clients receive standards-aligned `consent_required` or `interaction_required` results when the server cannot safely continue without the user.
+
+## Authorization follows principal and resource lifecycle
+
+Fine-grained authorization now fails closed when a user or group is inactive, a service account is expired, or a resource or ancestor is inactive. The same lifecycle rules apply to point checks, authorization traces, and the SQL table-valued function used by EF Core query filters.
+
+Applications keep using the existing authorization APIs. Changing `IsActive` or `ExpiresAt` is enough to make the new state effective; developers do not have to find and delete every inherited grant manually.
+
+The implementation also closes race and parsing edges around group deactivation and typed subject resolution, so the SQL-time decision is based on current lifecycle state rather than a stale pre-check.
+
+## Security URLs no longer trust the request Host
+
+Invitation links, OIDC callbacks, device verification links, metadata, SSO portal links, and calendar callbacks now use one trusted public-origin resolver. An attacker-controlled `Host` header cannot rewrite them.
+
+Local development and the normal single-application setup remain automatic. SqlOS derives the trusted origin from the configured issuer and application model. `AuthServer.PublicOrigin` remains available only as an optional production-readiness override for deployments whose externally visible origin differs behind a reverse proxy.
+
+No cloud service or external key system is involved.
+
+## Hosted login forms now resist login CSRF automatically
+
+Every state-changing hosted AuthPage form now carries a short-lived, cryptographically protected browser transaction. Cross-site requests cannot establish or replace the AuthPage session even when an attacker supplies valid credentials.
+
+The token and its HttpOnly, `SameSite=Strict` cookie are injected and validated inside SqlOS. Cookie names and protection purposes are derived from the mounted auth path, which keeps multiple SqlOS applications on one host isolated. Headless and native JSON integrations remain separate and do not inherit an HTML form-token requirement.
+
+SqlOS owns this mechanism instead of changing the host application's global ASP.NET Core antiforgery options. Existing MVC and Razor Pages antiforgery configuration therefore continues to work independently.
+
+## Public account operations require the right authority
+
+The public account-management surface now consistently distinguishes anonymous recovery operations from authenticated account changes. Sensitive changes validate the caller and current session rather than relying on a user identifier supplied by the request.
+
+This closes an authorization gap without making ordinary signup, password recovery, or hosted account flows harder to integrate.
+
+## Tested as protocols, not only helper methods
+
+The release exercises these boundaries through the real ASP.NET Core hosts and SQL Server, including:
+
+- access- and refresh-token use after password reset;
+- concurrent and cross-instance TOTP attempts;
+- hosted and headless silent SSO with consent, organization, and MFA changes;
+- FGA point checks, traces, and EF Core query-filter parity;
+- hostile `Host` headers across every security-sensitive URL producer; and
+- cross-site hosted login attempts followed by a real OAuth authorization request.
+
+Each security change went through an adversarial review and a follow-up implementation pass before merge. SqlOS 3.20 raises the internet-facing security floor while preserving the reason to use an embedded identity server in the first place: the straightforward path stays straightforward.

--- a/web/content/docs/docs-index.mdx
+++ b/web/content/docs/docs-index.mdx
@@ -5,7 +5,7 @@ order: 0
 ---
 
 <Callout type="info" title="Version contract">
-  These docs target **SqlOS 3.19.0**, **.NET 9**, **EF Core 9**, and **SQL Server**. Use the same package version as the docs: published `3.16.0` predates the ASP.NET Core protected-state schema upgrade and the complete current source/reference contract.
+  These docs target **SqlOS 3.20.0**, **.NET 9**, **EF Core 9**, and **SQL Server**. Use the same package version as the docs: published `3.16.0` predates the ASP.NET Core protected-state schema upgrade and the complete current source/reference contract.
 </Callout>
 
 ## Get useful proof first

--- a/web/content/docs/getting-started.mdx
+++ b/web/content/docs/getting-started.mdx
@@ -14,7 +14,7 @@ order: 0
 </Banner>
 
 <Callout type="info" title="Supported stack">
-  - **SqlOS 3.19.0**
+  - **SqlOS 3.20.0**
   - **.NET 9** (`net9.0`)
   - **EF Core 9**
   - **SQL Server**

--- a/web/content/docs/quickstarts/add-to-app.mdx
+++ b/web/content/docs/quickstarts/add-to-app.mdx
@@ -11,7 +11,7 @@ section: quickstarts
   href="#complete-program"
   actionLabel="View the code"
 >
-  Install SqlOS 3.19.0, register one SQL Server `DbContext`, declare one application, and map the routes. FGA modeling and advanced client registration can wait.
+  Install SqlOS 3.20.0, register one SQL Server `DbContext`, declare one application, and map the routes. FGA modeling and advanced client registration can wait.
 </Banner>
 
 ## Goal
@@ -30,16 +30,16 @@ Start an ASP.NET Core application with:
 - EF Core 9;
 - an existing SQL Server database and a login allowed to create tables, indexes, and functions.
 
-SqlOS 3.19.0 targets `net9.0`; it is not compatible with a `net8.0` host.
+SqlOS 3.20.0 targets `net9.0`; it is not compatible with a `net8.0` host.
 
 ## Install
 
 ```bash
-dotnet add package SqlOS --version 3.19.0
+dotnet add package SqlOS --version 3.20.0
 ```
 
 <Callout type="warning" title="Do not substitute 3.16.0">
-  The `3.19.0` package is the version contract for this guide. If NuGet does not list it yet, run the source examples from this repository or wait for the release; `3.16.0` predates the ASP.NET Core protected-state schema upgrade and other post-tag contracts documented here.
+  The `3.20.0` package is the version contract for this guide. If NuGet does not list it yet, run the source examples from this repository or wait for the release; `3.16.0` predates the ASP.NET Core protected-state schema upgrade and other post-tag contracts documented here.
 </Callout>
 
 For a new project, store local values with user secrets:

--- a/web/content/docs/quickstarts/ef-authorization.mdx
+++ b/web/content/docs/quickstarts/ef-authorization.mdx
@@ -20,7 +20,7 @@ Create projects through an audience-protected API and return only projects the s
 
 ## Prerequisites
 
-- SqlOS 3.19.0;
+- SqlOS 3.20.0;
 - .NET 9, EF Core 9, and SQL Server;
 - a completed [Protect an API](/docs/quickstarts/protect-api) flow;
 - a valid access token whose `aud` is `http://localhost:5050/api`.

--- a/web/content/docs/quickstarts/protect-api.mdx
+++ b/web/content/docs/quickstarts/protect-api.mdx
@@ -20,7 +20,7 @@ Add `/api/me` to a one-application SqlOS host. Requests without a bearer token r
 
 ## Prerequisites
 
-- SqlOS 3.19.0;
+- SqlOS 3.20.0;
 - .NET 9 and EF Core 9;
 - the [Add SqlOS to one app](/docs/quickstarts/add-to-app) setup;
 - the working [.NET hosted-login flow](/docs/quickstarts/aspnet-core-login), adapted so its registered callback matches your handler and its audience is `http://localhost:5050/api`, or another PKCE client that does the same.

--- a/web/content/docs/quickstarts/run-example-stack.mdx
+++ b/web/content/docs/quickstarts/run-example-stack.mdx
@@ -20,7 +20,7 @@ Compare hosted and headless auth, organization workflows, SSO, sessions, audit l
 
 ## Prerequisites
 
-- SqlOS repository checked out at version 3.19.0;
+- SqlOS repository checked out at version 3.20.0;
 - .NET 9 SDK;
 - Node.js and npm;
 - Docker running with enough memory for SQL Server;

--- a/web/content/docs/quickstarts/run-todo.mdx
+++ b/web/content/docs/quickstarts/run-todo.mdx
@@ -25,7 +25,7 @@ Create an account through the SqlOS hosted AuthPage, return to a secure ASP.NET 
 - Docker running with enough memory for SQL Server;
 - ports `1435`, `5080`, `5090`, `18890`, and `18891` available.
 
-This quickstart uses the source at **SqlOS 3.19.0**. Local password authentication is the default, so the first run does not require Azure Communication Services, Twilio, or an OIDC provider.
+This quickstart uses the source at **SqlOS 3.20.0**. Local password authentication is the default, so the first run does not require Azure Communication Services, Twilio, or an OIDC provider.
 
 ## Run
 

--- a/web/content/docs/reference/index.mdx
+++ b/web/content/docs/reference/index.mdx
@@ -1,13 +1,13 @@
 ---
 title: "Reference"
-description: "Source-aligned reference for SqlOS 3.19.0 hosting, authentication, authorization, and integration APIs."
+description: "Source-aligned reference for SqlOS 3.20.0 hosting, authentication, authorization, and integration APIs."
 order: 7
 section: reference
 ---
 
 <Banner
   eyebrow="Reference"
-  title="SqlOS 3.19.0 application API"
+  title="SqlOS 3.20.0 application API"
   href="/docs/getting-started"
   actionLabel="Start with a guide"
 >
@@ -19,7 +19,7 @@ section: reference
 | Item | Value |
 | --- | --- |
 | Package | `SqlOS` |
-| Current source version | `3.19.0` |
+| Current source version | `3.20.0` |
 | Assembly | `SqlOS.dll` |
 | Target framework | `net9.0` |
 | EF Core provider | SQL Server, EF Core 9 |


### PR DESCRIPTION
## Summary

- bump the package, README, and source-aligned documentation contract from 3.19.0 to 3.20.0
- publish the 3.20 release post covering session revocation, bounded TOTP attempts, silent SSO policy re-evaluation, FGA lifecycle enforcement, trusted security URLs, hosted login CSRF protection, and account-management authorization
- keep the release story explicit about zero-setup local ergonomics, password-first defaults, and no required cloud identity or key-management service

## Developer impact

The security controls merged for 3.20 are automatic underneath existing hosted and headless flows. Normal single-application and localhost setups do not gain a new required setting, service, middleware ordering rule, or external dependency.

## Validation

- Release solution build: 0 warnings, 0 errors
- unit suites: 554 library tests + 2 ASP.NET Core example tests passing
- docs/source validation and all documented .NET snippets compile against 3.20.0
- website lint, TypeScript, production build, and 166-file link validation passing
- `SqlOS.3.20.0.nupkg` created successfully

The GitHub Release will be created only after this PR is green and merged. The release body will include the required compatibility checklist so the publish workflow reruns the build, unit suites, real SQL/protocol integration suites, documentation checks, package build, and NuGet publication from the tag.
