### PR TITLE
Add persistent SAML replay protection

### DIFF
--- a/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerModelConfiguration.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerModelConfiguration.cs
@@ -807,10 +807,6 @@ public static class SqlOSAuthServerModelConfiguration
             entity.HasIndex(x => new { x.ConnectionId, x.ResponseId }).IsUnique();
             entity.HasIndex(x => new { x.ConnectionId, x.AssertionId }).IsUnique();
             entity.HasIndex(x => x.ExpiresAt);
-            entity.HasOne(x => x.Connection)
-                .WithMany()
-                .HasForeignKey(x => x.ConnectionId)
-                .OnDelete(DeleteBehavior.Cascade);
         });
 
         modelBuilder.Entity<SqlOSAuthorizationCode>(entity =>

--- a/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerModelConfiguration.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerModelConfiguration.cs
@@ -798,6 +798,21 @@ public static class SqlOSAuthServerModelConfiguration
                 .OnDelete(DeleteBehavior.Restrict);
         });
 
+        modelBuilder.Entity<SqlOSSamlReplay>(entity =>
+        {
+            entity.ToTable("SqlOSSamlReplays", schema, t => t.ExcludeFromMigrations());
+            entity.HasKey(x => x.Id);
+            entity.Property(x => x.ResponseId).HasMaxLength(450);
+            entity.Property(x => x.AssertionId).HasMaxLength(450);
+            entity.HasIndex(x => new { x.ConnectionId, x.ResponseId }).IsUnique();
+            entity.HasIndex(x => new { x.ConnectionId, x.AssertionId }).IsUnique();
+            entity.HasIndex(x => x.ExpiresAt);
+            entity.HasOne(x => x.Connection)
+                .WithMany()
+                .HasForeignKey(x => x.ConnectionId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
         modelBuilder.Entity<SqlOSAuthorizationCode>(entity =>
         {
             entity.ToTable("SqlOSAuthorizationCodes", schema, t => t.ExcludeFromMigrations());

--- a/src/SqlOS/AuthServer/Models/SqlOSEntities.cs
+++ b/src/SqlOS/AuthServer/Models/SqlOSEntities.cs
@@ -815,6 +815,18 @@ public sealed class SqlOSAuthorizationRequest
     public SqlOSInvitation? Invitation { get; set; }
 }
 
+public sealed class SqlOSSamlReplay
+{
+    public string Id { get; set; } = string.Empty;
+    public string ConnectionId { get; set; } = string.Empty;
+    public string ResponseId { get; set; } = string.Empty;
+    public string AssertionId { get; set; } = string.Empty;
+    public DateTime ConsumedAt { get; set; }
+    public DateTime ExpiresAt { get; set; }
+
+    public SqlOSSsoConnection? Connection { get; set; }
+}
+
 public sealed class SqlOSAuthorizationCode
 {
     public string Id { get; set; } = string.Empty;

--- a/src/SqlOS/AuthServer/Models/SqlOSEntities.cs
+++ b/src/SqlOS/AuthServer/Models/SqlOSEntities.cs
@@ -823,8 +823,6 @@ public sealed class SqlOSSamlReplay
     public string AssertionId { get; set; } = string.Empty;
     public DateTime ConsumedAt { get; set; }
     public DateTime ExpiresAt { get; set; }
-
-    public SqlOSSsoConnection? Connection { get; set; }
 }
 
 public sealed class SqlOSAuthorizationCode

--- a/src/SqlOS/AuthServer/Schema/031_SamlReplayProtection.sql
+++ b/src/SqlOS/AuthServer/Schema/031_SamlReplayProtection.sql
@@ -6,9 +6,7 @@ BEGIN
         [ResponseId] NVARCHAR(450) NOT NULL,
         [AssertionId] NVARCHAR(450) NOT NULL,
         [ConsumedAt] DATETIME2 NOT NULL,
-        [ExpiresAt] DATETIME2 NOT NULL,
-        CONSTRAINT [FK_SqlOSSamlReplays_SsoConnections_ConnectionId]
-            FOREIGN KEY ([ConnectionId]) REFERENCES [{Schema}].[SqlOSSsoConnections]([Id]) ON DELETE CASCADE
+        [ExpiresAt] DATETIME2 NOT NULL
     );
 
     CREATE UNIQUE INDEX [UX_SqlOSSamlReplays_Connection_Response]

--- a/src/SqlOS/AuthServer/Schema/031_SamlReplayProtection.sql
+++ b/src/SqlOS/AuthServer/Schema/031_SamlReplayProtection.sql
@@ -1,0 +1,26 @@
+IF OBJECT_ID('[{Schema}].[SqlOSSamlReplays]', 'U') IS NULL
+BEGIN
+    CREATE TABLE [{Schema}].[SqlOSSamlReplays] (
+        [Id] NVARCHAR(64) NOT NULL CONSTRAINT [PK_SqlOSSamlReplays] PRIMARY KEY,
+        [ConnectionId] NVARCHAR(64) NOT NULL,
+        [ResponseId] NVARCHAR(450) NOT NULL,
+        [AssertionId] NVARCHAR(450) NOT NULL,
+        [ConsumedAt] DATETIME2 NOT NULL,
+        [ExpiresAt] DATETIME2 NOT NULL,
+        CONSTRAINT [FK_SqlOSSamlReplays_SsoConnections_ConnectionId]
+            FOREIGN KEY ([ConnectionId]) REFERENCES [{Schema}].[SqlOSSsoConnections]([Id]) ON DELETE CASCADE
+    );
+
+    CREATE UNIQUE INDEX [UX_SqlOSSamlReplays_Connection_Response]
+        ON [{Schema}].[SqlOSSamlReplays]([ConnectionId], [ResponseId]);
+    CREATE UNIQUE INDEX [UX_SqlOSSamlReplays_Connection_Assertion]
+        ON [{Schema}].[SqlOSSamlReplays]([ConnectionId], [AssertionId]);
+    CREATE INDEX [IX_SqlOSSamlReplays_ExpiresAt]
+        ON [{Schema}].[SqlOSSamlReplays]([ExpiresAt]);
+END
+
+UPDATE [{Schema}].[SqlOSSchema] SET [Version] = 31;
+IF @@ROWCOUNT = 0
+BEGIN
+    INSERT INTO [{Schema}].[SqlOSSchema] ([Version]) VALUES (31);
+END

--- a/src/SqlOS/AuthServer/Services/SqlOSSamlService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSSamlService.cs
@@ -373,7 +373,7 @@ public sealed class SqlOSSamlService
     {
         var now = DateTime.UtcNow;
         await _context.Set<SqlOSSamlReplay>()
-            .Where(x => x.ConnectionId == connectionId && x.ExpiresAt <= now)
+            .Where(x => x.ExpiresAt <= now)
             .ExecuteDeleteAsync(cancellationToken);
 
         var replay = new SqlOSSamlReplay

--- a/src/SqlOS/AuthServer/Services/SqlOSSamlService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSSamlService.cs
@@ -156,11 +156,12 @@ public sealed class SqlOSSamlService
 
             var samlState = ReadSamlRequestState(authorizationRequest.UiContextJson)
                 ?? throw new InvalidOperationException("SAML request state is missing.");
-            var principal = ParseAndValidateAssertion(
+            var assertion = ParseAndValidateAssertion(
                 samlResponse,
                 connection,
                 new SamlValidationContext(samlState.RequestId, samlState.AssertionConsumerServiceUrl, _adminService.GetServiceProviderEntityId()));
-            return await HandleAuthorizationRequestAcsAsync(connection, authorizationRequest, principal, httpContext, cancellationToken);
+            await ConsumeReplayIdentifiersAsync(connection.Id, assertion, cancellationToken);
+            return await HandleAuthorizationRequestAcsAsync(connection, authorizationRequest, assertion.Principal, httpContext, cancellationToken);
         }
 
         throw new InvalidOperationException("SAML authorization request is invalid or expired.");
@@ -282,7 +283,7 @@ public sealed class SqlOSSamlService
         return $"{connection.SingleSignOnUrl}{separator}{query}";
     }
 
-    private SqlOSSamlPrincipal ParseAndValidateAssertion(
+    private ValidatedSamlAssertion ParseAndValidateAssertion(
         string base64Response,
         SqlOSSsoConnection connection,
         SamlValidationContext validationContext)
@@ -303,11 +304,14 @@ public sealed class SqlOSSamlService
             throw new InvalidOperationException("SAML response is invalid.");
         }
 
+        var responseId = RequireSamlIdentifier(responseElement, "response");
+
         var assertionNodes = responseElement.SelectNodes("saml:Assertion", ns);
         if (assertionNodes == null || assertionNodes.Count != 1 || assertionNodes[0] is not XmlElement assertionElement)
         {
             throw new InvalidOperationException("SAML response must contain exactly one assertion.");
         }
+        var assertionId = RequireSamlIdentifier(assertionElement, "assertion");
 
         var signedElement = ValidateSignature(xmlDoc, connection.X509CertificatePem, ns);
         if (!ReferenceEquals(signedElement, responseElement) && !ReferenceEquals(signedElement, assertionElement))
@@ -335,7 +339,7 @@ public sealed class SqlOSSamlService
         }
 
         ValidateResponseCorrelation(responseElement, validationContext);
-        ValidateAssertionConditions(assertionElement, validationContext, ns);
+        var expiresAt = ValidateAssertionConditions(assertionElement, validationContext, ns);
 
         var nameId = assertionElement.SelectSingleNode("saml:Subject/saml:NameID", ns)?.InnerText
             ?? throw new InvalidOperationException("SAML assertion NameID missing.");
@@ -355,7 +359,54 @@ public sealed class SqlOSSamlService
             }
         }
 
