### PR TITLE
Unify FGA hierarchy depth enforcement

### DIFF
--- a/src/SqlOS/Configuration/SqlOSOptionsValidator.cs
+++ b/src/SqlOS/Configuration/SqlOSOptionsValidator.cs
@@ -57,6 +57,10 @@ internal static class SqlOSOptionsValidator
 
         ValidateDashboardLoginThrottlingOptions(options.Dashboard.LoginThrottling, errors);
         ValidateBrowserSecurityOptions(options.BrowserSecurity, errors);
+        if (options.Fga.MaxResourceHierarchyDepth <= 0)
+        {
+            errors.Add("Fga.MaxResourceHierarchyDepth must be greater than zero.");
+        }
 
         var issuer = ValidateAbsoluteUri(options.AuthServer.Issuer, "AuthServer.Issuer", errors);
         if (issuer != null && authBasePath != null)

--- a/src/SqlOS/Extensions/ServiceCollectionExtensions.cs
+++ b/src/SqlOS/Extensions/ServiceCollectionExtensions.cs
@@ -128,6 +128,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<SqlOSFgaSeedService>();
         services.AddScoped<SqlOSFgaFunctionInitializer>();
         services.AddScoped<SqlOSFgaSchemaInitializer>();
+        services.AddScoped<SqlOSFgaHierarchyValidator>();
         services.AddHostedService<SqlOSSigningKeyRotationService>();
         services.AddHostedService<SqlOSCalendarSyncHostedService>();
         services.AddHostedService<SqlOSBootstrapHostedService>();

--- a/src/SqlOS/Extensions/SqlOSErgonomicsExtensions.cs
+++ b/src/SqlOS/Extensions/SqlOSErgonomicsExtensions.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 using SqlOS.AuthServer.Configuration;
 using SqlOS.AuthServer.Extensions;
 using SqlOS.AuthServer.Services;
+using SqlOS.Fga;
 using SqlOS.Fga.Interfaces;
 using SqlOS.Fga.Models;
 
