### PR TITLE
Centralize admin API authorization

### DIFF
--- a/src/SqlOS/AuditLogs/SqlOSAuditLogEndpointRouteBuilderExtensions.cs
+++ b/src/SqlOS/AuditLogs/SqlOSAuditLogEndpointRouteBuilderExtensions.cs
@@ -18,7 +18,8 @@ public static class SqlOSAuditLogEndpointRouteBuilderExtensions
         string dashboardBasePath)
     {
         var adminPrefix = $"{dashboardBasePath.TrimEnd('/')}/admin/audit";
-        var api = endpoints.MapGroup($"{adminPrefix}/api");
+        var api = endpoints.MapGroup($"{adminPrefix}/api")
+            .RequireSqlOSAdminAuthorization();
         api.ExcludeFromDescription();
 
         api.MapGet("/events", async (

--- a/src/SqlOS/AuthServer/Extensions/EndpointRouteBuilderExtensions.cs
+++ b/src/SqlOS/AuthServer/Extensions/EndpointRouteBuilderExtensions.cs
@@ -45,9 +45,11 @@ public static class EndpointRouteBuilderExtensions
         var adminRoot = endpoints.MapGroup(adminPrefix);
         adminRoot.ExcludeFromDescription();
 
-        var adminApi = adminRoot.MapGroup("/api");
+        var adminApi = adminRoot.MapGroup("/api")
+            .RequireSqlOSAdminAuthorization();
         var ssoSetupApi = endpoints.MapGroup(resolvedSsoSetupApiPath);
         ssoSetupApi.ExcludeFromDescription();
+        ssoSetupApi.AllowSqlOSAdminPublicException("SSO setup APIs require a scoped portal session.");
 
         if (authOptions.EnableScim)
         {
@@ -3581,6 +3583,7 @@ public static class EndpointRouteBuilderExtensions
 
         var ssoPortal = adminRoot.MapGroup("/sso-portal");
         ssoPortal.ExcludeFromDescription();
+        ssoPortal.AllowSqlOSAdminPublicException("SSO portal routes require a scoped portal session token.");
         MapSsoPortalEndpoints(adminApi, ssoPortal, ssoSetupApi);
 
         adminApi.MapGet("/stats", async (HttpContext context, SqlOSAdminService adminService, IOptions<SqlOSAuthServerOptions> options, IHostEnvironment environment, CancellationToken cancellationToken) =>

--- a/src/SqlOS/Calendar/Extensions/EndpointRouteBuilderExtensions.cs
+++ b/src/SqlOS/Calendar/Extensions/EndpointRouteBuilderExtensions.cs
@@ -45,7 +45,8 @@ public static class EndpointRouteBuilderExtensions
         var admin = endpoints.MapGroup(prefix);
         admin.ExcludeFromDescription();
 
-        var api = admin.MapGroup("/api");
+        var api = admin.MapGroup("/api")
+            .RequireSqlOSAdminAuthorization();
 
         api.MapGet("/connections", async (
             HttpContext context,

--- a/src/SqlOS/Dashboard/SqlOSAdminAuthorization.cs
+++ b/src/SqlOS/Dashboard/SqlOSAdminAuthorization.cs
@@ -45,12 +45,17 @@ internal sealed class SqlOSAdminAuthorizationFilter : IEndpointFilter
         EndpointFilterDelegate next)
     {
         var services = context.HttpContext.RequestServices;
+        if (services.GetService<SqlOSDashboardSessionService>() == null)
+        {
+            return Results.NotFound();
+        }
+
         var dashboardOptions = services.GetService<IOptions<SqlOSOptions>>()?.Value.Dashboard
-            ?? services.GetService<IOptions<SqlOSAuthServerOptions>>()?.Value.Dashboard
-            ?? new SqlOSDashboardOptions();
+            ?? services.GetService<IOptions<SqlOSAuthServerOptions>>()?.Value.Dashboard;
         var environment = services.GetRequiredService<IHostEnvironment>();
 
-        if (!await IsAuthorizedAsync(context.HttpContext, dashboardOptions, environment))
+        if (dashboardOptions == null
+            || !await IsAuthorizedAsync(context.HttpContext, dashboardOptions, environment))
         {
             return Results.NotFound();
         }

--- a/src/SqlOS/Dashboard/SqlOSAdminAuthorization.cs
+++ b/src/SqlOS/Dashboard/SqlOSAdminAuthorization.cs
@@ -1,0 +1,85 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using SqlOS.AuthServer.Configuration;
+using SqlOS.Configuration;
+
+namespace SqlOS.Dashboard;
+
+internal sealed class SqlOSAdminRequiredMetadata
+{
+    public static SqlOSAdminRequiredMetadata Instance { get; } = new();
+
+    private SqlOSAdminRequiredMetadata()
+    {
+    }
+}
+
+internal sealed record SqlOSAdminPublicExceptionMetadata(string Reason);
+
+internal static class SqlOSAdminAuthorizationRouteGroupExtensions
+{
+    public static RouteGroupBuilder RequireSqlOSAdminAuthorization(this RouteGroupBuilder group)
+    {
+        group.WithMetadata(SqlOSAdminRequiredMetadata.Instance);
+        group.AddEndpointFilter<SqlOSAdminAuthorizationFilter>();
+        return group;
+    }
+
+    public static RouteGroupBuilder AllowSqlOSAdminPublicException(
+        this RouteGroupBuilder group,
+        string reason)
+    {
+        group.WithMetadata(new SqlOSAdminPublicExceptionMetadata(reason));
+        return group;
+    }
+}
+
+internal sealed class SqlOSAdminAuthorizationFilter : IEndpointFilter
+{
+    public async ValueTask<object?> InvokeAsync(
+        EndpointFilterInvocationContext context,
+        EndpointFilterDelegate next)
+    {
+        var services = context.HttpContext.RequestServices;
+        var dashboardOptions = services.GetService<IOptions<SqlOSOptions>>()?.Value.Dashboard
+            ?? services.GetService<IOptions<SqlOSAuthServerOptions>>()?.Value.Dashboard
+            ?? new SqlOSDashboardOptions();
+        var environment = services.GetRequiredService<IHostEnvironment>();
+
+        if (!await IsAuthorizedAsync(context.HttpContext, dashboardOptions, environment))
+        {
+            return Results.NotFound();
+        }
+
+        return await next(context);
+    }
+
+    private static async Task<bool> IsAuthorizedAsync(
+        HttpContext context,
+        SqlOSDashboardOptions options,
+        IHostEnvironment environment)
+    {
+        if (options.AuthMode == SqlOSDashboardAuthMode.Password)
+        {
+            var sessionService = context.RequestServices.GetService<SqlOSDashboardSessionService>();
+            if (sessionService == null || !sessionService.HasActiveSession(context))
+            {
+                return false;
+            }
+
+            return options.AuthorizationCallback == null
+                || await options.AuthorizationCallback(context);
+        }
+
+        if (options.AuthorizationCallback != null)
+        {
+            return await options.AuthorizationCallback(context);
+        }
+
+        return environment.IsDevelopment();
+    }
+}

--- a/src/SqlOS/Email/Extensions/EndpointRouteBuilderExtensions.cs
+++ b/src/SqlOS/Email/Extensions/EndpointRouteBuilderExtensions.cs
@@ -21,7 +21,8 @@ public static class EndpointRouteBuilderExtensions
         var admin = endpoints.MapGroup(prefix);
         admin.ExcludeFromDescription();
 
-        var api = admin.MapGroup("/api");
+        var api = admin.MapGroup("/api")
+            .RequireSqlOSAdminAuthorization();
 
         api.MapGet("/templates", async (
             HttpContext context,

--- a/tests/SqlOS.Tests/SqlOSAdminAuthorizationMetadataTests.cs
+++ b/tests/SqlOS.Tests/SqlOSAdminAuthorizationMetadataTests.cs
@@ -1,0 +1,110 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SqlOS.Dashboard;
+using SqlOS.Extensions;
+using SqlOS.Tests.Infrastructure;
+
+namespace SqlOS.Tests;
+
+[TestClass]
+public sealed class SqlOSAdminAuthorizationMetadataTests
+{
+    private const string PortalApiPrefix = "/sqlos/admin/auth/sso-portal/api";
+
+    [TestMethod]
+    public async Task AdminApiRouteInventory_RequiresCentralAuthorizationOrExplicitException()
+    {
+        await using var app = await CreateAppAsync(Environments.Production);
+
+        var endpoints = app.Services.GetRequiredService<EndpointDataSource>().Endpoints
+            .OfType<RouteEndpoint>()
+            .Where(endpoint => endpoint.RoutePattern.RawText?.Contains("/admin/", StringComparison.Ordinal) == true)
+            .Where(endpoint => endpoint.RoutePattern.RawText?.Contains("/api", StringComparison.Ordinal) == true)
+            .ToArray();
+
+        endpoints.Should().NotBeEmpty();
+        foreach (var endpoint in endpoints)
+        {
+            var path = endpoint.RoutePattern.RawText!;
+            var requiresAdmin = endpoint.Metadata.GetMetadata<SqlOSAdminRequiredMetadata>() != null;
+            var publicException = endpoint.Metadata.GetMetadata<SqlOSAdminPublicExceptionMetadata>();
+
+            (requiresAdmin ^ (publicException != null)).Should().BeTrue(
+                $"{path} must be centrally protected or carry one explicit public-exception marker");
+
+            if (publicException != null)
+            {
+                path.Should().StartWith(PortalApiPrefix);
+                publicException.Reason.Should().Contain("portal session");
+            }
+        }
+    }
+
+    [TestMethod]
+    public async Task AdminApiRouteInventory_AllHttpMethodsFailClosedWithoutDashboardAuthorization()
+    {
+        await using var app = await CreateAppAsync(Environments.Production);
+        var client = app.GetTestClient();
+
+        var responses = new[]
+        {
+            await client.GetAsync("/sqlos/admin/auth/api/stats"),
+            await client.PostAsJsonAsync("/sqlos/admin/auth/api/users", new { }),
+            await client.PutAsJsonAsync("/sqlos/admin/email/api/templates/missing", new { }),
+            await client.DeleteAsync("/sqlos/admin/email/api/templates/missing")
+        };
+
+        responses.Should().OnlyContain(response => response.StatusCode == HttpStatusCode.NotFound);
+    }
+
+    [TestMethod]
+    public async Task PortalSessionApis_AreExplicitExceptions_NotDashboardAdminRoutes()
+    {
+        await using var app = await CreateAppAsync(Environments.Production);
+
+        var portalEndpoints = app.Services.GetRequiredService<EndpointDataSource>().Endpoints
+            .OfType<RouteEndpoint>()
+            .Where(endpoint => endpoint.RoutePattern.RawText?.StartsWith(PortalApiPrefix, StringComparison.Ordinal) == true)
+            .ToArray();
+
+        portalEndpoints.Should().NotBeEmpty();
+        portalEndpoints.Should().OnlyContain(endpoint =>
+            endpoint.Metadata.GetMetadata<SqlOSAdminPublicExceptionMetadata>() != null
+            && endpoint.Metadata.GetMetadata<SqlOSAdminRequiredMetadata>() == null);
+    }
+
+    private static async Task<WebApplication> CreateAppAsync(string environment)
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            EnvironmentName = environment
+        });
+        builder.WebHost.UseTestServer();
+        builder.Services.AddDbContext<TestSqlOSInMemoryDbContext>(database =>
+            database.UseInMemoryDatabase($"admin-auth-routes-{Guid.NewGuid():N}"));
+        builder.Services.AddSqlOS<TestSqlOSInMemoryDbContext>(options =>
+        {
+            options.AuthServer.Issuer = "https://auth.example.test/sqlos/auth";
+            options.AuthServer.SsoPortal.UseHostedPortal = true;
+            options.AuthServer.SsoPortal.EnableApi = true;
+            options.Calendar.Enabled = true;
+        });
+        builder.Services.RemoveAll<IHostedService>();
+
+        var app = builder.Build();
+        app.MapSqlOS();
+        await app.StartAsync();
+        return app;
+    }
+}

--- a/tests/SqlOS.Tests/SqlOSAdminAuthorizationMetadataTests.cs
+++ b/tests/SqlOS.Tests/SqlOSAdminAuthorizationMetadataTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Json;
 using FluentAssertions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.TestHost;
@@ -20,17 +21,18 @@ namespace SqlOS.Tests;
 [TestClass]
 public sealed class SqlOSAdminAuthorizationMetadataTests
 {
-    private const string PortalApiPrefix = "/sqlos/admin/auth/sso-portal/api";
+    private const string PortalPrefix = "/sqlos/admin/auth/sso-portal";
+    private const string PortalApiPrefix = $"{PortalPrefix}/api";
 
     [TestMethod]
-    public async Task AdminApiRouteInventory_RequiresCentralAuthorizationOrExplicitException()
+    public async Task AdminRouteInventory_RequiresCentralAuthorizationOrExplicitException()
     {
         await using var app = await CreateAppAsync(Environments.Production);
 
         var endpoints = app.Services.GetRequiredService<EndpointDataSource>().Endpoints
             .OfType<RouteEndpoint>()
             .Where(endpoint => endpoint.RoutePattern.RawText?.Contains("/admin/", StringComparison.Ordinal) == true)
-            .Where(endpoint => endpoint.RoutePattern.RawText?.Contains("/api", StringComparison.Ordinal) == true)
+            .Where(endpoint => endpoint.Metadata.GetMetadata<IHttpMethodMetadata>() != null)
             .ToArray();
 
         endpoints.Should().NotBeEmpty();
@@ -45,10 +47,30 @@ public sealed class SqlOSAdminAuthorizationMetadataTests
 
             if (publicException != null)
             {
-                path.Should().StartWith(PortalApiPrefix);
+                path.Should().StartWith(PortalPrefix);
                 publicException.Reason.Should().Contain("portal session");
             }
         }
+    }
+
+    [TestMethod]
+    public async Task AdminAuthorizationFilter_MissingSqlOSOptions_FailsClosedInDevelopment()
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            EnvironmentName = Environments.Development
+        });
+        builder.WebHost.UseTestServer();
+
+        await using var app = builder.Build();
+        app.MapGroup("/admin")
+            .RequireSqlOSAdminAuthorization()
+            .MapGet("/probe", () => Results.Ok());
+        await app.StartAsync();
+
+        var response = await app.GetTestClient().GetAsync("/admin/probe");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
     [TestMethod]

--- a/tests/SqlOS.Tests/SqlOSCalendarEndpointsTests.cs
+++ b/tests/SqlOS.Tests/SqlOSCalendarEndpointsTests.cs
@@ -18,6 +18,7 @@ using SqlOS.Calendar.Interfaces;
 using SqlOS.Calendar.Models;
 using SqlOS.Calendar.Services;
 using SqlOS.Configuration;
+using SqlOS.Dashboard;
 using SqlOS.Security;
 using SqlOS.Tests.Infrastructure;
 
@@ -160,6 +161,7 @@ public sealed class SqlOSCalendarEndpointsTests
                     services.AddSingleton(Options.Create(sqlosOptions.AuthServer));
                     services.AddSingleton<SqlOSBrowserSecurityHeaders>();
                     services.AddSingleton<IDataProtectionProvider>(new EphemeralDataProtectionProvider());
+                    services.AddSingleton<SqlOSDashboardSessionService>();
                     services.AddSingleton<IHttpClientFactory, FakeCalendarProviderHttpClientFactory>();
                     services.AddSingleton<ISqlOSCalendarProviderAdapter, SqlOSGoogleCalendarAdapter>();
                     services.AddSingleton<ISqlOSCalendarProviderAdapter, SqlOSMicrosoftGraphCalendarAdapter>();


### PR DESCRIPTION
Closes #106.

## What changed

- attaches required-admin metadata and a centralized endpoint filter to AuthServer, audit, email, and calendar admin API route groups
- preserves the existing dashboard password/session/callback and DevelopmentOnly authorization semantics
- marks SSO portal-session APIs as explicit, named exceptions rather than silently treating them as dashboard-admin endpoints
- adds a route-inventory contract that fails when a new admin API endpoint lacks required or explicit-exception metadata
- proves unauthenticated GET, POST, PUT, and DELETE requests fail closed

## Developer impact

No new setup or middleware is required. Existing dashboard authorization configuration continues to apply, while future admin routes inherit protection automatically from their route group.

## Validation

- focused admin/calendar/audit suite: 21 passed
- full library unit suite: 584 passed
- example unit suite: 2 passed
- solution build: 0 warnings, 0 errors
- docs contracts, snippets, lint, TypeScript, production build, images, and 167-file link validation passed

An adversarial review and resolution iteration will be recorded in PR comments before merge.