-        return new SqlOSSamlPrincipal(issuer, nameId, attributes);
+        return new ValidatedSamlAssertion(
+            new SqlOSSamlPrincipal(issuer, nameId, attributes),
+            responseId,
+            assertionId,
+            expiresAt + SamlClockSkew);
+    }
+
+    private async Task ConsumeReplayIdentifiersAsync(
+        string connectionId,
+        ValidatedSamlAssertion assertion,
+        CancellationToken cancellationToken)
+    {
+        var now = DateTime.UtcNow;
+        await _context.Set<SqlOSSamlReplay>()
+            .Where(x => x.ConnectionId == connectionId && x.ExpiresAt <= now)
+            .ExecuteDeleteAsync(cancellationToken);
+
+        var replay = new SqlOSSamlReplay
+        {
+            Id = _cryptoService.GenerateId("srp"),
+            ConnectionId = connectionId,
+            ResponseId = assertion.ResponseId,
+            AssertionId = assertion.AssertionId,
+            ConsumedAt = now,
+            ExpiresAt = assertion.ReplayExpiresAt
+        };
+        _context.Set<SqlOSSamlReplay>().Add(replay);
+
+        try
+        {
+            await _context.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
+        {
+            _context.Set<SqlOSSamlReplay>().Remove(replay);
+            throw new InvalidOperationException("SAML response has already been consumed.", ex);
+        }
+    }
+
+    private static string RequireSamlIdentifier(XmlElement element, string kind)
+    {
+        var id = element.GetAttribute("ID");
+        if (string.IsNullOrWhiteSpace(id) || id.Length > 450)
+        {
+            throw new InvalidOperationException($"SAML {kind} ID is missing or invalid.");
+        }
+
+        return id;
     }
 
     private static XmlDocument LoadSamlDocument(string xml)
@@ -516,7 +567,7 @@ public sealed class SqlOSSamlService
         }
     }
 
