### PR TITLE
Harden dashboard auth-mode and path boundaries

### DIFF
--- a/src/SqlOS/Dashboard/SqlOSDashboardMiddleware.cs
+++ b/src/SqlOS/Dashboard/SqlOSDashboardMiddleware.cs
@@ -47,7 +47,7 @@ public sealed class SqlOSDashboardMiddleware
     public async Task InvokeAsync(HttpContext context)
     {
         var path = context.Request.Path.Value ?? string.Empty;
-        if (!path.StartsWith(_pathPrefix, StringComparison.OrdinalIgnoreCase))
+        if (!IsPathOrChild(path, _pathPrefix))
         {
             await _next(context);
             return;
@@ -355,50 +355,50 @@ public sealed class SqlOSDashboardMiddleware
 
     private bool ShouldPassThrough(string relativePath, bool embedMode)
     {
-        if (relativePath.StartsWith("admin/fga", StringComparison.OrdinalIgnoreCase))
+        if (IsPathOrChild(relativePath, "admin/fga"))
         {
             return true;
         }
 
-        if (relativePath.StartsWith("admin/email/api/", StringComparison.OrdinalIgnoreCase))
+        if (IsPathOrChild(relativePath, "admin/email/api"))
         {
             return true;
         }
 
-        if (relativePath.StartsWith("admin/audit/api/", StringComparison.OrdinalIgnoreCase))
+        if (IsPathOrChild(relativePath, "admin/audit/api"))
         {
             return true;
         }
 
-        if (relativePath.StartsWith("admin/calendar/api/", StringComparison.OrdinalIgnoreCase))
+        if (IsPathOrChild(relativePath, "admin/calendar/api"))
         {
             return true;
         }
 
-        if (relativePath.StartsWith("auth/", StringComparison.OrdinalIgnoreCase)
-            || relativePath.StartsWith("admin/auth/api/", StringComparison.OrdinalIgnoreCase)
-            || relativePath.StartsWith("admin/auth/sso-portal", StringComparison.OrdinalIgnoreCase)
-            || relativePath.StartsWith("admin/auth/.well-known/", StringComparison.OrdinalIgnoreCase)
-            || relativePath.StartsWith("admin/auth/saml/", StringComparison.OrdinalIgnoreCase))
+        if (IsPathOrChild(relativePath, "auth")
+            || IsPathOrChild(relativePath, "admin/auth/api")
+            || IsPathOrChild(relativePath, "admin/auth/sso-portal")
+            || IsPathOrChild(relativePath, "admin/auth/.well-known")
+            || IsPathOrChild(relativePath, "admin/auth/saml"))
         {
             return true;
         }
 
         if (Path.HasExtension(relativePath)
-            && (relativePath.StartsWith("admin/auth/", StringComparison.OrdinalIgnoreCase)
-                || relativePath.StartsWith("admin/fga/", StringComparison.OrdinalIgnoreCase)
-                || relativePath.StartsWith("admin/audit/", StringComparison.OrdinalIgnoreCase)
-                || relativePath.StartsWith("admin/email/", StringComparison.OrdinalIgnoreCase)
-                || relativePath.StartsWith("admin/calendar/", StringComparison.OrdinalIgnoreCase)))
+            && (IsPathOrChild(relativePath, "admin/auth")
+                || IsPathOrChild(relativePath, "admin/fga")
+                || IsPathOrChild(relativePath, "admin/audit")
+                || IsPathOrChild(relativePath, "admin/email")
+                || IsPathOrChild(relativePath, "admin/calendar")))
         {
             return true;
         }
 
-        if (embedMode && (relativePath.StartsWith("admin/auth", StringComparison.OrdinalIgnoreCase)
-                          || relativePath.StartsWith("admin/fga", StringComparison.OrdinalIgnoreCase)
-                          || relativePath.StartsWith("admin/audit", StringComparison.OrdinalIgnoreCase)
-                          || relativePath.StartsWith("admin/email", StringComparison.OrdinalIgnoreCase)
-                          || relativePath.StartsWith("admin/calendar", StringComparison.OrdinalIgnoreCase)))
+        if (embedMode && (IsPathOrChild(relativePath, "admin/auth")
+                          || IsPathOrChild(relativePath, "admin/fga")
+                          || IsPathOrChild(relativePath, "admin/audit")
+                          || IsPathOrChild(relativePath, "admin/email")
+                          || IsPathOrChild(relativePath, "admin/calendar")))
         {
             return true;
         }
@@ -427,10 +427,10 @@ public sealed class SqlOSDashboardMiddleware
             return true;
         }
 
-        if (relativePath.StartsWith("admin/auth", StringComparison.OrdinalIgnoreCase)
-            || relativePath.StartsWith("admin/audit", StringComparison.OrdinalIgnoreCase)
-            || relativePath.StartsWith("admin/email", StringComparison.OrdinalIgnoreCase)
-            || relativePath.StartsWith("admin/calendar", StringComparison.OrdinalIgnoreCase))
+        if (IsPathOrChild(relativePath, "admin/auth")
+            || IsPathOrChild(relativePath, "admin/audit")
+            || IsPathOrChild(relativePath, "admin/email")
+            || IsPathOrChild(relativePath, "admin/calendar"))
         {
             return true;
         }
@@ -494,6 +494,17 @@ public sealed class SqlOSDashboardMiddleware
 
     private static IFileProvider CreateFileProvider()
         => new ManifestEmbeddedFileProvider(typeof(SqlOSDashboardMiddleware).Assembly, "Dashboard/wwwroot");
+
+    private static bool IsPathOrChild(string path, string prefix)
+    {
+        if (string.IsNullOrEmpty(prefix))
+        {
+            return path.StartsWith("/", StringComparison.Ordinal);
+        }
+
+        return path.Equals(prefix, StringComparison.OrdinalIgnoreCase)
+            || path.StartsWith(prefix + "/", StringComparison.OrdinalIgnoreCase);
+    }
 
     private sealed record DashboardLoginRequest(string Password);
 }

