### PR TITLE
Enforce safe CIMD redirect URI schemes

### DIFF
--- a/examples/SqlOS.Todo.IntegrationTests/TodoSampleIntegrationTests.cs
+++ b/examples/SqlOS.Todo.IntegrationTests/TodoSampleIntegrationTests.cs
@@ -598,6 +598,56 @@ public sealed class TodoSampleIntegrationTests
     }
 
     [TestMethod]
+    public async Task CimdClient_RejectsInsecureMetadataRedirect_WithoutRedirectingToClient()
+    {
+        const string clientMetadataUrl = "https://portable.todo.test/clients/insecure.json";
+        const string insecureRedirectUri = "http://attacker.example.test/callback";
+
+        await using var factory = TodoApiFixture.CreateFactory(builder =>
+        {
+            builder.UseSetting("TodoSample:EnableHeadless", "true");
+            builder.UseSetting("TodoSample:CimdTrustedHosts:0", "portable.todo.test");
+            builder.ConfigureServices(services =>
+            {
+                services.AddSingleton<IHttpClientFactory>(new FakeTodoCimdHttpClientFactory(new Dictionary<string, string>
+                {
+                    [clientMetadataUrl] = JsonSerializer.Serialize(new Dictionary<string, object?>
+                    {
+                        ["client_id"] = clientMetadataUrl,
+                        ["client_name"] = "Insecure Portable Client",
+                        ["redirect_uris"] = new[] { insecureRedirectUri },
+                        ["grant_types"] = new[] { "authorization_code", "refresh_token" },
+                        ["response_types"] = new[] { "code" },
+                        ["token_endpoint_auth_method"] = "none"
+                    })
+                }));
+            });
+        });
+        using var client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false
+        });
+        var codeVerifier = CreateCodeVerifier();
+
+        var response = await client.GetAsync(QueryHelpers.AddQueryString("/sqlos/auth/authorize", new Dictionary<string, string?>
+        {
+            ["response_type"] = "code",
+            ["client_id"] = clientMetadataUrl,
+            ["redirect_uri"] = insecureRedirectUri,
+            ["state"] = "attacker-state",
+            ["scope"] = "openid profile",
+            ["code_challenge"] = CreateCodeChallenge(codeVerifier),
+            ["code_challenge_method"] = "S256"
+        }));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Redirect);
+        response.Headers.Location.Should().NotBeNull();
+        response.Headers.Location!.Host.Should().Be("todo.example.test");
+        response.Headers.Location.AbsoluteUri.Should().NotContain(insecureRedirectUri);
+        response.Headers.Location.AbsoluteUri.Should().Contain("error=The%20authorization%20request%20is%20invalid.");
+    }
+
+    [TestMethod]
     public async Task DcrClient_CanRegister_AndUseAuthorizationCodeFlow_WhenEnabled()
     {
         const string redirectUri = "https://dcr.todo.test/callback";

--- a/src/SqlOS/AuthServer/Services/SqlOSCimdClientService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSCimdClientService.cs
@@ -52,7 +52,7 @@ public sealed class SqlOSCimdClientService
 
         if (existingClient != null && !ShouldRefreshMetadata(existingClient))
         {
-            ValidateRedirectUri(existingClient.RedirectUrisJson, redirectUri, clientId);
+            await ValidateCachedRedirectUrisAsync(existingClient.RedirectUrisJson, redirectUri, clientId, cancellationToken);
             existingClient.LastSeenAt = DateTime.UtcNow;
             await _context.SaveChangesAsync(cancellationToken);
             return new SqlOSResolvedClient(existingClient, "cimd");
@@ -104,7 +104,7 @@ public sealed class SqlOSCimdClientService
             existingClient.MetadataExpiresAt = ResolveMetadataExpiry(response, now);
             existingClient.LastSeenAt = now;
             await _context.SaveChangesAsync(cancellationToken);
-            ValidateRedirectUri(existingClient.RedirectUrisJson, redirectUri, clientId);
+            await ValidateCachedRedirectUrisAsync(existingClient.RedirectUrisJson, redirectUri, clientId, cancellationToken);
             return new SqlOSResolvedClient(existingClient, "cimd");
         }
 
@@ -360,17 +360,46 @@ public sealed class SqlOSCimdClientService
         return now.Add(_options.ClientRegistration.Cimd.DefaultCacheTtl);
     }
 
