### PR TITLE
Make FGA TVF deployment-safe and cycle-tolerant

### DIFF
--- a/src/SqlOS/Configuration/SqlOSOptionsValidator.cs
+++ b/src/SqlOS/Configuration/SqlOSOptionsValidator.cs
@@ -1,6 +1,7 @@
 using SqlOS.AuthServer.Configuration;
 using SqlOS.Calendar.Configuration;
 using SqlOS.Email.Configuration;
+using SqlOS.Fga;
 
 namespace SqlOS.Configuration;
 
@@ -60,6 +61,12 @@ internal static class SqlOSOptionsValidator
         if (options.Fga.MaxResourceHierarchyDepth <= 0)
         {
             errors.Add("Fga.MaxResourceHierarchyDepth must be greater than zero.");
+        }
+        else if (options.Fga.MaxResourceHierarchyDepth > SqlOSFgaHierarchyDepth.SqlServerRecursiveCteMaximum)
+        {
+            errors.Add(
+                $"Fga.MaxResourceHierarchyDepth cannot exceed {SqlOSFgaHierarchyDepth.SqlServerRecursiveCteMaximum}, "
+                + "the SQL Server recursive CTE limit used by FGA list authorization.");
         }
 
         var issuer = ValidateAbsoluteUri(options.AuthServer.Issuer, "AuthServer.Issuer", errors);

--- a/src/SqlOS/Fga/Services/SqlOSFgaFunctionInitializer.cs
+++ b/src/SqlOS/Fga/Services/SqlOSFgaFunctionInitializer.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using System.Globalization;
 using SqlOS.Fga.Configuration;
 using SqlOS.Fga.Interfaces;
 
@@ -31,14 +32,41 @@ public class SqlOSFgaFunctionInitializer
 
     private async Task EnsureIsResourceAccessibleFunctionAsync(CancellationToken cancellationToken)
     {
-        var schema = _options.Schema;
-        var tables = _options.TableNames;
-        var maxDepth = Math.Max(1, _options.MaxResourceHierarchyDepth);
+        var functionSql = BuildIsResourceAccessibleFunctionSql(_options);
 
-        var dropFunctionSql = $"DROP FUNCTION IF EXISTS [{schema}].fn_IsResourceAccessible";
+        try
+        {
+            _logger.LogDebug("Creating or updating fn_IsResourceAccessible TVF...");
+            await _context.Database.ExecuteSqlRawAsync(functionSql, cancellationToken);
+            _logger.LogInformation("fn_IsResourceAccessible TVF is ready.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to create or update fn_IsResourceAccessible TVF. Authorization queries may fail.");
+            throw;
+        }
+    }
 
