### PR TITLE
Add secure browser headers to hosted UI

### DIFF
--- a/src/SqlOS/AuthServer/Extensions/EndpointRouteBuilderExtensions.cs
+++ b/src/SqlOS/AuthServer/Extensions/EndpointRouteBuilderExtensions.cs
@@ -3481,14 +3481,13 @@ public static class EndpointRouteBuilderExtensions
                 await authService.VerifyEmailAsync(
                     new SqlOSVerifyEmailRequest(context.Request.Query["token"].ToString()),
                     cancellationToken);
-                return Results.Content(BuildEmailVerificationPage(error: null), contentType: "text/html");
+                return HostedHtml(BuildEmailVerificationPage(error: null));
             }
             catch (InvalidOperationException ex)
             {
-                return Results.Content(
+                return HostedHtml(
                     BuildEmailVerificationPage(await PublicAuthMessageAsync(context, ex, SqlOSPublicAuthErrorSurface.HostedPage, cancellationToken)),
-                    contentType: "text/html",
-                    statusCode: StatusCodes.Status400BadRequest);
+                    StatusCodes.Status400BadRequest);
             }
         });
 
@@ -4043,12 +4042,12 @@ public static class EndpointRouteBuilderExtensions
             }
             catch (InvalidOperationException ex)
             {
-                return Results.Content(SqlOSSsoPortalPageRenderer.RenderStartError(ex.Message), "text/html; charset=utf-8", statusCode: StatusCodes.Status400BadRequest);
+                return HostedHtml(SqlOSSsoPortalPageRenderer.RenderStartError(ex.Message), StatusCodes.Status400BadRequest);
             }
         });
 
         portal.MapGet("", (SqlOSSsoPortalService portalService) => portalService.IsHostedPortalEnabled
-            ? Results.Content(SqlOSSsoPortalPageRenderer.RenderShell(), "text/html; charset=utf-8")
+            ? HostedHtml(SqlOSSsoPortalPageRenderer.RenderShell())
             : Results.NotFound());
 
         var api = portal.MapGroup("/api");

--- a/src/SqlOS/AuthServer/Security/SqlOSHostedFormAntiforgery.cs
+++ b/src/SqlOS/AuthServer/Security/SqlOSHostedFormAntiforgery.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using SqlOS.AuthServer.Configuration;
+using SqlOS.Security;
 
 namespace SqlOS.AuthServer.Security;
 
@@ -240,7 +241,8 @@ internal sealed class SqlOSHostedHtmlResult(string html, int statusCode) : IResu
 
     public async Task ExecuteAsync(HttpContext httpContext)
     {
-        var responseHtml = html;
+        var securityHeaders = httpContext.RequestServices.GetRequiredService<SqlOSBrowserSecurityHeaders>();
+        var responseHtml = securityHeaders.PrepareHtml(httpContext, html);
         if (PostFormPattern.IsMatch(responseHtml))
         {
             var antiforgery = httpContext.RequestServices.GetRequiredService<SqlOSHostedFormAntiforgery>();

--- a/src/SqlOS/AuthServer/Services/SqlOSOidcBrowserAuthService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSOidcBrowserAuthService.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
+using SqlOS.AuthServer.Security;
 using SqlOS.AuthServer.Configuration;
 using SqlOS.AuthServer.Contracts;
 using SqlOS.AuthServer.Errors;
@@ -504,17 +505,20 @@ public sealed class SqlOSOidcBrowserAuthService
     }
 
     private static IResult RenderCallbackError(string message)
-        => Results.Content(
-            $"""
+        => new SqlOSHostedHtmlResult(
+            $$"""
             <html>
-              <head><title>SqlOS social login error</title></head>
-              <body style="font-family: ui-sans-serif, system-ui, sans-serif; padding: 32px;">
+              <head>
+                <title>SqlOS social login error</title>
+                <style>body { font-family: ui-sans-serif, system-ui, sans-serif; padding: 32px; }</style>
+              </head>
+              <body>
                 <h1>SqlOS social login error</h1>
-                <p>{System.Net.WebUtility.HtmlEncode(message)}</p>
+                <p>{{System.Net.WebUtility.HtmlEncode(message)}}</p>
               </body>
             </html>
             """,
-            "text/html");
+            StatusCodes.Status400BadRequest);
 
     private static async Task<OidcCallbackInput> ReadCallbackInputAsync(HttpContext httpContext, CancellationToken cancellationToken)
     {

--- a/src/SqlOS/AuthServer/Services/SqlOSSsoPortalPageRenderer.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSSsoPortalPageRenderer.cs
@@ -54,9 +54,11 @@ public static class SqlOSSsoPortalPageRenderer
                 button.danger { background: #991b1b; }
                 button:disabled { opacity: .45; cursor: not-allowed; }
                 .row { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
+                .row-between { justify-content: space-between; }
                 .check-row { display: flex; gap: 10px; align-items: flex-start; padding: 8px 0; }
                 .check-row input { width: auto; margin-top: 2px; }
                 .field-grid { display: grid; gap: 10px; }
+                .field-grid-spaced { margin-top: 12px; }
                 label { display: grid; gap: 6px; font-size: 12px; color: var(--muted); font-weight: 700; }
                 input, textarea { width: 100%; border: 1px solid var(--line); border-radius: 8px; padding: 10px; font: inherit; background: #fff; color: var(--ink); }
                 textarea { min-height: 180px; resize: vertical; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 12px; }
@@ -115,14 +117,14 @@ public static class SqlOSSsoPortalPageRenderer
                     </aside>
                     <div class="stack">
                         <section class="panel">
-                            <div class="row" style="justify-content: space-between;">
+                            <div class="row row-between">
                                 <div>
                                     <h2>Service Provider Values</h2>
                                     <p>Copy these into the identity provider application.</p>
                                 </div>
                                 <span id="setup-status" class="badge"></span>
                             </div>
-                            <div id="sp-values" class="field-grid" style="margin-top: 12px;"></div>
+                            <div id="sp-values" class="field-grid field-grid-spaced"></div>
                         </section>
                         <section class="panel">
                             <h2 id="guide-title">Setup Steps</h2>

--- a/src/SqlOS/Calendar/Services/SqlOSCalendarService.cs
+++ b/src/SqlOS/Calendar/Services/SqlOSCalendarService.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using SqlOS.AuthServer.Security;
 using SqlOS.AuthServer.Configuration;
 using SqlOS.AuthServer.Contracts;
 using SqlOS.AuthServer.Interfaces;
@@ -894,17 +895,20 @@ public sealed class SqlOSCalendarService
         => httpContext?.Connection.RemoteIpAddress?.ToString();
 
     private static IResult RenderCallbackError(string message)
-        => Results.Content(
-            $"""
+        => new SqlOSHostedHtmlResult(
+            $$"""
             <html>
-              <head><title>SqlOS calendar connect error</title></head>
-              <body style="font-family: ui-sans-serif, system-ui, sans-serif; padding: 32px;">
+              <head>
+                <title>SqlOS calendar connect error</title>
+                <style>body { font-family: ui-sans-serif, system-ui, sans-serif; padding: 32px; }</style>
+              </head>
+              <body>
                 <h1>SqlOS calendar connect error</h1>
-                <p>{System.Net.WebUtility.HtmlEncode(message)}</p>
+                <p>{{System.Net.WebUtility.HtmlEncode(message)}}</p>
               </body>
             </html>
             """,
-            "text/html");
+            StatusCodes.Status400BadRequest);
 
     internal sealed record SqlOSProviderEndpoints(string AuthorizationEndpoint, string TokenEndpoint);
 }

