### PR TITLE
Trust upstream federation MFA only through explicit policy

### DIFF
--- a/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerModelConfiguration.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerModelConfiguration.cs
@@ -155,6 +155,7 @@ public static class SqlOSAuthServerModelConfiguration
             entity.ToTable("SqlOSSsoConnections", schema, t => t.ExcludeFromMigrations());
             entity.HasKey(x => x.Id);
             entity.Property(x => x.DisplayName).HasMaxLength(200);
+            entity.Property(x => x.AcceptedAuthnContextClassRefsJson).HasDefaultValue("[]");
             entity.HasOne(x => x.Organization)
                 .WithMany(x => x.SsoConnections)
                 .HasForeignKey(x => x.OrganizationId)
@@ -364,6 +365,8 @@ public static class SqlOSAuthServerModelConfiguration
             entity.Property(x => x.MicrosoftTenant).HasMaxLength(200);
             entity.Property(x => x.AppleTeamId).HasMaxLength(100);
             entity.Property(x => x.AppleKeyId).HasMaxLength(100);
+            entity.Property(x => x.AcceptedAmrValuesJson).HasDefaultValue("[]");
+            entity.Property(x => x.AcceptedAcrValuesJson).HasDefaultValue("[]");
         });
 
         modelBuilder.Entity<SqlOSExternalIdentity>(entity =>

--- a/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerSeedOptions.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerSeedOptions.cs
@@ -147,6 +147,9 @@ public sealed class SqlOSOidcConnectionSeedOptions
     public string? AppleKeyId { get; set; }
     public string? ApplePrivateKeyPem { get; set; }
     public string? LogoDataUrl { get; set; }
+    public bool TrustUpstreamMfa { get; set; }
+    public List<string> AcceptedAmrValues { get; } = [];
+    public List<string> AcceptedAcrValues { get; } = [];
 
     /// <summary>
     /// Whether the connection should be enabled when first seeded. After the connection exists,

--- a/src/SqlOS/AuthServer/Contracts/SqlOSContracts.cs
+++ b/src/SqlOS/AuthServer/Contracts/SqlOSContracts.cs
@@ -362,7 +362,9 @@ public sealed record SqlOSCreateSsoConnectionRequest(
     bool AutoLinkByEmail,
     string? EmailAttributeName,
     string? FirstNameAttributeName,
-    string? LastNameAttributeName);
+    string? LastNameAttributeName,
+    bool TrustUpstreamMfa = false,
+    List<string>? AcceptedAuthnContextClassRefs = null);
 
 public static class SqlOSScimGroupMappingMatchTypes
 {
@@ -448,7 +450,10 @@ public sealed record SqlOSCreateOidcConnectionRequest(
     string? AppleTeamId = null,
     string? AppleKeyId = null,
     string? ApplePrivateKeyPem = null,
-    string? LogoDataUrl = null);
+    string? LogoDataUrl = null,
+    bool TrustUpstreamMfa = false,
+    List<string>? AcceptedAmrValues = null,
+    List<string>? AcceptedAcrValues = null);
 
 public sealed record SqlOSUpdateOidcConnectionRequest(
     string DisplayName,
@@ -470,7 +475,10 @@ public sealed record SqlOSUpdateOidcConnectionRequest(
     string? AppleTeamId = null,
     string? AppleKeyId = null,
     string? ApplePrivateKeyPem = null,
-    string? LogoDataUrl = null);
+    string? LogoDataUrl = null,
+    bool TrustUpstreamMfa = false,
+    List<string>? AcceptedAmrValues = null,
+    List<string>? AcceptedAcrValues = null);
 
 public sealed record SqlOSAuthorizationUrlRequest(
     string ConnectionId,

--- a/src/SqlOS/AuthServer/Endpoints/AdminConfigurationEndpoints.cs
+++ b/src/SqlOS/AuthServer/Endpoints/AdminConfigurationEndpoints.cs
@@ -75,7 +75,10 @@ public static partial class EndpointRouteBuilderExtensions
                 request.AppleTeamId,
                 request.AppleKeyId,
                 request.ApplePrivateKeyPem,
-                request.LogoDataUrl), cancellationToken);
+                request.LogoDataUrl,
+                request.TrustUpstreamMfa,
+                request.AcceptedAmrValues,
+                request.AcceptedAcrValues), cancellationToken);
             return Results.Ok(ToOidcConnectionResponse(connection));
         });
 
@@ -111,7 +114,10 @@ public static partial class EndpointRouteBuilderExtensions
                 request.AppleTeamId,
                 request.AppleKeyId,
                 request.ApplePrivateKeyPem,
-                request.LogoDataUrl), cancellationToken);
+                request.LogoDataUrl,
+                request.TrustUpstreamMfa,
+                request.AcceptedAmrValues,
+                request.AcceptedAcrValues), cancellationToken);
             return Results.Ok(ToOidcConnectionResponse(connection));
         });
 
@@ -214,6 +220,9 @@ public static partial class EndpointRouteBuilderExtensions
                 connection.SingleSignOnUrl,
                 connection.AutoProvisionUsers,
                 connection.AutoLinkByEmail,
+                connection.TrustUpstreamMfa,
+                AcceptedAuthnContextClassRefs =
+                    SqlOSAdminService.DeserializeJsonList(connection.AcceptedAuthnContextClassRefsJson),
                 connection.CreatedAt,
                 connection.UpdatedAt
             });

--- a/src/SqlOS/AuthServer/Endpoints/EndpointContracts.cs
+++ b/src/SqlOS/AuthServer/Endpoints/EndpointContracts.cs
@@ -82,6 +82,9 @@ public static partial class EndpointRouteBuilderExtensions
         connection.UseUserInfo,
         connection.AppleTeamId,
         connection.AppleKeyId,
+        connection.TrustUpstreamMfa,
+        AcceptedAmrValues = SqlOSAdminService.DeserializeJsonList(connection.AcceptedAmrValuesJson),
+        AcceptedAcrValues = SqlOSAdminService.DeserializeJsonList(connection.AcceptedAcrValuesJson),
         connection.IsEnabled,
         connection.CreatedAt,
         connection.UpdatedAt
@@ -108,7 +111,10 @@ public static partial class EndpointRouteBuilderExtensions
         string? AppleTeamId,
         string? AppleKeyId,
         string? ApplePrivateKeyPem,
-        string? LogoDataUrl);
+        string? LogoDataUrl,
+        bool TrustUpstreamMfa = false,
+        List<string>? AcceptedAmrValues = null,
+        List<string>? AcceptedAcrValues = null);
 
     private sealed record UpdateOidcConnectionRequest(
         string DisplayName,
@@ -130,7 +136,10 @@ public static partial class EndpointRouteBuilderExtensions
         string? AppleTeamId,
         string? AppleKeyId,
         string? ApplePrivateKeyPem,
-        string? LogoDataUrl);
+        string? LogoDataUrl,
+        bool TrustUpstreamMfa = false,
+        List<string>? AcceptedAmrValues = null,
+        List<string>? AcceptedAcrValues = null);
 
     private sealed record ClientLifecycleRequest(string? Reason);
     private sealed record CreateScimConnectionDashboardRequest(string DisplayName, bool Enabled = true);

--- a/src/SqlOS/AuthServer/Models/SqlOSEntities.cs
+++ b/src/SqlOS/AuthServer/Models/SqlOSEntities.cs
@@ -166,6 +166,8 @@ public sealed class SqlOSSsoConnection
     public string LastNameAttributeName { get; set; } = "last_name";
     public bool AutoProvisionUsers { get; set; } = true;
     public bool AutoLinkByEmail { get; set; }
+    public bool TrustUpstreamMfa { get; set; }
+    public string AcceptedAuthnContextClassRefsJson { get; set; } = "[]";
     public DateTime CreatedAt { get; set; }
     public DateTime UpdatedAt { get; set; }
 
@@ -363,6 +365,9 @@ public sealed class SqlOSOidcConnection
     public string? AppleKeyId { get; set; }
     public string? ApplePrivateKeyEncrypted { get; set; }
     public bool IsEnabled { get; set; } = true;
+    public bool TrustUpstreamMfa { get; set; }
+    public string AcceptedAmrValuesJson { get; set; } = "[]";
+    public string AcceptedAcrValuesJson { get; set; } = "[]";
     public DateTime CreatedAt { get; set; }
     public DateTime UpdatedAt { get; set; }
 

--- a/src/SqlOS/AuthServer/Schema/033_UpstreamMfaTrust.sql
+++ b/src/SqlOS/AuthServer/Schema/033_UpstreamMfaTrust.sql
@@ -1,0 +1,39 @@
+IF OBJECT_ID(N'[{Schema}].[SqlOSSsoConnections]', N'U') IS NOT NULL
+    AND COL_LENGTH('[{Schema}].[SqlOSSsoConnections]', 'TrustUpstreamMfa') IS NULL
+BEGIN
+    ALTER TABLE [{Schema}].[SqlOSSsoConnections]
+        ADD [TrustUpstreamMfa] BIT NOT NULL
+            CONSTRAINT [DF_SqlOSSsoConnections_TrustUpstreamMfa] DEFAULT 0;
+END
+
+IF OBJECT_ID(N'[{Schema}].[SqlOSSsoConnections]', N'U') IS NOT NULL
+    AND COL_LENGTH('[{Schema}].[SqlOSSsoConnections]', 'AcceptedAuthnContextClassRefsJson') IS NULL
+BEGIN
+    ALTER TABLE [{Schema}].[SqlOSSsoConnections]
+        ADD [AcceptedAuthnContextClassRefsJson] NVARCHAR(MAX) NOT NULL
+            CONSTRAINT [DF_SqlOSSsoConnections_AcceptedAuthnContextClassRefsJson] DEFAULT N'[]';
+END
+
+IF OBJECT_ID(N'[{Schema}].[SqlOSAuthOidcConnections]', N'U') IS NOT NULL
+    AND COL_LENGTH('[{Schema}].[SqlOSAuthOidcConnections]', 'TrustUpstreamMfa') IS NULL
+BEGIN
+    ALTER TABLE [{Schema}].[SqlOSAuthOidcConnections]
+        ADD [TrustUpstreamMfa] BIT NOT NULL
+            CONSTRAINT [DF_SqlOSAuthOidcConnections_TrustUpstreamMfa] DEFAULT 0;
+END
+
+IF OBJECT_ID(N'[{Schema}].[SqlOSAuthOidcConnections]', N'U') IS NOT NULL
+    AND COL_LENGTH('[{Schema}].[SqlOSAuthOidcConnections]', 'AcceptedAmrValuesJson') IS NULL
+BEGIN
+    ALTER TABLE [{Schema}].[SqlOSAuthOidcConnections]
+        ADD [AcceptedAmrValuesJson] NVARCHAR(MAX) NOT NULL
+            CONSTRAINT [DF_SqlOSAuthOidcConnections_AcceptedAmrValuesJson] DEFAULT N'[]';
+END
+
+IF OBJECT_ID(N'[{Schema}].[SqlOSAuthOidcConnections]', N'U') IS NOT NULL
+    AND COL_LENGTH('[{Schema}].[SqlOSAuthOidcConnections]', 'AcceptedAcrValuesJson') IS NULL
+BEGIN
+    ALTER TABLE [{Schema}].[SqlOSAuthOidcConnections]
+        ADD [AcceptedAcrValuesJson] NVARCHAR(MAX) NOT NULL
+            CONSTRAINT [DF_SqlOSAuthOidcConnections_AcceptedAcrValuesJson] DEFAULT N'[]';
+END

