### PR TITLE
Harden public throttling for multi-instance deployments

### DIFF
--- a/src/SqlOS/AuthServer/Schema/032_DistributedRateLimits.sql
+++ b/src/SqlOS/AuthServer/Schema/032_DistributedRateLimits.sql
@@ -1,0 +1,16 @@
+IF OBJECT_ID('[{Schema}].[SqlOSRateLimitBuckets]', 'U') IS NULL
+BEGIN
+    CREATE TABLE [{Schema}].[SqlOSRateLimitBuckets] (
+        [Scope] NVARCHAR(64) NOT NULL,
+        [BucketKey] NVARCHAR(384) NOT NULL,
+        [WindowStartedAt] DATETIME2 NOT NULL,
+        [Count] INT NOT NULL,
+        [LockedUntil] DATETIME2 NULL,
+        [UpdatedAt] DATETIME2 NOT NULL,
+        CONSTRAINT [PK_SqlOSRateLimitBuckets] PRIMARY KEY ([Scope], [BucketKey]),
+        CONSTRAINT [CK_SqlOSRateLimitBuckets_Count] CHECK ([Count] >= 0)
+    );
+
+    CREATE INDEX [IX_SqlOSRateLimitBuckets_UpdatedAt]
+        ON [{Schema}].[SqlOSRateLimitBuckets] ([UpdatedAt]);
+END

--- a/src/SqlOS/AuthServer/Services/SqlOSDynamicClientRegistrationRateLimiter.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSDynamicClientRegistrationRateLimiter.cs
@@ -1,30 +1,38 @@
-using System.Collections.Concurrent;
+using SqlOS.Security;
 
 namespace SqlOS.AuthServer.Services;
 
 public sealed class SqlOSDynamicClientRegistrationRateLimiter
 {
-    private readonly ConcurrentDictionary<string, Queue<DateTime>> _registrations = new(StringComparer.Ordinal);
+    private const string Scope = "dcr";
+    private readonly ISqlOSRateLimitStore _store;
 
-    public bool TryConsume(string key, TimeSpan window, int maxRegistrations)
+    public SqlOSDynamicClientRegistrationRateLimiter()
+        : this(new SqlOSInMemoryRateLimitStore())
     {
-        var now = DateTime.UtcNow;
-        var queue = _registrations.GetOrAdd(key, static _ => new Queue<DateTime>());
+    }
 
-        lock (queue)
-        {
-            while (queue.Count > 0 && now - queue.Peek() > window)
-            {
-                queue.Dequeue();
-            }
+    internal SqlOSDynamicClientRegistrationRateLimiter(ISqlOSRateLimitStore store)
+    {
+        _store = store;
+    }
 
-            if (queue.Count >= maxRegistrations)
-            {
-                return false;
-            }
+    public async Task<bool> TryConsumeAsync(
+        string key,
+        TimeSpan window,
+        int maxRegistrations,
+        DateTimeOffset now,
+        CancellationToken cancellationToken = default)
+    {
+        var state = await _store.IncrementAsync(
+            Scope,
+            key,
+            checked(maxRegistrations + 1),
+            window,
+            window,
+            now,
+            cancellationToken);
 
-            queue.Enqueue(now);
-            return true;
-        }
+        return state.LockedUntil is null;
     }
 }

--- a/src/SqlOS/AuthServer/Services/SqlOSDynamicClientRegistrationService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSDynamicClientRegistrationService.cs
@@ -6,6 +6,7 @@ using SqlOS.AuthServer.Configuration;
 using SqlOS.AuthServer.Contracts;
 using SqlOS.AuthServer.Interfaces;
 using SqlOS.AuthServer.Models;
+using SqlOS.Security;
 
 namespace SqlOS.AuthServer.Services;
 
@@ -46,7 +47,7 @@ public sealed class SqlOSDynamicClientRegistrationService
                 throw new SqlOSClientRegistrationException("unsupported_operation", "Dynamic client registration is disabled.");
             }
 
-            EnforceRateLimit(httpContext);
+            await EnforceRateLimitAsync(httpContext, cancellationToken);
 
             var normalized = await NormalizeRequestAsync(request, httpContext, cancellationToken);
             var clientId = await GenerateUniqueClientIdAsync(cancellationToken);
@@ -136,13 +137,17 @@ public sealed class SqlOSDynamicClientRegistrationService
         }
     }
 