-    private static void ValidateRedirectUri(string redirectUrisJson, string? redirectUri, string clientId)
+    private async Task ValidateCachedRedirectUrisAsync(
+        string redirectUrisJson,
+        string? redirectUri,
+        string clientId,
+        CancellationToken cancellationToken)
     {
-        if (string.IsNullOrWhiteSpace(redirectUri))
+        try
         {
-            return;
+            var redirectUris = SqlOSAdminService.DeserializeJsonList(redirectUrisJson);
+            ValidateRedirectUriPolicy(redirectUris, clientId);
+            if (!string.IsNullOrWhiteSpace(redirectUri)
+                && !redirectUris.Contains(redirectUri, StringComparer.Ordinal))
+            {
+                throw new InvalidOperationException($"Redirect URI '{redirectUri}' is not allowed for client '{clientId}'.");
+            }
         }
-
-        var redirectUris = SqlOSAdminService.DeserializeJsonList(redirectUrisJson);
-        if (!redirectUris.Contains(redirectUri, StringComparer.Ordinal))
+        catch (InvalidOperationException ex)
         {
-            throw new InvalidOperationException($"Redirect URI '{redirectUri}' is not allowed for client '{clientId}'.");
+            await RecordAuditAsync(
+                "client.cimd.validation-failed",
+                clientId,
+                new { error = ex.Message },
+                cancellationToken);
+            throw new InvalidOperationException("Client metadata document validation failed.", ex);
+        }
+    }
+
+    private void ValidateRedirectUriPolicy(IEnumerable<string> redirectUris, string clientId)
+    {
+        foreach (var redirectUri in redirectUris)
+        {
+            if (!Uri.TryCreate(redirectUri, UriKind.Absolute, out var parsedRedirectUri)
+                || !SqlOSRedirectUriPolicy.IsAllowed(
+                    parsedRedirectUri,
+                    _options.ClientRegistration.Dcr.AllowHttpsRedirectUris,
+                    _options.ClientRegistration.Dcr.AllowLoopbackRedirectUris))
+            {
+                throw new InvalidOperationException(
+                    $"Client metadata document for '{clientId}' contains redirect URI '{redirectUri}' that must use HTTPS or an HTTP loopback address.");
+            }
         }
     }
 
@@ -418,7 +447,7 @@ public sealed class SqlOSCimdClientService
         await _context.SaveChangesAsync(cancellationToken);
     }
 
-    private static ParsedCimdDocument ParseMetadataDocument(JsonElement root, string clientId, string? redirectUri)
+    private ParsedCimdDocument ParseMetadataDocument(JsonElement root, string clientId, string? redirectUri)
     {
         if (root.ValueKind != JsonValueKind.Object)
         {
@@ -438,13 +467,7 @@ public sealed class SqlOSCimdClientService
             throw new InvalidOperationException($"Client metadata document for '{clientId}' must include at least one redirect URI.");
         }
 
-        foreach (var uri in redirectUris)
-        {
-            if (!Uri.TryCreate(uri, UriKind.Absolute, out _))
-            {
-                throw new InvalidOperationException($"Client metadata document for '{clientId}' contains an invalid redirect URI '{uri}'.");
-            }
-        }
+        ValidateRedirectUriPolicy(redirectUris, clientId);
 
         if (!string.IsNullOrWhiteSpace(redirectUri)
             && !redirectUris.Contains(redirectUri, StringComparer.Ordinal))

--- a/src/SqlOS/AuthServer/Services/SqlOSDynamicClientRegistrationService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSDynamicClientRegistrationService.cs
@@ -255,7 +255,7 @@ public sealed class SqlOSDynamicClientRegistrationService
             {
                 throw new SqlOSClientRegistrationException(
                     "invalid_redirect_uri",
-                    $"Redirect URI '{redirectUri}' must use https or a loopback localhost redirect.");
+                    $"Redirect URI '{redirectUri}' must use HTTPS or an HTTP loopback address.");
             }
         }
 