--- a/src/SqlOS/Configuration/SqlOSOptions.cs
+++ b/src/SqlOS/Configuration/SqlOSOptions.cs
@@ -23,6 +23,7 @@ public sealed class SqlOSOptions
 
     public string DashboardBasePath { get; set; } = "/sqlos";
     public SqlOSDashboardOptions Dashboard { get; } = new();
+    public SqlOSBrowserSecurityOptions BrowserSecurity { get; } = new();
     public SqlOSFgaOptions Fga { get; } = new();
     public SqlOSAuthServerOptions AuthServer { get; } = new();
     public SqlOSEmailOptions Email { get; } = new();
@@ -77,6 +78,23 @@ public sealed class SqlOSOptions
         configure(Calendar);
         return this;
     }
+}
+
+public sealed class SqlOSBrowserSecurityOptions
+{
+    /// <summary>
+    /// Placeholder replaced with a fresh nonce on every SqlOS HTML response.
+    /// </summary>
+    public const string NoncePlaceholder = "{nonce}";
+
+    /// <summary>
+    /// Content Security Policy applied to hosted SqlOS HTML. SqlOS always appends
+    /// <c>frame-ancestors 'none'</c>; callers cannot relax the anti-framing boundary.
+    /// </summary>
+    public string ContentSecurityPolicy { get; set; } =
+        "default-src 'none'; base-uri 'none'; object-src 'none'; form-action 'self'; " +
+        "img-src 'self' data:; font-src 'self' data:; connect-src 'self'; " +
+        "script-src 'self' 'nonce-{nonce}'; style-src 'self' 'nonce-{nonce}'";
 }
 
 public sealed class SqlOSDashboardOptions

--- a/src/SqlOS/Configuration/SqlOSOptionsValidator.cs
+++ b/src/SqlOS/Configuration/SqlOSOptionsValidator.cs
@@ -56,6 +56,7 @@ internal static class SqlOSOptionsValidator
         }
 
         ValidateDashboardLoginThrottlingOptions(options.Dashboard.LoginThrottling, errors);
+        ValidateBrowserSecurityOptions(options.BrowserSecurity, errors);
 
         var issuer = ValidateAbsoluteUri(options.AuthServer.Issuer, "AuthServer.Issuer", errors);
         if (issuer != null && authBasePath != null)
