### PR TITLE
Make schema migrations crash safe

### DIFF
--- a/src/SqlOS/AuthServer/Services/SqlOSSchemaInitializer.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSSchemaInitializer.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using System.Text.RegularExpressions;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using SqlOS.AuthServer.Configuration;
@@ -42,22 +43,63 @@ END
 IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'SqlOSSchema' AND schema_id = SCHEMA_ID('{schema}'))
 BEGIN
     CREATE TABLE [{schema}].[SqlOSSchema] ([Version] INT NOT NULL);
+END
+IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'SqlOSAppliedMigrations' AND schema_id = SCHEMA_ID('{schema}'))
+BEGIN
+    CREATE TABLE [{schema}].[SqlOSAppliedMigrations] (
+        [Sequence] BIGINT IDENTITY(1,1) NOT NULL,
+        [ScriptName] NVARCHAR(450) NOT NULL,
+        [Version] INT NOT NULL,
+        [AppliedAt] DATETIME2 NOT NULL,
+        CONSTRAINT [PK_SqlOSAppliedMigrations] PRIMARY KEY ([ScriptName]),
+        CONSTRAINT [UX_SqlOSAppliedMigrations_Sequence] UNIQUE ([Sequence])
+    );
 END";
         await _context.Database.ExecuteSqlRawAsync(ensureVersionTableSql, cancellationToken);
 
         var currentVersion = await GetCurrentVersionAsync(schema, cancellationToken);
-        var targetVersion = migrations.Max(x => x.Version);
-        if (currentVersion >= targetVersion)
+        var orderedMigrations = migrations
+            .OrderBy(x => x.Version)
+            .ThenBy(x => x.ResourceName, StringComparer.Ordinal)
+            .ToList();
+        var appliedMigrations = await GetAppliedMigrationsAsync(schema, cancellationToken);
+        if (appliedMigrations.Count == 0 && currentVersion > 0)
+        {
+            // Legacy installations only recorded the latest version. Scripts below that
+            // version must have completed. A unique script at the current version also
+            // completed, while every member of a duplicate-version group is rerun because
+            // the old marker cannot tell which member committed before a crash.
+            var currentVersionScriptCount = orderedMigrations.Count(x => x.Version == currentVersion);
+            foreach (var migration in orderedMigrations.Where(x =>
+                         x.Version < currentVersion
+                         || (x.Version == currentVersion && currentVersionScriptCount == 1)))
+            {
+                await RecordAppliedMigrationAsync(schema, migration, cancellationToken);
+                appliedMigrations.Add(migration.ResourceName);
+            }
+        }
+
+        var pendingMigrations = orderedMigrations
+            .Where(x => !appliedMigrations.Contains(x.ResourceName))
+            .ToList();
+        if (pendingMigrations.Count == 0)
         {
             _logger.LogInformation("SqlOS schema is up to date at version {Version}.", currentVersion);
             return;
         }
 
-        foreach (var migration in migrations.Where(x => x.Version > currentVersion).OrderBy(x => x.Version))
+        foreach (var migration in pendingMigrations)
         {
             _logger.LogInformation("Running SqlOS schema migration {Version}: {Name}", migration.Version, migration.Name);
+            await using var transaction = await _context.Database.BeginTransactionAsync(cancellationToken);
             await RunScriptAsync(migration.ResourceName, cancellationToken);
+            await RecordAppliedMigrationAsync(schema, migration, cancellationToken);
+            await transaction.CommitAsync(cancellationToken);
         }
+
+        var targetVersion = orderedMigrations.Max(x => x.Version);
+        var updateVersionSql = $"UPDATE [{schema}].[SqlOSSchema] SET [Version] = @targetVersion";
+        await _context.Database.ExecuteSqlRawAsync(updateVersionSql, [new SqlParameter("@targetVersion", targetVersion)], cancellationToken);
     }
 
     private List<MigrationScript> DiscoverMigrations()
@@ -103,6 +145,50 @@ END";
                 await connection.CloseAsync();
             }
         }