-    private static void ValidateAssertionConditions(XmlElement assertionElement, SamlValidationContext validationContext, XmlNamespaceManager ns)
+    private static DateTime ValidateAssertionConditions(XmlElement assertionElement, SamlValidationContext validationContext, XmlNamespaceManager ns)
     {
         var now = DateTime.UtcNow;
         var conditions = assertionElement.SelectSingleNode("saml:Conditions", ns) as XmlElement
@@ -551,6 +602,8 @@ public sealed class SqlOSSamlService
         {
             throw new InvalidOperationException("SAML subject confirmation mismatch.");
         }
+
+        return notOnOrAfter;
     }
 
     private static bool IsValidSubjectConfirmation(XmlElement subjectConfirmationData, SamlValidationContext validationContext, DateTime now)
@@ -575,7 +628,7 @@ public sealed class SqlOSSamlService
         }
 
         var notOnOrAfter = ParseSamlDateTimeOrNull(subjectConfirmationData.GetAttribute("NotOnOrAfter"));
-        return !notOnOrAfter.HasValue || now - SamlClockSkew < notOnOrAfter.Value;
+        return notOnOrAfter.HasValue && now - SamlClockSkew < notOnOrAfter.Value;
     }
 
     private static DateTime? ParseSamlDateTimeOrNull(string? value)