@@ -112,6 +113,34 @@ internal static class SqlOSOptionsValidator
         {
             throw new InvalidOperationException(
                 "Invalid SqlOS configuration:" + Environment.NewLine + string.Join(Environment.NewLine, errors.Select(static error => $"- {error}")));
+        }
+    }
+
+    private static void ValidateBrowserSecurityOptions(
+        SqlOSBrowserSecurityOptions options,
+        List<string> errors)
+    {
+        if (string.IsNullOrWhiteSpace(options.ContentSecurityPolicy))
+        {
+            errors.Add("BrowserSecurity.ContentSecurityPolicy cannot be empty.");
+            return;
+        }
+
+        if (options.ContentSecurityPolicy.Contains('\r') || options.ContentSecurityPolicy.Contains('\n'))
+        {
+            errors.Add("BrowserSecurity.ContentSecurityPolicy must be a single header-safe line.");
+        }
+
+        if (!options.ContentSecurityPolicy.Contains(
+                SqlOSBrowserSecurityOptions.NoncePlaceholder,
+                StringComparison.Ordinal))
+        {
+            errors.Add("BrowserSecurity.ContentSecurityPolicy must include the {nonce} placeholder for SqlOS inline scripts and styles.");
+        }
+
+        if (options.ContentSecurityPolicy.Contains("frame-ancestors", StringComparison.OrdinalIgnoreCase))
+        {
+            errors.Add("BrowserSecurity.ContentSecurityPolicy cannot configure frame-ancestors; SqlOS always enforces frame-ancestors 'none'.");
         }
     }
 

--- a/src/SqlOS/Configuration/SqlOSOptionsValidator.cs
+++ b/src/SqlOS/Configuration/SqlOSOptionsValidator.cs
@@ -131,11 +131,31 @@ internal static class SqlOSOptionsValidator
             errors.Add("BrowserSecurity.ContentSecurityPolicy must be a single header-safe line.");
         }
 
-        if (!options.ContentSecurityPolicy.Contains(
-                SqlOSBrowserSecurityOptions.NoncePlaceholder,
-                StringComparison.Ordinal))
+        var scriptDirective = FindCspDirective(options.ContentSecurityPolicy, "script-src");
+        var styleDirective = FindCspDirective(options.ContentSecurityPolicy, "style-src");
+        if (scriptDirective == null
+            || !scriptDirective.Contains(SqlOSBrowserSecurityOptions.NoncePlaceholder, StringComparison.Ordinal))
         {
-            errors.Add("BrowserSecurity.ContentSecurityPolicy must include the {nonce} placeholder for SqlOS inline scripts and styles.");
+            errors.Add("BrowserSecurity.ContentSecurityPolicy script-src must include the {nonce} placeholder.");
+        }
+
+        if (styleDirective == null
+            || !styleDirective.Contains(SqlOSBrowserSecurityOptions.NoncePlaceholder, StringComparison.Ordinal))
+        {
+            errors.Add("BrowserSecurity.ContentSecurityPolicy style-src must include the {nonce} placeholder.");
+        }
+
+        if (scriptDirective != null
+            && (scriptDirective.Contains("'unsafe-inline'", StringComparison.OrdinalIgnoreCase)
+                || scriptDirective.Contains("'unsafe-eval'", StringComparison.OrdinalIgnoreCase)))
+        {
+            errors.Add("BrowserSecurity.ContentSecurityPolicy script-src cannot allow unsafe-inline or unsafe-eval.");
+        }
+
+        if (styleDirective != null
+            && styleDirective.Contains("'unsafe-inline'", StringComparison.OrdinalIgnoreCase))
+        {
+            errors.Add("BrowserSecurity.ContentSecurityPolicy style-src cannot allow unsafe-inline.");
         }
 
         if (options.ContentSecurityPolicy.Contains("frame-ancestors", StringComparison.OrdinalIgnoreCase))
@@ -143,6 +163,12 @@ internal static class SqlOSOptionsValidator
             errors.Add("BrowserSecurity.ContentSecurityPolicy cannot configure frame-ancestors; SqlOS always enforces frame-ancestors 'none'.");
         }
     }
+
+    private static string? FindCspDirective(string policy, string directiveName)
+        => policy.Split(';', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+            .FirstOrDefault(directive =>
+                directive.Equals(directiveName, StringComparison.OrdinalIgnoreCase)
+                || directive.StartsWith(directiveName + " ", StringComparison.OrdinalIgnoreCase));
 
     private static void ValidateMfaOptions(SqlOSMfaOptions options, List<string> errors)
     {

--- a/src/SqlOS/Dashboard/SqlOSDashboardMiddleware.cs
+++ b/src/SqlOS/Dashboard/SqlOSDashboardMiddleware.cs
@@ -2,10 +2,12 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using System.Text;
 using System.Text.Json;
 using SqlOS.AuthServer.Services;
 using SqlOS.Configuration;
+using SqlOS.Security;
 
 namespace SqlOS.Dashboard;
 
@@ -24,6 +26,7 @@ public sealed class SqlOSDashboardMiddleware
     private readonly SqlOSDashboardSessionService _sessionService;
     private readonly SqlOSDashboardLoginThrottlingService _loginThrottlingService;
     private readonly IFileProvider _fileProvider;
+    private readonly SqlOSBrowserSecurityHeaders _securityHeaders;
 
     public SqlOSDashboardMiddleware(
         RequestDelegate next,
@@ -32,7 +35,8 @@ public sealed class SqlOSDashboardMiddleware
         SqlOSDashboardOptions options,
         bool scimEnabled,
         SqlOSDashboardSessionService sessionService,
-        SqlOSDashboardLoginThrottlingService loginThrottlingService)
+        SqlOSDashboardLoginThrottlingService loginThrottlingService,
+        IOptions<SqlOSOptions> hostOptions)
     {
         _next = next;
         _pathPrefix = pathPrefix.TrimEnd('/');
@@ -41,6 +45,7 @@ public sealed class SqlOSDashboardMiddleware
         _options = options;
         _sessionService = sessionService;
         _loginThrottlingService = loginThrottlingService;
+        _securityHeaders = new SqlOSBrowserSecurityHeaders(hostOptions);
         _fileProvider = CreateFileProvider();
     }
 
@@ -67,6 +72,8 @@ public sealed class SqlOSDashboardMiddleware
             await _next(context);
             return;
         }