+    }
+
+    private async Task<HashSet<string>> GetAppliedMigrationsAsync(string schema, CancellationToken cancellationToken)
+    {
+        var connection = _context.Database.GetDbConnection();
+        var wasOpen = connection.State == System.Data.ConnectionState.Open;
+        if (!wasOpen)
+        {
+            await connection.OpenAsync(cancellationToken);
+        }
+
+        try
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = $"SELECT [ScriptName] FROM [{schema}].[SqlOSAppliedMigrations]";
+            var result = new HashSet<string>(StringComparer.Ordinal);
+            await using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
+            while (await reader.ReadAsync(cancellationToken))
+            {
+                result.Add(reader.GetString(0));
+            }
+
+            return result;
+        }
+        finally
+        {
+            if (!wasOpen)
+            {
+                await connection.CloseAsync();
+            }
+        }
+    }
+
+    private Task RecordAppliedMigrationAsync(string schema, MigrationScript migration, CancellationToken cancellationToken)
+    {
+        var sql = $@"
+IF NOT EXISTS (SELECT 1 FROM [{schema}].[SqlOSAppliedMigrations] WHERE [ScriptName] = @scriptName)
+BEGIN
+    INSERT INTO [{schema}].[SqlOSAppliedMigrations] ([ScriptName], [Version], [AppliedAt])
+    VALUES (@scriptName, @version, SYSUTCDATETIME());
+END";
+        return _context.Database.ExecuteSqlRawAsync(sql,
+            [new SqlParameter("@scriptName", migration.ResourceName), new SqlParameter("@version", migration.Version)],
+            cancellationToken);
     }
 
     private async Task RunScriptAsync(string resourceName, CancellationToken cancellationToken)

--- a/src/SqlOS/AuthServer/Services/SqlOSSchemaInitializer.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSSchemaInitializer.cs
@@ -70,11 +70,19 @@ END";
             // completed, while every member of a duplicate-version group is rerun because
             // the old marker cannot tell which member committed before a crash.
             var currentVersionScriptCount = orderedMigrations.Count(x => x.Version == currentVersion);
-            foreach (var migration in orderedMigrations.Where(x =>
-                         x.Version < currentVersion
-                         || (x.Version == currentVersion && currentVersionScriptCount == 1)))
+            var legacyAppliedMigrations = orderedMigrations.Where(x =>
+                    x.Version < currentVersion
+                    || (x.Version == currentVersion && currentVersionScriptCount == 1))
+                .ToList();
+            await ExecuteInTransactionAsync(async () =>
             {
-                await RecordAppliedMigrationAsync(schema, migration, cancellationToken);
+                foreach (var migration in legacyAppliedMigrations)
+                {
+                    await RecordAppliedMigrationAsync(schema, migration, cancellationToken);
+                }
+            }, cancellationToken);
+            foreach (var migration in legacyAppliedMigrations)
+            {
                 appliedMigrations.Add(migration.ResourceName);
             }
         }
@@ -91,10 +99,11 @@ END";
         foreach (var migration in pendingMigrations)
         {
             _logger.LogInformation("Running SqlOS schema migration {Version}: {Name}", migration.Version, migration.Name);
-            await using var transaction = await _context.Database.BeginTransactionAsync(cancellationToken);
-            await RunScriptAsync(migration.ResourceName, cancellationToken);
-            await RecordAppliedMigrationAsync(schema, migration, cancellationToken);
-            await transaction.CommitAsync(cancellationToken);
+            await ExecuteInTransactionAsync(async () =>
+            {
+                await RunScriptAsync(migration.ResourceName, cancellationToken);
+                await RecordAppliedMigrationAsync(schema, migration, cancellationToken);
+            }, cancellationToken);
         }
 
         var targetVersion = orderedMigrations.Max(x => x.Version);
@@ -189,6 +198,17 @@ END";
         return _context.Database.ExecuteSqlRawAsync(sql,
             [new SqlParameter("@scriptName", migration.ResourceName), new SqlParameter("@version", migration.Version)],
             cancellationToken);
+    }
+
+    private async Task ExecuteInTransactionAsync(Func<Task> operation, CancellationToken cancellationToken)
+    {
+        var strategy = _context.Database.CreateExecutionStrategy();
+        await strategy.ExecuteAsync(async () =>
+        {
+            await using var transaction = await _context.Database.BeginTransactionAsync(cancellationToken);
+            await operation();
+            await transaction.CommitAsync(cancellationToken);
+        });
     }
 
     private async Task RunScriptAsync(string resourceName, CancellationToken cancellationToken)