-        var createFunctionSql = $@"
-CREATE FUNCTION [{schema}].fn_IsResourceAccessible(
+    internal static string BuildIsResourceAccessibleFunctionSql(SqlOSFgaOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var schema = EscapeIdentifier(options.Schema);
+        var tables = options.TableNames;
+        var resources = EscapeIdentifier(tables.Resources);
+        var grants = EscapeIdentifier(tables.Grants);
+        var rolePermissions = EscapeIdentifier(tables.RolePermissions);
+        var subjects = EscapeIdentifier(tables.Subjects);
+        var users = EscapeIdentifier(tables.Users);
+        var serviceAccounts = EscapeIdentifier(tables.ServiceAccounts);
+        var userGroups = EscapeIdentifier(tables.UserGroups);
+        var agents = EscapeIdentifier(tables.Agents);
+        var permissions = EscapeIdentifier(tables.Permissions);
+        var maxDepth = Math.Max(1, options.MaxResourceHierarchyDepth)
+            .ToString(CultureInfo.InvariantCulture);
+
+        return $@"
+CREATE OR ALTER FUNCTION [{schema}].fn_IsResourceAccessible(
     @ResourceId NVARCHAR(128),
     @SubjectIds NVARCHAR(MAX),
     @PermissionId NVARCHAR(128)
@@ -48,32 +76,54 @@ AS
 RETURN
 (
     WITH ancestors AS (
-        SELECT Id, ParentId, 0 AS Depth
-        FROM [{schema}].[{tables.Resources}]
+        SELECT
+            Id,
+            ParentId,
+            0 AS Depth,
+            CAST(N'|' + Id + N'|' AS NVARCHAR(MAX)) AS VisitedPath,
+            CAST(0 AS BIT) AS CycleDetected
+        FROM [{schema}].[{resources}]
         WHERE Id = @ResourceId AND IsActive = 1
 
         UNION ALL
 
-	        SELECT r.Id, r.ParentId, a.Depth + 1
-	        FROM [{schema}].[{tables.Resources}] r
-	        INNER JOIN ancestors a ON r.Id = a.ParentId
-	        WHERE a.Depth < {maxDepth} AND r.IsActive = 1
-	    )
+        SELECT
+            r.Id,
+            r.ParentId,
+            a.Depth + 1,
+            CAST(a.VisitedPath + r.Id + N'|' AS NVARCHAR(MAX)),
+            CAST(CASE
+                WHEN CHARINDEX(N'|' + r.Id + N'|', a.VisitedPath) > 0 THEN 1
+                ELSE 0
+            END AS BIT)
+        FROM [{schema}].[{resources}] r
+        INNER JOIN ancestors a ON r.Id = a.ParentId
+        WHERE a.Depth < {maxDepth}
+          AND a.CycleDetected = 0
+          AND r.IsActive = 1
+    )
     SELECT TOP 1 a.Id
     FROM ancestors a
-    INNER JOIN [{schema}].[{tables.Grants}] g ON a.Id = g.ResourceId
-    INNER JOIN [{schema}].[{tables.RolePermissions}] rp ON g.RoleId = rp.RoleId
-    INNER JOIN [{schema}].[{tables.Subjects}] s ON g.SubjectId = s.Id
-    LEFT JOIN [{schema}].[{tables.Users}] u ON s.Id = u.SubjectId
-    LEFT JOIN [{schema}].[{tables.ServiceAccounts}] sa ON s.Id = sa.SubjectId
-    LEFT JOIN [{schema}].[{tables.UserGroups}] ug ON s.Id = ug.SubjectId
-    LEFT JOIN [{schema}].[{tables.Agents}] ag ON s.Id = ag.SubjectId
+    INNER JOIN [{schema}].[{grants}] g ON a.Id = g.ResourceId
+    INNER JOIN [{schema}].[{rolePermissions}] rp ON g.RoleId = rp.RoleId
+    INNER JOIN [{schema}].[{subjects}] s ON g.SubjectId = s.Id
+    LEFT JOIN [{schema}].[{users}] u ON s.Id = u.SubjectId
+    LEFT JOIN [{schema}].[{serviceAccounts}] sa ON s.Id = sa.SubjectId
+    LEFT JOIN [{schema}].[{userGroups}] ug ON s.Id = ug.SubjectId
+    LEFT JOIN [{schema}].[{agents}] ag ON s.Id = ag.SubjectId
     WHERE g.SubjectId IN (SELECT CONVERT(NVARCHAR(450), [value]) FROM OPENJSON(@SubjectIds))
       AND rp.PermissionId = @PermissionId
+      AND NOT EXISTS (SELECT 1 FROM ancestors malformed WHERE malformed.CycleDetected = 1)
+      AND NOT EXISTS (
+          SELECT 1
+          FROM ancestors truncated
+          WHERE truncated.Depth = {maxDepth}
+            AND truncated.ParentId IS NOT NULL
+      )
       AND EXISTS (
           SELECT 1
-          FROM [{schema}].[{tables.Resources}] target
-          INNER JOIN [{schema}].[{tables.Permissions}] permission ON permission.Id = @PermissionId
+          FROM [{schema}].[{resources}] target
+          INNER JOIN [{schema}].[{permissions}] permission ON permission.Id = @PermissionId
           WHERE target.Id = @ResourceId
             AND (permission.ResourceTypeId IS NULL OR permission.ResourceTypeId = target.ResourceTypeId)
       )
@@ -83,11 +133,11 @@ RETURN
       AND (s.SubjectTypeId <> 'agent' OR ag.SubjectId IS NOT NULL)
       AND EXISTS (
           SELECT 1
-          FROM [{schema}].[{tables.Subjects}] caller
-          LEFT JOIN [{schema}].[{tables.Users}] callerUser ON caller.Id = callerUser.SubjectId
-          LEFT JOIN [{schema}].[{tables.ServiceAccounts}] callerSa ON caller.Id = callerSa.SubjectId
-          LEFT JOIN [{schema}].[{tables.UserGroups}] callerGroup ON caller.Id = callerGroup.SubjectId
-          LEFT JOIN [{schema}].[{tables.Agents}] callerAgent ON caller.Id = callerAgent.SubjectId
+          FROM [{schema}].[{subjects}] caller
+          LEFT JOIN [{schema}].[{users}] callerUser ON caller.Id = callerUser.SubjectId
+          LEFT JOIN [{schema}].[{serviceAccounts}] callerSa ON caller.Id = callerSa.SubjectId
+          LEFT JOIN [{schema}].[{userGroups}] callerGroup ON caller.Id = callerGroup.SubjectId
+          LEFT JOIN [{schema}].[{agents}] callerAgent ON caller.Id = callerAgent.SubjectId
           WHERE caller.Id = JSON_VALUE(@SubjectIds, '$[0]')
             AND (caller.SubjectTypeId <> 'user' OR callerUser.IsActive = 1)
             AND (caller.SubjectTypeId <> 'service_account' OR (callerSa.SubjectId IS NOT NULL AND (callerSa.ExpiresAt IS NULL OR callerSa.ExpiresAt > GETUTCDATE())))
@@ -97,18 +147,8 @@ RETURN
       AND (g.EffectiveFrom IS NULL OR g.EffectiveFrom <= GETUTCDATE())
       AND (g.EffectiveTo IS NULL OR g.EffectiveTo >= GETUTCDATE())
 )";
-
-        try
-        {
-            _logger.LogDebug("Creating fn_IsResourceAccessible TVF...");
-            await _context.Database.ExecuteSqlRawAsync(dropFunctionSql, cancellationToken);
-            await _context.Database.ExecuteSqlRawAsync(createFunctionSql, cancellationToken);
-            _logger.LogInformation("fn_IsResourceAccessible TVF created successfully.");
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to create fn_IsResourceAccessible TVF. Authorization queries may fail.");
-            throw;
-        }
     }
+
+    private static string EscapeIdentifier(string identifier)
+        => identifier.Replace("]", "]]", StringComparison.Ordinal);
 }

--- a/src/SqlOS/Fga/SqlOSFgaHierarchyDepth.cs
+++ b/src/SqlOS/Fga/SqlOSFgaHierarchyDepth.cs
@@ -9,6 +9,7 @@ namespace SqlOS.Fga;
 internal static class SqlOSFgaHierarchyDepth
 {
     public const int Default = 10;
+    public const int SqlServerRecursiveCteMaximum = 100;
     public const string ModelAnnotationName = "SqlOS:Fga:MaxResourceHierarchyDepth";
 
     public static int Resolve(ISqlOSFgaDbContext context)

--- a/tests/SqlOS.IntegrationTests/Fga/SqlOSFgaFunctionInitializerIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/Fga/SqlOSFgaFunctionInitializerIntegrationTests.cs
@@ -199,23 +199,33 @@ public class SqlOSFgaFunctionInitializerIntegrationTests : FgaIntegrationTestBas
         var loggerFactory = LoggerFactory.Create(b => b.AddConsole());
         var connectionString = Context.Database.GetConnectionString()
             ?? throw new InvalidOperationException("The integration database has no connection string.");
-        var updater = CreateContext(connectionString);
-        await using (updater)
+        await using var firstUpdater = CreateContext(connectionString);
+        await using var secondUpdater = CreateContext(connectionString);
+        var startGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        async Task RunInitializerAsync(TestSqlOSDbContext updater)
         {
             var initializer = new SqlOSFgaFunctionInitializer(
                 updater,
                 Options.Create(new SqlOSFgaOptions()),
                 loggerFactory.CreateLogger<SqlOSFgaFunctionInitializer>());
 
-            var updates = Task.Run(async () =>
+            await startGate.Task;
+            for (var i = 0; i < 5; i++)
             {
-                for (var i = 0; i < 5; i++)
-                {
-                    await initializer.EnsureFunctionsExistAsync();
-                }
-            });
+                await initializer.EnsureFunctionsExistAsync();
+            }
+        }
 
-            var reads = Enumerable.Range(0, 20).Select(async _ =>
+        var updates = new[]
+        {
+            RunInitializerAsync(firstUpdater),
+            RunInitializerAsync(secondUpdater)
+        };
+        var reads = Enumerable.Range(0, 10).Select(async _ =>
+        {
+            await startGate.Task;
+            for (var attempt = 0; attempt < 5; attempt++)
             {
                 await using var connection = new SqlConnection(connectionString);
                 await connection.OpenAsync();
@@ -232,13 +242,12 @@ public class SqlOSFgaFunctionInitializerIntegrationTests : FgaIntegrationTestBas
                     "@subjectIds",
                     JsonSerializer.Serialize(new[] { FgaTestDataSeeder.SystemAdminSubjectId }));
                 command.Parameters.AddWithValue("@permissionId", FgaTestDataSeeder.ViewPermissionId);
-                return Convert.ToInt32(await command.ExecuteScalarAsync());
-            });
+                Convert.ToInt32(await command.ExecuteScalarAsync()).Should().Be(1);
+            }
+        }).ToArray();
 