@@ -17,8 +18,6 @@ namespace SqlOS.Extensions;
 /// </summary>
 public static class SqlOSErgonomicsExtensions
 {
-    private const int DefaultMaxResourceHierarchyDepth = 10;
-
     /// <summary>
     /// Requires every endpoint in a route group to present a valid SqlOS bearer access token
     /// containing the specified audience.
@@ -719,7 +718,8 @@ public static class SqlOSErgonomicsExtensions
 
         var visited = new HashSet<string>(StringComparer.Ordinal) { resourceId };
         var currentId = parentId;
-        var depth = 0;
+        var depth = 1;
+        var maxDepth = SqlOSFgaHierarchyDepth.Resolve(context);
 
         while (!string.IsNullOrWhiteSpace(currentId))
         {
@@ -728,9 +728,9 @@ public static class SqlOSErgonomicsExtensions
                 throw new InvalidOperationException("FGA resource hierarchy contains a cycle.");
             }
 
-            if (depth > DefaultMaxResourceHierarchyDepth)
+            if (depth > maxDepth)
             {
-                throw new InvalidOperationException($"FGA resource hierarchy exceeds the maximum depth of {DefaultMaxResourceHierarchyDepth}.");
+                throw new InvalidOperationException($"FGA resource hierarchy exceeds the configured maximum depth of {maxDepth}.");
             }
 
             var localParent = context.Set<SqlOSFgaResource>().Local.FirstOrDefault(r => r.Id == currentId);

--- a/src/SqlOS/Fga/Configuration/SqlOSFgaModelConfiguration.cs
+++ b/src/SqlOS/Fga/Configuration/SqlOSFgaModelConfiguration.cs
@@ -14,6 +14,9 @@ public static class SqlOSFgaModelConfiguration
     {
         var schema = options.Schema;
         var tables = options.TableNames;
+        modelBuilder.Model.SetAnnotation(
+            SqlOSFgaHierarchyDepth.ModelAnnotationName,
+            SqlOSFgaHierarchyDepth.Normalize(options.MaxResourceHierarchyDepth));
 
         // SubjectType
         modelBuilder.Entity<SqlOSFgaSubjectType>(entity =>

--- a/src/SqlOS/Fga/Extensions/SqlOSFgaConvenienceExtensions.cs
+++ b/src/SqlOS/Fga/Extensions/SqlOSFgaConvenienceExtensions.cs
@@ -1,6 +1,7 @@
 using System.Linq.Expressions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
+using SqlOS.Fga;
 using SqlOS.Fga.Interfaces;
 using SqlOS.Fga.Models;
 
@@ -11,8 +12,6 @@ namespace SqlOS.Fga.Extensions;
 /// </summary>
 public static class SqlOSFgaConvenienceExtensions
 {
-    private const int DefaultMaxResourceHierarchyDepth = 10;
-
     /// <summary>
     /// Lower-level/manual helper that creates a <see cref="SqlOSFgaResource"/> and adds it to
     /// the context (not yet saved). Use this for manual or ad hoc resource lifecycles. For
@@ -40,7 +39,11 @@ public static class SqlOSFgaConvenienceExtensions
         string? id = null)
     {
         var resourceId = id ?? Guid.NewGuid().ToString();
-        EnsureParentChainDoesNotCreateCycle(context, resourceId, parentId);
+        EnsureParentChainDoesNotCreateCycle(
+            context,
+            resourceId,
+            parentId,
+            SqlOSFgaHierarchyDepth.Resolve(context));
         var resource = new SqlOSFgaResource
         {
             Id = resourceId,
@@ -55,7 +58,8 @@ public static class SqlOSFgaConvenienceExtensions
     private static void EnsureParentChainDoesNotCreateCycle(
         ISqlOSFgaDbContext context,
         string resourceId,
-        string parentId)
+        string parentId,
+        int maxDepth)
     {
         if (string.Equals(resourceId, parentId, StringComparison.Ordinal))
         {
@@ -64,7 +68,7 @@ public static class SqlOSFgaConvenienceExtensions
 
         var visited = new HashSet<string>(StringComparer.Ordinal) { resourceId };
         string? currentId = parentId;
-        var depth = 0;
+        var depth = 1;
 
         while (!string.IsNullOrWhiteSpace(currentId))
         {
@@ -73,9 +77,9 @@ public static class SqlOSFgaConvenienceExtensions
                 throw new InvalidOperationException("FGA resource hierarchy contains a cycle.");
             }
 
-            if (depth > DefaultMaxResourceHierarchyDepth)
+            if (depth > maxDepth)
             {
-                throw new InvalidOperationException($"FGA resource hierarchy exceeds the maximum depth of {DefaultMaxResourceHierarchyDepth}.");
+                throw new InvalidOperationException($"FGA resource hierarchy exceeds the configured maximum depth of {maxDepth}.");
             }
 
             var parent = context.Set<SqlOSFgaResource>()

--- a/src/SqlOS/Fga/Services/SqlOSFgaHierarchyValidator.cs
+++ b/src/SqlOS/Fga/Services/SqlOSFgaHierarchyValidator.cs
@@ -1,0 +1,69 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using SqlOS.Fga.Configuration;
+using SqlOS.Fga.Interfaces;
+using SqlOS.Fga.Models;
+
+namespace SqlOS.Fga.Services;
+
+/// <summary>
+/// Validates persisted FGA resource hierarchy data against the configured depth and cycle policy.
+/// </summary>
+public sealed class SqlOSFgaHierarchyValidator
+{
+    private readonly ISqlOSFgaDbContext _context;
+    private readonly int _maxDepth;
+
+    public SqlOSFgaHierarchyValidator(
+        ISqlOSFgaDbContext context,
+        IOptions<SqlOSFgaOptions> options)
+    {
+        _context = context;
+        _maxDepth = SqlOSFgaHierarchyDepth.Normalize(options.Value.MaxResourceHierarchyDepth);
+    }
+
+    public async Task ValidateExistingDataAsync(CancellationToken cancellationToken = default)
+    {
+        var resources = await _context.Set<SqlOSFgaResource>()
+            .AsNoTracking()
+            .Select(resource => new { resource.Id, resource.ParentId })
+            .ToListAsync(cancellationToken);
+        var parents = resources.ToDictionary(
+            resource => resource.Id,
+            resource => resource.ParentId,
+            StringComparer.Ordinal);
+
+        foreach (var resource in resources)
+        {
+            ValidateResource(resource.Id, parents);
+        }
+    }
+
+    private void ValidateResource(
+        string resourceId,
+        IReadOnlyDictionary<string, string?> parents)
+    {
+        var visited = new HashSet<string>(StringComparer.Ordinal);
+        string? currentId = resourceId;
+        var depth = 0;
+
+        while (!string.IsNullOrWhiteSpace(currentId))
+        {
+            if (!visited.Add(currentId))
+            {
+                throw new InvalidOperationException(
+                    $"FGA resource hierarchy contains a cycle involving resource '{resourceId}'.");
+            }
+
+            if (depth > _maxDepth)
+            {
+                throw new InvalidOperationException(
+                    $"FGA resource '{resourceId}' exceeds the configured maximum hierarchy depth of {_maxDepth}. "
+                    + "Increase Fga.MaxResourceHierarchyDepth or repair the persisted resource hierarchy before startup.");
+            }
+
+            currentId = parents.GetValueOrDefault(currentId);
+            depth++;
+        }
+    }
+}

--- a/src/SqlOS/Fga/Services/SqlOSFgaHierarchyValidator.cs
+++ b/src/SqlOS/Fga/Services/SqlOSFgaHierarchyValidator.cs
@@ -62,7 +62,14 @@ public sealed class SqlOSFgaHierarchyValidator
                     + "Increase Fga.MaxResourceHierarchyDepth or repair the persisted resource hierarchy before startup.");
             }
 
-            currentId = parents.GetValueOrDefault(currentId);
+            if (!parents.TryGetValue(currentId, out var parentId))
+            {
+                throw new InvalidOperationException(
+                    $"FGA resource '{resourceId}' references missing parent resource '{currentId}'. "
+                    + "Repair the persisted resource hierarchy before startup.");
+            }
+
+            currentId = parentId;
             depth++;
         }
     }

--- a/src/SqlOS/Fga/SqlOSFgaHierarchyDepth.cs
+++ b/src/SqlOS/Fga/SqlOSFgaHierarchyDepth.cs
@@ -1,0 +1,39 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.Options;
+using SqlOS.Fga.Configuration;
+using SqlOS.Fga.Interfaces;
+
+namespace SqlOS.Fga;
+
+internal static class SqlOSFgaHierarchyDepth
+{
+    public const int Default = 10;
+    public const string ModelAnnotationName = "SqlOS:Fga:MaxResourceHierarchyDepth";
+
+    public static int Resolve(ISqlOSFgaDbContext context)
+    {
+        try
+        {
+            return Normalize(context.Database
+                .GetService<IOptions<SqlOSFgaOptions>>()
+                .Value
+                .MaxResourceHierarchyDepth);
+        }
+        catch (InvalidOperationException)
+        {
+            // Manually constructed DbContexts do not always have application services.
+        }
+
+        if (context is DbContext dbContext
+            && dbContext.Model.FindAnnotation(ModelAnnotationName)?.Value is int annotated)
+        {
+            return Normalize(annotated);
+        }
+
+        return Default;
+    }
+
+    public static int Normalize(int configured)
+        => Math.Max(1, configured);
+}

--- a/src/SqlOS/Fga/SqlOSResourceEntitySynchronizer.cs
+++ b/src/SqlOS/Fga/SqlOSResourceEntitySynchronizer.cs
@@ -7,8 +7,6 @@ namespace SqlOS.Fga;
 
 internal static class SqlOSResourceEntitySynchronizer
 {
-    private const int DefaultMaxResourceHierarchyDepth = 10;
-
     public static void Sync(DbContext context)
     {
         var changes = GetResourceEntityChanges(context);
@@ -19,7 +17,11 @@ internal static class SqlOSResourceEntitySynchronizer
 
         ValidateUniqueResourceIds(changes);
         var changesById = changes.ToDictionary(change => change.ResourceId, StringComparer.Ordinal);
-        ValidateResourceChanges(context, changes, changesById);
+        ValidateResourceChanges(
+            context,
+            changes,
+            changesById,
+            SqlOSFgaHierarchyDepth.Resolve((ISqlOSFgaDbContext)context));
         ApplyResourceChanges(context, changes);
     }
 
@@ -33,7 +35,12 @@ internal static class SqlOSResourceEntitySynchronizer
 
         ValidateUniqueResourceIds(changes);
         var changesById = changes.ToDictionary(change => change.ResourceId, StringComparer.Ordinal);
-        await ValidateResourceChangesAsync(context, changes, changesById, cancellationToken);
+        await ValidateResourceChangesAsync(
+            context,
+            changes,
+            changesById,
+            SqlOSFgaHierarchyDepth.Resolve((ISqlOSFgaDbContext)context),
+            cancellationToken);
         await ApplyResourceChangesAsync(context, changes, cancellationToken);
     }
 
@@ -59,7 +66,8 @@ internal static class SqlOSResourceEntitySynchronizer
     private static void ValidateResourceChanges(
         DbContext context,
         IReadOnlyCollection<ResourceEntityChange> changes,
-        IReadOnlyDictionary<string, ResourceEntityChange> changesById)
+        IReadOnlyDictionary<string, ResourceEntityChange> changesById,
+        int maxDepth)
     {
         foreach (var change in changes.Where(change => change.State != EntityState.Deleted))
         {
@@ -75,7 +83,7 @@ internal static class SqlOSResourceEntitySynchronizer
                 throw new InvalidOperationException($"FGA resource '{change.ParentResourceId}' was not found.");
             }
 
-            EnsureParentChainDoesNotCreateCycle(context, change, changesById);
+            EnsureParentChainDoesNotCreateCycle(context, change, changesById, maxDepth);
         }
 
         foreach (var added in changes.Where(change => change.State == EntityState.Added))
@@ -114,6 +122,7 @@ internal static class SqlOSResourceEntitySynchronizer
         DbContext context,
         IReadOnlyCollection<ResourceEntityChange> changes,
         IReadOnlyDictionary<string, ResourceEntityChange> changesById,
+        int maxDepth,
         CancellationToken cancellationToken)
     {
         foreach (var change in changes.Where(change => change.State != EntityState.Deleted))
@@ -130,7 +139,12 @@ internal static class SqlOSResourceEntitySynchronizer
                 throw new InvalidOperationException($"FGA resource '{change.ParentResourceId}' was not found.");
             }
 
