### PR TITLE
Release SqlOS 3.22.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![NuGet](https://img.shields.io/nuget/v/SqlOS)](https://www.nuget.org/packages/SqlOS)
 [![.NET 9](https://img.shields.io/badge/.NET-9.0-purple)](https://dotnet.microsoft.com)
 
-SqlOS 3.21.0 provides a hosted OAuth server, branded login, organizations, sessions, and optional fine-grained authorization to an ASP.NET Core application. It runs in your process and stores its data in your SQL Server database, so you do not need a separate identity or authorization service to get started.
+SqlOS 3.22.0 provides a hosted OAuth server, branded login, organizations, sessions, and optional fine-grained authorization to an ASP.NET Core application. It runs in your process and stores its data in your SQL Server database, so you do not need a separate identity or authorization service to get started.
 
 Start with one application and hosted login. Add SAML SSO, social login, Email OTP, audit logs, calendar connections, or hierarchical authorization when your product needs them.
 
@@ -35,10 +35,10 @@ Requirements:
 Install the package:
 
 ```bash
-dotnet add package SqlOS --version 3.21.0
+dotnet add package SqlOS --version 3.22.0
 ```
 
-> The `main` branch is staged for the 3.21.0 package contract. If NuGet does not list 3.21.0 yet, run the repository examples from source or wait for the package release; do not pair these source docs with an older package.
+> The `main` branch is staged for the 3.22.0 package contract. If NuGet does not list 3.22.0 yet, run the repository examples from source or wait for the package release; do not pair these source docs with an older package.
 
 Use `SqlOSDbContext<TContext>` so SqlOS can register its EF Core model, then declare one application with `UseSingleApplication`:
 

--- a/src/SqlOS/SqlOS.csproj
+++ b/src/SqlOS/SqlOS.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>SqlOS</PackageId>
-    <Version>3.21.0</Version>
+    <Version>3.22.0</Version>
     <Authors>Ross Slaney</Authors>
     <Description>Embedded auth server and fine-grained authorization runtime for .NET + SQL Server + EF Core.</Description>
     <PackageTags>authentication;authorization;fga;saml;jwt;sessions;efcore;sqlserver</PackageTags>

--- a/web/content/blog/hierarchical-authorization-native-ef-core.mdx
+++ b/web/content/blog/hierarchical-authorization-native-ef-core.mdx
@@ -128,7 +128,7 @@ Create the host and install the same package version used to compile this articl
 ```bash
 dotnet new web --framework net9.0 --name HierarchicalEf
 cd HierarchicalEf
-dotnet add package SqlOS --version 3.21.0
+dotnet add package SqlOS --version 3.22.0
 ```
 
 Replace `Program.cs` with the program below. It assumes SQL Server is running and that callers obtain an audience-bound access token through the [Protect an API quickstart](/docs/quickstarts/protect-api). That keeps the sample focused on upgrading the EF model rather than rebuilding the OAuth client flow in the same file.

--- a/web/content/docs/docs-index.mdx
+++ b/web/content/docs/docs-index.mdx
@@ -5,7 +5,7 @@ order: 0
 ---
 
 <Callout type="info" title="Version contract">
-  These docs target **SqlOS 3.21.0**, **.NET 9**, **EF Core 9**, and **SQL Server**. Use the same package version as the docs; older releases do not include the complete current schema and source/reference contract.
+  These docs target **SqlOS 3.22.0**, **.NET 9**, **EF Core 9**, and **SQL Server**. Use the same package version as the docs; older releases do not include the complete current schema and source/reference contract.
 </Callout>
 
 ## Get useful proof first

--- a/web/content/docs/getting-started.mdx
+++ b/web/content/docs/getting-started.mdx
@@ -14,7 +14,7 @@ order: 0
 </Banner>
 
 <Callout type="info" title="Supported stack">
-  - **SqlOS 3.21.0**
+  - **SqlOS 3.22.0**
   - **.NET 9** (`net9.0`)
   - **EF Core 9**
   - **SQL Server**

--- a/web/content/docs/quickstarts/add-to-app.mdx
+++ b/web/content/docs/quickstarts/add-to-app.mdx
@@ -11,7 +11,7 @@ section: quickstarts
   href="#complete-program"
   actionLabel="View the code"
 >
-  Install SqlOS 3.21.0, register one SQL Server `DbContext`, declare one application, and map the routes. FGA modeling and advanced client registration can wait.
+  Install SqlOS 3.22.0, register one SQL Server `DbContext`, declare one application, and map the routes. FGA modeling and advanced client registration can wait.
 </Banner>
 
 ## Goal
@@ -30,16 +30,16 @@ Start an ASP.NET Core application with:
 - EF Core 9;
 - an existing SQL Server database and a login allowed to create tables, indexes, and functions.
 
-SqlOS 3.21.0 targets `net9.0`; it is not compatible with a `net8.0` host.
+SqlOS 3.22.0 targets `net9.0`; it is not compatible with a `net8.0` host.
 
 ## Install
 
 ```bash
-dotnet add package SqlOS --version 3.21.0
+dotnet add package SqlOS --version 3.22.0
 ```
 
 <Callout type="warning" title="Use the matching package version">
-  The `3.21.0` package is the version contract for this guide. If NuGet does not list it yet, run the source examples from this repository or wait for the release; older packages may not contain the schema and APIs documented here.
+  The `3.22.0` package is the version contract for this guide. If NuGet does not list it yet, run the source examples from this repository or wait for the release; older packages may not contain the schema and APIs documented here.
 </Callout>
 
 For a new project, store local values with user secrets:

--- a/web/content/docs/quickstarts/ef-authorization.mdx
+++ b/web/content/docs/quickstarts/ef-authorization.mdx
@@ -20,7 +20,7 @@ Create projects through an audience-protected API and return only projects the s
 
 ## Prerequisites
 
-- SqlOS 3.21.0;
+- SqlOS 3.22.0;
 - .NET 9, EF Core 9, and SQL Server;
 - a completed [Protect an API](/docs/quickstarts/protect-api) flow;
 - a valid access token whose `aud` is `http://localhost:5050/api`.

--- a/web/content/docs/quickstarts/protect-api.mdx
+++ b/web/content/docs/quickstarts/protect-api.mdx
@@ -20,7 +20,7 @@ Add `/api/me` to a one-application SqlOS host. Requests without a bearer token r
 
 ## Prerequisites
 
-- SqlOS 3.21.0;
+- SqlOS 3.22.0;
 - .NET 9 and EF Core 9;
 - the [Add SqlOS to one app](/docs/quickstarts/add-to-app) setup;
 - the working [.NET hosted-login flow](/docs/quickstarts/aspnet-core-login), adapted so its registered callback matches your handler and its audience is `http://localhost:5050/api`, or another PKCE client that does the same.

--- a/web/content/docs/quickstarts/run-example-stack.mdx
+++ b/web/content/docs/quickstarts/run-example-stack.mdx
@@ -20,7 +20,7 @@ Compare hosted and headless auth, organization workflows, SSO, sessions, audit l
 
 ## Prerequisites
 
-- SqlOS repository checked out at version 3.21.0;
+- SqlOS repository checked out at version 3.22.0;
 - .NET 9 SDK;
 - Node.js and npm;
 - Docker running with enough memory for SQL Server;

--- a/web/content/docs/quickstarts/run-todo.mdx
+++ b/web/content/docs/quickstarts/run-todo.mdx
@@ -25,7 +25,7 @@ Create an account through the SqlOS hosted AuthPage, return to a secure ASP.NET 
 - Docker running with enough memory for SQL Server;
 - ports `1435`, `5080`, `5090`, `18890`, and `18891` available.
 
-This quickstart uses the source at **SqlOS 3.21.0**. Local password authentication is the default, so the first run does not require Azure Communication Services, Twilio, or an OIDC provider.
+This quickstart uses the source at **SqlOS 3.22.0**. Local password authentication is the default, so the first run does not require Azure Communication Services, Twilio, or an OIDC provider.
 
 ## Run
 

--- a/web/content/docs/reference/index.mdx
+++ b/web/content/docs/reference/index.mdx
@@ -1,13 +1,13 @@
 ---
 title: "Reference"
-description: "Source-aligned reference for SqlOS 3.21.0 hosting, authentication, authorization, and integration APIs."
+description: "Source-aligned reference for SqlOS 3.22.0 hosting, authentication, authorization, and integration APIs."
 order: 7
 section: reference
 ---
 
 <Banner
   eyebrow="Reference"
-  title="SqlOS 3.21.0 application API"
+  title="SqlOS 3.22.0 application API"
   href="/docs/getting-started"
   actionLabel="Start with a guide"
 >
@@ -19,7 +19,7 @@ section: reference
 | Item | Value |
 | --- | --- |
 | Package | `SqlOS` |
-| Current source version | `3.21.0` |
+| Current source version | `3.22.0` |
 | Assembly | `SqlOS.dll` |
 | Target framework | `net9.0` |
 | EF Core provider | SQL Server, EF Core 9 |


### PR DESCRIPTION
## Summary

- bump the SqlOS package version from 3.21.0 to 3.22.0
- align README, quickstarts, reference docs, and source-aligned install examples with the 3.22.0 package contract
- release the dashboard authorization-boundary and automatic browser-security-header work merged in #199 and #200

## Developer impact

No new setup, middleware ordering, cloud dependency, or external key/header service is required. Dashboard path checks and hosted browser security headers remain automatic and secure by default.

## Validation

- solution build: 0 warnings, 0 errors
- library unit tests: 581 passed
- example unit tests: 2 passed
- docs source contracts, compiled snippets, lint, TypeScript, production build, image validation, and link validation passed
- package created and inspected as `SqlOS.3.22.0.nupkg`

The full real SQL integration and coverage matrix will run in PR CI before merge.