-            var results = await Task.WhenAll(reads.Append(updates.ContinueWith(_ => 1)));
-            await updates;
-            results.Should().OnlyContain(count => count == 1);
-        }
+        startGate.SetResult();
+        await Task.WhenAll(updates.Concat(reads));
     }
 
     private static TestSqlOSDbContext CreateContext(string connectionString)

--- a/tests/SqlOS.IntegrationTests/Fga/SqlOSFgaFunctionInitializerIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/Fga/SqlOSFgaFunctionInitializerIntegrationTests.cs
@@ -1,11 +1,13 @@
 using FluentAssertions;
 using System.Text.Json;
+using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SqlOS.Fga.Configuration;
 using SqlOS.IntegrationTests.Fga.Infrastructure;
+using SqlOS.IntegrationTests.Infrastructure;
 using SqlOS.Fga.Models;
 using SqlOS.Fga.Services;
 
@@ -26,6 +28,9 @@ public class SqlOSFgaFunctionInitializerIntegrationTests : FgaIntegrationTestBas
         // Should not throw when run multiple times
         await initializer.EnsureFunctionsExistAsync();
         await initializer.EnsureFunctionsExistAsync();
+
+        var definition = await GetFunctionDefinitionAsync();
+        definition.Should().Contain("CycleDetected");
     }
 
     [TestMethod]