@@ -904,6 +957,11 @@ public sealed class SqlOSSamlService
     private sealed record SamlRequestState(string RequestId, string AssertionConsumerServiceUrl);
     private sealed record SamlValidationContext(string RequestId, string AssertionConsumerServiceUrl, string Audience);
     private sealed record SqlOSSamlPrincipal(string Issuer, string Subject, Dictionary<string, string> Attributes);
+    private sealed record ValidatedSamlAssertion(
+        SqlOSSamlPrincipal Principal,
+        string ResponseId,
+        string AssertionId,
+        DateTime ReplayExpiresAt);
 
     private static bool IsUniqueConstraintViolation(DbUpdateException exception)
         => exception.InnerException is SqlException { Number: 2601 or 2627 };

--- a/tests/SqlOS.IntegrationTests/SamlServiceIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/SamlServiceIntegrationTests.cs
@@ -207,6 +207,95 @@ public sealed class SamlServiceIntegrationTests
     }
 
     [TestMethod]
+    public async Task SignedSamlResponses_WithDuplicateIdentifiers_AreRejectedAcrossAuthorizationRequests()
+    {
+        var (_, admin, saml) = CreateSamlServices();
+        var org = await admin.CreateOrganizationAsync(new SqlOSCreateOrganizationRequest($"Replay {Guid.NewGuid():N}", null));
+        var client = await CreateSamlClientAsync(admin, "replay");
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest("CN=SqlOSReplayIdP", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        using var certificate = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(30));
+        var connection = await admin.CreateSsoConnectionAsync(new SqlOSCreateSsoConnectionRequest(
+            org.Id, "Replay SSO", $"urn:replay:{Guid.NewGuid():N}:idp", "https://idp.example.test/sso",
+            certificate.ExportCertificatePem(), true, false, "email", "first_name", "last_name"));
+        var responseId = $"_{Guid.NewGuid():N}";
+        var assertionId = $"_{Guid.NewGuid():N}";
+
+        var firstFlow = await StartSamlRequestAsync(saml, connection.Id, client.ClientId);
+        var firstResponse = BuildSignedSamlResponse(
+            certificate, connection.IdentityProviderEntityId, $"replay-{Guid.NewGuid():N}@example.com", "Replay", "User",
+            firstFlow, responseId: responseId, assertionId: assertionId);
+        (await saml.HandleAcsAsync(connection.Id, firstResponse, firstFlow.RelayState)).Should().Contain("code=");
+
+        var secondFlow = await StartSamlRequestAsync(saml, connection.Id, client.ClientId);
+        var duplicateResponse = BuildSignedSamlResponse(
+            certificate, connection.IdentityProviderEntityId, $"replay-{Guid.NewGuid():N}@example.com", "Replay", "User",
+            secondFlow, responseId: responseId, assertionId: assertionId);
+        var action = async () => await saml.HandleAcsAsync(connection.Id, duplicateResponse, secondFlow.RelayState);
+
+        await action.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("SAML response has already been consumed.");
+    }
+
+    [TestMethod]
+    public async Task SignedSamlResponses_WithDuplicateIdentifiersConcurrently_AllowExactlyOne()
+    {
+        var (_, admin, saml) = CreateSamlServices();
+        var org = await admin.CreateOrganizationAsync(new SqlOSCreateOrganizationRequest($"Concurrent replay {Guid.NewGuid():N}", null));
+        var client = await CreateSamlClientAsync(admin, "concurrent-replay");
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest("CN=SqlOSConcurrentReplayIdP", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        using var certificate = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(30));
+        var connection = await admin.CreateSsoConnectionAsync(new SqlOSCreateSsoConnectionRequest(
+            org.Id, "Concurrent Replay SSO", $"urn:concurrent-replay:{Guid.NewGuid():N}:idp", "https://idp.example.test/sso",
+            certificate.ExportCertificatePem(), true, false, "email", "first_name", "last_name"));
+        var firstFlow = await StartSamlRequestAsync(saml, connection.Id, client.ClientId);
+        var secondFlow = await StartSamlRequestAsync(saml, connection.Id, client.ClientId);
+        var responseId = $"_{Guid.NewGuid():N}";
+        var assertionId = $"_{Guid.NewGuid():N}";
+        var email = $"concurrent-replay-{Guid.NewGuid():N}@example.com";
+        var firstResponse = BuildSignedSamlResponse(certificate, connection.IdentityProviderEntityId, email, "Replay", "User", firstFlow,
+            responseId: responseId, assertionId: assertionId);
+        var secondResponse = BuildSignedSamlResponse(certificate, connection.IdentityProviderEntityId, email, "Replay", "User", secondFlow,
+            responseId: responseId, assertionId: assertionId);
+
+        await using var firstContext = CreateIsolatedContext();
+        await using var secondContext = CreateIsolatedContext();
+        var firstService = CreateSamlService(firstContext);
+        var secondService = CreateSamlService(secondContext);
+        var results = await Task.WhenAll(
+            CaptureAcsAsync(firstService, connection.Id, firstResponse, firstFlow.RelayState),
+            CaptureAcsAsync(secondService, connection.Id, secondResponse, secondFlow.RelayState));
+
+        results.Count(x => x.Redirect?.Contains("code=", StringComparison.Ordinal) == true).Should().Be(1);
+        results.Count(x => x.Error?.Message == "SAML response has already been consumed.").Should().Be(1);
+    }
+
+    [TestMethod]
+    public async Task SignedSamlResponse_WithoutBearerConfirmationExpiry_IsRejected()
+    {
+        var (_, admin, saml) = CreateSamlServices();
+        var org = await admin.CreateOrganizationAsync(new SqlOSCreateOrganizationRequest($"Missing confirmation expiry {Guid.NewGuid():N}", null));
+        var client = await CreateSamlClientAsync(admin, "missing-expiry");
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest("CN=SqlOSMissingExpiryIdP", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        using var certificate = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(30));
+        var connection = await admin.CreateSsoConnectionAsync(new SqlOSCreateSsoConnectionRequest(
+            org.Id, "Missing Expiry SSO", $"urn:missing-expiry:{Guid.NewGuid():N}:idp", "https://idp.example.test/sso",
+            certificate.ExportCertificatePem(), true, false, "email", "first_name", "last_name"));
+        var flow = await StartSamlRequestAsync(saml, connection.Id, client.ClientId);
+        var samlResponse = BuildSignedSamlResponse(
+            certificate, connection.IdentityProviderEntityId, $"expiry-{Guid.NewGuid():N}@example.com", "Expiry", "User", flow,
+            mutateBeforeSigning: (_, _, assertion) => assertion
+                .GetElementsByTagName("SubjectConfirmationData", "urn:oasis:names:tc:SAML:2.0:assertion")
+                .OfType<XmlElement>().Single().RemoveAttribute("NotOnOrAfter"));
+
+        var action = async () => await saml.HandleAcsAsync(connection.Id, samlResponse, flow.RelayState);
+        await action.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("SAML subject confirmation mismatch.");
+    }
+
+    [TestMethod]
     public async Task LegacyTemporaryRelayState_CannotReachSamlCodeIssuance()
     {
         var (crypto, admin, saml) = CreateSamlServices();
@@ -1220,6 +1309,29 @@ public sealed class SamlServiceIntegrationTests
         return new TestSqlOSDbContext(dbOptions);
     }
 