--- a/src/SqlOS/AuthServer/Security/SqlOSUpstreamMfaTrust.cs
+++ b/src/SqlOS/AuthServer/Security/SqlOSUpstreamMfaTrust.cs
@@ -1,0 +1,161 @@
+using System.Security.Claims;
+using System.Text.Json;
+using SqlOS.AuthServer.Models;
+
+namespace SqlOS.AuthServer.Security;
+
+internal static class SqlOSUpstreamMfaTrust
+{
+    public const string AuthenticationMethod = "upstream_mfa";
+
+    public static SqlOSUpstreamMfaDecision EvaluateOidc(
+        SqlOSOidcConnection connection,
+        ClaimsPrincipal validatedIdToken)
+    {
+        var amr = ReadClaimValues(validatedIdToken, "amr");
+        var acr = ReadClaimValues(validatedIdToken, "acr");
+        var present = amr.Length > 0 || acr.Length > 0;
+        if (!connection.TrustUpstreamMfa)
+        {
+            return SqlOSUpstreamMfaDecision.NotAccepted(
+                present,
+                present ? "trust_disabled" : "evidence_missing",
+                amr,
+                acr);
+        }
+
+        var acceptedAmr = ParseConfiguredValues(connection.AcceptedAmrValuesJson);
+        var acceptedAcr = ParseConfiguredValues(connection.AcceptedAcrValuesJson);
+        var matchedAmr = amr.FirstOrDefault(value =>
+            acceptedAmr.Contains(value, StringComparer.OrdinalIgnoreCase));
+        if (matchedAmr != null)
+        {
+            return SqlOSUpstreamMfaDecision.AcceptedBy("amr", matchedAmr, amr, acr);
+        }
+
+        var matchedAcr = acr.FirstOrDefault(value =>
+            acceptedAcr.Contains(value, StringComparer.Ordinal));
+        return matchedAcr != null
+            ? SqlOSUpstreamMfaDecision.AcceptedBy("acr", matchedAcr, amr, acr)
+            : SqlOSUpstreamMfaDecision.NotAccepted(
+                present,
+                present ? "evidence_unrecognized" : "evidence_missing",
+                amr,
+                acr);
+    }
+
+    public static SqlOSUpstreamMfaDecision EvaluateSaml(
+        SqlOSSsoConnection connection,
+        IReadOnlyList<string> authnContextClassRefs)
+    {
+        var evidence = authnContextClassRefs
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .Select(static value => value.Trim())
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        if (!connection.TrustUpstreamMfa)
+        {
+            return SqlOSUpstreamMfaDecision.NotAccepted(
+                evidence.Length > 0,
+                evidence.Length > 0 ? "trust_disabled" : "evidence_missing",
+                samlAuthnContextClassRefs: evidence);
+        }
+
+        var accepted = ParseConfiguredValues(connection.AcceptedAuthnContextClassRefsJson);
+        var matched = evidence.FirstOrDefault(value => accepted.Contains(value, StringComparer.Ordinal));
+        return matched != null
+            ? SqlOSUpstreamMfaDecision.AcceptedBy(
+                "saml_authn_context",
+                matched,
+                samlAuthnContextClassRefs: evidence)
+            : SqlOSUpstreamMfaDecision.NotAccepted(
+                evidence.Length > 0,
+                evidence.Length > 0 ? "evidence_unrecognized" : "evidence_missing",
+                samlAuthnContextClassRefs: evidence);
+    }
+
+    private static string[] ReadClaimValues(ClaimsPrincipal principal, string type)
+        => principal.Claims
+            .Where(claim => string.Equals(claim.Type, type, StringComparison.Ordinal))
+            .SelectMany(claim => ExpandClaimValue(claim.Value))
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .Select(static value => value.Trim())
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+    private static IEnumerable<string> ExpandClaimValue(string value)
+    {
+        if (!value.TrimStart().StartsWith("[", StringComparison.Ordinal))
+        {
+            return [value];
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<string[]>(value) ?? [];
+        }
+        catch (JsonException)
+        {
+            return [value];
+        }
+    }
+
+    private static string[] ParseConfiguredValues(string json)
+    {
+        try
+        {
+            return (JsonSerializer.Deserialize<string[]>(json) ?? [])
+                .Where(static value => !string.IsNullOrWhiteSpace(value))
+                .Select(static value => value.Trim())
+                .Distinct(StringComparer.Ordinal)
+                .ToArray();
+        }
+        catch (JsonException)
+        {
+            return [];
+        }
+    }
+}
+
+internal sealed record SqlOSUpstreamMfaDecision(
+    bool EvidencePresent,
+    bool Accepted,
+    string Reason,
+    string? AcceptedClaim,
+    string? AcceptedValue,
+    IReadOnlyList<string> AmrValues,
+    IReadOnlyList<string> AcrValues,
+    IReadOnlyList<string> SamlAuthnContextClassRefs)
+{
+    public static SqlOSUpstreamMfaDecision AcceptedBy(
+        string claim,
+        string value,
+        IReadOnlyList<string>? amrValues = null,
+        IReadOnlyList<string>? acrValues = null,
+        IReadOnlyList<string>? samlAuthnContextClassRefs = null)
+        => new(
+            true,
+            true,
+            "accepted",
+            claim,
+            value,
+            amrValues ?? [],
+            acrValues ?? [],
+            samlAuthnContextClassRefs ?? []);
+
+    public static SqlOSUpstreamMfaDecision NotAccepted(
+        bool evidencePresent,
+        string reason,
+        IReadOnlyList<string>? amrValues = null,
+        IReadOnlyList<string>? acrValues = null,
+        IReadOnlyList<string>? samlAuthnContextClassRefs = null)
+        => new(
+            evidencePresent,
+            false,
+            reason,
+            null,
+            null,
+            amrValues ?? [],
+            acrValues ?? [],
+            samlAuthnContextClassRefs ?? []);
+}

--- a/src/SqlOS/AuthServer/Security/SqlOSUpstreamMfaTrust.cs
+++ b/src/SqlOS/AuthServer/Security/SqlOSUpstreamMfaTrust.cs
@@ -7,6 +7,8 @@ namespace SqlOS.AuthServer.Security;
 internal static class SqlOSUpstreamMfaTrust
 {
     public const string AuthenticationMethod = "upstream_mfa";
+    private const int MaxEvidenceValues = 32;
+    private const int MaxEvidenceValueLength = 500;
 
     public static SqlOSUpstreamMfaDecision EvaluateOidc(
         SqlOSOidcConnection connection,
@@ -14,74 +16,100 @@ internal static class SqlOSUpstreamMfaTrust
     {
         var amr = ReadClaimValues(validatedIdToken, "amr");
         var acr = ReadClaimValues(validatedIdToken, "acr");
-        var present = amr.Length > 0 || acr.Length > 0;
+        var present = amr.Values.Length > 0 || acr.Values.Length > 0 || amr.ExceededLimits || acr.ExceededLimits;
+        if (amr.ExceededLimits || acr.ExceededLimits)
+        {
+            return SqlOSUpstreamMfaDecision.NotAccepted(
+                present,
+                "evidence_limits_exceeded",
+                amr.Values,
+                acr.Values);
+        }
+
         if (!connection.TrustUpstreamMfa)
         {
             return SqlOSUpstreamMfaDecision.NotAccepted(
                 present,
                 present ? "trust_disabled" : "evidence_missing",
-                amr,
-                acr);
+                amr.Values,
+                acr.Values);
         }
 
         var acceptedAmr = ParseConfiguredValues(connection.AcceptedAmrValuesJson);
         var acceptedAcr = ParseConfiguredValues(connection.AcceptedAcrValuesJson);
-        var matchedAmr = amr.FirstOrDefault(value =>
+        var matchedAmr = amr.Values.FirstOrDefault(value =>
             acceptedAmr.Contains(value, StringComparer.OrdinalIgnoreCase));
         if (matchedAmr != null)
         {
-            return SqlOSUpstreamMfaDecision.AcceptedBy("amr", matchedAmr, amr, acr);
+            return SqlOSUpstreamMfaDecision.AcceptedBy("amr", matchedAmr, amr.Values, acr.Values);
         }
 
-        var matchedAcr = acr.FirstOrDefault(value =>
+        var matchedAcr = acr.Values.FirstOrDefault(value =>
             acceptedAcr.Contains(value, StringComparer.Ordinal));
         return matchedAcr != null
-            ? SqlOSUpstreamMfaDecision.AcceptedBy("acr", matchedAcr, amr, acr)
+            ? SqlOSUpstreamMfaDecision.AcceptedBy("acr", matchedAcr, amr.Values, acr.Values)
             : SqlOSUpstreamMfaDecision.NotAccepted(
                 present,
                 present ? "evidence_unrecognized" : "evidence_missing",
-                amr,
-                acr);
+                amr.Values,
+                acr.Values);
     }
 
     public static SqlOSUpstreamMfaDecision EvaluateSaml(
         SqlOSSsoConnection connection,
         IReadOnlyList<string> authnContextClassRefs)
     {
-        var evidence = authnContextClassRefs
-            .Where(static value => !string.IsNullOrWhiteSpace(value))
-            .Select(static value => value.Trim())
-            .Distinct(StringComparer.Ordinal)
-            .ToArray();
+        var evidence = NormalizeEvidence(authnContextClassRefs);
+        if (evidence.ExceededLimits)
+        {
+            return SqlOSUpstreamMfaDecision.NotAccepted(
+                true,
+                "evidence_limits_exceeded",
+                samlAuthnContextClassRefs: evidence.Values);
+        }
+
         if (!connection.TrustUpstreamMfa)
         {
             return SqlOSUpstreamMfaDecision.NotAccepted(
-                evidence.Length > 0,
-                evidence.Length > 0 ? "trust_disabled" : "evidence_missing",
-                samlAuthnContextClassRefs: evidence);
+                evidence.Values.Length > 0,
+                evidence.Values.Length > 0 ? "trust_disabled" : "evidence_missing",
+                samlAuthnContextClassRefs: evidence.Values);
         }
 
         var accepted = ParseConfiguredValues(connection.AcceptedAuthnContextClassRefsJson);
-        var matched = evidence.FirstOrDefault(value => accepted.Contains(value, StringComparer.Ordinal));
+        var matched = evidence.Values.FirstOrDefault(value => accepted.Contains(value, StringComparer.Ordinal));
         return matched != null
             ? SqlOSUpstreamMfaDecision.AcceptedBy(
                 "saml_authn_context",
                 matched,
-                samlAuthnContextClassRefs: evidence)
+                samlAuthnContextClassRefs: evidence.Values)
             : SqlOSUpstreamMfaDecision.NotAccepted(
-                evidence.Length > 0,
-                evidence.Length > 0 ? "evidence_unrecognized" : "evidence_missing",
-                samlAuthnContextClassRefs: evidence);
+                evidence.Values.Length > 0,
+                evidence.Values.Length > 0 ? "evidence_unrecognized" : "evidence_missing",
+                samlAuthnContextClassRefs: evidence.Values);
     }
 