@@ -42,7 +47,8 @@ public class SqlOSFgaFunctionInitializerIntegrationTests : FgaIntegrationTestBas
             await initializer.EnsureFunctionsExistAsync();
 
             var definition = await GetFunctionDefinitionAsync();
-            definition.Should().Contain("WHERE a.Depth < 3");
+            definition.Should().Contain("a.Depth < 3");
+            definition.Should().Contain("truncated.Depth = 3");
         }
         finally
         {
@@ -126,6 +132,121 @@ public class SqlOSFgaFunctionInitializerIntegrationTests : FgaIntegrationTestBas
         definition.Should().Contain("OPENJSON(@SubjectIds)");
         definition.Should().Contain("JSON_VALUE(@SubjectIds, '$[0]')");
         definition.Should().Contain("permission.ResourceTypeId IS NULL OR permission.ResourceTypeId = target.ResourceTypeId");
+    }
+
+    [TestMethod]
+    public async Task CyclicHierarchy_FailsClosedWithoutSqlRecursionFailure()
+    {
+        var loggerFactory = LoggerFactory.Create(b => b.AddConsole());
+        var initializer = new SqlOSFgaFunctionInitializer(
+            Context,
+            Options.Create(new SqlOSFgaOptions()),
+            loggerFactory.CreateLogger<SqlOSFgaFunctionInitializer>());
+        var suffix = Guid.NewGuid().ToString("N");
+        var first = new SqlOSFgaResource
+        {
+            Id = $"cycle_a_{suffix}",
+            Name = "Cycle A",
+            ResourceTypeId = "agency"
+        };
+        var second = new SqlOSFgaResource
+        {
+            Id = $"cycle_b_{suffix}",
+            ParentId = first.Id,
+            Name = "Cycle B",
+            ResourceTypeId = "agency"
+        };
+        var grant = new SqlOSFgaGrant
+        {
+            Id = $"cycle_grant_{suffix}",
+            SubjectId = FgaTestDataSeeder.SystemAdminSubjectId,
+            ResourceId = first.Id,
+            RoleId = FgaTestDataSeeder.SystemAdminRoleId
+        };
+
+        try
+        {
+            Context.Set<SqlOSFgaResource>().AddRange(first, second);
+            Context.Set<SqlOSFgaGrant>().Add(grant);
+            await Context.SaveChangesAsync();
+            await Context.Database.ExecuteSqlInterpolatedAsync(
+                $"UPDATE [dbo].[SqlOSFgaResources] SET ParentId = {second.Id} WHERE Id = {first.Id}");
+            Context.ChangeTracker.Clear();
+            await initializer.EnsureFunctionsExistAsync();
+
+            var visible = await Context.IsResourceAccessible(
+                    first.Id,
+                    JsonSerializer.Serialize(new[] { FgaTestDataSeeder.SystemAdminSubjectId }),
+                    FgaTestDataSeeder.ViewPermissionId)
+                .AnyAsync();
+
+            visible.Should().BeFalse();
+        }
+        finally
+        {
+            await Context.Database.ExecuteSqlInterpolatedAsync(
+                $"UPDATE [dbo].[SqlOSFgaResources] SET ParentId = NULL WHERE Id = {first.Id}");
+            Context.ChangeTracker.Clear();
+            Context.Set<SqlOSFgaGrant>().Remove(grant);
+            Context.Set<SqlOSFgaResource>().RemoveRange(second, first);
+            await Context.SaveChangesAsync();
+        }
+    }
+
+    [TestMethod]
+    public async Task CreateOrAlter_KeepsFunctionCallableDuringRepeatedInitialization()
+    {
+        var loggerFactory = LoggerFactory.Create(b => b.AddConsole());
+        var connectionString = Context.Database.GetConnectionString()
+            ?? throw new InvalidOperationException("The integration database has no connection string.");
+        var updater = CreateContext(connectionString);
+        await using (updater)
+        {
+            var initializer = new SqlOSFgaFunctionInitializer(
+                updater,
+                Options.Create(new SqlOSFgaOptions()),
+                loggerFactory.CreateLogger<SqlOSFgaFunctionInitializer>());
+
+            var updates = Task.Run(async () =>
+            {
+                for (var i = 0; i < 5; i++)
+                {
+                    await initializer.EnsureFunctionsExistAsync();
+                }
+            });
+
+            var reads = Enumerable.Range(0, 20).Select(async _ =>
+            {
+                await using var connection = new SqlConnection(connectionString);
+                await connection.OpenAsync();
+                await using var command = connection.CreateCommand();
+                command.CommandText = """
+                    SELECT COUNT(*)
+                    FROM [dbo].fn_IsResourceAccessible(
+                        @resourceId,
+                        @subjectIds,
+                        @permissionId)
+                    """;
+                command.Parameters.AddWithValue("@resourceId", FgaTestDataSeeder.TestAgencyResourceId);
+                command.Parameters.AddWithValue(
+                    "@subjectIds",
+                    JsonSerializer.Serialize(new[] { FgaTestDataSeeder.SystemAdminSubjectId }));
+                command.Parameters.AddWithValue("@permissionId", FgaTestDataSeeder.ViewPermissionId);
+                return Convert.ToInt32(await command.ExecuteScalarAsync());
+            });
+
+            var results = await Task.WhenAll(reads.Append(updates.ContinueWith(_ => 1)));
+            await updates;
+            results.Should().OnlyContain(count => count == 1);
+        }
+    }
+
+    private static TestSqlOSDbContext CreateContext(string connectionString)
+    {
+        var options = new DbContextOptionsBuilder<TestSqlOSDbContext>()
+            .UseSqlServer(connectionString)
+            .Options;
+        return new TestSqlOSDbContext(options);
     }
 
     private static async Task<string> GetFunctionDefinitionAsync()