+    private static SqlOSSamlService CreateSamlService(TestSqlOSDbContext context)
+    {
+        var options = Options.Create(AspireFixture.Options);
+        var crypto = new SqlOSCryptoService(context, options, AspireFixture.DataProtectionProvider);
+        return new SqlOSSamlService(context, options, new SqlOSAdminService(context, options, crypto), crypto);
+    }
+
+    private static async Task<(string? Redirect, Exception? Error)> CaptureAcsAsync(
+        SqlOSSamlService service,
+        string connectionId,
+        string response,
+        string relayState)
+    {
+        try
+        {
+            return (await service.HandleAcsAsync(connectionId, response, relayState), null);
+        }
+        catch (Exception ex)
+        {
+            return (null, ex);
+        }
+    }
+
     private static SqlOSSsoAuthorizationService BuildSsoAuthorizationService(TestSqlOSDbContext context)
     {
         var options = Options.Create(AspireFixture.Options);
@@ -1373,11 +1485,13 @@ public sealed class SamlServiceIntegrationTests
         string? inResponseTo = null,
         DateTime? notBefore = null,
         DateTime? notOnOrAfter = null,
+        string? responseId = null,
+        string? assertionId = null,
         Action<XmlDocument, XmlElement, XmlElement>? mutateBeforeSigning = null,
         Action<XmlDocument, XmlElement>? mutateAfterSigning = null)
     {
-        var responseId = $"_{Guid.NewGuid():N}";
-        var assertionId = $"_{Guid.NewGuid():N}";
+        responseId ??= $"_{Guid.NewGuid():N}";
+        assertionId ??= $"_{Guid.NewGuid():N}";
         var issueInstant = DateTime.UtcNow.ToString("o");
         var effectiveAudience = audience ?? AspireFixture.Options.Issuer;
         var effectiveRecipient = recipient ?? flow.AssertionConsumerServiceUrl;

--- a/tests/SqlOS.IntegrationTests/SamlServiceIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/SamlServiceIntegrationTests.cs
@@ -206,8 +206,12 @@ public sealed class SamlServiceIntegrationTests
         tokens.AccessToken.Should().NotBeNullOrWhiteSpace();
     }
 