-            await EnsureParentChainDoesNotCreateCycleAsync(context, change, changesById, cancellationToken);
+            await EnsureParentChainDoesNotCreateCycleAsync(
+                context,
+                change,
+                changesById,
+                maxDepth,
+                cancellationToken);
         }
 
         foreach (var added in changes.Where(change => change.State == EntityState.Added))
@@ -255,11 +269,12 @@ internal static class SqlOSResourceEntitySynchronizer
     private static void EnsureParentChainDoesNotCreateCycle(
         DbContext context,
         ResourceEntityChange change,
-        IReadOnlyDictionary<string, ResourceEntityChange> changesById)
+        IReadOnlyDictionary<string, ResourceEntityChange> changesById,
+        int maxDepth)
     {
         var visited = new HashSet<string>(StringComparer.Ordinal) { change.ResourceId };
         var currentId = change.ParentResourceId;
-        var depth = 0;
+        var depth = 1;
 
         while (!string.IsNullOrWhiteSpace(currentId))
         {
@@ -268,9 +283,9 @@ internal static class SqlOSResourceEntitySynchronizer
                 throw new InvalidOperationException("FGA resource hierarchy contains a cycle.");
             }
 
-            if (depth > DefaultMaxResourceHierarchyDepth)
+            if (depth > maxDepth)
             {
-                throw new InvalidOperationException($"FGA resource hierarchy exceeds the maximum depth of {DefaultMaxResourceHierarchyDepth}.");
+                throw new InvalidOperationException($"FGA resource hierarchy exceeds the configured maximum depth of {maxDepth}.");
             }
 
             currentId = GetParentId(context, currentId, changesById);
@@ -282,11 +297,12 @@ internal static class SqlOSResourceEntitySynchronizer
         DbContext context,
         ResourceEntityChange change,
         IReadOnlyDictionary<string, ResourceEntityChange> changesById,
+        int maxDepth,
         CancellationToken cancellationToken)
     {
         var visited = new HashSet<string>(StringComparer.Ordinal) { change.ResourceId };
         var currentId = change.ParentResourceId;
-        var depth = 0;
+        var depth = 1;
 
         while (!string.IsNullOrWhiteSpace(currentId))
         {
@@ -295,9 +311,9 @@ internal static class SqlOSResourceEntitySynchronizer
                 throw new InvalidOperationException("FGA resource hierarchy contains a cycle.");
             }
 
-            if (depth > DefaultMaxResourceHierarchyDepth)
+            if (depth > maxDepth)
             {
-                throw new InvalidOperationException($"FGA resource hierarchy exceeds the maximum depth of {DefaultMaxResourceHierarchyDepth}.");
+                throw new InvalidOperationException($"FGA resource hierarchy exceeds the configured maximum depth of {maxDepth}.");
             }
 
             currentId = await GetParentIdAsync(context, currentId, changesById, cancellationToken);

--- a/src/SqlOS/Services/SqlOSBootstrapper.cs
+++ b/src/SqlOS/Services/SqlOSBootstrapper.cs
@@ -17,6 +17,7 @@ public sealed class SqlOSBootstrapper
     private readonly SqlOSEmailAdminService _emailAdminService;
     private readonly SqlOSFgaSchemaInitializer _fgaSchemaInitializer;
     private readonly SqlOSFgaFunctionInitializer _fgaFunctionInitializer;
+    private readonly SqlOSFgaHierarchyValidator _fgaHierarchyValidator;
     private readonly SqlOSFgaSeedService _fgaSeedService;
     private readonly ILogger<SqlOSBootstrapper> _logger;
 
@@ -29,6 +30,7 @@ public sealed class SqlOSBootstrapper
         SqlOSEmailAdminService emailAdminService,
         SqlOSFgaSchemaInitializer fgaSchemaInitializer,
         SqlOSFgaFunctionInitializer fgaFunctionInitializer,
+        SqlOSFgaHierarchyValidator fgaHierarchyValidator,
         SqlOSFgaSeedService fgaSeedService,
         ILogger<SqlOSBootstrapper> logger)
     {
@@ -40,6 +42,7 @@ public sealed class SqlOSBootstrapper
         _emailAdminService = emailAdminService;
         _fgaSchemaInitializer = fgaSchemaInitializer;
         _fgaFunctionInitializer = fgaFunctionInitializer;
+        _fgaHierarchyValidator = fgaHierarchyValidator;
         _fgaSeedService = fgaSeedService;
         _logger = logger;
     }