-    private void EnforceRateLimit(HttpContext httpContext)
+    private async Task EnforceRateLimitAsync(
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
     {
-        var key = GetIpAddress(httpContext) ?? "unknown";
-        if (_rateLimiter.TryConsume(
+        var key = SqlOSClientIpAddress.Get(httpContext);
+        if (await _rateLimiter.TryConsumeAsync(
                 key,
                 _options.ClientRegistration.Dcr.RateLimitWindow,
-                _options.ClientRegistration.Dcr.MaxRegistrationsPerWindow))
+                _options.ClientRegistration.Dcr.MaxRegistrationsPerWindow,
+                DateTimeOffset.UtcNow,
+                cancellationToken))
         {
             return;
         }
@@ -349,7 +354,7 @@ public sealed class SqlOSDynamicClientRegistrationService
     }
 
     private static string? GetIpAddress(HttpContext httpContext)
-        => httpContext.Connection.RemoteIpAddress?.ToString();
+        => SqlOSClientIpAddress.Get(httpContext);
 
     private sealed record NormalizedDcrRequest(
         string ClientName,

--- a/src/SqlOS/Dashboard/SqlOSDashboardLoginThrottlingService.cs
+++ b/src/SqlOS/Dashboard/SqlOSDashboardLoginThrottlingService.cs
@@ -1,18 +1,30 @@
 using SqlOS.Configuration;
+using SqlOS.Security;
 
 namespace SqlOS.Dashboard;
 
 public sealed class SqlOSDashboardLoginThrottlingService
 {
-    private const string UnknownClientIp = "unknown";
-    private readonly object _sync = new();
-    private readonly Dictionary<string, FailureBucket> _ipFailures = new(StringComparer.Ordinal);
-    private readonly FailureBucket _globalFailures = new();
+    private const string IpScope = "dashboard-ip";
+    private const string GlobalScope = "dashboard-global";
+    private const string GlobalKey = "all";
+    private readonly ISqlOSRateLimitStore _store;
 
-    public SqlOSDashboardLoginThrottleRejection? GetRejection(
+    public SqlOSDashboardLoginThrottlingService()
+        : this(new SqlOSInMemoryRateLimitStore())
+    {
+    }
+
+    internal SqlOSDashboardLoginThrottlingService(ISqlOSRateLimitStore store)
+    {
+        _store = store;
+    }
+
+    public async Task<SqlOSDashboardLoginThrottleRejection?> GetRejectionAsync(
         string? clientIp,
         SqlOSDashboardLoginThrottlingOptions options,
-        DateTimeOffset now)
+        DateTimeOffset now,
+        CancellationToken cancellationToken = default)
     {
         if (!options.Enabled)
         {
@@ -20,36 +32,33 @@ public sealed class SqlOSDashboardLoginThrottlingService
         }
 
         var normalizedIp = NormalizeClientIp(clientIp);
-        lock (_sync)
+        var ipState = await _store.GetAsync(
+            IpScope,
+            normalizedIp,
+            now,
+            options.Window,
+            cancellationToken);
+        if (ipState?.LockedUntil is { } ipLockedUntil && ipLockedUntil > now)
         {
-            if (_ipFailures.TryGetValue(normalizedIp, out var ipBucket))
-            {
-                ResetIfExpired(ipBucket, options, now);
-                if (ipBucket.LockedUntil is { } ipLockedUntil && ipLockedUntil > now)
-                {
-                    return new SqlOSDashboardLoginThrottleRejection("ip", ipLockedUntil);
-                }
-
-                if (ipBucket.Count == 0)
-                {
-                    _ipFailures.Remove(normalizedIp);
-                }
-            }
-
-            ResetIfExpired(_globalFailures, options, now);
-            if (_globalFailures.LockedUntil is { } globalLockedUntil && globalLockedUntil > now)
-            {
-                return new SqlOSDashboardLoginThrottleRejection("global", globalLockedUntil);
-            }
-
-            return null;
+            return new SqlOSDashboardLoginThrottleRejection("ip", ipLockedUntil);
         }
+
+        var globalState = await _store.GetAsync(
+            GlobalScope,
+            GlobalKey,
+            now,
+            options.Window,
+            cancellationToken);
+        return globalState?.LockedUntil is { } globalLockedUntil && globalLockedUntil > now
+            ? new SqlOSDashboardLoginThrottleRejection("global", globalLockedUntil)
+            : null;
     }
 
-    public SqlOSDashboardLoginLockoutResult RecordFailure(
+    public async Task<SqlOSDashboardLoginLockoutResult> RecordFailureAsync(
         string? clientIp,
         SqlOSDashboardLoginThrottlingOptions options,
-        DateTimeOffset now)
+        DateTimeOffset now,
+        CancellationToken cancellationToken = default)
     {
         if (!options.Enabled)
         {
@@ -57,22 +66,33 @@ public sealed class SqlOSDashboardLoginThrottlingService
         }
 
         var normalizedIp = NormalizeClientIp(clientIp);
-        lock (_sync)
-        {
-            var ipBucket = GetActiveIpBucket(normalizedIp, options, now);
-            var perIpLockedUntil = RecordFailure(ipBucket, options.MaxFailuresPerIp, options.LockoutDuration, now);
+        var ipState = await _store.IncrementAsync(
+            IpScope,
+            normalizedIp,
+            options.MaxFailuresPerIp,
+            options.Window,
+            options.LockoutDuration,
+            now,
+            cancellationToken);
+        var globalState = await _store.IncrementAsync(
+            GlobalScope,
+            GlobalKey,
+            options.MaxGlobalFailures,
+            options.Window,
+            options.LockoutDuration,
+            now,
+            cancellationToken);
 
-            ResetIfExpired(_globalFailures, options, now);
-            var globalLockedUntil = RecordFailure(_globalFailures, options.MaxGlobalFailures, options.LockoutDuration, now);
-
-            return new SqlOSDashboardLoginLockoutResult(perIpLockedUntil, globalLockedUntil);
-        }
+        return new SqlOSDashboardLoginLockoutResult(
+            ipState.LockedUntil,
+            globalState.LockedUntil);
     }
 
-    public void RecordSuccess(
+    public async Task RecordSuccessAsync(
         string? clientIp,
         SqlOSDashboardLoginThrottlingOptions options,
-        DateTimeOffset now)
+        DateTimeOffset now,
+        CancellationToken cancellationToken = default)
     {
         if (!options.Enabled)
         {
@@ -80,90 +100,12 @@ public sealed class SqlOSDashboardLoginThrottlingService
         }
 
         var normalizedIp = NormalizeClientIp(clientIp);
-        lock (_sync)
-        {
-            _ipFailures.Remove(normalizedIp);
-
-            ResetIfExpired(_globalFailures, options, now);
-            if (_globalFailures.LockedUntil is null && _globalFailures.Count > 0)
-            {
-                _globalFailures.Count--;
-                if (_globalFailures.Count == 0)
-                {
-                    _globalFailures.WindowStartedAt = null;
-                }
-            }
-        }
-    }
-
-    private FailureBucket GetActiveIpBucket(
-        string clientIp,
-        SqlOSDashboardLoginThrottlingOptions options,
-        DateTimeOffset now)
-    {
-        if (!_ipFailures.TryGetValue(clientIp, out var bucket))
-        {
-            bucket = new FailureBucket();
-            _ipFailures[clientIp] = bucket;
-            return bucket;
-        }
-
-        ResetIfExpired(bucket, options, now);
-        return bucket;
-    }
-
-    private static DateTimeOffset? RecordFailure(
-        FailureBucket bucket,
-        int threshold,
-        TimeSpan lockoutDuration,
-        DateTimeOffset now)
-    {
-        bucket.WindowStartedAt ??= now;
-        bucket.Count++;
-
-        if (bucket.Count < threshold || bucket.LockedUntil is not null)
-        {
-            return null;
-        }
-
-        bucket.LockedUntil = now.Add(lockoutDuration);
-        return bucket.LockedUntil;
-    }
-
-    private static void ResetIfExpired(
-        FailureBucket bucket,
-        SqlOSDashboardLoginThrottlingOptions options,
-        DateTimeOffset now)
-    {
-        if (bucket.LockedUntil is { } lockedUntil)
-        {
-            if (lockedUntil > now)
-            {
-                return;
-            }
-
-            bucket.Count = 0;
-            bucket.WindowStartedAt = null;
-            bucket.LockedUntil = null;
-            return;
-        }
-
-        if (bucket.WindowStartedAt is { } windowStartedAt && now - windowStartedAt >= options.Window)
-        {
-            bucket.Count = 0;
-            bucket.WindowStartedAt = null;
-        }
+        await _store.DeleteAsync(IpScope, normalizedIp, cancellationToken);
+        await _store.DecrementAsync(GlobalScope, GlobalKey, now, cancellationToken);
     }
 
     private static string NormalizeClientIp(string? clientIp)
-        => string.IsNullOrWhiteSpace(clientIp) ? UnknownClientIp : clientIp.Trim();
-
-    private sealed class FailureBucket
-    {
-        public DateTimeOffset? WindowStartedAt { get; set; }
-        public int Count { get; set; }
-        public DateTimeOffset? LockedUntil { get; set; }
-    }
+        => string.IsNullOrWhiteSpace(clientIp) ? SqlOSClientIpAddress.Unknown : clientIp.Trim();
 }
 
 public sealed record SqlOSDashboardLoginThrottleRejection(string Scope, DateTimeOffset RetryAfter);

--- a/src/SqlOS/Dashboard/SqlOSDashboardMiddleware.cs
+++ b/src/SqlOS/Dashboard/SqlOSDashboardMiddleware.cs
@@ -24,7 +24,6 @@ public sealed class SqlOSDashboardMiddleware
     private readonly bool _scimEnabled;
     private readonly SqlOSDashboardOptions _options;
     private readonly SqlOSDashboardSessionService _sessionService;
-    private readonly SqlOSDashboardLoginThrottlingService _loginThrottlingService;
     private readonly IFileProvider _fileProvider;
     private readonly SqlOSBrowserSecurityHeaders _securityHeaders;
 
@@ -35,7 +34,6 @@ public sealed class SqlOSDashboardMiddleware
         SqlOSDashboardOptions options,
         bool scimEnabled,
         SqlOSDashboardSessionService sessionService,
-        SqlOSDashboardLoginThrottlingService loginThrottlingService,
         IOptions<SqlOSOptions> hostOptions)
     {
         _next = next;
@@ -44,12 +42,13 @@ public sealed class SqlOSDashboardMiddleware
         _scimEnabled = scimEnabled;
         _options = options;
         _sessionService = sessionService;
-        _loginThrottlingService = loginThrottlingService;
         _securityHeaders = new SqlOSBrowserSecurityHeaders(hostOptions);
         _fileProvider = CreateFileProvider();
     }
 
-    public async Task InvokeAsync(HttpContext context)
+    public async Task InvokeAsync(
+        HttpContext context,
+        SqlOSDashboardLoginThrottlingService loginThrottlingService)
     {
         var path = context.Request.Path.Value ?? string.Empty;
         if (!IsPathOrChild(path, _pathPrefix))
@@ -77,7 +76,7 @@ public sealed class SqlOSDashboardMiddleware
 
         if (IsDashboardAuthEndpoint(relativePath))
         {
-            await HandleDashboardAuthRequestAsync(context, relativePath);
+            await HandleDashboardAuthRequestAsync(context, relativePath, loginThrottlingService);
             return;
         }
 
@@ -136,7 +135,10 @@ public sealed class SqlOSDashboardMiddleware
             _options.AuthorizationCallback);
     }
 