-    [TestMethod]
-    public async Task SignedSamlResponses_WithDuplicateIdentifiers_AreRejectedAcrossAuthorizationRequests()
+    [DataTestMethod]
+    [DataRow(true, false, DisplayName = "Duplicate response ID is rejected")]
+    [DataRow(false, true, DisplayName = "Duplicate assertion ID is rejected")]
+    public async Task SignedSamlResponses_WithEitherDuplicateIdentifier_AreRejectedAcrossAuthorizationRequests(
+        bool reuseResponseId,
+        bool reuseAssertionId)
     {
         var (_, admin, saml) = CreateSamlServices();
         var org = await admin.CreateOrganizationAsync(new SqlOSCreateOrganizationRequest($"Replay {Guid.NewGuid():N}", null));
@@ -230,7 +234,9 @@ public sealed class SamlServiceIntegrationTests
         var secondFlow = await StartSamlRequestAsync(saml, connection.Id, client.ClientId);
         var duplicateResponse = BuildSignedSamlResponse(
             certificate, connection.IdentityProviderEntityId, $"replay-{Guid.NewGuid():N}@example.com", "Replay", "User",
-            secondFlow, responseId: responseId, assertionId: assertionId);
+            secondFlow,
+            responseId: reuseResponseId ? responseId : $"_{Guid.NewGuid():N}",
+            assertionId: reuseAssertionId ? assertionId : $"_{Guid.NewGuid():N}");
         var action = async () => await saml.HandleAcsAsync(connection.Id, duplicateResponse, secondFlow.RelayState);
 
         await action.Should().ThrowAsync<InvalidOperationException>()