--- a/tests/SqlOS.IntegrationTests/SchemaInitializerIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/SchemaInitializerIntegrationTests.cs
@@ -70,7 +70,7 @@ public sealed class SchemaInitializerIntegrationTests
         try
         {
             var dbOptions = new DbContextOptionsBuilder<TestSqlOSDbContext>()
-                .UseSqlServer(databaseConnectionString)
+                .UseSqlServer(databaseConnectionString, sql => sql.EnableRetryOnFailure())
                 .Options;
             await using var context = new TestSqlOSDbContext(dbOptions);
             var initializer = new SqlOSSchemaInitializer(

--- a/tests/SqlOS.IntegrationTests/SchemaInitializerIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/SchemaInitializerIntegrationTests.cs
@@ -1,4 +1,5 @@
 using System.Security.Cryptography;
+using System.Text.RegularExpressions;
 using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -51,10 +52,69 @@ public sealed class SchemaInitializerIntegrationTests
                      "SqlOSCalendarConnections",
                      "SqlOSCalendarSyncStates",
                      "SqlOSCalendarEvents",
-                     "SqlOSSchema"
+                     "SqlOSSchema",
+                     "SqlOSAppliedMigrations"
                  })
         {
             Assert.IsTrue(await TableExistsAsync(table), $"Table {table} should exist.");
+        }
+    }
+
+    [TestMethod]
+    public async Task EnsureSchema_ResumesMissingSameVersionScripts_AndRecordsDeterministicOrder()
+    {
+        var databaseName = $"SqlOSLedger_{Guid.NewGuid():N}"[..30];
+        var databaseConnectionString = BuildDatabaseConnectionString(databaseName);
+        await CreateDatabaseAsync(databaseName);
+
+        try
+        {
+            var dbOptions = new DbContextOptionsBuilder<TestSqlOSDbContext>()
+                .UseSqlServer(databaseConnectionString)
+                .Options;
+            await using var context = new TestSqlOSDbContext(dbOptions);
+            var initializer = new SqlOSSchemaInitializer(
+                context,
+                Options.Create(AspireFixture.Options),
+                LoggerFactory.Create(b => b.AddConsole()).CreateLogger<SqlOSSchemaInitializer>());
+
+            await initializer.EnsureSchemaAsync();
+
+            var initialOrder = await ReadAppliedMigrationOrderAsync(context);
+            var expectedOrder = initialOrder
+                .OrderBy(ParseMigrationVersion)
+                .ThenBy(x => x, StringComparer.Ordinal)
+                .ToList();
+            CollectionAssert.AreEqual(expectedOrder, initialOrder,
+                "Migration order must be version-first and script-name deterministic.");
+
+            await context.Database.ExecuteSqlRawAsync("""
+                DROP TABLE [dbo].[SqlOSEmailDeliveries];
+                DROP TABLE [dbo].[SqlOSEmailTemplates];
+                DROP TABLE [dbo].[SqlOSPasswordLoginBuckets];
+                DELETE FROM [dbo].[SqlOSAppliedMigrations]
+                WHERE [ScriptName] IN (
+                    'SqlOS.AuthServer.Schema.017_PasswordLoginAbuse.sql',
+                    'SqlOS.AuthServer.Schema.017_TransactionalEmail.sql');
+                UPDATE [dbo].[SqlOSSchema] SET [Version] = 17;
+                """);
+
+            await initializer.EnsureSchemaAsync();
+
+            Assert.AreEqual(3, await ScalarIntAsync(context,
+                "SELECT COUNT(*) FROM [dbo].[SqlOSAppliedMigrations] WHERE [Version] = 17"));
+            Assert.AreEqual(1, await ScalarIntAsync(context,
+                "SELECT COUNT(*) FROM sys.tables WHERE [name] = 'SqlOSPasswordLoginBuckets'"));
+            Assert.AreEqual(1, await ScalarIntAsync(context,
+                "SELECT COUNT(*) FROM sys.tables WHERE [name] = 'SqlOSEmailTemplates'"));
+            Assert.AreEqual(1, await ScalarIntAsync(context,
+                "SELECT COUNT(*) FROM sys.tables WHERE [name] = 'SqlOSEmailDeliveries'"));
+            Assert.AreEqual(30, await ScalarIntAsync(context, "SELECT TOP 1 [Version] FROM [dbo].[SqlOSSchema]"));
+        }
+        finally
+        {
+            SqlConnection.ClearAllPools();
+            await DropDatabaseAsync(databaseName);
         }
     }
 