@@ -84,6 +87,8 @@ public sealed class SqlOSBootstrapper
         {
             await _fgaSeedService.SeedAuthorizationDataAsync(_options.Fga.StartupSeedData, cancellationToken);
         }
+
+        await _fgaHierarchyValidator.ValidateExistingDataAsync(cancellationToken);
 
         _logger.LogInformation("SqlOS initialization complete.");
     }

--- a/tests/SqlOS.IntegrationTests/Fga/SqlOSFgaFunctionInitializerIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/Fga/SqlOSFgaFunctionInitializerIntegrationTests.cs
@@ -1,10 +1,12 @@
 using FluentAssertions;
+using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SqlOS.Fga.Configuration;
 using SqlOS.IntegrationTests.Fga.Infrastructure;
+using SqlOS.Fga.Models;
 using SqlOS.Fga.Services;
 
 namespace SqlOS.IntegrationTests.Fga;
@@ -44,6 +46,66 @@ public class SqlOSFgaFunctionInitializerIntegrationTests : FgaIntegrationTestBas
         }
         finally
         {
+            var defaultInitializer = new SqlOSFgaFunctionInitializer(
+                Context,
+                Options.Create(new SqlOSFgaOptions()),
+                loggerFactory.CreateLogger<SqlOSFgaFunctionInitializer>());
+            await defaultInitializer.EnsureFunctionsExistAsync();
+        }
+    }
+
+    [TestMethod]
+    public async Task ConfiguredDepth_AllowsGrantVisibilityAtAcceptedBoundary()
+    {
+        var loggerFactory = LoggerFactory.Create(b => b.AddConsole());
+        var options = new SqlOSFgaOptions { MaxResourceHierarchyDepth = 2 };
+        var initializer = new SqlOSFgaFunctionInitializer(
+            Context,
+            Options.Create(options),
+            loggerFactory.CreateLogger<SqlOSFgaFunctionInitializer>());
+        var suffix = Guid.NewGuid().ToString("N");
+        var level1 = new SqlOSFgaResource
+        {
+            Id = $"depth_level_1_{suffix}",
+            ParentId = "root",
+            Name = "Depth level 1",
+            ResourceTypeId = "agency"
+        };
+        var level2 = new SqlOSFgaResource
+        {
+            Id = $"depth_level_2_{suffix}",
+            ParentId = level1.Id,
+            Name = "Depth level 2",
+            ResourceTypeId = "project"
+        };
+
+        try
+        {
+            Context.Set<SqlOSFgaResource>().AddRange(level1, level2);
+            await Context.SaveChangesAsync();
+            await initializer.EnsureFunctionsExistAsync();
+            var authService = new SqlOSFgaAuthService(
+                Context,
+                Options.Create(options),
+                loggerFactory.CreateLogger<SqlOSFgaAuthService>());
+
+            var pointCheck = await authService.CheckAccessAsync(
+                FgaTestDataSeeder.SystemAdminSubjectId,
+                "TEST_VIEW",
+                level2.Id);
+            var sqlFilterVisible = await Context.IsResourceAccessible(
+                    level2.Id,
+                    JsonSerializer.Serialize(new[] { FgaTestDataSeeder.SystemAdminSubjectId }),
+                    FgaTestDataSeeder.ViewPermissionId)
+                .AnyAsync();
+
+            pointCheck.Allowed.Should().BeTrue();
+            sqlFilterVisible.Should().BeTrue();
+        }
+        finally
+        {
+            Context.Set<SqlOSFgaResource>().RemoveRange(level2, level1);
+            await Context.SaveChangesAsync();
             var defaultInitializer = new SqlOSFgaFunctionInitializer(
                 Context,
                 Options.Create(new SqlOSFgaOptions()),

--- a/tests/SqlOS.Tests/SqlOSDbContextErgonomicsTests.cs
+++ b/tests/SqlOS.Tests/SqlOSDbContextErgonomicsTests.cs
@@ -1,12 +1,14 @@
 using FluentAssertions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SqlOS.AuthServer.Interfaces;
 using SqlOS.Configuration;
 using SqlOS.Extensions;
+using SqlOS.Fga.Configuration;
 using SqlOS.Fga.Interfaces;
 
 namespace SqlOS.Tests;
@@ -53,6 +55,22 @@ public sealed class SqlOSDbContextErgonomicsTests
         scope.ServiceProvider.GetRequiredService<ISqlOSAuthServerDbContext>().Should().BeSameAs(context);
         scope.ServiceProvider.GetRequiredService<ISqlOSFgaDbContext>().Should().BeSameAs(context);
         app.Services.GetRequiredService<IOptions<SqlOSOptions>>().Value.Fga.RootResourceId.Should().Be("recommended_setup_root");
+    }
+
+    [TestMethod]
+    public void SqlOSDbContext_CanResolveConfiguredFgaOptionsFromApplicationServices()
+    {
+        var builder = WebApplication.CreateBuilder();
+
+        builder.AddSqlOS<RecommendedSetupTestDbContext>(
+            db => db.UseInMemoryDatabase(Guid.NewGuid().ToString("N")),
+            sqlos => sqlos.Fga.MaxResourceHierarchyDepth = 3);
+
+        using var app = builder.Build();
+        using var scope = app.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<RecommendedSetupTestDbContext>();
+
+        context.GetService<IOptions<SqlOSFgaOptions>>().Value.MaxResourceHierarchyDepth.Should().Be(3);
     }
 
     [TestMethod]

--- a/tests/SqlOS.Tests/SqlOSErgonomicsExtensionsTests.cs
+++ b/tests/SqlOS.Tests/SqlOSErgonomicsExtensionsTests.cs
@@ -173,6 +173,34 @@ public sealed class SqlOSErgonomicsExtensionsTests
     }
 
     [TestMethod]
+    public void ConvenienceHelper_UsesManualModelHierarchyDepth()
+    {
+        var options = new DbContextOptionsBuilder<ManualDepthFgaDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .Options;
+        using var context = new ManualDepthFgaDbContext(options);
+        context.Set<SqlOSFgaResourceType>().AddRange(
+            new SqlOSFgaResourceType { Id = "root", Name = "Root" },
+            new SqlOSFgaResourceType { Id = "workspace", Name = "Workspace" });
+        context.Set<SqlOSFgaResource>().Add(new SqlOSFgaResource
+        {
+            Id = "root",
+            Name = "Root",
+            ResourceTypeId = "root"
+        });
+        context.SaveChanges();
+        context.CreateResource("root", "Level 1", "workspace", "level_1");
+        context.SaveChanges();
+        context.CreateResource("level_1", "Level 2", "workspace", "level_2");
+        context.SaveChanges();
+
+        Action act = () => context.CreateResource("level_2", "Level 3", "workspace", "level_3");
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*configured maximum depth of 2*");
+    }
+
+    [TestMethod]
     public async Task ProvisionResourceWithIdAsync_ValidatesParentAndResourceTypeWhenUpdating()
     {
         using var context = CreateContext();
@@ -507,5 +535,19 @@ public sealed class SqlOSErgonomicsExtensionsTests
         public Task<Expression<Func<T, bool>>> GetAuthorizationFilterAsync<T>(string subjectId, string permissionKey)
             where T : IHasResourceId
             => throw new NotImplementedException();
+    }
+
+    private sealed class ManualDepthFgaDbContext(DbContextOptions<ManualDepthFgaDbContext> options)
+        : DbContext(options), ISqlOSFgaDbContext
+    {
+        public IQueryable<SqlOSFgaAccessibleResource> IsResourceAccessible(
+            string resourceId,
+            string subjectIds,
+            string permissionId)
+            => throw new NotSupportedException();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.ApplySqlOSFgaModel(options =>
+                options.MaxResourceHierarchyDepth = 2);
     }
 }