--- a/src/SqlOS/Dashboard/wwwroot/app.js
+++ b/src/SqlOS/Dashboard/wwwroot/app.js
@@ -421,7 +421,10 @@
                 return `${dashboardBasePath}/`;
             }
 
-            if (!parsed.pathname.startsWith(dashboardBasePath || "/")) {
+            const isDashboardPath = dashboardBasePath === "/"
+                ? parsed.pathname.startsWith("/")
+                : parsed.pathname === dashboardBasePath || parsed.pathname.startsWith(`${dashboardBasePath}/`);
+            if (!isDashboardPath) {
                 return `${dashboardBasePath}/`;
             }
 

--- a/src/SqlOS/Fga/Dashboard/SqlOSFgaDashboardMiddleware.cs
+++ b/src/SqlOS/Fga/Dashboard/SqlOSFgaDashboardMiddleware.cs
@@ -50,7 +50,8 @@ public class SqlOSFgaDashboardMiddleware
     {
         var path = context.Request.Path.Value ?? "";
 
-        if (!path.StartsWith(_pathPrefix, StringComparison.OrdinalIgnoreCase))
+        if (!path.Equals(_pathPrefix, StringComparison.OrdinalIgnoreCase)
+            && !path.StartsWith(_pathPrefix + "/", StringComparison.OrdinalIgnoreCase))
         {
             await _next(context);
             return;

--- a/src/SqlOS/Hosting/SqlOSPipelineStartupFilter.cs
+++ b/src/SqlOS/Hosting/SqlOSPipelineStartupFilter.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using SqlOS.Configuration;
 using SqlOS.Fga.Dashboard;
@@ -14,6 +15,13 @@ namespace SqlOS.Hosting;
 /// </summary>
 internal sealed class SqlOSPipelineStartupFilter : IStartupFilter
 {
+    private readonly ILogger<SqlOSPipelineStartupFilter> _logger;
+
+    public SqlOSPipelineStartupFilter(ILogger<SqlOSPipelineStartupFilter> logger)
+    {
+        _logger = logger;
+    }
+
     public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next) => app =>
     {
         var services = app.ApplicationServices;
@@ -26,6 +34,23 @@ internal sealed class SqlOSPipelineStartupFilter : IStartupFilter
 
         var environment = services.GetRequiredService<IHostEnvironment>();
         var prefix = hostOptions.DashboardBasePath.TrimEnd('/');
+
+        if (hostOptions.Dashboard.AuthMode == SqlOSDashboardAuthMode.DevelopmentOnly
+            && hostOptions.Dashboard.AuthorizationCallback == null)
+        {
+            if (environment.IsDevelopment())
+            {
+                _logger.LogWarning(
+                    "SqlOS dashboard authentication is DevelopmentOnly and the host environment is Development. " +
+                    "The dashboard and admin APIs are available without a login. Do not use Development in a production deployment.");
+            }
+            else
+            {
+                _logger.LogWarning(
+                    "SqlOS dashboard authentication is DevelopmentOnly. The dashboard and admin APIs return 404 outside Development. " +
+                    "Configure Dashboard.AuthMode = Password or Dashboard.AuthorizationCallback before exposing operator access.");
+            }
+        }
 
         // Apply only the host-configured, trusted ForwardedHeaders options. The
         // startup filter must do this before dashboard middleware so dashboard

--- a/tests/SqlOS.Tests/SqlOSDashboardAuthMiddlewareTests.cs
+++ b/tests/SqlOS.Tests/SqlOSDashboardAuthMiddlewareTests.cs
@@ -223,6 +223,21 @@ public sealed class SqlOSDashboardAuthMiddlewareTests
         context.Response.StatusCode.Should().Be(StatusCodes.Status418ImATeapot);
     }
 
+    [TestMethod]
+    public async Task DashboardClientReturnPath_UsesExactOrChildSegmentBoundary()
+    {
+        var files = new ManifestEmbeddedFileProvider(
+            typeof(SqlOSDashboardMiddleware).Assembly,
+            "Dashboard/wwwroot");
+        await using var stream = files.GetFileInfo("app.js").CreateReadStream();
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        var source = await reader.ReadToEndAsync();
+
+        source.Should().Contain("parsed.pathname === dashboardBasePath");
+        source.Should().Contain("parsed.pathname.startsWith(`${dashboardBasePath}/`)");
+        source.Should().NotContain("parsed.pathname.startsWith(dashboardBasePath || \"/\")");
+    }
+
     private static DashboardMiddlewareHarness CreateHarness(
         Action<SqlOSDashboardOptions>? configure = null,
         bool scimEnabled = false)

--- a/tests/SqlOS.Tests/SqlOSDashboardAuthMiddlewareTests.cs
+++ b/tests/SqlOS.Tests/SqlOSDashboardAuthMiddlewareTests.cs
@@ -14,6 +14,7 @@ using SqlOS.AuthServer.Models;
 using SqlOS.AuthServer.Services;
 using SqlOS.Configuration;
 using SqlOS.Dashboard;
+using SqlOS.Fga.Dashboard;
 using SqlOS.Tests.Infrastructure;
 
 namespace SqlOS.Tests;
@@ -165,6 +166,63 @@ public sealed class SqlOSDashboardAuthMiddlewareTests
         enabled.Body.Should().Contain("window.__SQL_OS_CAPABILITIES__ = {\"scimEnabled\":true};");
     }
 
+    [TestMethod]
+    public async Task DashboardPathPrefix_RejectsLookalikeSegment()
+    {
+        using var harness = CreateHarness(options =>
+        {
+            options.AuthMode = SqlOSDashboardAuthMode.DevelopmentOnly;
+            options.AuthorizationCallback = null;
+        });
+
+        var response = await harness.GetAsync("/sqlos-evil/admin/auth");
+
+        response.StatusCode.Should().Be(StatusCodes.Status418ImATeapot,
+            "lookalike paths must continue to the host pipeline instead of entering dashboard authorization");
+    }
+
+    [TestMethod]
+    public async Task DashboardPassThrough_RequiresCompleteAdminFamilySegment()
+    {
+        using var harness = CreateHarness(options =>
+        {
+            options.AuthMode = SqlOSDashboardAuthMode.DevelopmentOnly;
+            options.AuthorizationCallback = null;
+        });
+
+        var lookalike = await harness.GetAsync("/sqlos/admin/fga-evil", "?embed=1");
+        var realFamily = await harness.GetAsync("/sqlos/admin/fga/resources", "?embed=1");
+
+        lookalike.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+        realFamily.StatusCode.Should().Be(StatusCodes.Status418ImATeapot);
+    }
+
+    [TestMethod]
+    public async Task FgaDashboardPathPrefix_RejectsLookalikeSegment()
+    {
+        var services = new ServiceCollection();
+        services.AddDataProtection();
+        services.AddSingleton<SqlOSDashboardSessionService>();
+        await using var provider = services.BuildServiceProvider();
+        var options = new SqlOSDashboardOptions();
+        var middleware = new SqlOSFgaDashboardMiddleware(
+            context =>
+            {
+                context.Response.StatusCode = StatusCodes.Status418ImATeapot;
+                return Task.CompletedTask;
+            },
+            "/sqlos/admin/fga",
+            new TestHostEnvironment(),
+            options,
+            provider.GetRequiredService<SqlOSDashboardSessionService>());
+        var context = new DefaultHttpContext { RequestServices = provider };
+        context.Request.Path = "/sqlos/admin/fga-evil";
+
+        await middleware.InvokeAsync(context);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status418ImATeapot);
+    }
+
     private static DashboardMiddlewareHarness CreateHarness(
         Action<SqlOSDashboardOptions>? configure = null,
         bool scimEnabled = false)
@@ -190,7 +248,11 @@ public sealed class SqlOSDashboardAuthMiddlewareTests
 
         var provider = services.BuildServiceProvider(validateScopes: true);
         var middleware = new SqlOSDashboardMiddleware(
-            _ => Task.CompletedTask,
+            context =>
+            {
+                context.Response.StatusCode = StatusCodes.Status418ImATeapot;
+                return Task.CompletedTask;
+            },
             "/sqlos",
             new TestHostEnvironment(),
             dashboardOptions,
@@ -225,6 +287,9 @@ public sealed class SqlOSDashboardAuthMiddlewareTests
         public Task<DashboardResponse> GetDashboardAsync()
             => SendAsync(HttpMethods.Get, "/sqlos/admin/auth/organizations", null, "203.0.113.60");
 
+        public Task<DashboardResponse> GetAsync(string path, string? queryString = null)
+            => SendAsync(HttpMethods.Get, path, null, "203.0.113.61", queryString);
+
         public async Task<List<SqlOSAuditEvent>> ListAuditEventsAsync()
         {
             using var scope = _services.CreateScope();
@@ -238,7 +303,8 @@ public sealed class SqlOSDashboardAuthMiddlewareTests
             string method,
             string path,
             string? body,
-            string ipAddress)
+            string ipAddress,
+            string? queryString = null)
         {
             using var scope = _services.CreateScope();
             var context = new DefaultHttpContext
@@ -247,6 +313,10 @@ public sealed class SqlOSDashboardAuthMiddlewareTests
             };
             context.Request.Method = method;
             context.Request.Path = path;
+            if (!string.IsNullOrWhiteSpace(queryString))
+            {
+                context.Request.QueryString = new QueryString(queryString);
+            }
             context.Request.Scheme = Uri.UriSchemeHttps;
             context.Connection.RemoteIpAddress = IPAddress.Parse(ipAddress);
             context.Response.Body = new MemoryStream();

--- a/tests/SqlOS.Tests/SqlOSPipelineStartupFilterTests.cs
+++ b/tests/SqlOS.Tests/SqlOSPipelineStartupFilterTests.cs
@@ -77,6 +77,31 @@ public sealed class SqlOSPipelineStartupFilterTests
             && message.Contains("return 404 outside Development", StringComparison.Ordinal));
     }
 