+
+        _securityHeaders.ApplyBaseline(context.Response);
 
         if (IsDashboardAuthEndpoint(relativePath))
         {
@@ -482,6 +489,7 @@ public sealed class SqlOSDashboardMiddleware
             JsonSerializer.Serialize(new { scimEnabled = _scimEnabled }),
             StringComparison.Ordinal);
         html = html.Replace("__SQL_OS_BASE_PATH__", _pathPrefix, StringComparison.Ordinal);
+        html = _securityHeaders.PrepareHtml(context, html);
         await context.Response.WriteAsync(html);
     }
 

--- a/src/SqlOS/Extensions/ServiceCollectionExtensions.cs
+++ b/src/SqlOS/Extensions/ServiceCollectionExtensions.cs
@@ -20,6 +20,7 @@ using SqlOS.Fga.Interfaces;
 using SqlOS.Fga.Services;
 using SqlOS.Hosting;
 using SqlOS.Services;
+using SqlOS.Security;
 
 namespace SqlOS.Extensions;
 
@@ -45,6 +46,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton(Options.Create(options.Calendar));
         services.AddDataProtection();
         services.AddSingleton<SqlOSHostedFormAntiforgery>();
+        services.AddSingleton<SqlOSBrowserSecurityHeaders>();
         services.AddHttpClient();
         services.AddHttpClient(nameof(SqlOSOidcAuthService), client =>
         {

--- a/src/SqlOS/Fga/Dashboard/SqlOSFgaDashboardMiddleware.cs
+++ b/src/SqlOS/Fga/Dashboard/SqlOSFgaDashboardMiddleware.cs
@@ -5,12 +5,14 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using SqlOS.Configuration;
 using SqlOS.Dashboard;
 using SqlOS.Fga.Configuration;
 using SqlOS.Fga.Interfaces;
 using SqlOS.Fga.Models;
 using SqlOS.Fga.Services;
+using SqlOS.Security;
 
 namespace SqlOS.Fga.Dashboard;
 
@@ -22,6 +24,7 @@ public class SqlOSFgaDashboardMiddleware
     private readonly SqlOSDashboardOptions _dashboardOptions;
     private readonly SqlOSDashboardSessionService _sessionService;
     private readonly IFileProvider _fileProvider;
+    private readonly SqlOSBrowserSecurityHeaders _securityHeaders;
     private const int DefaultPageSize = 25;
     private const int MaxPageSize = 100;
     private const int MaxAncestorTraversalDepth = 50;
@@ -36,13 +39,15 @@ public class SqlOSFgaDashboardMiddleware
         string pathPrefix,
         IHostEnvironment environment,
         SqlOSDashboardOptions dashboardOptions,
-        SqlOSDashboardSessionService sessionService)
+        SqlOSDashboardSessionService sessionService,
+        IOptions<SqlOSOptions> hostOptions)
     {
         _next = next;
         _pathPrefix = pathPrefix.TrimEnd('/');
         _isDevelopment = environment.IsDevelopment();
         _dashboardOptions = dashboardOptions;
         _sessionService = sessionService;
+        _securityHeaders = new SqlOSBrowserSecurityHeaders(hostOptions);
         _fileProvider = CreateFileProvider();
     }
 
@@ -57,6 +62,7 @@ public class SqlOSFgaDashboardMiddleware
         }
 
         var relativePath = path[_pathPrefix.Length..].TrimStart('/');
+        _securityHeaders.ApplyBaseline(context.Response);
         var isApiRequest = relativePath.StartsWith("api/", StringComparison.OrdinalIgnoreCase);
 
         if (!await IsAuthorizedAsync(context))
@@ -1039,6 +1045,7 @@ public class SqlOSFgaDashboardMiddleware
             var html = await reader.ReadToEndAsync();
             html = html.Replace("__SQL_OS_FGA_DASHBOARD_BASE_PATH_JSON__", JsonSerializer.Serialize(GetDashboardShellPrefix().TrimEnd('/')), StringComparison.Ordinal);
             html = html.Replace("__SQL_OS_BASE_PATH__", GetDashboardShellPrefix().TrimEnd('/'), StringComparison.Ordinal);
+            html = _securityHeaders.PrepareHtml(context, html);
             await context.Response.WriteAsync(html);
             return;
         }