--- a/tests/SqlOS.Tests/SqlOSErgonomicsExtensionsTests.cs
+++ b/tests/SqlOS.Tests/SqlOSErgonomicsExtensionsTests.cs
@@ -1,11 +1,14 @@
 using System.Linq.Expressions;
 using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SqlOS.AuthServer.Configuration;
 using SqlOS.AuthServer.Extensions;
 using SqlOS.Extensions;
 using SqlOS.Fga.Configuration;
+using SqlOS.Fga.Extensions;
 using SqlOS.Fga.Interfaces;
 using SqlOS.Fga.Models;
 using SqlOS.Tests.Infrastructure;
@@ -129,6 +132,44 @@ public sealed class SqlOSErgonomicsExtensionsTests
         await missingResourceType.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("*resource type 'workpsace' was not found*");
         context.Set<SqlOSFgaResource>().Local.Should().NotContain(x => x.Id == "workspace_1");
+    }
+
+    [TestMethod]
+    public async Task ResourceHelpers_UseConfiguredHierarchyDepth()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.Services.AddDbContext<TestSqlOSInMemoryDbContext>(database =>
+            database.UseInMemoryDatabase(Guid.NewGuid().ToString("N")));
+        builder.Services.AddSqlOS<TestSqlOSInMemoryDbContext>(options =>
+            options.Fga.MaxResourceHierarchyDepth = 2);
+
+        using var app = builder.Build();
+        using var scope = app.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<TestSqlOSInMemoryDbContext>();
+        SeedFgaCore(context);
+        await context.SaveChangesAsync();
+        await context.CreateResourceWithIdAsync("level_1", "workspace", "Level 1", "root");
+        await context.CreateResourceWithIdAsync("level_2", "workspace", "Level 2", "level_1");
+        await context.SaveChangesAsync();
+
+        var ergonomicsAct = async () => await context.CreateResourceWithIdAsync(
+            "level_3",
+            "workspace",
+            "Level 3",
+            "level_2");
+
+        await ergonomicsAct.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*configured maximum depth of 2*");
+
+        context.ChangeTracker.Clear();
+        Action convenienceAct = () => context.CreateResource(
+            "level_2",
+            "Level 3",
+            "workspace",
+            "level_3");
+
+        convenienceAct.Should().Throw<InvalidOperationException>()
+            .WithMessage("*configured maximum depth of 2*");
     }
 
     [TestMethod]