--- a/tests/SqlOS.Tests/SqlOSFgaFunctionInitializerTests.cs
+++ b/tests/SqlOS.Tests/SqlOSFgaFunctionInitializerTests.cs
@@ -1,0 +1,37 @@
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SqlOS.Fga.Configuration;
+using SqlOS.Fga.Services;
+
+namespace SqlOS.Tests;
+
+[TestClass]
+public class SqlOSFgaFunctionInitializerTests
+{
+    [TestMethod]
+    public void BuildFunctionSql_UsesAtomicDefinitionUpdateAndCycleGuard()
+    {
+        var sql = SqlOSFgaFunctionInitializer.BuildIsResourceAccessibleFunctionSql(
+            new SqlOSFgaOptions { MaxResourceHierarchyDepth = 7 });
+
+        sql.Should().Contain("CREATE OR ALTER FUNCTION");
+        sql.Should().NotContain("DROP FUNCTION");
+        sql.Should().Contain("CycleDetected");
+        sql.Should().Contain("CHARINDEX");
+        sql.Should().Contain("malformed.CycleDetected = 1");
+        sql.Should().Contain("truncated.Depth = 7");
+        sql.Should().Contain("a.Depth < 7");
+    }
+
+    [TestMethod]
+    public void BuildFunctionSql_EscapesConfiguredIdentifiers()
+    {
+        var options = new SqlOSFgaOptions { Schema = "tenant]one" };
+        options.TableNames.Resources = "resources]current";
+
+        var sql = SqlOSFgaFunctionInitializer.BuildIsResourceAccessibleFunctionSql(options);
+
+        sql.Should().Contain("[tenant]]one].fn_IsResourceAccessible");
+        sql.Should().Contain("[tenant]]one].[resources]]current]");
+    }
+}