--- a/src/SqlOS/Fga/Dashboard/wwwroot/app.js
+++ b/src/SqlOS/Fga/Dashboard/wwwroot/app.js
@@ -956,7 +956,7 @@
             </div>`;
 
         $('#modal').innerHTML = html;
-        $('#modal-overlay').style.display = 'flex';
+        $('#modal-overlay').hidden = false;
 
         $('#role-cancel').addEventListener('click', closeModal);
         $('#modal-overlay').onclick = (e) => { if (e.target === $('#modal-overlay')) closeModal(); };
@@ -1007,7 +1007,7 @@
             </div>`;
 
         $('#modal').innerHTML = html;
-        $('#modal-overlay').style.display = 'flex';
+        $('#modal-overlay').hidden = false;
 
         $('#add-perm-cancel').addEventListener('click', closeModal);
         $('#modal-overlay').onclick = (e) => { if (e.target === $('#modal-overlay')) closeModal(); };
@@ -1094,7 +1094,7 @@
             </div>`;
 
         $('#modal').innerHTML = html;
-        $('#modal-overlay').style.display = 'flex';
+        $('#modal-overlay').hidden = false;
 
         $('#perm-cancel').addEventListener('click', closeModal);
         $('#modal-overlay').onclick = (e) => { if (e.target === $('#modal-overlay')) closeModal(); };
@@ -1372,7 +1372,7 @@
     }
 
     function closeModal() {
-        $('#modal-overlay').style.display = 'none';
+        $('#modal-overlay').hidden = true;
     }
 
     async function openGrantModal(subjectId, resourceId) {
@@ -1417,7 +1417,7 @@
         </div>`;
 
         $('#modal').innerHTML = html;
-        $('#modal-overlay').style.display = 'flex';
+        $('#modal-overlay').hidden = false;
 
         $('#grant-cancel').addEventListener('click', closeModal);
         $('#modal-overlay').onclick = (e) => { if (e.target === $('#modal-overlay')) closeModal(); };

--- a/src/SqlOS/Fga/Dashboard/wwwroot/index.html
+++ b/src/SqlOS/Fga/Dashboard/wwwroot/index.html
@@ -47,7 +47,7 @@
             </main>
         </div>
     </div>
-    <div id="modal-overlay" class="modal-overlay" style="display:none">
+    <div id="modal-overlay" class="modal-overlay" hidden>
         <div id="modal" class="modal"></div>
     </div>
     <script src="app.js"></script>

--- a/src/SqlOS/Fga/Dashboard/wwwroot/style.css
+++ b/src/SqlOS/Fga/Dashboard/wwwroot/style.css
@@ -222,6 +222,7 @@ td a:hover, .tree-resource-name:hover { color: var(--amber-600); }
 
 /* ── Modal ── */
 .modal-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.4); display: flex; align-items: center; justify-content: center; z-index: 1000; }
+.modal-overlay[hidden] { display: none; }
 .modal { background: #fff; border-radius: 8px; padding: 0; min-width: 400px; max-width: 90vw; max-height: 90vh; overflow-y: auto; box-shadow: 0 8px 32px rgba(0,0,0,0.12); border: 1px solid var(--zinc-200); }
 .modal h3 { padding: 1rem 1.25rem; border-bottom: 1px solid var(--zinc-200); font-size: 0.95rem; font-weight: 600; }
 .modal-field { padding: 0 1.25rem; margin-top: 0.75rem; }

--- a/src/SqlOS/Security/SqlOSBrowserSecurityHeaders.cs
+++ b/src/SqlOS/Security/SqlOSBrowserSecurityHeaders.cs
@@ -1,0 +1,48 @@
+using System.Net;
+using System.Security.Cryptography;
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Options;
+using SqlOS.Configuration;
+
+namespace SqlOS.Security;
+
+internal sealed class SqlOSBrowserSecurityHeaders
+{
+    private static readonly Regex InlineElementPattern = new(
+        "<(script|style)(?![^>]*\\bnonce\\s*=)",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant,
+        TimeSpan.FromSeconds(1));
+
+    private readonly SqlOSBrowserSecurityOptions _options;
+
+    public SqlOSBrowserSecurityHeaders(IOptions<SqlOSOptions> options)
+    {
+        _options = options.Value.BrowserSecurity;
+    }
+
+    public void ApplyBaseline(HttpResponse response)
+    {
+        response.Headers["X-Frame-Options"] = "DENY";
+        response.Headers["X-Content-Type-Options"] = "nosniff";
+        response.Headers["Referrer-Policy"] = "no-referrer";
+    }
+
+    public string PrepareHtml(HttpContext context, string html)
+    {
+        ApplyBaseline(context.Response);
+        var nonce = WebEncoders.Base64UrlEncode(RandomNumberGenerator.GetBytes(18));
+        var policy = _options.ContentSecurityPolicy.Replace(
+            SqlOSBrowserSecurityOptions.NoncePlaceholder,
+            nonce,
+            StringComparison.Ordinal);
+        context.Response.Headers["Content-Security-Policy"] =
+            $"{policy.Trim().TrimEnd(';')}; frame-ancestors 'none'";
+
+        var encodedNonce = WebUtility.HtmlEncode(nonce);
+        return InlineElementPattern.Replace(
+            html,
+            match => $"<{match.Groups[1].Value} nonce=\"{encodedNonce}\"");
+    }
+}

--- a/tests/SqlOS.IntegrationTests/AuthPageCsrfIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/AuthPageCsrfIntegrationTests.cs
@@ -99,6 +99,32 @@ public sealed class AuthPageCsrfIntegrationTests
         session.AuthenticationMethod.Should().Be("password");
     }
 