-    private static string[] ReadClaimValues(ClaimsPrincipal principal, string type)
-        => principal.Claims
+    private static EvidenceValues ReadClaimValues(ClaimsPrincipal principal, string type)
+        => NormalizeEvidence(principal.Claims
             .Where(claim => string.Equals(claim.Type, type, StringComparison.Ordinal))
-            .SelectMany(claim => ExpandClaimValue(claim.Value))
+            .SelectMany(claim => ExpandClaimValue(claim.Value)));
+
+    private static EvidenceValues NormalizeEvidence(IEnumerable<string> source)
+    {
+        var values = source
             .Where(static value => !string.IsNullOrWhiteSpace(value))
             .Select(static value => value.Trim())
             .Distinct(StringComparer.Ordinal)
             .ToArray();
+        var exceededLimits = values.Length > MaxEvidenceValues
+            || values.Any(static value => value.Length > MaxEvidenceValueLength);
+        return new EvidenceValues(
+            values
+                .Where(static value => value.Length <= MaxEvidenceValueLength)
+                .Take(MaxEvidenceValues)
+                .ToArray(),
+            exceededLimits);
+    }
 
     private static IEnumerable<string> ExpandClaimValue(string value)
     {
@@ -115,6 +143,8 @@ internal static class SqlOSUpstreamMfaTrust
             return [];
         }
     }
+
+    private sealed record EvidenceValues(string[] Values, bool ExceededLimits);
 }
 
 internal sealed record SqlOSUpstreamMfaDecision(

--- a/src/SqlOS/AuthServer/Services/SqlOSAdminService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSAdminService.cs
@@ -275,6 +275,9 @@ public sealed partial class SqlOSAdminService
                     AppleTeamId = normalized.AppleTeamId,
                     AppleKeyId = normalized.AppleKeyId,
                     ApplePrivateKeyEncrypted = string.IsNullOrWhiteSpace(seed.ApplePrivateKeyPem) ? null : _cryptoService.ProtectSecret(NormalizePrivateKey(seed.ApplePrivateKeyPem)),
+                    TrustUpstreamMfa = seed.TrustUpstreamMfa,
+                    AcceptedAmrValuesJson = JsonSerializer.Serialize(NormalizeTrustValues(seed.AcceptedAmrValues)),
+                    AcceptedAcrValuesJson = JsonSerializer.Serialize(NormalizeTrustValues(seed.AcceptedAcrValues)),
                     IsEnabled = seed.IsEnabled,
                     CreatedAt = DateTime.UtcNow,
                     UpdatedAt = DateTime.UtcNow
@@ -304,6 +307,9 @@ public sealed partial class SqlOSAdminService
             existing.UseUserInfo = normalized.UseUserInfo;
             existing.AppleTeamId = normalized.AppleTeamId;
             existing.AppleKeyId = normalized.AppleKeyId;
+            existing.TrustUpstreamMfa = seed.TrustUpstreamMfa;
+            existing.AcceptedAmrValuesJson = JsonSerializer.Serialize(NormalizeTrustValues(seed.AcceptedAmrValues));
+            existing.AcceptedAcrValuesJson = JsonSerializer.Serialize(NormalizeTrustValues(seed.AcceptedAcrValues));
             existing.UpdatedAt = DateTime.UtcNow;
 
             // Only overwrite secrets when the seed supplies them, so config without a secret
@@ -550,6 +556,9 @@ public sealed partial class SqlOSAdminService
             AppleTeamId = normalized.AppleTeamId,
             AppleKeyId = normalized.AppleKeyId,
             ApplePrivateKeyEncrypted = string.IsNullOrWhiteSpace(request.ApplePrivateKeyPem) ? null : _cryptoService.ProtectSecret(NormalizePrivateKey(request.ApplePrivateKeyPem)),
+            TrustUpstreamMfa = request.TrustUpstreamMfa,
+            AcceptedAmrValuesJson = JsonSerializer.Serialize(NormalizeTrustValues(request.AcceptedAmrValues)),
+            AcceptedAcrValuesJson = JsonSerializer.Serialize(NormalizeTrustValues(request.AcceptedAcrValues)),
             IsEnabled = true,
             CreatedAt = DateTime.UtcNow,
             UpdatedAt = DateTime.UtcNow
@@ -610,6 +619,9 @@ public sealed partial class SqlOSAdminService
         connection.UseUserInfo = normalized.UseUserInfo;
         connection.AppleTeamId = normalized.AppleTeamId;
         connection.AppleKeyId = normalized.AppleKeyId;
+        connection.TrustUpstreamMfa = request.TrustUpstreamMfa;
+        connection.AcceptedAmrValuesJson = JsonSerializer.Serialize(NormalizeTrustValues(request.AcceptedAmrValues));
+        connection.AcceptedAcrValuesJson = JsonSerializer.Serialize(NormalizeTrustValues(request.AcceptedAcrValues));
         connection.UpdatedAt = DateTime.UtcNow;
 
         if (!string.IsNullOrWhiteSpace(request.ClientSecret))
@@ -652,6 +664,9 @@ public sealed partial class SqlOSAdminService
             X509CertificatePem = request.X509CertificatePem,
             AutoProvisionUsers = request.AutoProvisionUsers,
             AutoLinkByEmail = request.AutoLinkByEmail,
+            TrustUpstreamMfa = request.TrustUpstreamMfa,
+            AcceptedAuthnContextClassRefsJson = JsonSerializer.Serialize(
+                NormalizeTrustValues(request.AcceptedAuthnContextClassRefs)),
             EmailAttributeName = request.EmailAttributeName ?? "email",
             FirstNameAttributeName = request.FirstNameAttributeName ?? "first_name",
             LastNameAttributeName = request.LastNameAttributeName ?? "last_name",
@@ -2282,6 +2297,26 @@ public sealed partial class SqlOSAdminService
         {
             throw new InvalidOperationException("This social login connection requires a client secret.");
         }
+    }
+
+    private static List<string> NormalizeTrustValues(IEnumerable<string>? values)
+    {
+        var normalized = (values ?? [])
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .Select(static value => value.Trim())
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+        if (normalized.Count > 32)
+        {
+            throw new InvalidOperationException("Upstream MFA trust policies support at most 32 accepted values.");
+        }
+
+        if (normalized.Any(static value => value.Length > 500))
+        {
+            throw new InvalidOperationException("Upstream MFA trust policy values cannot exceed 500 characters.");
+        }
+
+        return normalized;
     }
 
     private static NormalizedOidcConfiguration NormalizeOidcConfiguration(

--- a/src/SqlOS/AuthServer/Services/SqlOSMfaPolicyService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSMfaPolicyService.cs
@@ -5,6 +5,7 @@ using SqlOS.AuthServer.Configuration;
 using SqlOS.AuthServer.Contracts;
 using SqlOS.AuthServer.Interfaces;
 using SqlOS.AuthServer.Models;
+using SqlOS.AuthServer.Security;
 
 namespace SqlOS.AuthServer.Services;
 
@@ -158,6 +159,7 @@ public sealed class SqlOSMfaPolicyService
 
             if (string.Equals(method, SqlOSMfaFactorTypes.Totp, StringComparison.OrdinalIgnoreCase)
                 || string.Equals(method, SqlOSMfaFactorTypes.RecoveryCode, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(method, SqlOSUpstreamMfaTrust.AuthenticationMethod, StringComparison.OrdinalIgnoreCase)
                 || string.Equals(method, "passkey", StringComparison.OrdinalIgnoreCase)
                 || string.Equals(method, "webauthn", StringComparison.OrdinalIgnoreCase))
             {

--- a/src/SqlOS/AuthServer/Services/SqlOSOidcAuthService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSOidcAuthService.cs
@@ -11,6 +11,7 @@ using Microsoft.IdentityModel.Tokens;
 using SqlOS.AuthServer.Contracts;
 using SqlOS.AuthServer.Interfaces;
 using SqlOS.AuthServer.Models;
+using SqlOS.AuthServer.Security;
 
 namespace SqlOS.AuthServer.Services;
 
@@ -164,9 +165,12 @@ public sealed class SqlOSOidcAuthService
             connection = await RequireEnabledConnectionAsync(request.ConnectionId, cancellationToken);
 
             var resolved = await ResolveConfigurationAsync(connection, cancellationToken);
-            var providerUser = resolved.Protocol == SqlOSSocialProviderProtocol.OAuthProfile
-                ? await CompleteOAuthProfileAuthorizationAsync(connection, resolved, request, cancellationToken)
+            var completed = resolved.Protocol == SqlOSSocialProviderProtocol.OAuthProfile
+                ? new CompletedProviderAuthorization(
+                    await CompleteOAuthProfileAuthorizationAsync(connection, resolved, request, cancellationToken),
+                    SqlOSUpstreamMfaDecision.NotAccepted(false, "evidence_missing"))
                 : await CompleteOidcAuthorizationAsync(connection, resolved, request, ipAddress, cancellationToken);
+            var providerUser = completed.User;
             var provisioned = await ResolveOrProvisionUserAsync(connection, resolved, providerUser, ipAddress, cancellationToken);
             var organizations = await _adminService.GetUserOrganizationsAsync(provisioned.User.Id, cancellationToken);
             var organizationId = organizations.Count == 1 ? organizations[0].Id : null;
@@ -179,6 +183,12 @@ public sealed class SqlOSOidcAuthService
                 SqlOSOidcProviderType.Custom => "oidc",
                 _ => "oidc"
             };
+            if (completed.UpstreamMfa.Accepted)
+            {
+                authMethod = SqlOSMfaPolicyService.AddAuthenticationMethod(
+                    authMethod,
+                    SqlOSUpstreamMfaTrust.AuthenticationMethod);
+            }
 
             await _adminService.RecordAuditAsync(
                 "user.login.oidc.success",
@@ -191,7 +201,17 @@ public sealed class SqlOSOidcAuthService
                 {
                     provider = connection.ProviderType.ToString(),
                     protocol = resolved.Protocol.ToString(),
-                    oidcConnectionId = connection.Id
+                    oidcConnectionId = connection.Id,
+                    upstreamMfa = new
+                    {
+                        completed.UpstreamMfa.EvidencePresent,
+                        completed.UpstreamMfa.Accepted,
+                        completed.UpstreamMfa.Reason,
+                        completed.UpstreamMfa.AcceptedClaim,
+                        completed.UpstreamMfa.AcceptedValue,
+                        completed.UpstreamMfa.AmrValues,
+                        completed.UpstreamMfa.AcrValues
+                    }
                 },
                 cancellationToken: cancellationToken);
 
@@ -226,7 +246,7 @@ public sealed class SqlOSOidcAuthService
         }
     }
 