--- a/tests/SqlOS.IntegrationTests/SchemaInitializerIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/SchemaInitializerIntegrationTests.cs
@@ -13,6 +13,8 @@ namespace SqlOS.IntegrationTests;
 [TestClass]
 public sealed class SchemaInitializerIntegrationTests
 {
+    private const int CurrentSchemaVersion = 31;
+
     [TestMethod]
     public async Task EnsureSchema_CreatesCoreTables()
     {
@@ -187,7 +189,7 @@ public sealed class SchemaInitializerIntegrationTests
             Assert.IsTrue(await IndexExistsAsync(context, "SqlOSAuditEvents", "IX_SqlOSAuditEvents_Action_OccurredAt"));
             Assert.IsTrue(await IndexExistsAsync(context, "SqlOSAuditEvents", "UX_SqlOSAuditEvents_IdempotencyKeyHash"));
             Assert.AreEqual("user.login", await ScalarStringAsync(context, "SELECT TOP 1 [Action] FROM [dbo].[SqlOSAuditEvents]"));
-            Assert.AreEqual(30, await ScalarIntAsync(context, "SELECT TOP 1 [Version] FROM [dbo].[SqlOSSchema]"));
+            Assert.AreEqual(CurrentSchemaVersion, await ScalarIntAsync(context, "SELECT TOP 1 [Version] FROM [dbo].[SqlOSSchema]"));
         }
         finally
         {
@@ -227,7 +229,7 @@ public sealed class SchemaInitializerIntegrationTests
             Assert.IsTrue(await IndexExistsAsync(context, "SqlOSApplicationAssignments", "IX_SqlOSApplicationAssignments_Target"));
             Assert.IsTrue(await IndexExistsAsync(context, "SqlOSApplicationAssignments", "IX_SqlOSApplicationAssignments_ClientApplicationId_RevokedAt"));
             Assert.IsTrue(await IndexExistsAsync(context, "SqlOSApplicationAssignments", "IX_SqlOSApplicationAssignments_OrganizationId_RevokedAt"));
-            Assert.AreEqual(30, await ScalarIntAsync(context, "SELECT TOP 1 [Version] FROM [dbo].[SqlOSSchema]"));
+            Assert.AreEqual(CurrentSchemaVersion, await ScalarIntAsync(context, "SELECT TOP 1 [Version] FROM [dbo].[SqlOSSchema]"));
         }
         finally
         {
@@ -259,7 +261,7 @@ public sealed class SchemaInitializerIntegrationTests
             await initializer.EnsureSchemaAsync();
             await initializer.EnsureSchemaAsync();
 
-            Assert.AreEqual(30, await ScalarIntAsync(context, "SELECT TOP 1 [Version] FROM [dbo].[SqlOSSchema]"));
+            Assert.AreEqual(CurrentSchemaVersion, await ScalarIntAsync(context, "SELECT TOP 1 [Version] FROM [dbo].[SqlOSSchema]"));
             foreach (var column in new[] { "UserName", "PrimaryEmail", "FormattedName", "GivenName", "FamilyName", "DeletedAt", "OwnsUserLifecycle" })
             {
                 Assert.IsTrue(await ColumnExistsAsync(context, "SqlOSScimExternalIds", column));
@@ -404,7 +406,7 @@ public sealed class SchemaInitializerIntegrationTests
                     context,
                     "SELECT [State] FROM [dbo].[SqlOSAuthorizationRequests] WHERE [Id] = 'req_state_upgrade'"));
             Assert.AreEqual(
-                30,
+                CurrentSchemaVersion,
                 await ScalarIntAsync(context, "SELECT TOP 1 [Version] FROM [dbo].[SqlOSSchema]"));
         }
         finally
@@ -453,7 +455,7 @@ public sealed class SchemaInitializerIntegrationTests
                     context,
                     "SELECT LEN([State]) FROM [dbo].[SqlOSAuthorizationRequests] WHERE [Id] = 'req_state_wide'"));
             Assert.AreEqual(
-                30,
+                CurrentSchemaVersion,
                 await ScalarIntAsync(context, "SELECT TOP 1 [Version] FROM [dbo].[SqlOSSchema]"));
         }
         finally

--- a/web/content/docs/authserver/saml-sso.mdx
+++ b/web/content/docs/authserver/saml-sso.mdx
@@ -246,7 +246,9 @@ For metadata rotation, open the delegated portal again or use the dashboard, pas
 4. AuthServer binds the client, exact registered redirect URI (including path case), state, and validated S256 challenge to the SAML authorization request, then redirects to the IdP.
 5. User authenticates at the IdP.
 6. IdP POSTs a SAML Response to the ACS URL.
-7. AuthServer validates the assertion and returns an authorization code plus the original state to the registered redirect URI.
+7. AuthServer validates the assertion, requires an explicitly bounded bearer `SubjectConfirmationData`, and atomically records the signed Response ID and Assertion ID before returning an authorization code. Reuse of either identifier on the same connection is rejected, including concurrent replay.
 8. The client posts the code, client ID, exact redirect URI, and verifier to `/sqlos/auth/token`. Missing, wrong, downgraded, or `plain` PKCE is rejected.
 
 Use canonical `/sqlos/auth/authorize` and `/sqlos/auth/token` for hosted clients. The explicit `/sqlos/auth/sso/authorization-url` helper is retained for connection-directed flows, but it requires `state`, `codeChallenge`, and `codeChallengeMethod: "S256"` and produces the same PKCE-bound authorization-code record. The old `/sqlos/auth/token/exchange` and `/sqlos/auth/saml/login/{connectionId}` routes are retired.