-    private async Task HandleDashboardAuthRequestAsync(HttpContext context, string relativePath)
+    private async Task HandleDashboardAuthRequestAsync(
+        HttpContext context,
+        string relativePath,
+        SqlOSDashboardLoginThrottlingService loginThrottlingService)
     {
         var endpoint = relativePath.Length == DashboardAuthPrefix.Length
             ? string.Empty
@@ -196,7 +198,11 @@ public sealed class SqlOSDashboardMiddleware
 
             var clientIp = GetClientIpAddress(context);
             var now = DateTimeOffset.UtcNow;
-            var rejection = _loginThrottlingService.GetRejection(clientIp, _options.LoginThrottling, now);
+            var rejection = await loginThrottlingService.GetRejectionAsync(
+                clientIp,
+                _options.LoginThrottling,
+                now,
+                context.RequestAborted);
             if (rejection != null)
             {
                 await RecordDashboardAuditAsync(
@@ -220,7 +226,11 @@ public sealed class SqlOSDashboardMiddleware
                     clientIp,
                     new { reason = "invalid_password" });
 
-                var lockout = _loginThrottlingService.RecordFailure(clientIp, _options.LoginThrottling, now);
+                var lockout = await loginThrottlingService.RecordFailureAsync(
+                    clientIp,
+                    _options.LoginThrottling,
+                    now,
+                    context.RequestAborted);
                 if (lockout.PerIpLockedUntil is { } perIpLockedUntil)
                 {
                     await RecordDashboardAuditAsync(
@@ -253,7 +263,11 @@ public sealed class SqlOSDashboardMiddleware
                 return;
             }
 
-            _loginThrottlingService.RecordSuccess(clientIp, _options.LoginThrottling, now);
+            await loginThrottlingService.RecordSuccessAsync(
+                clientIp,
+                _options.LoginThrottling,
+                now,
+                context.RequestAborted);
             var allowInsecureCookie = _isDevelopment && !context.Request.IsHttps;
             var expiresAt = _sessionService.CreateSession(context, _pathPrefix, _options.SessionLifetime, allowInsecureCookie);
             await RecordDashboardAuditAsync(
@@ -313,7 +327,7 @@ public sealed class SqlOSDashboardMiddleware
     }
 
     private static string GetClientIpAddress(HttpContext context)
-        => context.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+        => SqlOSClientIpAddress.Get(context);
 
     private static int GetRetryAfterSeconds(DateTimeOffset retryAfter, DateTimeOffset now)
         => Math.Max(1, (int)Math.Ceiling((retryAfter - now).TotalSeconds));

--- a/src/SqlOS/Extensions/ServiceCollectionExtensions.cs
+++ b/src/SqlOS/Extensions/ServiceCollectionExtensions.cs
@@ -63,11 +63,14 @@ public static class ServiceCollectionExtensions
             client.Timeout = TimeSpan.FromSeconds(5);
         });
         services.AddSingleton<SqlOSDashboardSessionService>();
-        services.AddSingleton<SqlOSDashboardLoginThrottlingService>();
-        services.AddSingleton<SqlOSDynamicClientRegistrationRateLimiter>();
 
         services.AddScoped<ISqlOSAuthServerDbContext>(sp => sp.GetRequiredService<TContext>());
         services.AddScoped<ISqlOSFgaDbContext>(sp => sp.GetRequiredService<TContext>());
+        services.AddScoped<SqlOSDistributedRateLimitStore>();
+        services.AddScoped(sp => new SqlOSDashboardLoginThrottlingService(
+            sp.GetRequiredService<SqlOSDistributedRateLimitStore>()));
+        services.AddScoped(sp => new SqlOSDynamicClientRegistrationRateLimiter(
+            sp.GetRequiredService<SqlOSDistributedRateLimitStore>()));
 
         services.AddScoped<SqlOSSchemaInitializer>();
         services.AddScoped<SqlOSBootstrapper>();

--- a/src/SqlOS/Hosting/SqlOSPipelineStartupFilter.cs
+++ b/src/SqlOS/Hosting/SqlOSPipelineStartupFilter.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using System.Net;
 using SqlOS.Configuration;
 using SqlOS.Fga.Dashboard;
 using RootDashboardMiddleware = SqlOS.Dashboard.SqlOSDashboardMiddleware;
@@ -59,11 +60,10 @@ internal sealed class SqlOSPipelineStartupFilter : IStartupFilter
             || hostOptions.AuthServer.ClientRegistration.Dcr.Enabled;
         if (publicThrottleSurface
             && forwardedHeaders?.ForwardedHeaders.HasFlag(ForwardedHeaders.XForwardedFor) == true
-            && forwardedHeaders.KnownProxies.Count == 0
-            && forwardedHeaders.KnownNetworks.Count == 0)
+            && !HasNonLoopbackTrustedProxy(forwardedHeaders))
         {
             _logger.LogWarning(
-                "SqlOS public throttling is enabled while X-Forwarded-For has no KnownProxies or KnownNetworks. " +
+                "SqlOS public throttling is enabled while X-Forwarded-For has no non-loopback KnownProxies or KnownNetworks. " +
                 "Configure trusted proxy boundaries or disable X-Forwarded-For processing; untrusted forwarded client addresses can bypass or collapse rate-limit buckets.");
         }
 
@@ -80,4 +80,8 @@ internal sealed class SqlOSPipelineStartupFilter : IStartupFilter
 
         next(app);
     };
+
+    private static bool HasNonLoopbackTrustedProxy(ForwardedHeadersOptions options)
+        => options.KnownProxies.Any(address => !IPAddress.IsLoopback(address))
+           || options.KnownNetworks.Any(network => !IPAddress.IsLoopback(network.Prefix));
 }

--- a/src/SqlOS/Hosting/SqlOSPipelineStartupFilter.cs
+++ b/src/SqlOS/Hosting/SqlOSPipelineStartupFilter.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -50,6 +51,20 @@ internal sealed class SqlOSPipelineStartupFilter : IStartupFilter
                     "SqlOS dashboard authentication is DevelopmentOnly. The dashboard and admin APIs return 404 outside Development. " +
                     "Configure Dashboard.AuthMode = Password or Dashboard.AuthorizationCallback before exposing operator access.");
             }