--- a/src/SqlOS/AuthServer/Services/SqlOSDynamicClientRegistrationService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSDynamicClientRegistrationService.cs
@@ -248,13 +248,10 @@ public sealed class SqlOSDynamicClientRegistrationService
                     $"Redirect URI '{redirectUri}' is not a valid absolute URI.");
             }
 
-            var isHttps = _options.ClientRegistration.Dcr.AllowHttpsRedirectUris
-                && string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase);
-            var isLoopback = _options.ClientRegistration.Dcr.AllowLoopbackRedirectUris
-                && (string.Equals(uri.Host, "localhost", StringComparison.OrdinalIgnoreCase)
-                    || string.Equals(uri.Host, "127.0.0.1", StringComparison.OrdinalIgnoreCase));
-
-            if (!isHttps && !isLoopback)
+            if (!SqlOSRedirectUriPolicy.IsAllowed(
+                    uri,
+                    _options.ClientRegistration.Dcr.AllowHttpsRedirectUris,
+                    _options.ClientRegistration.Dcr.AllowLoopbackRedirectUris))
             {
                 throw new SqlOSClientRegistrationException(
                     "invalid_redirect_uri",

--- a/src/SqlOS/AuthServer/Services/SqlOSRedirectUriPolicy.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSRedirectUriPolicy.cs
@@ -1,0 +1,20 @@
+namespace SqlOS.AuthServer.Services;
+
+internal static class SqlOSRedirectUriPolicy
+{
+    public static bool IsAllowed(
+        Uri uri,
+        bool allowHttpsRedirectUris,
+        bool allowLoopbackRedirectUris)
+    {
+        if (allowHttpsRedirectUris
+            && string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return allowLoopbackRedirectUris
+            && string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
+            && uri.IsLoopback;
+    }
+}

--- a/tests/SqlOS.Tests/SqlOSCimdClientServiceTests.cs
+++ b/tests/SqlOS.Tests/SqlOSCimdClientServiceTests.cs
@@ -82,6 +82,85 @@ public sealed class SqlOSCimdClientServiceTests
         httpFactory.RequestCount.Should().Be(1);
     }
 
+    [DataTestMethod]
+    [DataRow("http://client.example.test/callback")]
+    [DataRow("ftp://client.example.test/callback")]
+    [DataRow("custom-scheme://client.example.test/callback")]
+    [DataRow("ftp://localhost/callback")]
+    public async Task ResolveRequiredClientAsync_RejectsUnsafeRedirectUriSchemes(string redirectUri)
+    {
+        using var context = CreateContext();
+        const string clientId = "https://client.example.test/oauth/client.json";
+        var httpFactory = new FakeHttpClientFactory(_ => JsonResponse(
+            $$"""
+            {
+              "client_id": "{{clientId}}",
+              "client_name": "Unsafe Redirect Client",
+              "redirect_uris": ["{{redirectUri}}"],
+              "token_endpoint_auth_method": "none"
+            }
+            """));
+        var resolver = CreateResolver(context, CreateOptions(), httpFactory);
+
+        var act = async () => await resolver.ResolveRequiredClientAsync(clientId, redirectUri);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Client metadata document validation failed.");
+        var audit = await context.Set<SqlOSAuditEvent>()
+            .SingleAsync(x => x.EventType == "client.cimd.validation-failed");
+        audit.DataJson.Should().Contain("must use HTTPS or an HTTP loopback address");
+        (await context.Set<SqlOSClientApplication>().AnyAsync()).Should().BeFalse();
+    }
+
+    [DataTestMethod]
+    [DataRow("http://localhost/callback")]
+    [DataRow("http://127.0.0.1:49152/callback")]
+    [DataRow("http://[::1]:49152/callback")]
+    public async Task ResolveRequiredClientAsync_AllowsHttpLoopbackRedirectUris(string redirectUri)
+    {
+        using var context = CreateContext();
+        const string clientId = "https://client.example.test/oauth/client.json";
+        var httpFactory = new FakeHttpClientFactory(_ => JsonResponse(
+            $$"""
+            {
+              "client_id": "{{clientId}}",
+              "client_name": "Native Client",
+              "redirect_uris": ["{{redirectUri}}"],
+              "token_endpoint_auth_method": "none"
+            }
+            """));
+        var resolver = CreateResolver(context, CreateOptions(), httpFactory);
+
+        var resolved = await resolver.ResolveRequiredClientAsync(clientId, redirectUri);
+
+        resolved.Client.RedirectUrisJson.Should().Contain(redirectUri);
+    }
+
+    [TestMethod]
+    public async Task ResolveRequiredClientAsync_RejectsLoopbackWhenDisabledForDcrAndCimd()
+    {
+        using var context = CreateContext();
+        const string clientId = "https://client.example.test/oauth/client.json";
+        const string redirectUri = "http://127.0.0.1:49152/callback";
+        var options = CreateOptions();
+        options.ClientRegistration.Dcr.AllowLoopbackRedirectUris = false;
+        var httpFactory = new FakeHttpClientFactory(_ => JsonResponse(
+            $$"""
+            {
+              "client_id": "{{clientId}}",
+              "client_name": "Native Client",
+              "redirect_uris": ["{{redirectUri}}"],
+              "token_endpoint_auth_method": "none"
+            }
+            """));
+        var resolver = CreateResolver(context, options, httpFactory);
+
+        var act = async () => await resolver.ResolveRequiredClientAsync(clientId, redirectUri);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Client metadata document validation failed.");
+    }
+
     [TestMethod]
     public async Task ResolveRequiredClientAsync_UsesFreshCachedCimdClientWithoutRefetch()
     {
@@ -115,6 +194,43 @@ public sealed class SqlOSCimdClientServiceTests
         resolved.Client.Id.Should().Be(existing.Id);
         resolved.ResolutionKind.Should().Be("cimd");
         httpFactory.RequestCount.Should().Be(0);
+    }
+
+    [TestMethod]
+    public async Task ResolveRequiredClientAsync_RejectsUnsafeRedirectFromFreshCacheWithoutRefetch()
+    {
+        using var context = CreateContext();
+        var existing = new SqlOSClientApplication
+        {
+            Id = "cli_cached_unsafe",
+            ClientId = "https://client.example.test/oauth/client.json",
+            Name = "Cached Unsafe Client",
+            Audience = "sqlos",
+            ClientType = "public_pkce",
+            RegistrationSource = "cimd",
+            TokenEndpointAuthMethod = "none",
+            GrantTypesJson = "[\"authorization_code\",\"refresh_token\"]",
+            ResponseTypesJson = "[\"code\"]",
+            RedirectUrisJson = "[\"http://attacker.example.test/callback\"]",
+            MetadataDocumentUrl = "https://client.example.test/oauth/client.json",
+            MetadataFetchedAt = DateTime.UtcNow.AddMinutes(-1),
+            MetadataExpiresAt = DateTime.UtcNow.AddMinutes(10),
+            CreatedAt = DateTime.UtcNow,
+            IsActive = true
+        };
+        context.Set<SqlOSClientApplication>().Add(existing);
+        await context.SaveChangesAsync();
+        var httpFactory = new FakeHttpClientFactory(_ => throw new InvalidOperationException("Unsafe cached metadata must not be fetched or accepted."));
+        var resolver = CreateResolver(context, CreateOptions(), httpFactory);
+
+        var act = async () => await resolver.ResolveRequiredClientAsync(existing.ClientId, "http://attacker.example.test/callback");
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Client metadata document validation failed.");
+        httpFactory.RequestCount.Should().Be(0);
+        var audit = await context.Set<SqlOSAuditEvent>()
+            .SingleAsync(x => x.EventType == "client.cimd.validation-failed");
+        audit.DataJson.Should().Contain("must use HTTPS or an HTTP loopback address");
     }
 
     [TestMethod]

--- a/tests/SqlOS.Tests/SqlOSCimdClientServiceTests.cs
+++ b/tests/SqlOS.Tests/SqlOSCimdClientServiceTests.cs
@@ -278,6 +278,45 @@ public sealed class SqlOSCimdClientServiceTests
     }
 
     [TestMethod]
+    public async Task ResolveRequiredClientAsync_RejectsUnsafeCachedRedirectAfterNotModifiedResponse()
+    {
+        using var context = CreateContext();
+        var existing = new SqlOSClientApplication
+        {
+            Id = "cli_cached_unsafe_304",
+            ClientId = "https://client.example.test/oauth/client.json",
+            Name = "Cached Unsafe Client",
+            Audience = "sqlos",
+            ClientType = "public_pkce",
+            RegistrationSource = "cimd",
+            TokenEndpointAuthMethod = "none",
+            GrantTypesJson = "[\"authorization_code\",\"refresh_token\"]",
+            ResponseTypesJson = "[\"code\"]",
+            RedirectUrisJson = "[\"http://attacker.example.test/callback\"]",
+            MetadataDocumentUrl = "https://client.example.test/oauth/client.json",
+            MetadataFetchedAt = DateTime.UtcNow.AddHours(-2),
+            MetadataExpiresAt = DateTime.UtcNow.AddMinutes(-1),
+            MetadataEtag = "\"unsafe-v1\"",
+            CreatedAt = DateTime.UtcNow,
+            IsActive = true
+        };
+        context.Set<SqlOSClientApplication>().Add(existing);
+        await context.SaveChangesAsync();
+        var httpFactory = new FakeHttpClientFactory(_ => new HttpResponseMessage(HttpStatusCode.NotModified));
+        var resolver = CreateResolver(context, CreateOptions(), httpFactory);
+
+        var act = async () => await resolver.ResolveRequiredClientAsync(
+            existing.ClientId,
+            "http://attacker.example.test/callback");
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Client metadata document validation failed.");
+        httpFactory.RequestCount.Should().Be(1);
+        (await context.Set<SqlOSAuditEvent>().AnyAsync(x => x.EventType == "client.cimd.validation-failed"))
+            .Should().BeTrue();
+    }
+
+    [TestMethod]
     public async Task ResolveRequiredClientAsync_RejectsTrustPolicyDenial()
     {
         using var context = CreateContext();

--- a/tests/SqlOS.Tests/SqlOSDynamicClientRegistrationServiceTests.cs
+++ b/tests/SqlOS.Tests/SqlOSDynamicClientRegistrationServiceTests.cs
@@ -85,6 +85,25 @@ public sealed class SqlOSDynamicClientRegistrationServiceTests
         ex.Which.Error.Should().Be("invalid_redirect_uri");
     }
 
+    [DataTestMethod]
+    [DataRow("ftp://localhost/callback")]
+    [DataRow("custom-scheme://127.0.0.1/callback")]
+    public async Task RegisterAsync_RejectsNonHttpLoopbackRedirectUris(string redirectUri)
+    {
+        using var context = CreateContext();
+        var service = CreateService(context, CreateOptions(), new SqlOSDynamicClientRegistrationRateLimiter());
+        var httpContext = CreateHttpContext("10.0.0.3");
+
+        var act = async () => await service.RegisterAsync(new SqlOSDynamicClientRegistrationRequest
+        {
+            ClientName = "Bad Loopback Redirect",
+            RedirectUris = [redirectUri]
+        }, httpContext);
+
+        var ex = await act.Should().ThrowAsync<SqlOSClientRegistrationException>();
+        ex.Which.Error.Should().Be("invalid_redirect_uri");
+    }
+
     [TestMethod]
     public async Task RegisterAsync_RejectsWhenDisabled()
     {


### PR DESCRIPTION
Closes #136.

## What changed

- centralizes redirect scheme policy shared by DCR and CIMD
- requires HTTPS, except HTTP loopback redirects for native/local clients
- rejects non-HTTP loopback schemes and supports IPv4, IPv6, and localhost loopback addresses
- revalidates cached and HTTP 304 CIMD metadata so previously stored unsafe redirects cannot bypass the policy
- preserves generic public failures while recording detailed CIMD validation audit events

## Developer impact

No new configuration or service is required. Existing HTTPS clients continue to work, and normal local/native HTTP loopback callbacks continue to work across platforms. The existing DCR loopback option also governs CIMD, keeping one predictable policy surface.

## Validation

- focused unit suite: 46 passed
- Todo protocol integration: trusted CIMD authorization succeeds; unsafe CIMD redirect is rejected without redirecting to the untrusted client

An adversarial review and final full-suite validation will be recorded in PR comments before this is marked ready.