+    [TestMethod]
+    public async Task HostedAuthPage_UsesLockedBrowserSecurityHeadersAndPerResponseNonce()
+    {
+        await using var server = await AuthPageCsrfServer.CreateAsync();
+        using var client = server.App.GetTestClient();
+        client.BaseAddress = new Uri(TrustedOrigin);
+
+        var first = await client.GetAsync("/sqlos/auth/login");
+        var second = await client.GetAsync("/sqlos/auth/login");
+        var firstHtml = await first.Content.ReadAsStringAsync();
+        var secondHtml = await second.Content.ReadAsStringAsync();
+        var firstNonce = Regex.Match(firstHtml, "<style nonce=\"([A-Za-z0-9_-]+)\"").Groups[1].Value;
+        var secondNonce = Regex.Match(secondHtml, "<style nonce=\"([A-Za-z0-9_-]+)\"").Groups[1].Value;
+
+        first.Headers.GetValues("X-Frame-Options").Should().ContainSingle("DENY");
+        first.Headers.GetValues("X-Content-Type-Options").Should().ContainSingle("nosniff");
+        first.Headers.GetValues("Referrer-Policy").Should().ContainSingle("no-referrer");
+        var policy = first.Headers.GetValues("Content-Security-Policy").Single();
+        policy.Should().Contain("frame-ancestors 'none'");
+        policy.Should().Contain($"'nonce-{firstNonce}'");
+        policy.Should().NotContain("unsafe-inline");
+        firstHtml.Should().Contain($"<script nonce=\"{firstNonce}\">");
+        firstNonce.Should().NotBeNullOrWhiteSpace();
+        secondNonce.Should().NotBe(firstNonce, "every HTML response receives a fresh nonce");
+    }
+
     private static string ExtractInputValue(string html, string name)
     {
         var match = Regex.Match(

--- a/tests/SqlOS.Tests/SqlOSCalendarEndpointsTests.cs
+++ b/tests/SqlOS.Tests/SqlOSCalendarEndpointsTests.cs
@@ -18,6 +18,7 @@ using SqlOS.Calendar.Interfaces;
 using SqlOS.Calendar.Models;
 using SqlOS.Calendar.Services;
 using SqlOS.Configuration;
+using SqlOS.Security;
 using SqlOS.Tests.Infrastructure;
 
 namespace SqlOS.Tests;
@@ -132,7 +133,9 @@ public sealed class SqlOSCalendarEndpointsTests
 
         var callback = await client.GetAsync("/sqlos/auth/calendar/callback?code=success:missing@example.com");
 
-        callback.StatusCode.Should().Be(HttpStatusCode.OK);
+        callback.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        callback.Headers.GetValues("Content-Security-Policy").Single().Should().Contain("'nonce-");
+        callback.Headers.GetValues("X-Frame-Options").Single().Should().Be("DENY");
         (await callback.Content.ReadAsStringAsync()).Should().Contain("SqlOS calendar connect error");
     }
 
@@ -155,6 +158,7 @@ public sealed class SqlOSCalendarEndpointsTests
                     services.AddScoped<ISqlOSAuthServerDbContext>(sp => sp.GetRequiredService<TestSqlOSInMemoryDbContext>());
                     services.AddSingleton(Options.Create(sqlosOptions));
                     services.AddSingleton(Options.Create(sqlosOptions.AuthServer));
+                    services.AddSingleton<SqlOSBrowserSecurityHeaders>();
                     services.AddSingleton<IDataProtectionProvider>(new EphemeralDataProtectionProvider());
                     services.AddSingleton<IHttpClientFactory, FakeCalendarProviderHttpClientFactory>();
                     services.AddSingleton<ISqlOSCalendarProviderAdapter, SqlOSGoogleCalendarAdapter>();

--- a/tests/SqlOS.Tests/SqlOSDashboardAuthMiddlewareTests.cs
+++ b/tests/SqlOS.Tests/SqlOSDashboardAuthMiddlewareTests.cs
@@ -14,6 +14,7 @@ using SqlOS.AuthServer.Models;
 using SqlOS.AuthServer.Services;
 using SqlOS.Configuration;
 using SqlOS.Dashboard;
+using SqlOS.Security;
 using SqlOS.Tests.Infrastructure;
 
 namespace SqlOS.Tests;
@@ -165,6 +166,26 @@ public sealed class SqlOSDashboardAuthMiddlewareTests
         enabled.Body.Should().Contain("window.__SQL_OS_CAPABILITIES__ = {\"scimEnabled\":true};");
     }
 