+        }
+
+        var forwardedHeaders = services.GetService<IOptions<ForwardedHeadersOptions>>()?.Value;
+        var publicThrottleSurface =
+            hostOptions.Dashboard.AuthMode == SqlOSDashboardAuthMode.Password
+            || hostOptions.AuthServer.ClientRegistration.Dcr.Enabled;
+        if (publicThrottleSurface
+            && forwardedHeaders?.ForwardedHeaders.HasFlag(ForwardedHeaders.XForwardedFor) == true
+            && forwardedHeaders.KnownProxies.Count == 0
+            && forwardedHeaders.KnownNetworks.Count == 0)
+        {
+            _logger.LogWarning(
+                "SqlOS public throttling is enabled while X-Forwarded-For has no KnownProxies or KnownNetworks. " +
+                "Configure trusted proxy boundaries or disable X-Forwarded-For processing; untrusted forwarded client addresses can bypass or collapse rate-limit buckets.");
         }
 
         // Apply only the host-configured, trusted ForwardedHeaders options. The

--- a/src/SqlOS/Security/ISqlOSRateLimitStore.cs
+++ b/src/SqlOS/Security/ISqlOSRateLimitStore.cs
@@ -1,0 +1,33 @@
+namespace SqlOS.Security;
+
+internal interface ISqlOSRateLimitStore
+{
+    Task<SqlOSRateLimitBucketState> IncrementAsync(
+        string scope,
+        string key,
+        int lockThreshold,
+        TimeSpan window,
+        TimeSpan lockoutDuration,
+        DateTimeOffset now,
+        CancellationToken cancellationToken = default);
+
+    Task<SqlOSRateLimitBucketState?> GetAsync(
+        string scope,
+        string key,
+        DateTimeOffset now,
+        TimeSpan window,
+        CancellationToken cancellationToken = default);
+
+    Task DeleteAsync(
+        string scope,
+        string key,
+        CancellationToken cancellationToken = default);
+
+    Task DecrementAsync(
+        string scope,
+        string key,
+        DateTimeOffset now,
+        CancellationToken cancellationToken = default);
+}
+
+internal sealed record SqlOSRateLimitBucketState(int Count, DateTimeOffset? LockedUntil);

--- a/src/SqlOS/Security/SqlOSClientIpAddress.cs
+++ b/src/SqlOS/Security/SqlOSClientIpAddress.cs
@@ -1,0 +1,11 @@
+using Microsoft.AspNetCore.Http;
+
+namespace SqlOS.Security;
+
+internal static class SqlOSClientIpAddress
+{
+    public const string Unknown = "unknown";
+
+    public static string Get(HttpContext context)
+        => context.Connection.RemoteIpAddress?.ToString() ?? Unknown;
+}