--- a/tests/SqlOS.Tests/SqlOSFgaHierarchyValidatorTests.cs
+++ b/tests/SqlOS.Tests/SqlOSFgaHierarchyValidatorTests.cs
@@ -1,0 +1,88 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SqlOS.Fga.Configuration;
+using SqlOS.Fga.Models;
+using SqlOS.Fga.Services;
+using SqlOS.Tests.Infrastructure;
+
+namespace SqlOS.Tests;
+
+[TestClass]
+public sealed class SqlOSFgaHierarchyValidatorTests
+{
+    [TestMethod]
+    public async Task ValidateExistingDataAsync_ReportsPersistedTreeBeyondConfiguredDepth()
+    {
+        await using var context = CreateContext();
+        SeedResources(context,
+            ("root", null),
+            ("level_1", "root"),
+            ("level_2", "level_1"),
+            ("level_3", "level_2"));
+        await context.SaveChangesAsync();
+        var validator = new SqlOSFgaHierarchyValidator(
+            context,
+            Options.Create(new SqlOSFgaOptions { MaxResourceHierarchyDepth = 2 }));
+
+        var act = async () => await validator.ValidateExistingDataAsync();
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*'level_3'*configured maximum hierarchy depth of 2*repair*");
+    }
+
+    [TestMethod]
+    public async Task ValidateExistingDataAsync_AcceptsTreeAtConfiguredDepth()
+    {
+        await using var context = CreateContext();
+        SeedResources(context,
+            ("root", null),
+            ("level_1", "root"),
+            ("level_2", "level_1"));
+        await context.SaveChangesAsync();
+        var validator = new SqlOSFgaHierarchyValidator(
+            context,
+            Options.Create(new SqlOSFgaOptions { MaxResourceHierarchyDepth = 2 }));
+
+        var act = async () => await validator.ValidateExistingDataAsync();
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [TestMethod]
+    public async Task ValidateExistingDataAsync_ReportsPersistedCycle()
+    {
+        await using var context = CreateContext();
+        SeedResources(context,
+            ("resource_a", "resource_b"),
+            ("resource_b", "resource_a"));
+        await context.SaveChangesAsync();
+        var validator = new SqlOSFgaHierarchyValidator(
+            context,
+            Options.Create(new SqlOSFgaOptions()));
+
+        var act = async () => await validator.ValidateExistingDataAsync();
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*contains a cycle*");
+    }
+
+    private static TestSqlOSInMemoryDbContext CreateContext()
+        => new(new DbContextOptionsBuilder<TestSqlOSInMemoryDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .Options);
+
+    private static void SeedResources(
+        TestSqlOSInMemoryDbContext context,
+        params (string Id, string? ParentId)[] resources)
+    {
+        context.Set<SqlOSFgaResource>().AddRange(resources.Select(resource => new SqlOSFgaResource
+        {
+            Id = resource.Id,
+            ParentId = resource.ParentId,
+            Name = resource.Id,
+            ResourceTypeId = "workspace"
+        }));
+    }
+}

--- a/tests/SqlOS.Tests/SqlOSFgaHierarchyValidatorTests.cs
+++ b/tests/SqlOS.Tests/SqlOSFgaHierarchyValidatorTests.cs
@@ -68,6 +68,22 @@ public sealed class SqlOSFgaHierarchyValidatorTests
             .WithMessage("*contains a cycle*");
     }
 
