### PR TITLE
Enforce FGA permission integrity

### DIFF
--- a/examples/SqlOS.Example.Api/Program.cs
+++ b/examples/SqlOS.Example.Api/Program.cs
@@ -269,7 +269,7 @@ builder.AddSqlOS<ExampleAppDbContext>(
                 "perm_workspace_manage",
                 ExampleFgaService.WorkspaceManagePermission,
                 "Manage workspaces",
-                ExampleFgaService.WorkspaceResourceTypeId);
+                ExampleFgaService.OrganizationResourceTypeId);
             seed.Role(
                 "role_org_member",
                 ExampleFgaService.OrgMemberRole,

--- a/src/SqlOS/Fga/Configuration/SqlOSFgaModelConfiguration.cs
+++ b/src/SqlOS/Fga/Configuration/SqlOSFgaModelConfiguration.cs
@@ -112,6 +112,8 @@ public static class SqlOSFgaModelConfiguration
         {
             entity.ToTable(tables.Permissions, schema, t => t.ExcludeFromMigrations());
             entity.HasKey(e => e.Id);
+            entity.Property(e => e.Key).HasMaxLength(450);
+            entity.HasIndex(e => e.Key).IsUnique();
             entity.HasOne(e => e.ResourceType)
                 .WithMany(rt => rt.Permissions)
                 .HasForeignKey(e => e.ResourceTypeId)

--- a/src/SqlOS/Fga/Configuration/SqlOSFgaModelConfiguration.cs
+++ b/src/SqlOS/Fga/Configuration/SqlOSFgaModelConfiguration.cs
@@ -112,7 +112,7 @@ public static class SqlOSFgaModelConfiguration
         {
             entity.ToTable(tables.Permissions, schema, t => t.ExcludeFromMigrations());
             entity.HasKey(e => e.Id);
-            entity.Property(e => e.Key).HasMaxLength(450);
+            entity.Property(e => e.Key).HasMaxLength(SqlOSFgaPermission.MaxKeyLength);
             entity.HasIndex(e => e.Key).IsUnique();
             entity.HasOne(e => e.ResourceType)
                 .WithMany(rt => rt.Permissions)

--- a/src/SqlOS/Fga/Configuration/SqlOSFgaSeedBuilder.cs
+++ b/src/SqlOS/Fga/Configuration/SqlOSFgaSeedBuilder.cs
@@ -93,6 +93,11 @@ public sealed class SqlOSFgaSeedBuilder
     {
         var normalizedId = RequireValue(id, nameof(id));
         var normalizedKey = RequireValue(key, nameof(key));
+        if (normalizedKey.Length > SqlOSFgaPermission.MaxKeyLength)
+        {
+            throw new InvalidOperationException(
+                $"FGA permission keys cannot exceed {SqlOSFgaPermission.MaxKeyLength} characters.");
+        }
         if (_permissionsById.TryGetValue(normalizedId, out var existingPermission))
         {
             _permissionsByKey.Remove(existingPermission.Key);

--- a/src/SqlOS/Fga/Configuration/SqlOSFgaSeedBuilder.cs
+++ b/src/SqlOS/Fga/Configuration/SqlOSFgaSeedBuilder.cs
@@ -98,6 +98,13 @@ public sealed class SqlOSFgaSeedBuilder
             _permissionsByKey.Remove(existingPermission.Key);
         }
 
+        if (_permissionsByKey.TryGetValue(normalizedKey, out var permissionWithSameKey)
+            && !string.Equals(permissionWithSameKey.Id, normalizedId, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"FGA permission key '{normalizedKey}' is already assigned to permission '{permissionWithSameKey.Id}'. Permission keys must be unique.");
+        }
+
         var permission = new SqlOSFgaPermission
         {
             Id = normalizedId,

--- a/src/SqlOS/Fga/Dashboard/SqlOSFgaDashboardMiddleware.cs
+++ b/src/SqlOS/Fga/Dashboard/SqlOSFgaDashboardMiddleware.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
@@ -1247,7 +1248,7 @@ public class SqlOSFgaDashboardMiddleware
     private static async Task HandleCreateRole(HttpContext context, ISqlOSFgaDbContext dbContext)
     {
         var body = await JsonSerializer.DeserializeAsync<CreateRoleRequest>(context.Request.Body, JsonOptions);
-        if (body == null || string.IsNullOrEmpty(body.Key) || string.IsNullOrEmpty(body.Name))
+        if (body == null || string.IsNullOrWhiteSpace(body.Key) || string.IsNullOrWhiteSpace(body.Name))
         {
             context.Response.StatusCode = 400;
             await context.Response.WriteAsync("{\"error\":\"key and name are required\"}");
@@ -1344,17 +1345,34 @@ public class SqlOSFgaDashboardMiddleware
             return;
         }
 
+        var permissionKey = body.Key.Trim();
+        if (await dbContext.Set<SqlOSFgaPermission>().AnyAsync(p => p.Key == permissionKey))
+        {
+            context.Response.StatusCode = StatusCodes.Status409Conflict;
+            await context.Response.WriteAsync("{\"error\":\"A permission with this key already exists. Permission keys must be unique.\"}");
+            return;
+        }
+
         var permId = $"perm_{Guid.NewGuid():N}"[..30];
         var perm = new SqlOSFgaPermission
         {
             Id = permId,
-            Key = body.Key,
-            Name = body.Name,
+            Key = permissionKey,
+            Name = body.Name.Trim(),
             Description = body.Description,
             ResourceTypeId = body.ResourceTypeId
         };
         dbContext.Set<SqlOSFgaPermission>().Add(perm);
-        await dbContext.SaveChangesAsync();
+        try
+        {
+            await dbContext.SaveChangesAsync();
+        }
+        catch (DbUpdateException ex) when (ex.GetBaseException() is SqlException { Number: 2601 or 2627 })
+        {
+            context.Response.StatusCode = StatusCodes.Status409Conflict;
+            await context.Response.WriteAsync("{\"error\":\"A permission with this key already exists. Permission keys must be unique.\"}");
+            return;
+        }
 
         var created = await dbContext.Set<SqlOSFgaPermission>()
             .Include(p => p.ResourceType)

--- a/src/SqlOS/Fga/Dashboard/SqlOSFgaDashboardMiddleware.cs
+++ b/src/SqlOS/Fga/Dashboard/SqlOSFgaDashboardMiddleware.cs
@@ -1338,7 +1338,7 @@ public class SqlOSFgaDashboardMiddleware
     private static async Task HandleCreatePermission(HttpContext context, ISqlOSFgaDbContext dbContext)
     {
         var body = await JsonSerializer.DeserializeAsync<CreatePermissionRequest>(context.Request.Body, JsonOptions);
-        if (body == null || string.IsNullOrEmpty(body.Key) || string.IsNullOrEmpty(body.Name))
+        if (body == null || string.IsNullOrWhiteSpace(body.Key) || string.IsNullOrWhiteSpace(body.Name))
         {
             context.Response.StatusCode = 400;
             await context.Response.WriteAsync("{\"error\":\"key and name are required\"}");
@@ -1346,6 +1346,13 @@ public class SqlOSFgaDashboardMiddleware
         }
 
         var permissionKey = body.Key.Trim();
+        if (permissionKey.Length > SqlOSFgaPermission.MaxKeyLength)
+        {
+            context.Response.StatusCode = StatusCodes.Status400BadRequest;
+            await context.Response.WriteAsync($"{{\"error\":\"Permission keys cannot exceed {SqlOSFgaPermission.MaxKeyLength} characters.\"}}");
+            return;
+        }
+
         if (await dbContext.Set<SqlOSFgaPermission>().AnyAsync(p => p.Key == permissionKey))
         {
             context.Response.StatusCode = StatusCodes.Status409Conflict;

--- a/src/SqlOS/Fga/Models/SqlOSFgaPermission.cs
+++ b/src/SqlOS/Fga/Models/SqlOSFgaPermission.cs
@@ -6,6 +6,8 @@ namespace SqlOS.Fga.Models;
 /// </summary>
 public class SqlOSFgaPermission
 {
+    internal const int MaxKeyLength = 450;
+
     public string Id { get; set; } = string.Empty;
     public string? ResourceTypeId { get; set; }
     public string Key { get; set; } = string.Empty;

--- a/src/SqlOS/Fga/Schema/006_PermissionIntegrity.sql
+++ b/src/SqlOS/Fga/Schema/006_PermissionIntegrity.sql
@@ -9,6 +9,16 @@ BEGIN
 END
 GO
 
+IF EXISTS (
+    SELECT 1
+    FROM [{Schema}].[{Permissions}]
+    WHERE LEN([Key]) > 450
+)
+BEGIN
+    THROW 51001, 'SqlOS cannot index FGA permission keys longer than 450 characters. Shorten those permission keys and restart.', 1;
+END
+GO
+
 ALTER TABLE [{Schema}].[{Permissions}]
 ALTER COLUMN [Key] NVARCHAR(450) NOT NULL;
 GO

--- a/src/SqlOS/Fga/Schema/006_PermissionIntegrity.sql
+++ b/src/SqlOS/Fga/Schema/006_PermissionIntegrity.sql
@@ -1,0 +1,29 @@
+IF EXISTS (
+    SELECT [Key]
+    FROM [{Schema}].[{Permissions}]
+    GROUP BY [Key]
+    HAVING COUNT(*) > 1
+)
+BEGIN
+    THROW 51000, 'SqlOS cannot enforce unique FGA permission keys because duplicate keys already exist. Remove or rename duplicate permissions and restart.', 1;
+END
+GO
+
+ALTER TABLE [{Schema}].[{Permissions}]
+ALTER COLUMN [Key] NVARCHAR(450) NOT NULL;
+GO
+
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'UX_{Permissions}_Key'
+      AND object_id = OBJECT_ID('[{Schema}].[{Permissions}]')
+)
+BEGIN
+    CREATE UNIQUE NONCLUSTERED INDEX [UX_{Permissions}_Key]
+        ON [{Schema}].[{Permissions}]([Key]);
+END
+GO
+
+UPDATE [{Schema}].[SqlOSFgaSchema] SET [Version] = 6 WHERE [Version] < 6;
+GO

--- a/src/SqlOS/Fga/Services/SqlOSFgaAuthService.cs
+++ b/src/SqlOS/Fga/Services/SqlOSFgaAuthService.cs
@@ -61,6 +61,24 @@ public class SqlOSFgaAuthService : ISqlOSFgaAuthService
             return new SqlOSFgaAccessCheckResult { Allowed = false, Trace = trace, Error = $"Permission {permissionKey} not found" };
         }
 
+        if (permission.ResourceTypeId != null
+            && !string.Equals(permission.ResourceTypeId, resource.ResourceTypeId, StringComparison.Ordinal))
+        {
+            trace.Add(new SqlOSFgaAccessTrace
+            {
+                Step = "Permission Scope",
+                Detail = $"Permission {permission.Name} applies to resource type {permission.ResourceTypeId}, not {resource.ResourceTypeId}",
+                ResourceId = resource.Id,
+                ResourceName = resource.Name,
+            });
+            return new SqlOSFgaAccessCheckResult
+            {
+                Allowed = false,
+                Trace = trace,
+                Error = $"Permission {permissionKey} does not apply to resource type {resource.ResourceTypeId}"
+            };
+        }
+
         trace.Add(new SqlOSFgaAccessTrace
         {
             Step = "Permission",
@@ -188,6 +206,15 @@ public class SqlOSFgaAuthService : ISqlOSFgaAuthService
         }
 
         trace.PermissionName = permission.Name;
+
+        if (permission.ResourceTypeId != null
+            && !string.Equals(permission.ResourceTypeId, resource.ResourceTypeId, StringComparison.Ordinal))
+        {
+            trace.AccessGranted = false;
+            trace.DenialReason = $"Permission '{permissionKey}' applies to resource type '{permission.ResourceTypeId}', not '{resource.ResourceTypeId}'.";
+            trace.DecisionSummary = $"Access denied because permission '{permissionKey}' is not valid for this resource type.";
+            return trace;
+        }
 
         var allSubjects = await ResolveSubjectsWithInfoAsync(subjectId);
         trace.SubjectsChecked = allSubjects;

--- a/src/SqlOS/Fga/Services/SqlOSFgaFunctionInitializer.cs
+++ b/src/SqlOS/Fga/Services/SqlOSFgaFunctionInitializer.cs
@@ -70,6 +70,13 @@ RETURN
     LEFT JOIN [{schema}].[{tables.Agents}] ag ON s.Id = ag.SubjectId
     WHERE g.SubjectId IN (SELECT CONVERT(NVARCHAR(450), [value]) FROM OPENJSON(@SubjectIds))
       AND rp.PermissionId = @PermissionId
+      AND EXISTS (
+          SELECT 1
+          FROM [{schema}].[{tables.Resources}] target
+          INNER JOIN [{schema}].[{tables.Permissions}] permission ON permission.Id = @PermissionId
+          WHERE target.Id = @ResourceId
+            AND (permission.ResourceTypeId IS NULL OR permission.ResourceTypeId = target.ResourceTypeId)
+      )
       AND (s.SubjectTypeId <> 'user' OR u.IsActive = 1)
       AND (s.SubjectTypeId <> 'service_account' OR (sa.SubjectId IS NOT NULL AND (sa.ExpiresAt IS NULL OR sa.ExpiresAt > GETUTCDATE())))
       AND (s.SubjectTypeId <> 'group' OR ug.IsActive = 1)

--- a/tests/SqlOS.IntegrationTests/Fga/SqlOSFgaAuthServiceIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/Fga/SqlOSFgaAuthServiceIntegrationTests.cs
@@ -101,6 +101,56 @@ public class SqlOSFgaAuthServiceIntegrationTests : FgaIntegrationTestBase
     }
 
     [TestMethod]
+    public async Task TypeScopedPermission_DeniesDifferentTargetType_InPointTraceAndEfFilter()
+    {
+        var permission = await Context.Set<SqlOSFgaPermission>().SingleAsync(p => p.Key == "TEST_VIEW");
+        permission.ResourceTypeId = "team";
+        await Context.SaveChangesAsync();
+
+        var point = await _authService.CheckAccessAsync(
+            FgaTestDataSeeder.SystemAdminSubjectId,
+            "TEST_VIEW",
+            FgaTestDataSeeder.TestProjectResourceId);
+        var trace = await _authService.TraceResourceAccessAsync(
+            FgaTestDataSeeder.SystemAdminSubjectId,
+            FgaTestDataSeeder.TestProjectResourceId,
+            "TEST_VIEW");
+        Context.Set<LifecycleProtectedEntity>().Add(new LifecycleProtectedEntity
+        {
+            Id = $"typed_{Guid.NewGuid():N}",
+            ResourceId = FgaTestDataSeeder.TestProjectResourceId
+        });
+        await Context.SaveChangesAsync();
+        var filter = await _authService.GetAuthorizationFilterAsync<LifecycleProtectedEntity>(
+            FgaTestDataSeeder.SystemAdminSubjectId,
+            "TEST_VIEW");
+
+        Assert.IsFalse(point.Allowed);
+        Assert.IsTrue(point.Error?.Contains("does not apply to resource type project", StringComparison.Ordinal));
+        Assert.IsFalse(trace.AccessGranted);
+        Assert.IsTrue(trace.DenialReason?.Contains("applies to resource type 'team'", StringComparison.Ordinal));
+        Assert.IsFalse(await Context.Set<LifecycleProtectedEntity>()
+            .Where(x => x.ResourceId == FgaTestDataSeeder.TestProjectResourceId)
+            .Where(filter)
+            .AnyAsync());
+    }
+
+    [TestMethod]
+    public async Task TypeScopedPermission_AllowsTargetTypeViaAncestorGrant()
+    {
+        var permission = await Context.Set<SqlOSFgaPermission>().SingleAsync(p => p.Key == "TEST_VIEW");
+        permission.ResourceTypeId = "project";
+        await Context.SaveChangesAsync();
+
+        var result = await _authService.CheckAccessAsync(
+            FgaTestDataSeeder.AgencyAdminSubjectId,
+            "TEST_VIEW",
+            FgaTestDataSeeder.TestProjectResourceId);
+
+        Assert.IsTrue(result.Allowed, "a permission scoped to the target type should still inherit through an ancestor grant");
+    }
+
+    [TestMethod]
     public async Task InactiveUser_IsDeniedByPointCheckAndEfFilterDespiteExistingGrant()
     {
         var subjectService = CreateSubjectService();

--- a/tests/SqlOS.IntegrationTests/Fga/SqlOSFgaAuthServiceIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/Fga/SqlOSFgaAuthServiceIntegrationTests.cs
@@ -103,18 +103,30 @@ public class SqlOSFgaAuthServiceIntegrationTests : FgaIntegrationTestBase
     [TestMethod]
     public async Task TypeScopedPermission_DeniesDifferentTargetType_InPointTraceAndEfFilter()
     {
-        var permission = await Context.Set<SqlOSFgaPermission>().SingleAsync(p => p.Key == "TEST_VIEW");
-        permission.ResourceTypeId = "team";
+        var suffix = Guid.NewGuid().ToString("N");
+        var permission = new SqlOSFgaPermission
+        {
+            Id = $"perm_typed_deny_{suffix}",
+            Key = $"TYPED_DENY_{suffix}",
+            Name = "Team-only permission",
+            ResourceTypeId = "team"
+        };
+        Context.Set<SqlOSFgaPermission>().Add(permission);
+        Context.Set<SqlOSFgaRolePermission>().Add(new SqlOSFgaRolePermission
+        {
+            RoleId = FgaTestDataSeeder.SystemAdminRoleId,
+            PermissionId = permission.Id
+        });
         await Context.SaveChangesAsync();
 
         var point = await _authService.CheckAccessAsync(
             FgaTestDataSeeder.SystemAdminSubjectId,
-            "TEST_VIEW",
+            permission.Key,
             FgaTestDataSeeder.TestProjectResourceId);
         var trace = await _authService.TraceResourceAccessAsync(
             FgaTestDataSeeder.SystemAdminSubjectId,
             FgaTestDataSeeder.TestProjectResourceId,
-            "TEST_VIEW");
+            permission.Key);
         Context.Set<LifecycleProtectedEntity>().Add(new LifecycleProtectedEntity
         {
             Id = $"typed_{Guid.NewGuid():N}",
@@ -123,7 +135,7 @@ public class SqlOSFgaAuthServiceIntegrationTests : FgaIntegrationTestBase
         await Context.SaveChangesAsync();
         var filter = await _authService.GetAuthorizationFilterAsync<LifecycleProtectedEntity>(
             FgaTestDataSeeder.SystemAdminSubjectId,
-            "TEST_VIEW");
+            permission.Key);
 
         Assert.IsFalse(point.Allowed);
         Assert.IsTrue(point.Error?.Contains("does not apply to resource type project", StringComparison.Ordinal));
@@ -138,13 +150,25 @@ public class SqlOSFgaAuthServiceIntegrationTests : FgaIntegrationTestBase
     [TestMethod]
     public async Task TypeScopedPermission_AllowsTargetTypeViaAncestorGrant()
     {
-        var permission = await Context.Set<SqlOSFgaPermission>().SingleAsync(p => p.Key == "TEST_VIEW");
-        permission.ResourceTypeId = "project";
+        var suffix = Guid.NewGuid().ToString("N");
+        var permission = new SqlOSFgaPermission
+        {
+            Id = $"perm_typed_allow_{suffix}",
+            Key = $"TYPED_ALLOW_{suffix}",
+            Name = "Project permission",
+            ResourceTypeId = "project"
+        };
+        Context.Set<SqlOSFgaPermission>().Add(permission);
+        Context.Set<SqlOSFgaRolePermission>().Add(new SqlOSFgaRolePermission
+        {
+            RoleId = FgaTestDataSeeder.AgencyAdminRoleId,
+            PermissionId = permission.Id
+        });
         await Context.SaveChangesAsync();
 
         var result = await _authService.CheckAccessAsync(
             FgaTestDataSeeder.AgencyAdminSubjectId,
-            "TEST_VIEW",
+            permission.Key,
             FgaTestDataSeeder.TestProjectResourceId);
 
         Assert.IsTrue(result.Allowed, "a permission scoped to the target type should still inherit through an ancestor grant");

--- a/tests/SqlOS.IntegrationTests/Fga/SqlOSFgaFunctionInitializerIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/Fga/SqlOSFgaFunctionInitializerIntegrationTests.cs
@@ -63,6 +63,7 @@ public class SqlOSFgaFunctionInitializerIntegrationTests : FgaIntegrationTestBas
         definition.Should().Contain("ug.IsActive = 1");
         definition.Should().Contain("OPENJSON(@SubjectIds)");
         definition.Should().Contain("JSON_VALUE(@SubjectIds, '$[0]')");
+        definition.Should().Contain("permission.ResourceTypeId IS NULL OR permission.ResourceTypeId = target.ResourceTypeId");
     }
 
     private static async Task<string> GetFunctionDefinitionAsync()

--- a/tests/SqlOS.IntegrationTests/Fga/SqlOSFgaSchemaInitializerIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/Fga/SqlOSFgaSchemaInitializerIntegrationTests.cs
@@ -108,6 +108,29 @@ public class SqlOSFgaSchemaInitializerIntegrationTests : FgaIntegrationTestBase
     }
 
     [TestMethod]
+    public async Task EnsureSchema_V6Migration_EnforcesUniquePermissionKeys()
+    {
+        var loggerFactory = LoggerFactory.Create(b => b.AddConsole());
+        var initializer = new SqlOSFgaSchemaInitializer(
+            Context,
+            Options.Create(new SqlOSFgaOptions()),
+            loggerFactory.CreateLogger<SqlOSFgaSchemaInitializer>());
+
+        await initializer.EnsureSchemaAsync();
+
+        Assert.IsTrue(await IndexExistsAsync("SqlOSFgaPermissions", "UX_SqlOSFgaPermissions_Key"));
+
+        Context.Set<SqlOS.Fga.Models.SqlOSFgaPermission>().Add(new()
+        {
+            Id = $"perm_duplicate_{Guid.NewGuid():N}",
+            Key = "TEST_VIEW",
+            Name = "Duplicate View"
+        });
+        await Assert.ThrowsExceptionAsync<DbUpdateException>(() => Context.SaveChangesAsync());
+        Context.ChangeTracker.Clear();
+    }
+
+    [TestMethod]
     public async Task EnsureSchema_SetsCorrectVersion()
     {
         var loggerFactory = LoggerFactory.Create(b => b.AddConsole());
@@ -119,7 +142,7 @@ public class SqlOSFgaSchemaInitializerIntegrationTests : FgaIntegrationTestBase
         await initializer.EnsureSchemaAsync();
 
         var version = await GetSchemaVersionAsync();
-        Assert.IsTrue(version >= 5, $"Schema version should be at least 5, was {version}");
+        Assert.IsTrue(version >= 6, $"Schema version should be at least 6, was {version}");
     }
 
     private async Task<bool> TableExistsAsync(string tableName)

--- a/tests/SqlOS.Tests/SqlOSErgonomicsExtensionsTests.cs
+++ b/tests/SqlOS.Tests/SqlOSErgonomicsExtensionsTests.cs
@@ -394,6 +394,17 @@ public sealed class SqlOSErgonomicsExtensionsTests
     }
 
     [TestMethod]
+    public void FgaSeedDsl_RejectsPermissionKeysThatCannotBeIndexed()
+    {
+        var seed = new SqlOSFgaSeedBuilder();
+
+        var act = () => seed.Permission("perm_oversized", new string('K', 451), "Oversized", "workspace");
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*permission keys cannot exceed 450 characters*");
+    }
+
+    [TestMethod]
     public void SeedDeviceFlowClient_CreatesDeviceFlowPublicClient()
     {
         var options = new SqlOSAuthServerOptions();

--- a/tests/SqlOS.Tests/SqlOSErgonomicsExtensionsTests.cs
+++ b/tests/SqlOS.Tests/SqlOSErgonomicsExtensionsTests.cs
@@ -382,6 +382,18 @@ public sealed class SqlOSErgonomicsExtensionsTests
     }
 
     [TestMethod]
+    public void FgaSeedDsl_RejectsDuplicatePermissionKeysBeforeStartup()
+    {
+        var seed = new SqlOSFgaSeedBuilder();
+        seed.Permission("perm_read_one", "CHECKLIST_READ", "Read", "workspace");
+
+        var act = () => seed.Permission("perm_read_two", "CHECKLIST_READ", "Duplicate Read", "workspace");
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*permission key 'CHECKLIST_READ'*must be unique*");
+    }
+
+    [TestMethod]
     public void SeedDeviceFlowClient_CreatesDeviceFlowPublicClient()
     {
         var options = new SqlOSAuthServerOptions();

--- a/web/content/docs/fga/permissions.mdx
+++ b/web/content/docs/fga/permissions.mdx
@@ -7,6 +7,8 @@ section: fga
 
 A permission is a capability key scoped to a resource type. Permissions define what actions can be performed on which kinds of resources.
 
+Permission keys are globally unique and limited to 450 characters. Startup seeding rejects duplicates and oversized keys immediately, while the database constraint protects dashboard and concurrent writes.
+
 ## Define permissions in startup
 
 ```csharp
@@ -64,7 +66,9 @@ public class SqlOSFgaPermission
 {
     public string Id { get; set; }
     public string Key { get; set; }            // "CHAIN_VIEW"
-    public string DisplayName { get; set; }    // "View Chain"
-    public string ResourceTypeId { get; set; } // "chain"
+    public string Name { get; set; }           // "View Chain"
+    public string? ResourceTypeId { get; set; }// "chain"
 }
 ```
+
+`ResourceTypeId` applies to the resource being authorized. A role granted on a parent may still provide a `chain` permission to a descendant chain, but that permission cannot authorize a location or inventory resource. A `null` resource type is intentionally unscoped and can apply to any resource type.


### PR DESCRIPTION
Closes #133.

## What changed

- adds a unique SQL index and EF model constraint for global permission keys
- fails the schema upgrade with an explicit message if legacy duplicate keys exist
- rejects duplicate keys early in the seed DSL and dashboard, including concurrent dashboard creation
- enforces `ResourceTypeId` against the target resource type in point checks, traces, and SQL-backed EF filters
- preserves inheritance: a permission scoped to a child type can still be granted through a role on an ancestor
- leaves `ResourceTypeId = null` as the existing unscoped behavior

## Developer impact

Normal seed and authorization APIs do not change. Invalid duplicate seed configuration now fails immediately with a useful message instead of producing nondeterministic authorization. Resource-type scoping now behaves as documented across every authorization path.

## Validation

- focused ergonomics/unit suite: 17 passed
- SQL-backed FGA integration suites: 27 passed, covering schema/index enforcement, point checks, traces, inheritance, and TVF/EF filtering

An adversarial review and final full-suite validation will be recorded in PR comments before this is marked ready.