--- a/src/SqlOS/Security/SqlOSDistributedRateLimitStore.cs
+++ b/src/SqlOS/Security/SqlOSDistributedRateLimitStore.cs
@@ -1,0 +1,289 @@
+using System.Data;
+using System.Data.Common;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using SqlOS.AuthServer.Configuration;
+using SqlOS.AuthServer.Interfaces;
+
+namespace SqlOS.Security;
+
+internal sealed class SqlOSDistributedRateLimitStore : ISqlOSRateLimitStore
+{
+    private const int CleanupBatchSize = 100;
+    private static readonly TimeSpan StaleBucketRetention = TimeSpan.FromDays(1);
+    private readonly ISqlOSAuthServerDbContext _context;
+    private readonly string _schema;
+
+    public SqlOSDistributedRateLimitStore(
+        ISqlOSAuthServerDbContext context,
+        IOptions<SqlOSAuthServerOptions> options)
+    {
+        _context = context;
+        _schema = EscapeIdentifier(options.Value.Schema);
+    }
+
+    public async Task<SqlOSRateLimitBucketState> IncrementAsync(
+        string scope,
+        string key,
+        int lockThreshold,
+        TimeSpan window,
+        TimeSpan lockoutDuration,
+        DateTimeOffset now,
+        CancellationToken cancellationToken = default)
+    {
+        var sql = $"""
+            SET XACT_ABORT ON;
+            SET NOCOUNT ON;
+            BEGIN TRANSACTION;
+
+            DECLARE @applicationLockResult INT;
+            DECLARE @applicationLockResource NVARCHAR(255) =
+                N'SqlOS:rate-limit:' + CONVERT(NVARCHAR(64), HASHBYTES('SHA2_256', @scope + N':' + @key), 2);
+            EXEC @applicationLockResult = sys.sp_getapplock
+                @Resource = @applicationLockResource,
+                @LockMode = 'Exclusive',
+                @LockOwner = 'Transaction',
+                @LockTimeout = 10000;
+            IF @applicationLockResult < 0
+                THROW 51000, 'Unable to acquire the SqlOS rate-limit lock.', 1;
+
+            DELETE FROM [{_schema}].[SqlOSRateLimitBuckets]
+            WHERE [Scope] = @scope
+              AND [BucketKey] = @key
+              AND ([LockedUntil] IS NULL OR [LockedUntil] <= @now)
+              AND [WindowStartedAt] <= @windowStartedBefore;
+
+            IF EXISTS (
+                SELECT 1
+                FROM [{_schema}].[SqlOSRateLimitBuckets] WITH (UPDLOCK, HOLDLOCK)
+                WHERE [Scope] = @scope AND [BucketKey] = @key)
+            BEGIN
+                UPDATE [{_schema}].[SqlOSRateLimitBuckets]
+                SET
+                    [Count] = CASE WHEN [LockedUntil] IS NOT NULL AND [LockedUntil] > @now
+                        THEN [Count] ELSE [Count] + 1 END,
+                    [LockedUntil] = CASE
+                        WHEN [LockedUntil] IS NOT NULL AND [LockedUntil] > @now THEN [LockedUntil]
+                        WHEN [Count] + 1 >= @lockThreshold
+                            THEN @lockedUntil
+                        ELSE NULL
+                    END,
+                    [UpdatedAt] = @now
+                WHERE [Scope] = @scope AND [BucketKey] = @key;
+            END
+            ELSE
+            BEGIN
+                INSERT INTO [{_schema}].[SqlOSRateLimitBuckets]
+                    ([Scope], [BucketKey], [WindowStartedAt], [Count], [LockedUntil], [UpdatedAt])
+                VALUES
+                    (@scope, @key, @now, 1,
+                     CASE WHEN @lockThreshold <= 1
+                        THEN @lockedUntil
+                        ELSE NULL END,
+                     @now);
+            END
+
+            DELETE FROM [{_schema}].[SqlOSRateLimitBuckets]
+            WHERE [Scope] = @scope
+              AND [BucketKey] IN (
+                  SELECT TOP (@cleanupBatchSize) [BucketKey]
+                  FROM [{_schema}].[SqlOSRateLimitBuckets]
+                  WHERE [Scope] = @scope
+                    AND [UpdatedAt] < @staleBefore
+                    AND ([LockedUntil] IS NULL OR [LockedUntil] <= @now)
+                  ORDER BY [UpdatedAt])
+              AND [UpdatedAt] < @staleBefore
+              AND ([LockedUntil] IS NULL OR [LockedUntil] <= @now);
+
+            SELECT [Count], [LockedUntil]
+            FROM [{_schema}].[SqlOSRateLimitBuckets]
+            WHERE [Scope] = @scope AND [BucketKey] = @key;
+
+            COMMIT TRANSACTION;
+            """;
+
+        return await ExecuteStateAsync(
+            sql,
+            scope,
+            key,
+            lockThreshold,
+            window,
+            lockoutDuration,
+            now,
+            cancellationToken)
+            ?? throw new InvalidOperationException("SqlOS rate-limit state was not returned by SQL Server.");
+    }
+
+    public async Task<SqlOSRateLimitBucketState?> GetAsync(
+        string scope,
+        string key,
+        DateTimeOffset now,
+        TimeSpan window,
+        CancellationToken cancellationToken = default)
+    {
+        var sql = $"""
+            SET NOCOUNT ON;
+
+            DELETE FROM [{_schema}].[SqlOSRateLimitBuckets]
+            WHERE [Scope] = @scope
+              AND [BucketKey] = @key
+              AND ([LockedUntil] IS NULL OR [LockedUntil] <= @now)
+              AND [WindowStartedAt] <= @windowStartedBefore;
+
+            SELECT [Count], [LockedUntil]
+            FROM [{_schema}].[SqlOSRateLimitBuckets]
+            WHERE [Scope] = @scope AND [BucketKey] = @key;
+            """;
+
+        return await ExecuteStateAsync(
+            sql,
+            scope,
+            key,
+            lockThreshold: int.MaxValue,
+            window,
+            lockoutDuration: TimeSpan.Zero,
+            now,
+            cancellationToken,
+            allowMissing: true);
+    }
+
+    public Task DeleteAsync(
+        string scope,
+        string key,
+        CancellationToken cancellationToken = default)
+        => ExecuteNonQueryAsync(
+            $"DELETE FROM [{_schema}].[SqlOSRateLimitBuckets] WHERE [Scope] = @scope AND [BucketKey] = @key",
+            scope,
+            key,
+            now: null,
+            cancellationToken);
+
+    public Task DecrementAsync(
+        string scope,
+        string key,
+        DateTimeOffset now,
+        CancellationToken cancellationToken = default)
+        => ExecuteNonQueryAsync(
+            $"""
+            UPDATE [{_schema}].[SqlOSRateLimitBuckets]
+            SET [Count] = CASE WHEN [Count] > 0 THEN [Count] - 1 ELSE 0 END,
+                [UpdatedAt] = @now
+            WHERE [Scope] = @scope
+              AND [BucketKey] = @key
+              AND ([LockedUntil] IS NULL OR [LockedUntil] <= @now);
+
+            DELETE FROM [{_schema}].[SqlOSRateLimitBuckets]
+            WHERE [Scope] = @scope AND [BucketKey] = @key AND [Count] = 0;
+            """,
+            scope,
+            key,
+            now,
+            cancellationToken);
+
+    private async Task ExecuteNonQueryAsync(
+        string sql,
+        string scope,
+        string key,
+        DateTimeOffset? now,
+        CancellationToken cancellationToken)
+    {
+        var connection = _context.Database.GetDbConnection();
+        var wasOpen = connection.State == ConnectionState.Open;
+        if (!wasOpen)
+        {
+            await connection.OpenAsync(cancellationToken);
+        }
+
+        try
+        {
+            await using var command = connection.CreateCommand();
+            command.CommandText = sql;
+            AddParameter(command, "@scope", scope);
+            AddParameter(command, "@key", NormalizeKey(key));
+            if (now.HasValue)
+            {
+                AddParameter(command, "@now", now.Value.UtcDateTime);
+            }
+
+            await command.ExecuteNonQueryAsync(cancellationToken);
+        }
+        finally
+        {
+            if (!wasOpen)
+            {
+                await connection.CloseAsync();
+            }
+        }
+    }
+
+    private async Task<SqlOSRateLimitBucketState?> ExecuteStateAsync(
+        string sql,
+        string scope,
+        string key,
+        int lockThreshold,
+        TimeSpan window,
+        TimeSpan lockoutDuration,
+        DateTimeOffset now,
+        CancellationToken cancellationToken,
+        bool allowMissing = false)
+    {
+        var connection = _context.Database.GetDbConnection();
+        var wasOpen = connection.State == ConnectionState.Open;
+        if (!wasOpen)
+        {
+            await connection.OpenAsync(cancellationToken);
+        }
+
+        try
+        {
+            await using var command = connection.CreateCommand();
+            command.CommandText = sql;
+            AddParameter(command, "@scope", scope);
+            AddParameter(command, "@key", NormalizeKey(key));
+            AddParameter(command, "@lockThreshold", lockThreshold);
+            AddParameter(command, "@now", now.UtcDateTime);
+            AddParameter(command, "@windowStartedBefore", now.Subtract(window).UtcDateTime);
+            AddParameter(command, "@lockedUntil", now.Add(lockoutDuration).UtcDateTime);
+            AddParameter(command, "@cleanupBatchSize", CleanupBatchSize);
+            AddParameter(command, "@staleBefore", now.Subtract(StaleBucketRetention).UtcDateTime);
+
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+            if (!await reader.ReadAsync(cancellationToken))
+            {
+                if (allowMissing)
+                {
+                    return null;
+                }
+
+                throw new InvalidOperationException("SqlOS rate-limit state was not returned by SQL Server.");
+            }
+
+            return new SqlOSRateLimitBucketState(
+                reader.GetInt32(0),
+                reader.IsDBNull(1)
+                    ? null
+                    : new DateTimeOffset(DateTime.SpecifyKind(reader.GetDateTime(1), DateTimeKind.Utc)));
+        }
+        finally
+        {
+            if (!wasOpen)
+            {
+                await connection.CloseAsync();
+            }
+        }
+    }
+
+    private static void AddParameter(DbCommand command, string name, object value)
+    {
+        var parameter = command.CreateParameter();
+        parameter.ParameterName = name;
+        parameter.Value = value;
+        command.Parameters.Add(parameter);
+    }
+
+    private static string NormalizeKey(string key)
+        => key.Length <= 384 ? key : key[..384];
+
+    private static string EscapeIdentifier(string identifier)
+        => identifier.Replace("]", "]]", StringComparison.Ordinal);
+}