-    private async Task<ProviderUser> CompleteOidcAuthorizationAsync(
+    private async Task<CompletedProviderAuthorization> CompleteOidcAuthorizationAsync(
         SqlOSOidcConnection connection,
         ResolvedOidcConfiguration resolved,
         SqlOSCompleteOidcAuthorizationRequest request,
@@ -240,7 +260,7 @@ public sealed class SqlOSOidcAuthService
         IReadOnlyDictionary<string, string>? userInfoClaims = resolved.UseUserInfo && !string.IsNullOrWhiteSpace(resolved.UserInfoEndpoint)
             ? await LoadUserInfoClaimsAsync(resolved.UserInfoEndpoint!, tokenPayload.AccessToken, cancellationToken)
             : null;
-        return await MapProviderUserAsync(
+        var providerUser = await MapProviderUserAsync(
             connection,
             resolved,
             idTokenPrincipal,
@@ -248,6 +268,9 @@ public sealed class SqlOSOidcAuthService
             request.UserPayloadJson,
             ipAddress,
             cancellationToken);
+        return new CompletedProviderAuthorization(
+            providerUser,
+            SqlOSUpstreamMfaTrust.EvaluateOidc(connection, idTokenPrincipal));
     }
 
     private async Task<ProviderUser> CompleteOAuthProfileAuthorizationAsync(
@@ -1263,6 +1286,10 @@ public sealed class SqlOSOidcAuthService
         bool EmailVerified,
         bool CanAutoLinkByEmail,
         string? EmailClaimSource = null);
+
+    private sealed record CompletedProviderAuthorization(
+        ProviderUser User,
+        SqlOSUpstreamMfaDecision UpstreamMfa);
 
     private sealed record ResolvedEmailClaims(string Email, bool EmailVerified, string Source);
 

--- a/src/SqlOS/AuthServer/Services/SqlOSSamlService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSSamlService.cs
@@ -14,6 +14,7 @@ using SqlOS.AuthServer.Configuration;
 using SqlOS.AuthServer.Contracts;
 using SqlOS.AuthServer.Interfaces;
 using SqlOS.AuthServer.Models;
+using SqlOS.AuthServer.Security;
 
 namespace SqlOS.AuthServer.Services;
 
@@ -161,7 +162,12 @@ public sealed class SqlOSSamlService
                 connection,
                 new SamlValidationContext(samlState.RequestId, samlState.AssertionConsumerServiceUrl, _adminService.GetServiceProviderEntityId()));
             await ConsumeReplayIdentifiersAsync(connection.Id, assertion, cancellationToken);
-            return await HandleAuthorizationRequestAcsAsync(connection, authorizationRequest, assertion.Principal, httpContext, cancellationToken);
+            return await HandleAuthorizationRequestAcsAsync(
+                connection,
+                authorizationRequest,
+                assertion,
+                httpContext,
+                cancellationToken);
         }
 
         throw new InvalidOperationException("SAML authorization request is invalid or expired.");
@@ -170,7 +176,7 @@ public sealed class SqlOSSamlService
     private async Task<string> HandleAuthorizationRequestAcsAsync(
         SqlOSSsoConnection connection,
         SqlOSAuthorizationRequest authorizationRequest,
-        SqlOSSamlPrincipal principal,
+        ValidatedSamlAssertion assertion,
         HttpContext? httpContext,
         CancellationToken cancellationToken)
     {
@@ -178,6 +184,16 @@ public sealed class SqlOSSamlService
         {
             throw new InvalidOperationException("Authorization request is no longer active.");
         }
+
+        var principal = assertion.Principal;
+        var upstreamMfa = SqlOSUpstreamMfaTrust.EvaluateSaml(
+            connection,
+            assertion.AuthnContextClassRefs);
+        var authenticationMethod = upstreamMfa.Accepted
+            ? SqlOSMfaPolicyService.AddAuthenticationMethod(
+                "saml",
+                SqlOSUpstreamMfaTrust.AuthenticationMethod)
+            : "saml";
 
         var hasAssertedEmail = principal.Attributes.TryGetValue(connection.EmailAttributeName, out var emailValue)
             && !string.IsNullOrWhiteSpace(emailValue);
@@ -189,6 +205,25 @@ public sealed class SqlOSSamlService
         var user = await ResolveUserAsync(connection, principal, email, hasAssertedEmail, organizationId, cancellationToken)
             ?? throw new InvalidOperationException("No user could be resolved from the SAML assertion.");
 
+        await _adminService.RecordAuditAsync(
+            "user.login.saml.assurance",
+            "sso_connection",
+            connection.Id,
+            userId: user.Id,
+            organizationId: organizationId,
+            data: new
+            {
+                connectionId = connection.Id,
+                assertionIssuer = principal.Issuer,
+                upstreamMfa.EvidencePresent,
+                upstreamMfa.Accepted,
+                upstreamMfa.Reason,
+                upstreamMfa.AcceptedClaim,
+                upstreamMfa.AcceptedValue,
+                upstreamMfa.SamlAuthnContextClassRefs
+            },
+            cancellationToken: cancellationToken);
+
         if (_authorizationServerService != null)
         {
             authorizationRequest.ResolvedConnectionId = connection.Id;
@@ -196,7 +231,7 @@ public sealed class SqlOSSamlService
                 authorizationRequest,
                 user,
                 organizationId,
-                "saml",
+                authenticationMethod,
                 httpContext ?? new DefaultHttpContext(),
                 cancellationToken);
         }
@@ -227,13 +262,13 @@ public sealed class SqlOSSamlService
             CodeHash = _cryptoService.HashToken(rawCode),
             CodeChallenge = authorizationRequest.CodeChallenge,
             CodeChallengeMethod = authorizationRequest.CodeChallengeMethod,
-            AuthenticationMethod = "saml",
+            AuthenticationMethod = authenticationMethod,
             CreatedAt = DateTime.UtcNow,
             ExpiresAt = DateTime.UtcNow.AddMinutes(5)
         });
 
         authorizationRequest.CompletedAt = DateTime.UtcNow;
-        authorizationRequest.ResolvedAuthMethod = "saml";
+        authorizationRequest.ResolvedAuthMethod = authenticationMethod;
         authorizationRequest.ResolvedOrganizationId = organizationId;
         authorizationRequest.ResolvedConnectionId = connection.Id;
         try
@@ -249,7 +284,13 @@ public sealed class SqlOSSamlService
             throw new InvalidOperationException("Authorization request is no longer active.", ex);
         }
 
-        await _adminService.RecordAuditAsync("user.login.saml", "user", user.Id, userId: user.Id, organizationId: organizationId, cancellationToken: cancellationToken);
+        await _adminService.RecordAuditAsync(
+            "user.login.saml",
+            "user",
+            user.Id,
+            userId: user.Id,
+            organizationId: organizationId,
+            cancellationToken: cancellationToken);
         var separator = authorizationRequest.RedirectUri.Contains('?', StringComparison.Ordinal) ? "&" : "?";
         return $"{authorizationRequest.RedirectUri}{separator}code={Uri.EscapeDataString(rawCode)}&state={Uri.EscapeDataString(authorizationRequest.State)}";
     }
@@ -359,11 +400,21 @@ public sealed class SqlOSSamlService
             }
         }
 