+    [TestMethod]
+    public async Task DashboardShell_IncludesLockedSecurityHeadersAndNonce()
+    {
+        using var harness = CreateHarness(options =>
+        {
+            options.AuthMode = SqlOSDashboardAuthMode.DevelopmentOnly;
+            options.AuthorizationCallback = _ => Task.FromResult(true);
+        });
+
+        var response = await harness.GetDashboardAsync();
+
+        response.XFrameOptions.Should().Be("DENY");
+        response.ContentTypeOptions.Should().Be("nosniff");
+        response.ReferrerPolicy.Should().Be("no-referrer");
+        response.ContentSecurityPolicy.Should().Contain("frame-ancestors 'none'");
+        response.ContentSecurityPolicy.Should().NotContain("unsafe-inline");
+        response.Body.Should().MatchRegex("<script nonce=\"[A-Za-z0-9_-]+\">");
+        response.Body.Should().MatchRegex("<script nonce=\"[A-Za-z0-9_-]+\" src=");
+    }
+
     private static DashboardMiddlewareHarness CreateHarness(
         Action<SqlOSDashboardOptions>? configure = null,
         bool scimEnabled = false)
@@ -182,11 +203,14 @@ public sealed class SqlOSDashboardAuthMiddlewareTests
         services.AddDbContext<TestSqlOSInMemoryDbContext>(options =>
             options.UseInMemoryDatabase(databaseName));
         services.AddScoped<ISqlOSAuthServerDbContext>(sp => sp.GetRequiredService<TestSqlOSInMemoryDbContext>());
+        var sqlosOptions = new SqlOSOptions();
+        services.AddSingleton(Options.Create(sqlosOptions));
         services.AddSingleton(Options.Create(new SqlOSAuthServerOptions()));
         services.AddScoped<SqlOSCryptoService>();
         services.AddScoped<SqlOSAdminService>();
         services.AddSingleton<SqlOSDashboardSessionService>();
         services.AddSingleton<SqlOSDashboardLoginThrottlingService>();
+        services.AddSingleton<SqlOSBrowserSecurityHeaders>();
 
         var provider = services.BuildServiceProvider(validateScopes: true);
         var middleware = new SqlOSDashboardMiddleware(
@@ -196,7 +220,8 @@ public sealed class SqlOSDashboardAuthMiddlewareTests
             dashboardOptions,
             scimEnabled,
             provider.GetRequiredService<SqlOSDashboardSessionService>(),
-            provider.GetRequiredService<SqlOSDashboardLoginThrottlingService>());
+            provider.GetRequiredService<SqlOSDashboardLoginThrottlingService>(),
+            provider.GetRequiredService<IOptions<SqlOSOptions>>());
 
         return new DashboardMiddlewareHarness(provider, middleware);
     }
@@ -271,7 +296,15 @@ public sealed class SqlOSDashboardAuthMiddlewareTests
                 ? retryAfterValues.ToString()
                 : null;
 
-            return new DashboardResponse(context.Response.StatusCode, responseBody, setCookie, retryAfter);
+            return new DashboardResponse(
+                context.Response.StatusCode,
+                responseBody,
+                setCookie,
+                retryAfter,
+                context.Response.Headers["X-Frame-Options"].ToString(),
+                context.Response.Headers["X-Content-Type-Options"].ToString(),
+                context.Response.Headers["Referrer-Policy"].ToString(),
+                context.Response.Headers["Content-Security-Policy"].ToString());
         }
 
         public void Dispose()
@@ -282,7 +315,11 @@ public sealed class SqlOSDashboardAuthMiddlewareTests
         int StatusCode,
         string Body,
         string[] SetCookie,
-        string? RetryAfter);
+        string? RetryAfter,
+        string XFrameOptions,
+        string ContentTypeOptions,
+        string ReferrerPolicy,
+        string ContentSecurityPolicy);
 
     private sealed class TestHostEnvironment : IHostEnvironment
     {

--- a/tests/SqlOS.Tests/SqlOSOptionsValidationTests.cs
+++ b/tests/SqlOS.Tests/SqlOSOptionsValidationTests.cs
@@ -152,6 +152,21 @@ public sealed class SqlOSOptionsValidationTests
         act.Should().NotThrow();
     }
 