--- a/tests/SqlOS.Tests/SqlOSOptionsValidationTests.cs
+++ b/tests/SqlOS.Tests/SqlOSOptionsValidationTests.cs
@@ -164,6 +164,20 @@ public sealed class SqlOSOptionsValidationTests
             .WithMessage("*Fga.MaxResourceHierarchyDepth must be greater than zero.*");
     }
 
+    [TestMethod]
+    public void AddSqlOS_RejectsFgaHierarchyDepthBeyondSqlServerLimit()
+    {
+        var services = new ServiceCollection();
+
+        Action act = () => services.AddSqlOS<TestSqlOSInMemoryDbContext>(options =>
+            options.Fga.MaxResourceHierarchyDepth = 101);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage(
+                "*Fga.MaxResourceHierarchyDepth cannot exceed 100, "
+                + "the SQL Server recursive CTE limit used by FGA list authorization.*");
+    }
+
     [DataTestMethod]
     [DataRow("default-src 'self'; script-src 'self'")]
     [DataRow("default-src 'self'; script-src 'nonce-{nonce}'; style-src 'self'")]

--- a/web/content/docs/guides/production-readiness.mdx
+++ b/web/content/docs/guides/production-readiness.mdx
@@ -223,7 +223,9 @@ SqlOS owns its tables separately from your EF Core migrations. At host startup, 
 4. applies the FGA scripts tracked by `SqlOSFgaSchema`;
 5. creates or verifies FGA functions and seed data when enabled.
 
-`Fga.MaxResourceHierarchyDepth` is one shared limit for resource synchronization, manual resource helpers, in-process authorization, and the SQL authorization function. Startup validates persisted resources against that limit and fails with the affected resource ID when existing data is deeper or cyclic. Before lowering the value, inspect and repair the stored hierarchy in a restored environment; do not lower it during a rollout and rely on authorization to silently truncate deeper ancestors.
+`Fga.MaxResourceHierarchyDepth` is one shared limit for resource synchronization, manual resource helpers, in-process authorization, and the SQL authorization function. Valid values are 1 through 100 because SQL Server limits the recursive CTE used by list authorization to 100 levels. Startup validates persisted resources against that limit and fails with the affected resource ID when existing data is deeper or cyclic. Before lowering the value, inspect and repair the stored hierarchy in a restored environment; do not lower it during a rollout and rely on authorization to silently truncate deeper ancestors.
+
+The SQL authorization function is installed with `CREATE OR ALTER FUNCTION`, which requires SQL Server 2016 SP1 or newer. Updating SqlOS does not drop the live function during startup, so concurrent authorization queries never observe a missing-function window. If manual database changes introduce a cycle or a hierarchy deeper than the configured limit, the function terminates and denies access rather than returning a partial inherited grant.
 
 Each AuthServer script and its ledger entry commit in one transaction, so an interrupted startup safely retries the unrecorded script. The initializer does **not** acquire a distributed migration lock, wrap the entire release upgrade in one cross-script transaction, or provide down migrations.
 


### PR DESCRIPTION
Closes #139

## Summary
- replace the drop/recreate authorization TVF lifecycle with one atomic `CREATE OR ALTER FUNCTION` statement
- make recursive hierarchy evaluation terminate and fail closed for cycles and over-depth data
- validate the SQL Server recursive CTE ceiling, escape configured SQL identifiers, and document the SQL Server prerequisite
- add definition-level tests plus real SQL tests for repeated initialization, concurrent availability, normal boundary grants, and deliberate cycles

## Validation
- `./scripts/build.sh`
- `./scripts/unit-tests.sh` (597 library + 2 example tests)
- `./scripts/integration-tests.sh` (162 library + 71 example + 15 Todo tests)
- `./scripts/docs-check.sh` (167 markdown files, compiled snippets, production site build)