+    [TestMethod]
+    public void Configure_DevelopmentOnlyDashboard_EmitsUnauthenticatedDevelopmentWarning()
+    {
+        var services = new ServiceCollection();
+        services.AddDataProtection();
+        services.AddLogging();
+        services.AddSingleton<IHostEnvironment>(new TestHostEnvironment
+        {
+            EnvironmentName = Environments.Development
+        });
+        services.AddSingleton(Options.Create(new SqlOSOptions()));
+        services.AddSingleton<SqlOSDashboardSessionService>();
+        services.AddSingleton<SqlOSDashboardLoginThrottlingService>();
+
+        using var provider = services.BuildServiceProvider();
+        var appBuilder = new ApplicationBuilder(provider);
+        var logger = new RecordingLogger<SqlOSPipelineStartupFilter>();
+
+        new SqlOSPipelineStartupFilter(logger).Configure(_ => { })(appBuilder);
+
+        logger.Messages.Should().ContainSingle(message =>
+            message.Contains("available without a login", StringComparison.Ordinal)
+            && message.Contains("Do not use Development in a production deployment", StringComparison.Ordinal));
+    }
+
     private sealed class RecordingLogger<T> : ILogger<T>
     {
         public List<string> Messages { get; } = [];

--- a/tests/SqlOS.Tests/SqlOSPipelineStartupFilterTests.cs
+++ b/tests/SqlOS.Tests/SqlOSPipelineStartupFilterTests.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SqlOS.Configuration;
@@ -37,7 +38,7 @@ public sealed class SqlOSPipelineStartupFilterTests
         await using var provider = services.BuildServiceProvider();
         var appBuilder = new ApplicationBuilder(provider);
         IPAddress? observedClientIp = null;
-        var filter = new SqlOSPipelineStartupFilter();
+        var filter = new SqlOSPipelineStartupFilter(new RecordingLogger<SqlOSPipelineStartupFilter>());
         filter.Configure(app => app.Run(context =>
         {
             observedClientIp = context.Connection.RemoteIpAddress;
@@ -52,6 +53,47 @@ public sealed class SqlOSPipelineStartupFilterTests
         await pipeline(context);
 
         observedClientIp.Should().Be(IPAddress.Parse("203.0.113.42"));
+    }
+
+    [TestMethod]
+    public void Configure_DevelopmentOnlyDashboard_EmitsProductionSafetyWarning()
+    {
+        var services = new ServiceCollection();
+        services.AddDataProtection();
+        services.AddLogging();
+        services.AddSingleton<IHostEnvironment>(new TestHostEnvironment());
+        services.AddSingleton(Options.Create(new SqlOSOptions()));
+        services.AddSingleton<SqlOSDashboardSessionService>();
+        services.AddSingleton<SqlOSDashboardLoginThrottlingService>();
+
+        using var provider = services.BuildServiceProvider();
+        var appBuilder = new ApplicationBuilder(provider);
+        var logger = new RecordingLogger<SqlOSPipelineStartupFilter>();
+
+        new SqlOSPipelineStartupFilter(logger).Configure(_ => { })(appBuilder);
+
+        logger.Messages.Should().ContainSingle(message =>
+            message.Contains("DevelopmentOnly", StringComparison.Ordinal)
+            && message.Contains("return 404 outside Development", StringComparison.Ordinal));
+    }
+
+    private sealed class RecordingLogger<T> : ILogger<T>
+    {
+        public List<string> Messages { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Messages.Add(formatter(state, exception));
+        }
     }
 
     private sealed class TestHostEnvironment : IHostEnvironment

--- a/web/content/docs/guides/production-readiness.mdx
+++ b/web/content/docs/guides/production-readiness.mdx
@@ -125,7 +125,7 @@ SqlOS still enforces its own dashboard policy inside the process. Edge protectio
 
 ## 3. Harden dashboard access
 
-The default dashboard mode is `DevelopmentOnly`. Without an authorization callback, it is available only when the host environment is Development and returns `404` in production. For an operator-accessible production dashboard, configure password mode explicitly:
+The default dashboard mode is `DevelopmentOnly`. Without an authorization callback, it is available without a login only when the host environment is Development and returns `404` otherwise. SqlOS logs a startup warning in either case so an accidentally deployed `Development` environment is visible in operational logs. Dashboard and admin path families are matched on complete URL segments, so lookalike paths such as `/sqlos-evil` or `/sqlos/admin/fga-evil` are never treated as SqlOS surfaces. For an operator-accessible production dashboard, configure password mode explicitly:
 
 ```csharp
 options.Dashboard.AuthMode = SqlOSDashboardAuthMode.Password;


### PR DESCRIPTION
Closes #137.

## What changed

- matches the dashboard root, FGA dashboard, pass-through families, embedded routes, and client-side return paths on complete URL segment boundaries
- emits a clear startup warning whenever the default DevelopmentOnly mode has no authorization callback, distinguishing unauthenticated Development access from production 404 behavior
- preserves the zero-configuration default: no new setting is required and non-Development hosts remain fail-closed
- documents the warning and path-boundary behavior in production readiness guidance

## Validation

- focused dashboard/pipeline suite: 12 passed
- full library unit suite: 572 passed
- example unit suite: 2 passed
- solution build: 0 warnings, 0 errors
- dashboard JavaScript syntax validation passed
- docs source contracts, snippets, lint, TypeScript, production build, images, and 166-file link validation passed

An adversarial review and one iteration will be recorded in PR comments before final handoff.