+    [TestMethod]
+    public async Task ValidateExistingDataAsync_ReportsMissingPersistedParent()
+    {
+        await using var context = CreateContext();
+        SeedResources(context, ("orphan", "missing_parent"));
+        await context.SaveChangesAsync();
+        var validator = new SqlOSFgaHierarchyValidator(
+            context,
+            Options.Create(new SqlOSFgaOptions()));
+
+        var act = async () => await validator.ValidateExistingDataAsync();
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*'orphan'*missing parent resource 'missing_parent'*repair*");
+    }
+
     private static TestSqlOSInMemoryDbContext CreateContext()
         => new(new DbContextOptionsBuilder<TestSqlOSInMemoryDbContext>()
             .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))

--- a/tests/SqlOS.Tests/SqlOSOptionsValidationTests.cs
+++ b/tests/SqlOS.Tests/SqlOSOptionsValidationTests.cs
@@ -152,6 +152,18 @@ public sealed class SqlOSOptionsValidationTests
         act.Should().NotThrow();
     }
 
+    [TestMethod]
+    public void AddSqlOS_RejectsNonPositiveFgaHierarchyDepth()
+    {
+        var services = new ServiceCollection();
+
+        Action act = () => services.AddSqlOS<TestSqlOSInMemoryDbContext>(options =>
+            options.Fga.MaxResourceHierarchyDepth = 0);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Fga.MaxResourceHierarchyDepth must be greater than zero.*");
+    }
+
     [DataTestMethod]
     [DataRow("default-src 'self'; script-src 'self'")]
     [DataRow("default-src 'self'; script-src 'nonce-{nonce}'; style-src 'self'")]