+        var authnContextClassRefs = assertionElement
+            .SelectNodes("saml:AuthnStatement/saml:AuthnContext/saml:AuthnContextClassRef", ns)?
+            .OfType<XmlNode>()
+            .Select(node => node.InnerText?.Trim())
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .Select(static value => value!)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray() ?? [];
+
         return new ValidatedSamlAssertion(
             new SqlOSSamlPrincipal(issuer, nameId, attributes),
             responseId,
             assertionId,
-            expiresAt + SamlClockSkew);
+            expiresAt + SamlClockSkew,
+            authnContextClassRefs);
     }
 
     private async Task ConsumeReplayIdentifiersAsync(
@@ -961,7 +1012,8 @@ public sealed class SqlOSSamlService
         SqlOSSamlPrincipal Principal,
         string ResponseId,
         string AssertionId,
-        DateTime ReplayExpiresAt);
+        DateTime ReplayExpiresAt,
+        IReadOnlyList<string> AuthnContextClassRefs);
 
     private static bool IsUniqueConstraintViolation(DbUpdateException exception)
         => exception.InnerException is SqlException { Number: 2601 or 2627 };

--- a/tests/SqlOS.IntegrationTests/Infrastructure/FakeOidcProviderHttpClientFactory.cs
+++ b/tests/SqlOS.IntegrationTests/Infrastructure/FakeOidcProviderHttpClientFactory.cs
@@ -58,7 +58,7 @@ internal sealed class FakeOidcProviderHttpClientFactory : IHttpClientFactory
                     access_token = $"{provider}|{code}",
                     token_type = "Bearer",
                     expires_in = 3600,
-                    id_token = CreateIdToken(provider, clientId, parsed.email, parsed.nonce, parsed.isVerified)
+                    id_token = CreateIdToken(provider, clientId, parsed.email, parsed.nonce, parsed.isVerified, parsed.mode)
                 });
             }
 
@@ -200,7 +200,13 @@ internal sealed class FakeOidcProviderHttpClientFactory : IHttpClientFactory
             return ("user@example.com", "user@example.com", "nonce", true, "success");
         }
 
-        private static string CreateIdToken(string provider, string clientId, string email, string nonce, bool isVerified)
+        private static string CreateIdToken(
+            string provider,
+            string clientId,
+            string email,
+            string nonce,
+            bool isVerified,
+            string mode)
         {
             var now = DateTime.UtcNow;
             var issuer = provider switch
@@ -245,6 +251,14 @@ internal sealed class FakeOidcProviderHttpClientFactory : IHttpClientFactory
                     new Claim("nonce", nonce)
                 ]
             };
+            if (string.Equals(mode, "amr-mfa", StringComparison.Ordinal))
+            {
+                claims = [.. claims, new Claim("amr", "pwd"), new Claim("amr", "mfa")];
+            }
+            else if (string.Equals(mode, "acr-loa2", StringComparison.Ordinal))
+            {
+                claims = [.. claims, new Claim("acr", "urn:example:loa:2")];
+            }
 
             var token = new JwtSecurityToken(
                 issuer: issuer,
@@ -254,7 +268,18 @@ internal sealed class FakeOidcProviderHttpClientFactory : IHttpClientFactory
                 expires: now.AddHours(1),
                 signingCredentials: new SigningCredentials(SigningKey, SecurityAlgorithms.RsaSha256));
             token.Header["kid"] = SigningKey.KeyId;
-            return new JwtSecurityTokenHandler().WriteToken(token);
+            var encoded = new JwtSecurityTokenHandler().WriteToken(token);
+            if (!string.Equals(mode, "tampered-amr", StringComparison.Ordinal))
+            {
+                return encoded;
+            }
+
+            var parts = encoded.Split('.');
+            var payload = JsonSerializer.Deserialize<Dictionary<string, object>>(
+                Base64UrlEncoder.DecodeBytes(parts[1]))!;
+            payload["amr"] = new[] { "pwd", "mfa" };
+            parts[1] = Base64UrlEncoder.Encode(JsonSerializer.SerializeToUtf8Bytes(payload));
+            return string.Join('.', parts);
         }
 
         private static object BuildJwk()

--- a/tests/SqlOS.IntegrationTests/OidcAuthIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/OidcAuthIntegrationTests.cs
@@ -1,4 +1,5 @@
 using System.Security.Cryptography;
+using System.IdentityModel.Tokens.Jwt;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -45,8 +46,13 @@ public sealed class OidcAuthIntegrationTests
             null,
             null,
             null,
-            customLogo));
+            LogoDataUrl: customLogo,
+            TrustUpstreamMfa: true,
+            AcceptedAmrValues: ["mfa"],
+            AcceptedAcrValues: ["urn:example:loa:2"]));
         connection.LogoDataUrl.Should().Be(customLogo);
+        connection.TrustUpstreamMfa.Should().BeTrue();
+        connection.AcceptedAmrValuesJson.Should().Contain("mfa");
 
         var updated = await admin.UpdateOidcConnectionAsync(connection.Id, new SqlOSUpdateOidcConnectionRequest(
             "Google Login",
@@ -67,11 +73,16 @@ public sealed class OidcAuthIntegrationTests
             null,
             null,
             null,
-            null));
+            LogoDataUrl: null,
+            TrustUpstreamMfa: false,
+            AcceptedAmrValues: [],
+            AcceptedAcrValues: []));
 
         updated.DisplayName.Should().Be("Google Login");
         updated.ClientId.Should().Be("google-client-updated");
         updated.LogoDataUrl.Should().BeNull();
+        updated.TrustUpstreamMfa.Should().BeFalse();
+        updated.AcceptedAmrValuesJson.Should().Be("[]");
 
         var disabled = await admin.SetOidcConnectionEnabledAsync(connection.Id, false);
         disabled.IsEnabled.Should().BeFalse();
@@ -147,6 +158,92 @@ public sealed class OidcAuthIntegrationTests
         tokens.RefreshToken.Should().NotBeNullOrWhiteSpace();
         postMembershipCompletion.OrganizationId.Should().Be(organization.Id);
         (await AspireFixture.SharedContext.Set<SqlOSExternalIdentity>().CountAsync(x => x.OidcConnectionId != null)).Should().Be(1);
+    }
+
+    [TestMethod]
+    public async Task TrustedOidcAmr_ProducesSessionAndTokenAssuranceWithoutLocalStepUp()
+    {
+        await ResetOidcStateAsync();
+
+        var options = Options.Create(AspireFixture.Options);
+        var crypto = new SqlOSCryptoService(
+            AspireFixture.SharedContext,
+            options,
+            AspireFixture.DataProtectionProvider);
+        var admin = new SqlOSAdminService(AspireFixture.SharedContext, options, crypto);
+        var emailSender = new TestAuthEmailSender();
+        var settings = new SqlOSSettingsService(AspireFixture.SharedContext, options, emailSender);
+        var emailOtp = new SqlOSEmailOtpService(
+            AspireFixture.SharedContext,
+            admin,
+            crypto,
+            settings,
+            emailSender,
+            options);
+        var auth = new SqlOSAuthService(
+            AspireFixture.SharedContext,
+            options,
+            admin,
+            crypto,
+            settings,
+            emailOtp);
+        var oidc = new SqlOSOidcAuthService(
+            AspireFixture.SharedContext,
+            admin,
+            crypto,
+            new FakeOidcProviderHttpClientFactory(),
+            NullLogger<SqlOSOidcAuthService>.Instance);
+        var client = await EnsureClientAsync(admin, "example-web-upstream-mfa");
+        var connection = await admin.CreateOidcConnectionAsync(new SqlOSCreateOidcConnectionRequest(
+            SqlOSOidcProviderType.Google,
+            "Google upstream MFA",
+            "google-client",
+            "google-secret",
+            ["https://app.example.local/callback/google"],
+            true,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null));
+        connection.TrustUpstreamMfa = true;
+        connection.AcceptedAmrValuesJson = """["mfa"]""";
+        await AspireFixture.SharedContext.SaveChangesAsync();
+
+        var completion = await oidc.CompleteAuthorizationAsync(
+            new SqlOSCompleteOidcAuthorizationRequest(
+                connection.Id,
+                client.ClientId,
+                "https://app.example.local/callback/google",
+                "amr-mfa:upstream-mfa@example.com:nonce-upstream-mfa",
+                "verifier",
+                "nonce-upstream-mfa",
+                null));
+        var user = await AspireFixture.SharedContext.Set<SqlOSUser>()
+            .SingleAsync(item => item.Id == completion.UserId);
+        var tokens = await auth.CreateSessionTokensForUserAsync(
+            user,
+            client,
+            completion.OrganizationId,
+            completion.AuthenticationMethod,
+            "integration-test",
+            "127.0.0.1");
+
+        completion.AuthenticationMethod.Should().Be("google+upstream_mfa");
+        var jwt = new JwtSecurityTokenHandler().ReadJwtToken(tokens.AccessToken);
+        jwt.Claims.Where(claim => claim.Type == "amr")
+            .Select(claim => claim.Value)
+            .Should().Contain(["google", "upstream_mfa"]);
+        (await crypto.ValidateAccessTokenAsync(tokens.AccessToken, client.Audience))
+            .Should().NotBeNull();
     }
 
     [TestMethod]