@@ -974,6 +1034,36 @@ public sealed class SchemaInitializerIntegrationTests
         {
             await connection.CloseAsync();
         }
+    }
+
+    private static async Task<List<string>> ReadAppliedMigrationOrderAsync(DbContext context)
+    {
+        var connection = context.Database.GetDbConnection();
+        await connection.OpenAsync();
+        try
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "SELECT [ScriptName] FROM [dbo].[SqlOSAppliedMigrations] ORDER BY [Sequence]";
+            await using var reader = await cmd.ExecuteReaderAsync();
+            var result = new List<string>();
+            while (await reader.ReadAsync())
+            {
+                result.Add(reader.GetString(0));
+            }
+
+            return result;
+        }
+        finally
+        {
+            await connection.CloseAsync();
+        }
+    }
+
+    private static int ParseMigrationVersion(string scriptName)
+    {
+        var match = Regex.Match(scriptName, @"\.Schema\.(\d+)_", RegexOptions.CultureInvariant);
+        Assert.IsTrue(match.Success, $"Unexpected migration resource name: {scriptName}");
+        return int.Parse(match.Groups[1].Value, System.Globalization.CultureInfo.InvariantCulture);
     }
 
     private static string BuildDatabaseConnectionString(string databaseName)

--- a/web/content/docs/guides/production-readiness.mdx
+++ b/web/content/docs/guides/production-readiness.mdx
@@ -195,12 +195,12 @@ SqlOS protects JWT private signing keys automatically; there is no signing-key f
 SqlOS owns its tables separately from your EF Core migrations. At host startup, `SqlOSBootstrapHostedService` calls `SqlOSBootstrapper`, which:
 
 1. discovers embedded, numbered AuthServer SQL scripts;
-2. applies pending scripts in ascending order and updates `SqlOSSchema`;
+2. applies pending scripts in deterministic version/name order and records each completed script in `SqlOSAppliedMigrations`;
 3. ensures an active signing key, settings, templates, and startup seeds;
 4. applies the FGA scripts tracked by `SqlOSFgaSchema`;
 5. creates or verifies FGA functions and seed data when enabled.
 
-The current initializers execute SQL batches directly. They do **not** acquire a distributed migration lock, wrap the entire release upgrade in one cross-script transaction, or provide down migrations.
+Each AuthServer script and its ledger entry commit in one transaction, so an interrupted startup safely retries the unrecorded script. The initializer does **not** acquire a distributed migration lock, wrap the entire release upgrade in one cross-script transaction, or provide down migrations.
 
 Use this rollout sequence:
 

--- a/web/content/docs/guides/test-your-integration.mdx
+++ b/web/content/docs/guides/test-your-integration.mdx
@@ -257,7 +257,7 @@ Start with one test in every row, then add cases for the features you enable.
 
 | Area | Happy-path proof | Negative proof |
 | --- | --- | --- |
-| Startup/schema | Fresh database boots and a second start is idempotent | Bad connection or failed migration keeps the revision unhealthy |
+| Startup/schema | Fresh database boots, scripts are deterministically ledgered, and a second start is idempotent | Bad connection fails startup; an interrupted script is retried without skipping same-version siblings |
 | Discovery/JWKS | Published issuer and endpoints match the public origin; active key validates a token | Internal host/scheme never appears in metadata or links |
 | Authorization code + PKCE | Hosted sign-in returns one exchangeable code and the expected state | Wrong verifier, redirect URI, client, reused code, or expired request fails |
 | Token validation | Correct issuer, signature, lifetime, and exact audience reach the API | Missing, malformed, expired, wrong-audience, or wrong-issuer token returns `401` |


### PR DESCRIPTION
## Summary

- track AuthServer migrations by full embedded script name in an internal applied-migration ledger
- apply each script and its ledger record transactionally in deterministic version/name order
- safely reconcile legacy version-only databases, including interrupted duplicate-version groups
- cover interrupted same-version startup against a real isolated SQL database and update production guidance

## Validation

- `dotnet test tests/SqlOS.Tests/SqlOS.Tests.csproj` (554 passed)
- focused real-SQL interrupted-migration and legacy-upgrade tests (2 passed)

Closes #138