--- a/tests/SqlOS.Tests/SqlOSResourceEntitySyncTests.cs
+++ b/tests/SqlOS.Tests/SqlOSResourceEntitySyncTests.cs
@@ -1,6 +1,8 @@
 using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SqlOS.AuthServer.Interfaces;
 using SqlOS.Extensions;
@@ -96,6 +98,36 @@ public sealed class SqlOSResourceEntitySyncTests
             .ParentId
             .Should()
             .Be("workspace_parent");
+    }
+
+    [TestMethod]
+    public void SaveChanges_UsesConfiguredHierarchyDepthFromApplicationServices()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.AddSqlOS<ResourceEntityTestDbContext>(
+            database => database.UseInMemoryDatabase(Guid.NewGuid().ToString("N")),
+            sqlos => sqlos.Fga.MaxResourceHierarchyDepth = 2);
+
+        using var app = builder.Build();
+        using var scope = app.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<ResourceEntityTestDbContext>();
+        SeedFgaCore(context);
+        context.Resources.AddRange(
+            new ResourceBackedEntity { Id = "level_1", Name = "Level 1", ParentId = "root" },
+            new ResourceBackedEntity { Id = "level_2", Name = "Level 2", ParentId = "level_1" });
+        context.SaveChanges();
+
+        context.Resources.Add(new ResourceBackedEntity
+        {
+            Id = "level_3",
+            Name = "Level 3",
+            ParentId = "level_2"
+        });
+
+        Action act = () => context.SaveChanges();
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*configured maximum depth of 2*");
     }
 
     [TestMethod]

--- a/web/content/docs/guides/production-readiness.mdx
+++ b/web/content/docs/guides/production-readiness.mdx
@@ -223,6 +223,8 @@ SqlOS owns its tables separately from your EF Core migrations. At host startup, 
 4. applies the FGA scripts tracked by `SqlOSFgaSchema`;
 5. creates or verifies FGA functions and seed data when enabled.
 
+`Fga.MaxResourceHierarchyDepth` is one shared limit for resource synchronization, manual resource helpers, in-process authorization, and the SQL authorization function. Startup validates persisted resources against that limit and fails with the affected resource ID when existing data is deeper or cyclic. Before lowering the value, inspect and repair the stored hierarchy in a restored environment; do not lower it during a rollout and rely on authorization to silently truncate deeper ancestors.
+
 Each AuthServer script and its ledger entry commit in one transaction, so an interrupted startup safely retries the unrecorded script. The initializer does **not** acquire a distributed migration lock, wrap the entire release upgrade in one cross-script transaction, or provide down migrations.
 
 Use this rollout sequence:


### PR DESCRIPTION
Closes #135.

## What changed

- resolves `Fga.MaxResourceHierarchyDepth` from the host configuration inside EF-backed synchronization and both manual resource-helper APIs
- aligns depth counting with in-process authorization and the SQL TVF: target depth 0, parent depth 1
- validates persisted resource trees during startup and reports the affected resource when a lowered limit or cycle makes existing data invalid
- rejects non-positive hierarchy-depth configuration
- stores the configured depth as EF model metadata for manually constructed contexts that do not expose application services
- documents the production rollout behavior when lowering the limit

## Developer impact

There is still one setting and no new registration step. The configured limit now means the same thing across sync, helpers, point checks, EF filters, and startup. Lowering it below existing data fails explicitly instead of silently hiding ancestor grants.

## Validation

- focused hierarchy/configuration unit suite: 56 passed
- full library unit suite: 592 passed
- example unit suite: 2 passed
- focused real SQL FGA integration suite: 20 passed, including configured-depth point/TVF visibility
- solution build: 0 warnings, 0 errors
- docs contracts, snippets, lint, TypeScript, production build, images, and 167-file link validation passed

An adversarial review and resolution iteration will be recorded in PR comments before merge.