--- a/tests/SqlOS.IntegrationTests/SamlServiceIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/SamlServiceIntegrationTests.cs
@@ -22,6 +22,164 @@ namespace SqlOS.IntegrationTests;
 [TestClass]
 public sealed class SamlServiceIntegrationTests
 {
+    private const string TrustedSamlMfaContext =
+        "urn:oasis:names:tc:SAML:2.0:ac:classes:TimeSyncToken";
+
+    [TestMethod]
+    public async Task SamlAuthnContext_WithoutTrustPolicy_DoesNotSatisfyMfa()
+    {
+        var (_, admin, saml) = CreateSamlServices();
+        var organization = await admin.CreateOrganizationAsync(new SqlOSCreateOrganizationRequest(
+            $"SAML no trust {Guid.NewGuid():N}",
+            null));
+        var client = await CreateSamlClientAsync(admin, "mfa-no-trust");
+        using var rsa = RSA.Create(2048);
+        var certificateRequest = new CertificateRequest(
+            "CN=SqlOSSamlNoTrust",
+            rsa,
+            HashAlgorithmName.SHA256,
+            RSASignaturePadding.Pkcs1);
+        using var certificate = certificateRequest.CreateSelfSigned(
+            DateTimeOffset.UtcNow.AddDays(-1),
+            DateTimeOffset.UtcNow.AddDays(30));
+        var connection = await CreatePolicySamlConnectionAsync(
+            admin,
+            organization.Id,
+            certificate,
+            "mfa-no-trust",
+            autoProvisionUsers: true,
+            autoLinkByEmail: true);
+        var flow = await StartSamlRequestAsync(saml, connection.Id, client.ClientId);
+        var response = BuildSignedSamlResponse(
+            certificate,
+            connection.IdentityProviderEntityId,
+            $"mfa-no-trust-{Guid.NewGuid():N}@example.com",
+            "No",
+            "Trust",
+            flow,
+            authnContextClassRef: TrustedSamlMfaContext);
+
+        await saml.HandleAcsAsync(connection.Id, response, flow.RelayState, default);
+
+        var request = await AspireFixture.SharedContext.Set<SqlOSAuthorizationRequest>()
+            .AsNoTracking()
+            .SingleAsync(item => item.Id == flow.RelayState);
+        request.ResolvedAuthMethod.Should().Be("saml");
+    }
+
+    [TestMethod]
+    public async Task SamlTrustedAuthnContext_SatisfiesMfaAndIsAudited()
+    {
+        var (_, admin, saml) = CreateSamlServices();
+        var organization = await admin.CreateOrganizationAsync(new SqlOSCreateOrganizationRequest(
+            $"SAML trusted {Guid.NewGuid():N}",
+            null));
+        var client = await CreateSamlClientAsync(admin, "mfa-trusted");
+        using var rsa = RSA.Create(2048);
+        var certificateRequest = new CertificateRequest(
+            "CN=SqlOSSamlTrusted",
+            rsa,
+            HashAlgorithmName.SHA256,
+            RSASignaturePadding.Pkcs1);
+        using var certificate = certificateRequest.CreateSelfSigned(
+            DateTimeOffset.UtcNow.AddDays(-1),
+            DateTimeOffset.UtcNow.AddDays(30));
+        var connection = await CreatePolicySamlConnectionAsync(
+            admin,
+            organization.Id,
+            certificate,
+            "mfa-trusted",
+            autoProvisionUsers: true,
+            autoLinkByEmail: true,
+            trustUpstreamMfa: true,
+            acceptedAuthnContextClassRefs: [TrustedSamlMfaContext]);
+        var flow = await StartSamlRequestAsync(saml, connection.Id, client.ClientId);
+        var response = BuildSignedSamlResponse(
+            certificate,
+            connection.IdentityProviderEntityId,
+            $"mfa-trusted-{Guid.NewGuid():N}@example.com",
+            "Trusted",
+            "MFA",
+            flow,
+            authnContextClassRef: TrustedSamlMfaContext);
+
+        await saml.HandleAcsAsync(connection.Id, response, flow.RelayState, default);
+
+        var request = await AspireFixture.SharedContext.Set<SqlOSAuthorizationRequest>()
+            .AsNoTracking()
+            .SingleAsync(item => item.Id == flow.RelayState);
+        request.ResolvedAuthMethod.Should().Be("saml+upstream_mfa");
+        var audit = await AspireFixture.SharedContext.Set<SqlOSAuditEvent>()
+            .AsNoTracking()
+            .OrderByDescending(item => item.OccurredAt)
+            .FirstAsync(item => item.EventType == "user.login.saml.assurance"
+                && item.DataJson != null
+                && item.DataJson.Contains(connection.Id));
+        audit.DataJson.Should().Contain("\"Accepted\":true");
+        audit.DataJson.Should().Contain(TrustedSamlMfaContext);
+    }
+
+    [TestMethod]
+    public async Task SamlTamperedAuthnContext_IsRejectedBeforeTrustEvaluation()
+    {
+        var (_, admin, saml) = CreateSamlServices();
+        var organization = await admin.CreateOrganizationAsync(new SqlOSCreateOrganizationRequest(
+            $"SAML tampered {Guid.NewGuid():N}",
+            null));
+        var client = await CreateSamlClientAsync(admin, "mfa-tampered");
+        using var rsa = RSA.Create(2048);
+        var certificateRequest = new CertificateRequest(
+            "CN=SqlOSSamlTampered",
+            rsa,
+            HashAlgorithmName.SHA256,
+            RSASignaturePadding.Pkcs1);
+        using var certificate = certificateRequest.CreateSelfSigned(
+            DateTimeOffset.UtcNow.AddDays(-1),
+            DateTimeOffset.UtcNow.AddDays(30));
+        var connection = await CreatePolicySamlConnectionAsync(
+            admin,
+            organization.Id,
+            certificate,
+            "mfa-tampered",
+            autoProvisionUsers: true,
+            autoLinkByEmail: true,
+            trustUpstreamMfa: true,
+            acceptedAuthnContextClassRefs: [TrustedSamlMfaContext]);
+        var flow = await StartSamlRequestAsync(saml, connection.Id, client.ClientId);
+        var response = BuildSignedSamlResponse(
+            certificate,
+            connection.IdentityProviderEntityId,
+            $"mfa-tampered-{Guid.NewGuid():N}@example.com",
+            "Tampered",
+            "MFA",
+            flow,
+            mutateAfterSigning: (_, responseElement) =>
+            {
+                var authnContext = responseElement
+                    .GetElementsByTagName(
+                        "AuthnContextClassRef",
+                        "urn:oasis:names:tc:SAML:2.0:assertion")
+                    .OfType<XmlElement>()
+                    .Single();
+                authnContext.InnerText = TrustedSamlMfaContext;
+            },
+            authnContextClassRef:
+                "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport");
+
+        var action = () => saml.HandleAcsAsync(
+            connection.Id,
+            response,
+            flow.RelayState,
+            default);
+
+        await action.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*signature*");
+        (await AspireFixture.SharedContext.Set<SqlOSAuthorizationRequest>()
+            .AsNoTracking()
+            .SingleAsync(item => item.Id == flow.RelayState))
+            .ResolvedAuthMethod.Should().BeNull();
+    }
+
     [TestMethod]
     public async Task InactiveUser_OidcAndSamlLogin_IsRejected()
     {
@@ -1448,7 +1606,9 @@ public sealed class SamlServiceIntegrationTests
         X509Certificate2 certificate,
         string prefix,
         bool autoProvisionUsers,
-        bool autoLinkByEmail)
+        bool autoLinkByEmail,
+        bool trustUpstreamMfa = false,
+        List<string>? acceptedAuthnContextClassRefs = null)
     {
         var suffix = Guid.NewGuid().ToString("N");
         return await admin.CreateSsoConnectionAsync(new SqlOSCreateSsoConnectionRequest(
@@ -1461,7 +1621,9 @@ public sealed class SamlServiceIntegrationTests
             AutoLinkByEmail: autoLinkByEmail,
             "email",
             "first_name",
-            "last_name"));
+            "last_name",
+            trustUpstreamMfa,
+            acceptedAuthnContextClassRefs));
     }
 
     private static void RemoveEmailAttributeBeforeSigning(
@@ -1494,7 +1656,8 @@ public sealed class SamlServiceIntegrationTests
         string? responseId = null,
         string? assertionId = null,
         Action<XmlDocument, XmlElement, XmlElement>? mutateBeforeSigning = null,
-        Action<XmlDocument, XmlElement>? mutateAfterSigning = null)
+        Action<XmlDocument, XmlElement>? mutateAfterSigning = null,
+        string? authnContextClassRef = null)
     {
         responseId ??= $"_{Guid.NewGuid():N}";
         assertionId ??= $"_{Guid.NewGuid():N}";
@@ -1511,6 +1674,15 @@ public sealed class SamlServiceIntegrationTests
                 </saml:Conditions>
             """
             : string.Empty;
+        var authnStatementXml = string.IsNullOrWhiteSpace(authnContextClassRef)
+            ? string.Empty
+            : $"""
+                <saml:AuthnStatement AuthnInstant="{issueInstant}">
+                  <saml:AuthnContext>
+                    <saml:AuthnContextClassRef>{SecurityElement.Escape(authnContextClassRef)}</saml:AuthnContextClassRef>
+                  </saml:AuthnContext>
+                </saml:AuthnStatement>
+            """;
         var xml = $"""
         <samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="{responseId}" Version="2.0" IssueInstant="{issueInstant}" Destination="{effectiveRecipient}" InResponseTo="{effectiveInResponseTo}">
           <saml:Issuer>{SecurityElement.Escape(issuer)}</saml:Issuer>
@@ -1524,6 +1696,7 @@ public sealed class SamlServiceIntegrationTests
               </saml:SubjectConfirmation>
             </saml:Subject>
             {conditionsXml}
+            {authnStatementXml}
             <saml:AttributeStatement>
               <saml:Attribute Name="email"><saml:AttributeValue>{SecurityElement.Escape(email)}</saml:AttributeValue></saml:Attribute>
               <saml:Attribute Name="first_name"><saml:AttributeValue>{SecurityElement.Escape(firstName)}</saml:AttributeValue></saml:Attribute>

--- a/tests/SqlOS.IntegrationTests/SchemaInitializerIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/SchemaInitializerIntegrationTests.cs
@@ -14,7 +14,7 @@ namespace SqlOS.IntegrationTests;
 [TestClass]
 public sealed class SchemaInitializerIntegrationTests
 {
-    private const int CurrentSchemaVersion = 32;
+    private const int CurrentSchemaVersion = 33;
 
     [TestMethod]
     public async Task EnsureSchema_CreatesCoreTables()
@@ -61,6 +61,16 @@ public sealed class SchemaInitializerIntegrationTests
         {
             Assert.IsTrue(await TableExistsAsync(table), $"Table {table} should exist.");
         }
+
+        Assert.IsTrue(await ColumnExistsAsync(
+            "SqlOSSsoConnections",
+            "AcceptedAuthnContextClassRefsJson"));
+        Assert.IsTrue(await ColumnExistsAsync(
+            "SqlOSAuthOidcConnections",
+            "AcceptedAmrValuesJson"));
+        Assert.IsTrue(await ColumnExistsAsync(
+            "SqlOSAuthOidcConnections",
+            "AcceptedAcrValuesJson"));
     }
 
     [TestMethod]

--- a/tests/SqlOS.Tests/Infrastructure/FakeOidcProviderHttpClientFactory.cs
+++ b/tests/SqlOS.Tests/Infrastructure/FakeOidcProviderHttpClientFactory.cs
@@ -95,7 +95,7 @@ internal sealed class FakeOidcProviderHttpClientFactory : IHttpClientFactory
                     access_token = $"{provider}|{code}",
                     token_type = "Bearer",
                     expires_in = 3600,
-                    id_token = CreateIdToken(provider, clientId, parsed.email, parsed.nonce, parsed.isVerified)
+                    id_token = CreateIdToken(provider, clientId, parsed.email, parsed.nonce, parsed.isVerified, parsed.mode)
                 });
             }
 