+    [DataTestMethod]
+    [DataRow("default-src 'self'; script-src 'self'")]
+    [DataRow("default-src 'self'; script-src 'nonce-{nonce}'; frame-ancestors https://example.test")]
+    [DataRow("default-src 'self'; script-src 'nonce-{nonce}'\r\nX-Test: injected")]
+    public void AddSqlOS_RejectsUnsafeBrowserSecurityPolicy(string policy)
+    {
+        var services = new ServiceCollection();
+
+        Action act = () => services.AddSqlOS<TestSqlOSInMemoryDbContext>(options =>
+            options.BrowserSecurity.ContentSecurityPolicy = policy);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*BrowserSecurity.ContentSecurityPolicy*");
+    }
+
     [TestMethod]
     public void AddSqlOS_SingleApplicationOriginDerivesIssuerWithoutPublicOriginSetup()
     {

--- a/tests/SqlOS.Tests/SqlOSOptionsValidationTests.cs
+++ b/tests/SqlOS.Tests/SqlOSOptionsValidationTests.cs
@@ -154,6 +154,9 @@ public sealed class SqlOSOptionsValidationTests
 
     [DataTestMethod]
     [DataRow("default-src 'self'; script-src 'self'")]
+    [DataRow("default-src 'self'; script-src 'nonce-{nonce}'; style-src 'self'")]
+    [DataRow("default-src 'self'; script-src 'self' 'unsafe-inline' 'nonce-{nonce}'; style-src 'nonce-{nonce}'")]
+    [DataRow("default-src 'self'; script-src 'self' 'nonce-{nonce}'; style-src 'unsafe-inline' 'nonce-{nonce}'")]
     [DataRow("default-src 'self'; script-src 'nonce-{nonce}'; frame-ancestors https://example.test")]
     [DataRow("default-src 'self'; script-src 'nonce-{nonce}'\r\nX-Test: injected")]
     public void AddSqlOS_RejectsUnsafeBrowserSecurityPolicy(string policy)

--- a/web/content/docs/guides/configuration.mdx
+++ b/web/content/docs/guides/configuration.mdx
@@ -196,6 +196,10 @@ For local development, `dotnet user-secrets set "SqlOS:Dashboard:Password" "..."
 
 Treat `/sqlos` and `/sqlos/admin` as administrative endpoints — restrict network access in production.
 
+## Hosted UI security headers
+
+Hosted auth and dashboard HTML use a restrictive nonce-based Content Security Policy and deny framing automatically. No setting is required for the built-in UI. If a reviewed customization loads scripts, styles, images, or fonts from another origin, set `options.BrowserSecurity.ContentSecurityPolicy` and keep the required `{nonce}` placeholder. `frame-ancestors 'none'` is always enforced and cannot be overridden. See [Production Readiness](/docs/guides/production-readiness#keep-the-hosted-ui-browser-boundary-intact) for the default headers and a customization example.
+
 ## Schema ownership
 
 SqlOS runs its own SQL scripts on startup. Your EF migrations **do not** own SqlOS tables. If you need SqlOS tables before your migrations, call `SqlOSBootstrapper.InitializeAsync()` once first.

--- a/web/content/docs/guides/production-readiness.mdx
+++ b/web/content/docs/guides/production-readiness.mdx
@@ -123,6 +123,29 @@ When CIMD is enabled, populate `Cimd.TrustedHosts` so an untrusted host is rejec
 
 SqlOS still enforces its own dashboard policy inside the process. Edge protection is defense in depth, not a replacement for configuring the dashboard.
 
+### Keep the hosted UI browser boundary intact
+
+SqlOS applies browser security headers automatically to every hosted AuthPage, verification page, SSO setup page, and dashboard HTML response:
+
+- `X-Frame-Options: DENY`;
+- `Content-Security-Policy` with `frame-ancestors 'none'`;
+- nonce-bound first-party scripts and styles, with no `unsafe-inline` script permission;
+- `X-Content-Type-Options: nosniff`;
+- `Referrer-Policy: no-referrer`.
+
+The default policy permits same-origin forms, scripts, styles, fonts, and API calls plus `data:` images/fonts used by embedded branding. Most applications should leave it alone. If a reviewed dashboard or AuthPage customization requires another trusted source, replace the policy prefix while retaining the per-response nonce placeholder:
+
+```csharp
+options.BrowserSecurity.ContentSecurityPolicy =
+    "default-src 'none'; base-uri 'none'; object-src 'none'; form-action 'self'; " +
+    "img-src 'self' data: https://cdn.example.com; font-src 'self' data:; connect-src 'self'; " +
+    "script-src 'self' 'nonce-{nonce}'; style-src 'self' 'nonce-{nonce}' https://cdn.example.com";
+```
+
+SqlOS validates this value at startup. It must be one header-safe line, must contain `{nonce}`, and cannot declare `frame-ancestors`; SqlOS always appends `frame-ancestors 'none'` so a customization cannot accidentally make credential or consent UI frameable.
+
+Set `Strict-Transport-Security` at the TLS-terminating reverse proxy or host for the whole application domain, not only SqlOS routes. Verify the header on `/sqlos`, `/sqlos/auth/login`, and normal application responses after deployment. Do not enable long-lived HSTS on a domain until every route is reliably HTTPS.
+
 ## 3. Harden dashboard access
 
 The default dashboard mode is `DevelopmentOnly`. Without an authorization callback, it is available only when the host environment is Development and returns `404` in production. For an operator-accessible production dashboard, configure password mode explicitly:


### PR DESCRIPTION
Closes #142.

## What changed

- applies X-Frame-Options DENY, locked CSP frame-ancestors none, nosniff, and no-referrer defaults to hosted auth, verification, SSO setup, and dashboard HTML
- generates a fresh nonce for every response and nonce-binds built-in inline scripts/styles without unsafe-inline script permission
- keeps the feature automatic while allowing a validated advanced CSP override with a required nonce placeholder; anti-framing cannot be relaxed
- removes the remaining built-in inline style attributes/state mutations that would conflict with the strict policy
- documents default headers, reviewed CDN extension, and domain-wide HSTS ownership

## Developer impact

No configuration or external service is required. Existing built-in pages receive the headers automatically. Only applications with deliberate custom external UI assets need to extend BrowserSecurity.ContentSecurityPolicy.

## Validation

- focused header/config/dashboard unit suite: 39 passed
- real SQL-backed hosted AuthPage header/nonce integration test: passed
- full library unit suite: 572 passed
- example unit suite: 2 passed
- solution build: 0 warnings, 0 errors
- dashboard JavaScript syntax validation passed
- docs source contracts, snippets, lint, TypeScript, production build, images, and 166-file link validation passed

An adversarial review and one iteration will be recorded in PR comments before final handoff.