+
+Replay protection uses SqlOS's existing SQL database and expires records after the assertion validity window plus clock skew. It is automatic: applications do not configure a cache or external coordination service.

--- a/web/content/docs/guides/test-your-integration.mdx
+++ b/web/content/docs/guides/test-your-integration.mdx
@@ -268,7 +268,7 @@ Start with one test in every row, then add cases for the features you enable.
 | Auth-to-FGA bridge | Login subject is provisioned and receives the intended role/resource grant | Unknown subject or missing resource never gains an implicit grant |
 | Email/phone OTP | Captured code completes once and produces the expected session | Wrong, expired, replayed, or mismatched challenge cannot authenticate |
 | Invitation | Bound email accepts once and creates only the intended membership | Wrong email, revoked/expired token, or replay creates no membership |
-| OIDC/SAML | Signed response maps the intended identity and organization | Bad nonce/signature/audience/time/`InResponseTo`, disabled connection, and JIT-off user fail |
+| OIDC/SAML | Signed response maps the intended identity and organization | Bad nonce/signature/audience/time/`InResponseTo`, missing bearer expiry, replayed response/assertion IDs, disabled connection, and JIT-off user fail |
 | Dashboard | Configured operator can access root, page, and admin API | Anonymous caller is redirected, `401`, or `404` according to the surface; auth routes remain public |
 | Data Protection | Replacement instance sharing the key ring reads existing protected material | Test configuration with a different/lost key ring fails visibly and safely |
 | Upgrade | Current build upgrades a restored previous-version database and completes smoke tests | Rollback/recovery procedure is exercised against an incompatible schema copy |
@@ -282,7 +282,7 @@ Use these as patterns, not as a substitute for product tests:
 - [Dashboard password protection](https://github.com/ross-slaney/sqlos/blob/main/examples/SqlOS.Example.IntegrationTests/SqlOSExampleApiIntegrationTests.cs) checks the root shell and AuthServer, FGA, and email admin APIs before and after login/logout.
 - [Refresh and logout](https://github.com/ross-slaney/sqlos/blob/main/examples/SqlOS.Example.IntegrationTests/SqlOSExampleWebAuthIntegrationTests.cs) verifies session revocation.
 - [Signing-key replacement resilience](https://github.com/ross-slaney/sqlos/blob/main/tests/SqlOS.IntegrationTests/AuthServerSigningKeyResilienceIntegrationTests.cs) exercises database-persisted keys across service instances.
-- [SAML rejection cases](https://github.com/ross-slaney/sqlos/blob/main/tests/SqlOS.IntegrationTests/SamlServiceIntegrationTests.cs) cover signatures, audience, response correlation, expiry, SHA-1, and unsafe XML.
+- [SAML rejection cases](https://github.com/ross-slaney/sqlos/blob/main/tests/SqlOS.IntegrationTests/SamlServiceIntegrationTests.cs) cover signatures, audience, response correlation, strict bearer expiry, sequential/concurrent replay, SHA-1, and unsafe XML.
 - [Authorization-code concurrency](https://github.com/ross-slaney/sqlos/blob/main/tests/SqlOS.IntegrationTests/OAuthArtifactConcurrencyIntegrationTests.cs) proves single consumption under parallel requests.
 
 ## Keep the database deterministic


### PR DESCRIPTION
## Summary

- persist and atomically consume signed SAML Response and Assertion identifiers per SSO connection
- require bearer SubjectConfirmationData to carry an explicit expiry
- expire replay rows after the assertion validity window plus clock skew, using the existing SqlOS database with no new host configuration
- cover sequential and concurrent replay with real SQL integration tests and document the secure default

## Validation

- `dotnet test tests/SqlOS.Tests/SqlOS.Tests.csproj` (554 passed)
- `dotnet test tests/SqlOS.IntegrationTests/SqlOS.IntegrationTests.csproj --filter FullyQualifiedName~SamlServiceIntegrationTests` (30 passed)

Closes #105