@@ -272,7 +272,13 @@ internal sealed class FakeOidcProviderHttpClientFactory : IHttpClientFactory
             return ("user@example.com", "user@example.com", "nonce", true, "success");
         }
 
-        private static string CreateIdToken(string provider, string clientId, string email, string nonce, bool isVerified)
+        private static string CreateIdToken(
+            string provider,
+            string clientId,
+            string email,
+            string nonce,
+            bool isVerified,
+            string mode)
         {
             var now = DateTime.UtcNow;
             var issuer = provider switch
@@ -317,6 +323,14 @@ internal sealed class FakeOidcProviderHttpClientFactory : IHttpClientFactory
                     new Claim("nonce", nonce)
                 ]
             };
+            if (string.Equals(mode, "amr-mfa", StringComparison.Ordinal))
+            {
+                claims = [.. claims, new Claim("amr", "pwd"), new Claim("amr", "mfa")];
+            }
+            else if (string.Equals(mode, "acr-loa2", StringComparison.Ordinal))
+            {
+                claims = [.. claims, new Claim("acr", "urn:example:loa:2")];
+            }
 
             var token = new JwtSecurityToken(
                 issuer: issuer,
@@ -326,7 +340,18 @@ internal sealed class FakeOidcProviderHttpClientFactory : IHttpClientFactory
                 expires: now.AddHours(1),
                 signingCredentials: new SigningCredentials(SigningKey, SecurityAlgorithms.RsaSha256));
             token.Header["kid"] = SigningKey.KeyId;
-            return new JwtSecurityTokenHandler().WriteToken(token);
+            var encoded = new JwtSecurityTokenHandler().WriteToken(token);
+            if (!string.Equals(mode, "tampered-amr", StringComparison.Ordinal))
+            {
+                return encoded;
+            }
+
+            var parts = encoded.Split('.');
+            var payload = JsonSerializer.Deserialize<Dictionary<string, object>>(
+                Base64UrlEncoder.DecodeBytes(parts[1]))!;
+            payload["amr"] = new[] { "pwd", "mfa" };
+            parts[1] = Base64UrlEncoder.Encode(JsonSerializer.SerializeToUtf8Bytes(payload));
+            return string.Join('.', parts);
         }
 
         private static object BuildJwk()

--- a/tests/SqlOS.Tests/SqlOSOidcAuthServiceTests.cs
+++ b/tests/SqlOS.Tests/SqlOSOidcAuthServiceTests.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.DataProtection;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Net;
 using System.Security.Cryptography;