--- a/src/SqlOS/Security/SqlOSInMemoryRateLimitStore.cs
+++ b/src/SqlOS/Security/SqlOSInMemoryRateLimitStore.cs
@@ -1,0 +1,173 @@
+namespace SqlOS.Security;
+
+internal sealed class SqlOSInMemoryRateLimitStore : ISqlOSRateLimitStore
+{
+    internal const int MaximumBuckets = 4096;
+    private readonly object _sync = new();
+    private readonly Dictionary<(string Scope, string Key), Bucket> _buckets = [];
+
+    public Task<SqlOSRateLimitBucketState> IncrementAsync(
+        string scope,
+        string key,
+        int lockThreshold,
+        TimeSpan window,
+        TimeSpan lockoutDuration,
+        DateTimeOffset now,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        lock (_sync)
+        {
+            EvictExpired(now);
+            var bucketKey = (scope, key);
+            if (!_buckets.TryGetValue(bucketKey, out var bucket))
+            {
+                if (!EnsureCapacity(now))
+                {
+                    return Task.FromResult(new SqlOSRateLimitBucketState(
+                        lockThreshold,
+                        now.Add(lockoutDuration)));
+                }
+
+                bucket = new Bucket(now);
+                _buckets[bucketKey] = bucket;
+            }
+            else if (IsExpired(bucket, now, window))
+            {
+                bucket = new Bucket(now);
+                _buckets[bucketKey] = bucket;
+            }
+
+            if (bucket.LockedUntil is null || bucket.LockedUntil <= now)
+            {
+                bucket.Count++;
+                bucket.LockedUntil = bucket.Count >= lockThreshold
+                    ? now.Add(lockoutDuration)
+                    : null;
+            }
+
+            bucket.UpdatedAt = now;
+            return Task.FromResult(new SqlOSRateLimitBucketState(bucket.Count, bucket.LockedUntil));
+        }
+    }
+
+    public Task<SqlOSRateLimitBucketState?> GetAsync(
+        string scope,
+        string key,
+        DateTimeOffset now,
+        TimeSpan window,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        lock (_sync)
+        {
+            if (!_buckets.TryGetValue((scope, key), out var bucket))
+            {
+                return Task.FromResult<SqlOSRateLimitBucketState?>(null);
+            }
+
+            if (IsExpired(bucket, now, window))
+            {
+                _buckets.Remove((scope, key));
+                return Task.FromResult<SqlOSRateLimitBucketState?>(null);
+            }
+
+            return Task.FromResult<SqlOSRateLimitBucketState?>(
+                new SqlOSRateLimitBucketState(bucket.Count, bucket.LockedUntil));
+        }
+    }
+
+    public Task DeleteAsync(
+        string scope,
+        string key,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        lock (_sync)
+        {
+            _buckets.Remove((scope, key));
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task DecrementAsync(
+        string scope,
+        string key,
+        DateTimeOffset now,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        lock (_sync)
+        {
+            if (_buckets.TryGetValue((scope, key), out var bucket)
+                && (bucket.LockedUntil is null || bucket.LockedUntil <= now))
+            {
+                bucket.Count = Math.Max(0, bucket.Count - 1);
+                bucket.UpdatedAt = now;
+                if (bucket.Count == 0)
+                {
+                    _buckets.Remove((scope, key));
+                }
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    internal int BucketCount
+    {
+        get
+        {
+            lock (_sync)
+            {
+                return _buckets.Count;
+            }
+        }
+    }
+
+    private bool EnsureCapacity(DateTimeOffset now)
+    {
+        if (_buckets.Count < MaximumBuckets)
+        {
+            return true;
+        }
+
+        var evictable = _buckets
+            .Where(entry => entry.Value.LockedUntil is null || entry.Value.LockedUntil <= now);
+        if (!evictable.Any())
+        {
+            return false;
+        }
+
+        var oldest = evictable.MinBy(entry => entry.Value.UpdatedAt);
+        _buckets.Remove(oldest.Key);
+        return true;
+    }
+
+    private void EvictExpired(DateTimeOffset now)
+    {
+        var staleBefore = now.AddDays(-1);
+        foreach (var key in _buckets
+                     .Where(entry =>
+                         entry.Value.UpdatedAt < staleBefore
+                         && (entry.Value.LockedUntil is null || entry.Value.LockedUntil <= now))
+                     .Select(entry => entry.Key)
+                     .ToArray())
+        {
+            _buckets.Remove(key);
+        }
+    }
+
+    private static bool IsExpired(Bucket bucket, DateTimeOffset now, TimeSpan window)
+        => (bucket.LockedUntil is null || bucket.LockedUntil <= now)
+           && now - bucket.WindowStartedAt >= window;
+
+    private sealed class Bucket(DateTimeOffset now)
+    {
+        public DateTimeOffset WindowStartedAt { get; } = now;
+        public DateTimeOffset UpdatedAt { get; set; } = now;
+        public int Count { get; set; }
+        public DateTimeOffset? LockedUntil { get; set; }
+    }
+}

--- a/tests/SqlOS.IntegrationTests/DistributedRateLimitIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/DistributedRateLimitIntegrationTests.cs
@@ -1,0 +1,116 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SqlOS.AuthServer.Configuration;
+using SqlOS.AuthServer.Services;
+using SqlOS.Configuration;
+using SqlOS.Dashboard;
+using SqlOS.IntegrationTests.Infrastructure;
+using SqlOS.Security;
+
+namespace SqlOS.IntegrationTests;
+
+[TestClass]
+public class DistributedRateLimitIntegrationTests
+{
+    [TestMethod]
+    public async Task DcrLimit_IsSharedAcrossApplicationInstances()
+    {
+        var connectionString = GetConnectionString();
+        await using var firstContext = CreateContext(connectionString);
+        await using var secondContext = CreateContext(connectionString);
+        var options = Options.Create(new SqlOSAuthServerOptions());
+        var first = new SqlOSDynamicClientRegistrationRateLimiter(
+            new SqlOSDistributedRateLimitStore(firstContext, options));
+        var second = new SqlOSDynamicClientRegistrationRateLimiter(
+            new SqlOSDistributedRateLimitStore(secondContext, options));
+        var key = $"dcr-{Guid.NewGuid():N}";
+        var now = DateTimeOffset.UtcNow;
+        var start = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        async Task<IReadOnlyList<bool>> ConsumeAsync(SqlOSDynamicClientRegistrationRateLimiter limiter)
+        {
+            await start.Task;
+            var results = new List<bool>();
+            for (var i = 0; i < 5; i++)
+            {
+                results.Add(await limiter.TryConsumeAsync(
+                    key,
+                    TimeSpan.FromMinutes(5),
+                    maxRegistrations: 3,
+                    now.AddMilliseconds(i)));
+            }
+
+            return results;
+        }
+
+        var firstAttempts = ConsumeAsync(first);
+        var secondAttempts = ConsumeAsync(second);
+        start.SetResult();
+
+        var results = (await Task.WhenAll(firstAttempts, secondAttempts)).SelectMany(x => x);
+        results.Count(allowed => allowed).Should().Be(3);
+        results.Count(allowed => !allowed).Should().Be(7);
+    }
+
+    [TestMethod]
+    public async Task DashboardPerIpAndGlobalLockouts_AreSharedAcrossApplicationInstances()
+    {
+        var connectionString = GetConnectionString();
+        await using var firstContext = CreateContext(connectionString);
+        await using var secondContext = CreateContext(connectionString);
+        var authOptions = Options.Create(new SqlOSAuthServerOptions());
+        var firstStore = new SqlOSDistributedRateLimitStore(firstContext, authOptions);
+        var secondStore = new SqlOSDistributedRateLimitStore(secondContext, authOptions);
+        var first = new SqlOSDashboardLoginThrottlingService(firstStore);
+        var second = new SqlOSDashboardLoginThrottlingService(secondStore);
+        var options = new SqlOSDashboardLoginThrottlingOptions
+        {
+            MaxFailuresPerIp = 2,
+            MaxGlobalFailures = 3,
+            Window = TimeSpan.FromMinutes(5),
+            LockoutDuration = TimeSpan.FromMinutes(10)
+        };
+        var ip = $"ip-{Guid.NewGuid():N}";
+        var otherIp = $"ip-{Guid.NewGuid():N}";
+        var now = DateTimeOffset.UtcNow;
+
+        try
+        {
+            (await first.RecordFailureAsync(ip, options, now)).PerIpLocked.Should().BeFalse();
+            (await second.RecordFailureAsync(ip, options, now.AddSeconds(1))).PerIpLocked.Should().BeTrue();
+
+            var perIpRejection = await first.GetRejectionAsync(ip, options, now.AddSeconds(2));
+            perIpRejection.Should().NotBeNull();
+            perIpRejection!.Scope.Should().Be("ip");
+
+            var globalResult = await first.RecordFailureAsync(otherIp, options, now.AddSeconds(3));
+            globalResult.GlobalLocked.Should().BeTrue();
+            var globalRejection = await second.GetRejectionAsync(
+                $"ip-{Guid.NewGuid():N}",
+                options,
+                now.AddSeconds(4));
+            globalRejection.Should().NotBeNull();
+            globalRejection!.Scope.Should().Be("global");
+        }
+        finally
+        {
+            await firstStore.DeleteAsync("dashboard-ip", ip);
+            await firstStore.DeleteAsync("dashboard-ip", otherIp);
+            await firstStore.DeleteAsync("dashboard-global", "all");
+        }
+    }
+
+    private static string GetConnectionString()
+        => AspireFixture.SharedContext?.Database.GetConnectionString()
+           ?? throw new InvalidOperationException("The integration database has no connection string.");
+
+    private static TestSqlOSDbContext CreateContext(string connectionString)
+    {
+        var options = new DbContextOptionsBuilder<TestSqlOSDbContext>()
+            .UseSqlServer(connectionString)
+            .Options;
+        return new TestSqlOSDbContext(options);
+    }
+}

--- a/tests/SqlOS.IntegrationTests/SchemaInitializerIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/SchemaInitializerIntegrationTests.cs
@@ -14,7 +14,7 @@ namespace SqlOS.IntegrationTests;
 [TestClass]
 public sealed class SchemaInitializerIntegrationTests
 {
-    private const int CurrentSchemaVersion = 31;
+    private const int CurrentSchemaVersion = 32;
 
     [TestMethod]
     public async Task EnsureSchema_CreatesCoreTables()
@@ -50,6 +50,7 @@ public sealed class SchemaInitializerIntegrationTests
                      "SqlOSScimManagedGrants",
                      "SqlOSScimSyncEvents",
                      "SqlOSScimOperationCommits",
+                     "SqlOSRateLimitBuckets",
                      "SqlOSPhoneOtpChallenges",
                      "SqlOSCalendarConnections",
                      "SqlOSCalendarSyncStates",

--- a/tests/SqlOS.Tests/SqlOSDashboardAuthMiddlewareTests.cs
+++ b/tests/SqlOS.Tests/SqlOSDashboardAuthMiddlewareTests.cs
@@ -298,7 +298,6 @@ public sealed class SqlOSDashboardAuthMiddlewareTests
             dashboardOptions,
             scimEnabled,
             provider.GetRequiredService<SqlOSDashboardSessionService>(),
-            provider.GetRequiredService<SqlOSDashboardLoginThrottlingService>(),
             provider.GetRequiredService<IOptions<SqlOSOptions>>());
 
         return new DashboardMiddlewareHarness(provider, middleware);
@@ -370,7 +369,9 @@ public sealed class SqlOSDashboardAuthMiddlewareTests
                 context.Request.ContentType = "application/json";
             }
 
-            await _middleware.InvokeAsync(context);
+            await _middleware.InvokeAsync(
+                context,
+                scope.ServiceProvider.GetRequiredService<SqlOSDashboardLoginThrottlingService>());
 
             context.Response.Body.Position = 0;
             using var reader = new StreamReader(context.Response.Body, Encoding.UTF8);

--- a/tests/SqlOS.Tests/SqlOSInMemoryRateLimitStoreTests.cs
+++ b/tests/SqlOS.Tests/SqlOSInMemoryRateLimitStoreTests.cs
@@ -1,0 +1,61 @@
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SqlOS.Security;
+
+namespace SqlOS.Tests;
+
+[TestClass]
+public class SqlOSInMemoryRateLimitStoreTests
+{
+    [TestMethod]
+    public async Task Fallback_EvictsOldestBucketAndNeverExceedsBound()
+    {
+        var store = new SqlOSInMemoryRateLimitStore();
+        var now = DateTimeOffset.UtcNow;
+
+        for (var i = 0; i < SqlOSInMemoryRateLimitStore.MaximumBuckets + 50; i++)
+        {
+            await store.IncrementAsync(
+                "test",
+                $"client-{i}",
+                lockThreshold: 10,
+                window: TimeSpan.FromMinutes(5),
+                lockoutDuration: TimeSpan.FromMinutes(5),
+                now: now.AddMilliseconds(i));
+        }
+
+        store.BucketCount.Should().Be(SqlOSInMemoryRateLimitStore.MaximumBuckets);
+        (await store.GetAsync("test", "client-0", now.AddMinutes(1), TimeSpan.FromMinutes(5)))
+            .Should().BeNull();
+    }
+
+    [TestMethod]
+    public async Task Fallback_WhenAllBucketsAreActivelyLocked_FailsClosedWithoutEvictingThem()
+    {
+        var store = new SqlOSInMemoryRateLimitStore();
+        var now = DateTimeOffset.UtcNow;
+        for (var i = 0; i < SqlOSInMemoryRateLimitStore.MaximumBuckets; i++)
+        {
+            await store.IncrementAsync(
+                "test",
+                $"locked-{i}",
+                lockThreshold: 1,
+                window: TimeSpan.FromDays(2),
+                lockoutDuration: TimeSpan.FromDays(2),
+                now);
+        }
+
+        var overflow = await store.IncrementAsync(
+            "test",
+            "overflow",
+            lockThreshold: 2,
+            window: TimeSpan.FromMinutes(5),
+            lockoutDuration: TimeSpan.FromMinutes(5),
+            now);
+
+        overflow.LockedUntil.Should().BeAfter(now);
+        store.BucketCount.Should().Be(SqlOSInMemoryRateLimitStore.MaximumBuckets);
+        (await store.GetAsync("test", "locked-0", now, TimeSpan.FromDays(2)))
+            .Should().NotBeNull();
+    }
+}

--- a/tests/SqlOS.Tests/SqlOSPipelineStartupFilterTests.cs
+++ b/tests/SqlOS.Tests/SqlOSPipelineStartupFilterTests.cs
@@ -92,7 +92,7 @@ public sealed class SqlOSPipelineStartupFilterTests
     }
 
     [TestMethod]
-    public void Configure_PublicThrottleWithTrustAllForwarding_EmitsSafetyWarning()
+    public void Configure_PublicThrottleWithOnlyLoopbackForwardingTrust_EmitsSafetyWarning()
     {
         var options = new SqlOSOptions();
         options.Dashboard.AuthMode = SqlOSDashboardAuthMode.Password;
@@ -109,6 +109,7 @@ public sealed class SqlOSPipelineStartupFilterTests
             forwarded.ForwardedHeaders = ForwardedHeaders.XForwardedFor;
             forwarded.KnownProxies.Clear();
             forwarded.KnownNetworks.Clear();
+            forwarded.KnownProxies.Add(IPAddress.Loopback);
         });
 
         using var provider = services.BuildServiceProvider();
@@ -118,7 +119,7 @@ public sealed class SqlOSPipelineStartupFilterTests
         new SqlOSPipelineStartupFilter(logger).Configure(_ => { })(appBuilder);
 
         logger.Messages.Should().Contain(message =>
-            message.Contains("no KnownProxies or KnownNetworks", StringComparison.Ordinal)
+            message.Contains("no non-loopback KnownProxies or KnownNetworks", StringComparison.Ordinal)
             && message.Contains("rate-limit buckets", StringComparison.Ordinal));
     }
 

--- a/tests/SqlOS.Tests/SqlOSPipelineStartupFilterTests.cs
+++ b/tests/SqlOS.Tests/SqlOSPipelineStartupFilterTests.cs
@@ -56,6 +56,73 @@ public sealed class SqlOSPipelineStartupFilterTests
     }
 
     [TestMethod]