@@ -18,6 +19,101 @@ namespace SqlOS.Tests;
 [TestClass]
 public sealed class SqlOSOidcAuthServiceTests
 {
+    [TestMethod]
+    public async Task CompleteAuthorization_AmrMfaWithoutTrustPolicy_DoesNotSatisfyMfa()
+    {
+        using var context = CreateContext();
+        var (admin, oidc) = CreateServices(context);
+        const string callbackUri = "https://app.example.local/callback/google";
+        await admin.CreateClientAsync(new SqlOSCreateClientRequest(
+            "example-web",
+            "Example Web",
+            "sqlos-example",
+            [callbackUri]));
+        var connection = await CreateGoogleConnectionAsync(admin, callbackUri);
+
+        var result = await oidc.CompleteAuthorizationAsync(new SqlOSCompleteOidcAuthorizationRequest(
+            connection.Id,
+            "example-web",
+            "https://app.example.local/callback/google",
+            "amr-mfa:no-trust@example.com:nonce-no-trust",
+            "verifier",
+            "nonce-no-trust",
+            null));
+
+        result.AuthenticationMethod.Should().Be("google");
+        var audit = await context.Set<SqlOSAuditEvent>()
+            .OrderByDescending(item => item.OccurredAt)
+            .FirstAsync(item => item.EventType == "user.login.oidc.success");
+        audit.DataJson.Should().Contain("\"EvidencePresent\":true");
+        audit.DataJson.Should().Contain("\"Accepted\":false");
+        audit.DataJson.Should().Contain("trust_disabled");
+    }
+
+    [TestMethod]
+    public async Task CompleteAuthorization_TrustedAmrMfa_AddsAssuranceMethod()
+    {
+        using var context = CreateContext();
+        var (admin, oidc) = CreateServices(context);
+        const string callbackUri = "https://app.example.local/callback/google";
+        await admin.CreateClientAsync(new SqlOSCreateClientRequest(
+            "example-web",
+            "Example Web",
+            "sqlos-example",
+            [callbackUri]));
+        var connection = await CreateGoogleConnectionAsync(admin, callbackUri);
+        connection.TrustUpstreamMfa = true;
+        connection.AcceptedAmrValuesJson = """["mfa"]""";
+        await context.SaveChangesAsync();
+
+        var result = await oidc.CompleteAuthorizationAsync(new SqlOSCompleteOidcAuthorizationRequest(
+            connection.Id,
+            "example-web",
+            "https://app.example.local/callback/google",
+            "amr-mfa:trusted@example.com:nonce-trusted",
+            "verifier",
+            "nonce-trusted",
+            null));
+
+        result.AuthenticationMethod.Should().Be("google+upstream_mfa");
+        var audit = await context.Set<SqlOSAuditEvent>()
+            .OrderByDescending(item => item.OccurredAt)
+            .FirstAsync(item => item.EventType == "user.login.oidc.success");
+        audit.DataJson.Should().Contain("\"Accepted\":true");
+        audit.DataJson.Should().Contain("\"AcceptedClaim\":\"amr\"");
+    }
+
+    [TestMethod]
+    public async Task CompleteAuthorization_TamperedAmrClaim_IsRejectedBeforeTrustEvaluation()
+    {
+        using var context = CreateContext();
+        var (admin, oidc) = CreateServices(context);
+        const string callbackUri = "https://app.example.local/callback/google";
+        await admin.CreateClientAsync(new SqlOSCreateClientRequest(
+            "example-web",
+            "Example Web",
+            "sqlos-example",
+            [callbackUri]));
+        var connection = await CreateGoogleConnectionAsync(admin, callbackUri);
+        connection.TrustUpstreamMfa = true;
+        connection.AcceptedAmrValuesJson = """["mfa"]""";
+        await context.SaveChangesAsync();
+
+        var action = () => oidc.CompleteAuthorizationAsync(
+            new SqlOSCompleteOidcAuthorizationRequest(
+                connection.Id,
+                "example-web",
+                callbackUri,
+                "tampered-amr:tampered@example.com:nonce-tampered",
+                "verifier",
+                "nonce-tampered",
+                null));
+
+        await action.Should().ThrowAsync<SecurityTokenInvalidSignatureException>();
+        (await context.Set<SqlOSAuditEvent>().AnyAsync(item =>
+            item.EventType == "user.login.oidc.success")).Should().BeFalse();
+    }
+
     [TestMethod]
     public async Task CompleteAuthorization_InactiveMappedUser_IsRejectedWithoutIdentityReuse()
     {
@@ -1035,6 +1131,7 @@ public sealed class SqlOSOidcAuthServiceTests
             .Options;
         return new TestSqlOSInMemoryDbContext(options);
     }
+
 
     private static readonly Lazy<string> TestApplePrivateKeyPem = new(() =>
     {

--- a/tests/SqlOS.Tests/SqlOSUpstreamMfaTrustTests.cs
+++ b/tests/SqlOS.Tests/SqlOSUpstreamMfaTrustTests.cs
@@ -1,0 +1,113 @@
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SqlOS.AuthServer.Configuration;
+using SqlOS.AuthServer.Models;
+using SqlOS.AuthServer.Security;
+using SqlOS.AuthServer.Services;
+
+namespace SqlOS.Tests;
+
+[TestClass]
+public class SqlOSUpstreamMfaTrustTests
+{
+    [TestMethod]
+    public void OidcMfaClaim_WithoutExplicitTrust_IsNotAccepted()
+    {
+        var connection = new SqlOSOidcConnection
+        {
+            TrustUpstreamMfa = false,
+            AcceptedAmrValuesJson = """["mfa"]"""
+        };
+        var principal = Principal(new Claim("amr", "mfa"));
+
+        var decision = SqlOSUpstreamMfaTrust.EvaluateOidc(connection, principal);
+
+        decision.EvidencePresent.Should().BeTrue();
+        decision.Accepted.Should().BeFalse();
+        decision.Reason.Should().Be("trust_disabled");
+    }
+
+    [TestMethod]
+    public void OidcTrustedAmrArray_IsAcceptedAndSatisfiesStrongMfa()
+    {
+        var connection = new SqlOSOidcConnection
+        {
+            TrustUpstreamMfa = true,
+            AcceptedAmrValuesJson = """["mfa"]"""
+        };
+        var principal = Principal(new Claim("amr", """["pwd","mfa"]"""));
+
+        var decision = SqlOSUpstreamMfaTrust.EvaluateOidc(connection, principal);
+        var policy = new SqlOSMfaPolicyService(Options.Create(new SqlOSAuthServerOptions()));
+
+        decision.Accepted.Should().BeTrue();
+        decision.AcceptedClaim.Should().Be("amr");
+        decision.AcceptedValue.Should().Be("mfa");
+        policy.SatisfiesStrongMfa("oidc+upstream_mfa").Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void OidcTrustedAcr_UsesExactConfiguredValue()
+    {
+        var connection = new SqlOSOidcConnection
+        {
+            TrustUpstreamMfa = true,
+            AcceptedAcrValuesJson = """["urn:example:loa:2"]"""
+        };
+
+        var accepted = SqlOSUpstreamMfaTrust.EvaluateOidc(
+            connection,
+            Principal(new Claim("acr", "urn:example:loa:2")));
+        var rejected = SqlOSUpstreamMfaTrust.EvaluateOidc(
+            connection,
+            Principal(new Claim("acr", "URN:EXAMPLE:LOA:2")));
+
+        accepted.Accepted.Should().BeTrue();
+        rejected.Accepted.Should().BeFalse();
+        rejected.Reason.Should().Be("evidence_unrecognized");
+    }
+
+    [TestMethod]
+    public void SamlAuthnContext_RequiresExactPerConnectionTrust()
+    {
+        var connection = new SqlOSSsoConnection
+        {
+            TrustUpstreamMfa = true,
+            AcceptedAuthnContextClassRefsJson =
+                """["urn:oasis:names:tc:SAML:2.0:ac:classes:TimeSyncToken"]"""
+        };
+
+        var accepted = SqlOSUpstreamMfaTrust.EvaluateSaml(
+            connection,
+            ["urn:oasis:names:tc:SAML:2.0:ac:classes:TimeSyncToken"]);
+        var rejected = SqlOSUpstreamMfaTrust.EvaluateSaml(
+            connection,
+            ["urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport"]);
+
+        accepted.Accepted.Should().BeTrue();
+        accepted.AcceptedClaim.Should().Be("saml_authn_context");
+        rejected.Accepted.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void MissingOrMalformedPolicy_FailsClosed()
+    {
+        var connection = new SqlOSOidcConnection
+        {
+            TrustUpstreamMfa = true,
+            AcceptedAmrValuesJson = "{not-json"
+        };
+
+        var decision = SqlOSUpstreamMfaTrust.EvaluateOidc(
+            connection,
+            Principal(new Claim("amr", "mfa")));
+
+        decision.Accepted.Should().BeFalse();
+        decision.Reason.Should().Be("evidence_unrecognized");
+    }
+
+    private static ClaimsPrincipal Principal(params Claim[] claims)
+        => new(new ClaimsIdentity(claims, "test"));
+}

--- a/tests/SqlOS.Tests/SqlOSUpstreamMfaTrustTests.cs
+++ b/tests/SqlOS.Tests/SqlOSUpstreamMfaTrustTests.cs
@@ -108,6 +108,42 @@ public class SqlOSUpstreamMfaTrustTests
         decision.Reason.Should().Be("evidence_unrecognized");
     }
 
+    [TestMethod]
+    public void OidcOversizedEvidence_FailsClosedWithoutRetainingOversizedValue()
+    {
+        var connection = new SqlOSOidcConnection
+        {
+            TrustUpstreamMfa = true,
+            AcceptedAmrValuesJson = """["mfa"]"""
+        };
+        var principal = Principal(
+            new Claim("amr", "mfa"),
+            new Claim("amr", new string('x', 501)));
+
+        var decision = SqlOSUpstreamMfaTrust.EvaluateOidc(connection, principal);
+
+        decision.Accepted.Should().BeFalse();
+        decision.Reason.Should().Be("evidence_limits_exceeded");
+        decision.AmrValues.Should().Equal("mfa");
+    }
+
+    [TestMethod]
+    public void SamlTooManyEvidenceValues_FailsClosedAndBoundsAuditEvidence()
+    {
+        var connection = new SqlOSSsoConnection
+        {
+            TrustUpstreamMfa = true,
+            AcceptedAuthnContextClassRefsJson = """["context-0"]"""
+        };
+        var evidence = Enumerable.Range(0, 33).Select(index => $"context-{index}").ToArray();
+
+        var decision = SqlOSUpstreamMfaTrust.EvaluateSaml(connection, evidence);
+
+        decision.Accepted.Should().BeFalse();
+        decision.Reason.Should().Be("evidence_limits_exceeded");
+        decision.SamlAuthnContextClassRefs.Should().HaveCount(32);
+    }
+
     private static ClaimsPrincipal Principal(params Claim[] claims)
         => new(new ClaimsIdentity(claims, "test"));
 }

--- a/web/content/docs/authserver/oidc-auth.mdx
+++ b/web/content/docs/authserver/oidc-auth.mdx
@@ -102,6 +102,32 @@ The provider callback is not an identity-claim source. Callback parameters canno
 
 GitHub remains a separate OAuth profile flow: SqlOS uses GitHub's stable numeric user id plus the verified primary address returned by GitHub's email API. It does not mix GitHub profile fields into the OIDC claim pipeline.
 
+### Upstream MFA is never trusted automatically
+
+An OIDC login proves the configured provider authenticated the user; it does not automatically prove that the provider performed MFA. SqlOS reads `amr` and `acr` only from the validated, signed ID token and treats them as assurance evidence only when that specific connection opts in with an explicit allowlist.
+
+Code-owned OIDC seeds can configure the policy without adding runtime infrastructure:
+
+```csharp
+options.AuthServer.SeedOidcConnection(oidc =>
+{
+    oidc.ProviderType = SqlOSOidcProviderType.Microsoft;
+    oidc.DisplayName = "Workforce Entra ID";
+    oidc.ClientId = builder.Configuration["Entra:ClientId"]!;
+    oidc.ClientSecret = builder.Configuration["Entra:ClientSecret"]!;
+    oidc.AllowedCallbackUris.Add(
+        "https://app.example.com/sqlos/auth/oidc/callback/{connectionId}");
+
+    oidc.TrustUpstreamMfa = true;
+    oidc.AcceptedAmrValues.Add("mfa");
+    oidc.AcceptedAcrValues.Add("urn:example:approved-assurance");
+});
+```
+
+`TrustUpstreamMfa` defaults to `false`. Missing evidence, disabled trust, or an unrecognized value leaves MFA unsatisfied, so an organization/client policy that requires MFA continues to local step-up. Accepted evidence keeps the primary method (for example, `microsoft`) and adds the separate `upstream_mfa` assurance method to sessions and tokens. Audit events record whether evidence was missing, untrusted, unrecognized, or accepted.
+
+Treat provider claim semantics as part of the connection configuration. Do not copy an `amr` or `acr` value from another IdP without confirming that your provider and tenant policy assign it the assurance meaning you expect.
+
 ### Backend code (from the example API)
 
 The normal application flow starts at `/sqlos/auth/authorize`; hosted AuthPage invokes the social provider and returns an OAuth authorization code to your application. Use the [ASP.NET Core login quickstart](/docs/quickstarts/aspnet-core-login) for that recommended path.

--- a/web/content/docs/authserver/saml-sso.mdx
+++ b/web/content/docs/authserver/saml-sso.mdx
@@ -218,6 +218,8 @@ When `/test` includes `clientId` and `redirectUri`, it must also include a fresh
 | --- | --- | --- |
 | `autoProvisionUsers` | `false` for portal-created connections | Create SqlOS users or memberships from SAML assertions on first login |
 | `autoLinkByEmail` | `true` for portal-created connections | Require existing verified org members to enroll and sign in through SSO |
+| `trustUpstreamMfa` | `false` | Allow this connection to satisfy MFA only through accepted signed `AuthnContextClassRef` values |
+| `acceptedAuthnContextClassRefs` | empty | Exact SAML authentication-context URIs accepted as upstream MFA |
 | `SsoPortal.EnableApi` | `true` | Expose portal and headless setup APIs |
 | `SsoPortal.UseHostedPortal` | `true` | Serve the bundled setup portal |
 | `SsoPortal.BuildUiUrl` | `null` | Redirect opened setup sessions to a host-owned UI |
@@ -226,6 +228,32 @@ When `/test` includes `clientId` and `redirectUri`, it must also include a fresh
 | `SsoPortal.DomainVerificationRecordPrefix` | `_sqlos-verify` | TXT record name prefix |
 | `SsoPortal.DomainVerificationRecordValuePrefix` | `sqlos-domain-verification` | TXT record value prefix |
 | `SsoPortal.ReservedDomainRoots` | empty | Domain roots customers cannot claim |
+
+### Upstream MFA trust
+
+SqlOS extracts `AuthnContextClassRef` only from the signature-covered assertion. A SAML connection does not satisfy local MFA merely because the primary method is `saml`.
+
+Platform-admin connection creation can opt in explicitly:
+
+```json
+{
+  "organizationId": "org_example",
+  "displayName": "Workforce SSO",
+  "identityProviderEntityId": "https://idp.example.com",
+  "singleSignOnUrl": "https://idp.example.com/sso",
+  "x509CertificatePem": "-----BEGIN CERTIFICATE-----...",
+  "autoProvisionUsers": true,
+  "autoLinkByEmail": false,
+  "trustUpstreamMfa": true,
+  "acceptedAuthnContextClassRefs": [
+    "urn:oasis:names:tc:SAML:2.0:ac:classes:TimeSyncToken"
+  ]
+}
+```
+
+Comparisons are exact per connection. Missing or unrecognized context leaves MFA unsatisfied, so the normal local step-up policy runs. Accepted evidence adds `upstream_mfa` alongside the `saml` primary method and records the assertion issuer, accepted class reference, and decision in the audit event.
+
+Only allowlist class references whose meaning you have verified for that IdP tenant. A URI name alone is not a guarantee that the upstream policy actually required a second factor.
 
 ## Provider notes
 


### PR DESCRIPTION
Closes #43

## Summary
- add per-connection, default-off trust policy for OIDC `amr`/`acr` and SAML `AuthnContextClassRef`
- evaluate only signature-validated ID-token or assertion evidence and keep the primary federation method separate from the accepted assurance marker
- let explicitly trusted upstream MFA satisfy strong-MFA policy while missing, disabled, malformed, or unrecognized evidence fails closed and continues to local step-up
- persist and expose the policy through seed/admin configuration, record assurance decisions in audit events, and document both protocols
- add upgrade-safe schema migration and real SQL/protocol tests for default-off behavior, accepted evidence, and post-signature tampering

## Developer ergonomics
Existing applications and connections require no changes: upstream MFA trust remains disabled unless a developer explicitly configures a connection allowlist. Local MFA behavior is unchanged by default.

## Validation
- `./scripts/build.sh`
- `./scripts/unit-tests.sh` (610 + 2 passed)
- `./scripts/integration-tests.sh` (168 + 71 + 15 passed)
- `./scripts/docs-check.sh`