+    public async Task Configure_IgnoresForwardedClientIpFromUntrustedProxy()
+    {
+        var services = new ServiceCollection();
+        services.AddDataProtection();
+        services.AddLogging();
+        services.AddSingleton<IHostEnvironment>(new TestHostEnvironment());
+        services.AddSingleton(Options.Create(new SqlOSOptions()));
+        services.AddSingleton<SqlOSDashboardSessionService>();
+        services.AddSingleton<SqlOSDashboardLoginThrottlingService>();
+        services.Configure<ForwardedHeadersOptions>(options =>
+        {
+            options.ForwardedHeaders = ForwardedHeaders.XForwardedFor;
+            options.KnownProxies.Add(IPAddress.Parse("10.0.0.10"));
+        });
+
+        await using var provider = services.BuildServiceProvider();
+        var appBuilder = new ApplicationBuilder(provider);
+        IPAddress? observedClientIp = null;
+        var filter = new SqlOSPipelineStartupFilter(new RecordingLogger<SqlOSPipelineStartupFilter>());
+        filter.Configure(app => app.Run(context =>
+        {
+            observedClientIp = context.Connection.RemoteIpAddress;
+            return Task.CompletedTask;
+        }))(appBuilder);
+        var pipeline = appBuilder.Build();
+        var context = new DefaultHttpContext { RequestServices = provider };
+        context.Request.Path = "/health";
+        context.Connection.RemoteIpAddress = IPAddress.Parse("10.0.0.11");
+        context.Request.Headers["X-Forwarded-For"] = "203.0.113.42";
+
+        await pipeline(context);
+
+        observedClientIp.Should().Be(IPAddress.Parse("10.0.0.11"));
+    }
+
+    [TestMethod]
+    public void Configure_PublicThrottleWithTrustAllForwarding_EmitsSafetyWarning()
+    {
+        var options = new SqlOSOptions();
+        options.Dashboard.AuthMode = SqlOSDashboardAuthMode.Password;
+        options.Dashboard.Password = "test-password";
+        var services = new ServiceCollection();
+        services.AddDataProtection();
+        services.AddLogging();
+        services.AddSingleton<IHostEnvironment>(new TestHostEnvironment());
+        services.AddSingleton(Options.Create(options));
+        services.AddSingleton<SqlOSDashboardSessionService>();
+        services.AddSingleton<SqlOSDashboardLoginThrottlingService>();
+        services.Configure<ForwardedHeadersOptions>(forwarded =>
+        {
+            forwarded.ForwardedHeaders = ForwardedHeaders.XForwardedFor;
+            forwarded.KnownProxies.Clear();
+            forwarded.KnownNetworks.Clear();
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var appBuilder = new ApplicationBuilder(provider);
+        var logger = new RecordingLogger<SqlOSPipelineStartupFilter>();
+
+        new SqlOSPipelineStartupFilter(logger).Configure(_ => { })(appBuilder);
+
+        logger.Messages.Should().Contain(message =>
+            message.Contains("no KnownProxies or KnownNetworks", StringComparison.Ordinal)
+            && message.Contains("rate-limit buckets", StringComparison.Ordinal));
+    }
+
+    [TestMethod]
     public void Configure_DevelopmentOnlyDashboard_EmitsProductionSafetyWarning()
     {
         var services = new ServiceCollection();

--- a/web/content/docs/guides/production-readiness.mdx
+++ b/web/content/docs/guides/production-readiness.mdx
@@ -96,6 +96,10 @@ Use your platform's known proxy or network configuration instead of copying an â
 
 `AddSqlOS` installs a startup filter that runs the configured Forwarded Headers middleware before its dashboard middleware. That ordering makes dashboard login throttling and audit events use the trusted external client IP. Configure `ForwardedHeadersOptions` before building the app; you do not need a second `UseForwardedHeaders()` call solely for SqlOS.
 
+Dashboard password failures and dynamic client registrations use the existing SqlOS database for shared rate-limit buckets. Multiple application instances therefore enforce one per-client and global state without Redis, a cloud rate-limiting service, or another production dependency. The schema is created automatically with the other SqlOS tables and stale buckets are deleted in bounded batches. Directly constructing the limiter classes outside dependency injection uses a bounded in-memory fallback intended for isolated tests and custom hosts, not multi-instance production.
+
+When `X-Forwarded-For` processing is enabled for a password dashboard or DCR, SqlOS warns at startup if both `KnownProxies` and `KnownNetworks` are empty. Do not suppress that warning by trusting every source: either list the actual proxy boundary or disable forwarded client-address processing and use the direct connection address. Test both a trusted proxy request and a forged header from an untrusted address before deployment.
+
 ## 2. Protect the right routes
 
 Do not place a blanket edge-authentication rule on `/sqlos/*`. That also captures the OAuth server and hosted sign-in page, causing login redirects, discovery, callbacks, and token exchange to fail.

--- a/web/content/docs/guides/production-readiness.mdx
+++ b/web/content/docs/guides/production-readiness.mdx
@@ -98,7 +98,7 @@ Use your platform's known proxy or network configuration instead of copying an â
 
 Dashboard password failures and dynamic client registrations use the existing SqlOS database for shared rate-limit buckets. Multiple application instances therefore enforce one per-client and global state without Redis, a cloud rate-limiting service, or another production dependency. The schema is created automatically with the other SqlOS tables and stale buckets are deleted in bounded batches. Directly constructing the limiter classes outside dependency injection uses a bounded in-memory fallback intended for isolated tests and custom hosts, not multi-instance production.
 
-When `X-Forwarded-For` processing is enabled for a password dashboard or DCR, SqlOS warns at startup if both `KnownProxies` and `KnownNetworks` are empty. Do not suppress that warning by trusting every source: either list the actual proxy boundary or disable forwarded client-address processing and use the direct connection address. Test both a trusted proxy request and a forged header from an untrusted address before deployment.
+When `X-Forwarded-For` processing is enabled for a password dashboard or DCR, SqlOS warns at startup if `KnownProxies` and `KnownNetworks` are empty or contain only loopback defaults. Do not suppress that warning by trusting every source: either list the actual proxy boundary or disable forwarded client-address processing and use the direct connection address. A loopback sidecar can be intentional, so this remains an operational warning rather than a startup failure. Test both a trusted proxy request and a forged header from an untrusted address before deployment.
 
 ## 2. Protect the right routes
 


### PR DESCRIPTION
Closes #107

## Summary
- persist dashboard password and DCR rate-limit buckets in SqlOS SQL Server storage so all app instances enforce one state without Redis or cloud dependencies
- serialize bucket mutations with SQL application locks, opportunistically prune stale rows, and retain a bounded fail-closed in-memory fallback for direct/manual construction
- centralize trusted client IP use after Forwarded Headers middleware and warn on trust-all proxy configuration for public throttled surfaces
- add migration, real SQL multi-instance races, trusted/untrusted proxy tests, per-IP/global lockout coverage, fallback capacity tests, and production-readiness documentation

## Validation
- `./scripts/build.sh` (zero warnings)
- `./scripts/unit-tests.sh` (601 library + 2 example tests)
- `./scripts/integration-tests.sh` (164 library + 71 example + 15 Todo tests)
- `./scripts/docs-check.sh` (167 markdown files, compiled snippets, production site build)
