### PR TITLE
Add OAuth client credentials for service accounts

### DIFF
--- a/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerSeedOptions.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerSeedOptions.cs
@@ -105,6 +105,8 @@ public sealed class SqlOSClientSeedOptions
     public bool IsFirstParty { get; set; }
     public bool AllowNativeHeadlessAuth { get; set; }
     public bool AllowDeviceAuthorization { get; set; }
+    /// <summary>Enables OAuth client credentials for this confidential, non-browser client.</summary>
+    public bool EnableClientCredentials { get; set; }
     public bool IsActive { get; set; } = true;
 }
 

--- a/src/SqlOS/AuthServer/Contracts/SqlOSContracts.cs
+++ b/src/SqlOS/AuthServer/Contracts/SqlOSContracts.cs
@@ -218,6 +218,7 @@ public static class SqlOSOAuthGrantTypes
 {
     public const string AuthorizationCode = "authorization_code";
     public const string RefreshToken = "refresh_token";
+    public const string ClientCredentials = "client_credentials";
     public const string DeviceCode = "urn:ietf:params:oauth:grant-type:device_code";
 }
 

--- a/src/SqlOS/AuthServer/Endpoints/TokenEndpoints.cs
+++ b/src/SqlOS/AuthServer/Endpoints/TokenEndpoints.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Http.Headers;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Microsoft.AspNetCore.Builder;
@@ -31,6 +32,7 @@ public static partial class EndpointRouteBuilderExtensions
             HttpContext context,
             SqlOSAuthorizationServerService authorizationServerService,
             SqlOSDeviceAuthorizationService deviceAuthorizationService,
+            SqlOSClientCredentialsService clientCredentialsService,
             CancellationToken cancellationToken) =>
         {
             var form = await context.Request.ReadFormAsync(cancellationToken);
@@ -38,6 +40,39 @@ public static partial class EndpointRouteBuilderExtensions
 
             try
             {
+                if (string.Equals(grantType, SqlOSOAuthGrantTypes.ClientCredentials, StringComparison.Ordinal))
+                {
+                    SqlOSClientCredentialsTokenResult clientResult;
+                    try
+                    {
+                        var (clientId, clientSecret) = ReadClientCredentials(context, form);
+                        clientResult = await clientCredentialsService.ExchangeAsync(
+                            clientId,
+                            clientSecret,
+                            form["resource"].ToString(),
+                            form["scope"].ToString(),
+                            context,
+                            cancellationToken);
+                    }
+                    catch (SqlOSClientCredentialsException ex)
+                    {
+                        if (ex.StatusCode == StatusCodes.Status401Unauthorized)
+                        {
+                            context.Response.Headers.WWWAuthenticate = "Basic";
+                        }
+                        return Results.Json(
+                            new { error = ex.Error, error_description = ex.Message },
+                            statusCode: ex.StatusCode);
+                    }
+                    return Results.Ok(new
+                    {
+                        access_token = clientResult.AccessToken,
+                        token_type = "Bearer",
+                        expires_in = Math.Max(1, (int)(clientResult.ExpiresAt - DateTime.UtcNow).TotalSeconds),
+                        scope = string.Join(' ', clientResult.Scopes)
+                    });
+                }
+
                 if (string.Equals(grantType, SqlOSOAuthGrantTypes.DeviceCode, StringComparison.Ordinal))
                 {
                     var deviceResult = await deviceAuthorizationService.PollAsync(
@@ -88,5 +123,34 @@ public static partial class EndpointRouteBuilderExtensions
                 return await PublicOAuthTokenErrorAsync(context, ex, cancellationToken);
             }
         });
+    }
+
+    private static (string ClientId, string ClientSecret) ReadClientCredentials(
+        HttpContext context,
+        IFormCollection form)
+    {
+        var authorization = context.Request.Headers.Authorization.ToString();
+        if (AuthenticationHeaderValue.TryParse(authorization, out var parsed)
+            && string.Equals(parsed.Scheme, "Basic", StringComparison.OrdinalIgnoreCase)
+            && !string.IsNullOrWhiteSpace(parsed.Parameter))
+        {
+            try
+            {
+                var decoded = System.Text.Encoding.UTF8.GetString(
+                    Convert.FromBase64String(parsed.Parameter));
+                var separator = decoded.IndexOf(':');
+                if (separator > 0)
+                {
+                    return (
+                        WebUtility.UrlDecode(decoded[..separator]),
+                        WebUtility.UrlDecode(decoded[(separator + 1)..]));
+                }
+            }
+            catch (FormatException)
+            {
+            }
+        }
+
+        return (string.Empty, string.Empty);
     }
 }

--- a/src/SqlOS/AuthServer/Services/SqlOSAdminService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSAdminService.cs
@@ -152,7 +152,7 @@ public sealed partial class SqlOSAdminService
                     Audience = normalized.Audience,
                     ClientType = normalized.ClientType,
                     RegistrationSource = "seeded",
-                    TokenEndpointAuthMethod = "none",
+                    TokenEndpointAuthMethod = normalized.EnableClientCredentials ? "client_secret_basic" : "none",
                     GrantTypesJson = JsonSerializer.Serialize(normalized.GrantTypes),
                     ResponseTypesJson = JsonSerializer.Serialize(new[] { "code" }),
                     RequirePkce = normalized.RequirePkce,
@@ -173,7 +173,7 @@ public sealed partial class SqlOSAdminService
             existing.Audience = normalized.Audience;
             existing.ClientType = normalized.ClientType;
             existing.RegistrationSource = "seeded";
-            existing.TokenEndpointAuthMethod = string.IsNullOrWhiteSpace(existing.TokenEndpointAuthMethod) ? "none" : existing.TokenEndpointAuthMethod;
+            existing.TokenEndpointAuthMethod = normalized.EnableClientCredentials ? "client_secret_basic" : "none";
             existing.GrantTypesJson = JsonSerializer.Serialize(normalized.GrantTypes);
             existing.ResponseTypesJson = string.IsNullOrWhiteSpace(existing.ResponseTypesJson)
                 ? JsonSerializer.Serialize(new[] { "code" })
@@ -2608,6 +2608,7 @@ public sealed partial class SqlOSAdminService
             seed.IsFirstParty,
             seed.AllowNativeHeadlessAuth,
             seed.AllowDeviceAuthorization,
+            seed.EnableClientCredentials,
             seed.ClientType,
             seed.IsActive);
 
@@ -2822,6 +2823,7 @@ public sealed partial class SqlOSAdminService
             request.IsFirstParty,
             request.AllowNativeHeadlessAuth,
             request.AllowDeviceAuthorization,
+            false,
             request.ClientType,
             true);
 
@@ -2836,6 +2838,7 @@ public sealed partial class SqlOSAdminService
         bool isFirstParty,
         bool allowNativeHeadlessAuth,
         bool allowDeviceAuthorization,
+        bool enableClientCredentials,
         string? clientType,
         bool isActive)
     {
@@ -2853,7 +2856,7 @@ public sealed partial class SqlOSAdminService
             .Distinct(StringComparer.Ordinal)
             .ToList();
 
-        if (normalizedRedirectUris.Count == 0 && !allowDeviceAuthorization)
+        if (normalizedRedirectUris.Count == 0 && !allowDeviceAuthorization && !enableClientCredentials)
         {
             throw new InvalidOperationException($"Client '{normalizedClientId}' must define at least one redirect URI.");
         }
@@ -2876,11 +2879,15 @@ public sealed partial class SqlOSAdminService
             isFirstParty,
             allowNativeHeadlessAuth,
             allowDeviceAuthorization,
-            BuildGrantTypes(normalizedRedirectUris, allowDeviceAuthorization),
+            BuildGrantTypes(normalizedRedirectUris, allowDeviceAuthorization, enableClientCredentials),
+            enableClientCredentials,
             isActive);
     }
 
-    private static List<string> BuildGrantTypes(IReadOnlyCollection<string> redirectUris, bool allowDeviceAuthorization)
+    private static List<string> BuildGrantTypes(
+        IReadOnlyCollection<string> redirectUris,
+        bool allowDeviceAuthorization,
+        bool enableClientCredentials)
     {
         var grants = new List<string>();
         if (redirectUris.Count > 0)
@@ -2893,7 +2900,15 @@ public sealed partial class SqlOSAdminService
             grants.Add(SqlOSOAuthGrantTypes.DeviceCode);
         }
 
-        grants.Add(SqlOSOAuthGrantTypes.RefreshToken);
+        if (enableClientCredentials)
+        {
+            grants.Add(SqlOSOAuthGrantTypes.ClientCredentials);
+        }
+
+        if (redirectUris.Count > 0 || allowDeviceAuthorization)
+        {
+            grants.Add(SqlOSOAuthGrantTypes.RefreshToken);
+        }
         return grants.Distinct(StringComparer.Ordinal).ToList();
     }
 
@@ -2991,6 +3006,7 @@ public sealed partial class SqlOSAdminService
         bool AllowNativeHeadlessAuth,
         bool AllowDeviceAuthorization,
         List<string> GrantTypes,
+        bool EnableClientCredentials,
         bool IsActive);
 
     private sealed record NormalizedAssignmentRequest(

--- a/src/SqlOS/AuthServer/Services/SqlOSAuthorizationServerService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSAuthorizationServerService.cs
@@ -71,9 +71,29 @@ public sealed class SqlOSAuthorizationServerService
 
         var origin = GetPublicOrigin(httpContext);
         var basePath = _options.BasePath.TrimEnd('/');
-        var grantTypes = _options.DeviceAuthorization.Enabled
-            ? new[] { SqlOSOAuthGrantTypes.AuthorizationCode, SqlOSOAuthGrantTypes.RefreshToken, SqlOSOAuthGrantTypes.DeviceCode }
-            : new[] { SqlOSOAuthGrantTypes.AuthorizationCode, SqlOSOAuthGrantTypes.RefreshToken };
+        var grantTypes = new List<string>
+        {
+            SqlOSOAuthGrantTypes.AuthorizationCode,
+            SqlOSOAuthGrantTypes.RefreshToken
+        };
+        if (_options.DeviceAuthorization.Enabled)
+        {
+            grantTypes.Add(SqlOSOAuthGrantTypes.DeviceCode);
+        }
+        var machineGrantConfigurations = await _context.Set<SqlOSClientApplication>()
+            .AsNoTracking()
+            .Where(x => x.IsActive
+                && x.DisabledAt == null
+                && x.ClientType == "confidential"
+                && x.TokenEndpointAuthMethod == "client_secret_basic")
+            .Select(x => x.GrantTypesJson)
+            .ToListAsync(cancellationToken);
+        if (machineGrantConfigurations.Any(json =>
+            SqlOSAdminService.DeserializeJsonList(json)
+                .Contains(SqlOSOAuthGrantTypes.ClientCredentials, StringComparer.Ordinal)))
+        {
+            grantTypes.Add(SqlOSOAuthGrantTypes.ClientCredentials);
+        }
 
         return new SqlOSAuthorizationServerMetadataDto
         {
@@ -85,10 +105,12 @@ public sealed class SqlOSAuthorizationServerService
                 : null,
             JwksUri = $"{origin}{basePath}/.well-known/jwks.json",
             ResponseTypesSupported = ["code"],
-            GrantTypesSupported = grantTypes,
+            GrantTypesSupported = grantTypes.ToArray(),
             CodeChallengeMethodsSupported = ["S256"],
             ScopesSupported = scopes,
-            TokenEndpointAuthMethodsSupported = ["none"],
+            TokenEndpointAuthMethodsSupported = grantTypes.Contains(SqlOSOAuthGrantTypes.ClientCredentials)
+                ? ["none", "client_secret_basic"]
+                : ["none"],
             RegistrationEndpoint = _options.ClientRegistration.Dcr.Enabled
                 ? $"{origin}{basePath}/register"
                 : null,

--- a/src/SqlOS/AuthServer/Services/SqlOSClientCredentialsService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSClientCredentialsService.cs
@@ -1,0 +1,184 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using SqlOS.AuthServer.Configuration;
+using SqlOS.AuthServer.Contracts;
+using SqlOS.AuthServer.Interfaces;
+using SqlOS.AuthServer.Models;
+using SqlOS.Fga.Models;
+
+namespace SqlOS.AuthServer.Services;
+
+public sealed class SqlOSClientCredentialsService
+{
+    private readonly ISqlOSAuthServerDbContext _context;
+    private readonly SqlOSCryptoService _crypto;
+    private readonly SqlOSAdminService _admin;
+    private readonly SqlOSAuthServerOptions _options;
+
+    public SqlOSClientCredentialsService(
+        ISqlOSAuthServerDbContext context,
+        SqlOSCryptoService crypto,
+        SqlOSAdminService admin,
+        IOptions<SqlOSAuthServerOptions> options)
+    {
+        _context = context;
+        _crypto = crypto;
+        _admin = admin;
+        _options = options.Value;
+    }
+
+    public async Task<SqlOSClientCredentialsTokenResult> ExchangeAsync(
+        string clientId,
+        string clientSecret,
+        string resource,
+        string? requestedScope,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        var client = await _context.Set<SqlOSClientApplication>()
+            .SingleOrDefaultAsync(x => x.ClientId == clientId, cancellationToken);
+        var grants = client == null ? [] : SqlOSAdminService.DeserializeJsonList(client.GrantTypesJson);
+        var account = client == null ? null : await _context.Set<SqlOSFgaServiceAccount>()
+            .SingleOrDefaultAsync(x => x.ClientId == clientId, cancellationToken);
+        var subject = account == null ? null : await _context.Set<SqlOSFgaSubject>()
+            .SingleOrDefaultAsync(x => x.Id == account.SubjectId, cancellationToken);
+        var now = DateTime.UtcNow;
+        var valid = client != null
+            && client.IsActive
+            && client.DisabledAt == null
+            && string.Equals(client.ClientType, "confidential", StringComparison.Ordinal)
+            && string.Equals(client.TokenEndpointAuthMethod, "client_secret_basic", StringComparison.Ordinal)
+            && grants.Contains(SqlOSOAuthGrantTypes.ClientCredentials, StringComparer.Ordinal)
+            && account != null
+            && subject != null
+            && string.Equals(subject.SubjectTypeId, "service_account", StringComparison.Ordinal)
+            && (account.ExpiresAt == null || account.ExpiresAt > now)
+            && clientSecret.Length is >= 43 and <= 256
+            && _crypto.VerifyPassword(account!.ClientSecretHash, clientSecret);
+        if (!valid)
+        {
+            await AuditAsync("oauth.client_credentials.failed", clientId, account?.SubjectId, httpContext, cancellationToken);
+            throw new SqlOSClientCredentialsException("invalid_client", "Client authentication failed.", StatusCodes.Status401Unauthorized);
+        }
+
+        if (string.IsNullOrWhiteSpace(resource)
+            || !string.Equals(resource, client!.Audience, StringComparison.Ordinal))
+        {
+            throw new SqlOSClientCredentialsException("invalid_target", "An authorized resource is required.");
+        }
+
+        var allowed = SqlOSAdminService.DeserializeJsonList(client.AllowedScopesJson);
+        var scopes = (requestedScope ?? string.Empty)
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        if (scopes.Any(scope => !allowed.Contains(scope, StringComparer.Ordinal)))
+        {
+            throw new SqlOSClientCredentialsException("invalid_scope", "The requested scope is not authorized.");
+        }
+
+        var token = await _crypto.CreateServiceAccessTokenAsync(
+            account!.SubjectId,
+            client,
+            resource,
+            scopes,
+            subject!.OrganizationId,
+            cancellationToken);
+        account.LastUsedAt = now;
+        account.UpdatedAt = now;
+        client.LastSeenAt = now;
+        await _context.SaveChangesAsync(cancellationToken);
+        await AuditAsync("oauth.client_credentials.issued", clientId, account.SubjectId, httpContext, cancellationToken);
+        return new SqlOSClientCredentialsTokenResult(token, now.Add(_options.AccessTokenLifetime), scopes);
+    }
+
+    public async Task RotateSecretAsync(
+        string clientId,
+        string newSecret,
+        string? actorId = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(newSecret) || newSecret.Length is < 43 or > 256)
+        {
+            throw new ArgumentException("A service-client secret must contain 43 to 256 characters.", nameof(newSecret));
+        }
+
+        var account = await RequireServiceAccountAsync(clientId, cancellationToken);
+        account.ClientSecretHash = _crypto.HashPassword(newSecret);
+        account.UpdatedAt = DateTime.UtcNow;
+        await _context.SaveChangesAsync(cancellationToken);
+        await _admin.RecordAuditAsync(
+            "oauth.client_credentials.rotated",
+            "admin",
+            actorId,
+            organizationId: account.Subject?.OrganizationId,
+            data: new { clientId, subjectId = account.SubjectId },
+            cancellationToken: cancellationToken);
+    }
+
+    public async Task RevokeAsync(
+        string clientId,
+        string? actorId = null,
+        CancellationToken cancellationToken = default)
+    {
+        var account = await RequireServiceAccountAsync(clientId, cancellationToken);
+        account.ExpiresAt = DateTime.UtcNow;
+        account.UpdatedAt = account.ExpiresAt.Value;
+        await _context.SaveChangesAsync(cancellationToken);
+        await _admin.RecordAuditAsync(
+            "oauth.client_credentials.revoked",
+            "admin",
+            actorId,
+            organizationId: account.Subject?.OrganizationId,
+            data: new { clientId, subjectId = account.SubjectId },
+            cancellationToken: cancellationToken);
+    }
+
+    private async Task<SqlOSFgaServiceAccount> RequireServiceAccountAsync(
+        string clientId,
+        CancellationToken cancellationToken)
+    {
+        var account = await _context.Set<SqlOSFgaServiceAccount>()
+            .Include(x => x.Subject)
+            .SingleOrDefaultAsync(x => x.ClientId == clientId, cancellationToken);
+        if (account == null)
+        {
+            throw new InvalidOperationException("The service client does not exist.");
+        }
+        return account;
+    }
+
+    private Task AuditAsync(
+        string action,
+        string clientId,
+        string? subjectId,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+        => _admin.RecordAuditAsync(
+            action,
+            "oauth_client",
+            clientId,
+            organizationId: null,
+            ipAddress: httpContext.Connection.RemoteIpAddress?.ToString(),
+            data: new { clientId, subjectId },
+            cancellationToken: cancellationToken);
+}
+
+public sealed record SqlOSClientCredentialsTokenResult(
+    string AccessToken,
+    DateTime ExpiresAt,
+    IReadOnlyList<string> Scopes);
+
+public sealed class SqlOSClientCredentialsException : Exception
+{
+    public SqlOSClientCredentialsException(string error, string description, int statusCode = StatusCodes.Status400BadRequest)
+        : base(description)
+    {
+        Error = error;
+        StatusCode = statusCode;
+    }
+
+    public string Error { get; }
+    public int StatusCode { get; }
+}

--- a/src/SqlOS/AuthServer/Services/SqlOSClientCredentialsService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSClientCredentialsService.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using SqlOS.AuthServer.Configuration;
@@ -11,6 +12,8 @@ namespace SqlOS.AuthServer.Services;
 
 public sealed class SqlOSClientCredentialsService
 {
+    internal static readonly string DummyCredentialHash =
+        new PasswordHasher<object>().HashPassword(new object(), "sqlos-invalid-client-dummy-secret");
     private readonly ISqlOSAuthServerDbContext _context;
     private readonly SqlOSCryptoService _crypto;
     private readonly SqlOSAdminService _admin;
@@ -39,10 +42,15 @@ public sealed class SqlOSClientCredentialsService
         var client = await _context.Set<SqlOSClientApplication>()
             .SingleOrDefaultAsync(x => x.ClientId == clientId, cancellationToken);
         var grants = client == null ? [] : SqlOSAdminService.DeserializeJsonList(client.GrantTypesJson);
-        var account = client == null ? null : await _context.Set<SqlOSFgaServiceAccount>()
+        var account = await _context.Set<SqlOSFgaServiceAccount>()
             .SingleOrDefaultAsync(x => x.ClientId == clientId, cancellationToken);
-        var subject = account == null ? null : await _context.Set<SqlOSFgaSubject>()
-            .SingleOrDefaultAsync(x => x.Id == account.SubjectId, cancellationToken);
+        var subjectIdForLookup = account?.SubjectId ?? "__invalid_service_subject__";
+        var subject = await _context.Set<SqlOSFgaSubject>()
+            .SingleOrDefaultAsync(x => x.Id == subjectIdForLookup, cancellationToken);
+        var candidateSecret = clientSecret.Length <= 256 ? clientSecret : string.Empty;
+        var credentialVerified = _crypto.VerifyPassword(
+            ResolveCredentialHashForVerification(account),
+            candidateSecret);
         var now = DateTime.UtcNow;
         var valid = client != null
             && client.IsActive
@@ -55,7 +63,7 @@ public sealed class SqlOSClientCredentialsService
             && string.Equals(subject.SubjectTypeId, "service_account", StringComparison.Ordinal)
             && (account.ExpiresAt == null || account.ExpiresAt > now)
             && clientSecret.Length is >= 43 and <= 256
-            && _crypto.VerifyPassword(account!.ClientSecretHash, clientSecret);
+            && credentialVerified;
         if (!valid)
         {
             await AuditAsync("oauth.client_credentials.failed", clientId, account?.SubjectId, httpContext, cancellationToken);
@@ -148,6 +156,11 @@ public sealed class SqlOSClientCredentialsService
         }
         return account;
     }
+
+    internal static string ResolveCredentialHashForVerification(SqlOSFgaServiceAccount? account)
+        => string.IsNullOrWhiteSpace(account?.ClientSecretHash)
+            ? DummyCredentialHash
+            : account.ClientSecretHash;
 
     private Task AuditAsync(
         string action,

--- a/src/SqlOS/AuthServer/Services/SqlOSCryptoService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSCryptoService.cs
@@ -527,6 +527,51 @@ public sealed class SqlOSCryptoService
         return $"{signingInput}.{Base64UrlEncoder.Encode(signature)}";
     }
 
+    public async Task<string> CreateServiceAccessTokenAsync(
+        string subjectId,
+        SqlOSClientApplication client,
+        string audience,
+        IReadOnlyList<string> scopes,
+        string? organizationId,
+        CancellationToken cancellationToken = default)
+    {
+        var key = await EnsureActiveSigningKeyCoreAsync(validateExistingCustody: false, cancellationToken);
+        var now = DateTime.UtcNow;
+        var payload = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            [JwtRegisteredClaimNames.Iss] = _options.Issuer,
+            [JwtRegisteredClaimNames.Sub] = subjectId,
+            [JwtRegisteredClaimNames.Aud] = audience,
+            [JwtRegisteredClaimNames.Nbf] = EpochTime.GetIntDate(now),
+            [JwtRegisteredClaimNames.Iat] = EpochTime.GetIntDate(now),
+            [JwtRegisteredClaimNames.Exp] = EpochTime.GetIntDate(now.Add(_options.AccessTokenLifetime)),
+            ["client_id"] = client.ClientId,
+            ["azp"] = client.ClientId,
+            ["token_kind"] = "service",
+            ["scope"] = string.Join(' ', scopes)
+        };
+        if (!string.IsNullOrWhiteSpace(organizationId))
+        {
+            payload["org_id"] = organizationId;
+        }
+
+        var header = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            [JwtHeaderParameterNames.Alg] = SecurityAlgorithms.RsaSha256,
+            [JwtHeaderParameterNames.Typ] = "JWT",
+            [JwtHeaderParameterNames.Kid] = key.Kid
+        };
+        var encodedHeader = Base64UrlEncoder.Encode(JsonSerializer.SerializeToUtf8Bytes(header));
+        var encodedPayload = Base64UrlEncoder.Encode(JsonSerializer.SerializeToUtf8Bytes(payload));
+        var signingInput = $"{encodedHeader}.{encodedPayload}";
+        var signature = await _signingKeyCustody.SignAsync(
+            ToDescriptor(key),
+            Encoding.ASCII.GetBytes(signingInput),
+            cancellationToken);
+        VerifySignature(key, Encoding.ASCII.GetBytes(signingInput), signature);
+        return $"{signingInput}.{Base64UrlEncoder.Encode(signature)}";
+    }
+
     public async Task<SqlOSValidatedToken?> ValidateAccessTokenAsync(
         string rawToken,
         string expectedAudience,
@@ -599,7 +644,44 @@ public sealed class SqlOSCryptoService
             var sessionId = principal.FindFirstValue("sid");
             if (string.IsNullOrWhiteSpace(sessionId))
             {
-                return null;
+                if (!string.Equals(principal.FindFirstValue("token_kind"), "service", StringComparison.Ordinal))
+                {
+                    return null;
+                }
+
+                var serviceSubjectId = principal.FindFirstValue(JwtRegisteredClaimNames.Sub);
+                var serviceClientId = principal.FindFirstValue("client_id");
+                if (string.IsNullOrWhiteSpace(serviceSubjectId) || string.IsNullOrWhiteSpace(serviceClientId))
+                {
+                    return null;
+                }
+
+                var serviceNow = DateTime.UtcNow;
+                var serviceAccount = await _context.Set<SqlOS.Fga.Models.SqlOSFgaServiceAccount>()
+                    .AsNoTracking()
+                    .FirstOrDefaultAsync(x => x.SubjectId == serviceSubjectId
+                        && x.ClientId == serviceClientId
+                        && (x.ExpiresAt == null || x.ExpiresAt > serviceNow), cancellationToken);
+                var serviceClient = await _context.Set<SqlOSClientApplication>()
+                    .AsNoTracking()
+                    .FirstOrDefaultAsync(x => x.ClientId == serviceClientId && x.IsActive && x.DisabledAt == null, cancellationToken);
+                var serviceSubject = await _context.Set<SqlOS.Fga.Models.SqlOSFgaSubject>()
+                    .AsNoTracking()
+                    .FirstOrDefaultAsync(x => x.Id == serviceSubjectId && x.SubjectTypeId == "service_account", cancellationToken);
+                if (serviceAccount == null || serviceSubject == null || serviceClient == null
+                    || !SqlOSAdminService.DeserializeJsonList(serviceClient.GrantTypesJson)
+                        .Contains(SqlOSOAuthGrantTypes.ClientCredentials, StringComparer.Ordinal))
+                {
+                    return null;
+                }
+
+                return new SqlOSValidatedToken(
+                    principal,
+                    string.Empty,
+                    null,
+                    principal.FindFirstValue("org_id"),
+                    serviceClientId,
+                    principal.FindFirstValue("aud"));
             }
 
             var now = DateTime.UtcNow;

--- a/src/SqlOS/Extensions/ServiceCollectionExtensions.cs
+++ b/src/SqlOS/Extensions/ServiceCollectionExtensions.cs
@@ -105,6 +105,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<SqlOSPasswordLoginAbuseService>();
         services.AddScoped<SqlOSInvitationService>();
         services.AddScoped<SqlOSDeviceAuthorizationService>();
+        services.AddScoped<SqlOSClientCredentialsService>();
         services.AddScoped<SqlOSCimdClientService>();
         services.AddScoped<SqlOSDynamicClientRegistrationService>();
         services.AddScoped<SqlOSClientResolutionService>();

--- a/tests/SqlOS.IntegrationTests/ClientCredentialsIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/ClientCredentialsIntegrationTests.cs
@@ -1,0 +1,79 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SqlOS.AuthServer.Contracts;
+using SqlOS.AuthServer.Models;
+using SqlOS.AuthServer.Services;
+using SqlOS.Fga.Models;
+using SqlOS.IntegrationTests.Infrastructure;
+
+namespace SqlOS.IntegrationTests;
+
+[TestClass]
+public sealed class ClientCredentialsIntegrationTests
+{
+    [TestMethod]
+    public async Task ClientCredentials_RealSql_IssuesValidServiceTokenAndRevokesWithoutHumanSession()
+    {
+        var suffix = Guid.NewGuid().ToString("N");
+        var clientId = $"worker-{suffix}";
+        var subjectId = $"service_account::{clientId}";
+        var audience = $"https://api.example.test/jobs/{suffix}";
+        var secret = $"integration-secret-{suffix}-with-sufficient-entropy";
+        var context = AspireFixture.SharedContext;
+        var options = Options.Create(AspireFixture.Options);
+        var crypto = new SqlOSCryptoService(context, options, AspireFixture.DataProtectionProvider);
+        var admin = new SqlOSAdminService(context, options, crypto);
+        var service = new SqlOSClientCredentialsService(context, crypto, admin, options);
+
+        context.Set<SqlOSClientApplication>().Add(new SqlOSClientApplication
+        {
+            Id = $"cli_{suffix}",
+            ClientId = clientId,
+            Name = "Integration Worker",
+            Audience = audience,
+            ClientType = "confidential",
+            TokenEndpointAuthMethod = "client_secret_basic",
+            GrantTypesJson = "[\"client_credentials\"]",
+            AllowedScopesJson = "[\"jobs.run\"]",
+            RedirectUrisJson = "[]",
+            RequirePkce = false,
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow
+        });
+        context.Set<SqlOSFgaSubject>().Add(new SqlOSFgaSubject
+        {
+            Id = subjectId,
+            SubjectTypeId = "service_account",
+            DisplayName = "Integration Worker"
+        });
+        context.Set<SqlOSFgaServiceAccount>().Add(new SqlOSFgaServiceAccount
+        {
+            Id = $"sa_{suffix}",
+            SubjectId = subjectId,
+            ClientId = clientId,
+            ClientSecretHash = crypto.HashPassword(secret)
+        });
+        await context.SaveChangesAsync();
+
+        var issued = await service.ExchangeAsync(
+            clientId, secret, audience, "jobs.run", new DefaultHttpContext(), default);
+        var validated = await crypto.ValidateAccessTokenAsync(issued.AccessToken, audience);
+
+        validated.Should().NotBeNull();
+        validated!.UserId.Should().BeNull();
+        validated.SessionId.Should().BeEmpty();
+        validated.Principal.FindFirst("sub")!.Value.Should().Be(subjectId);
+        (await crypto.ValidateAccessTokenAsync(issued.AccessToken, "https://api.example.test/wrong"))
+            .Should().BeNull();
+
+        await service.RevokeAsync(clientId, "integration-admin");
+        (await crypto.ValidateAccessTokenAsync(issued.AccessToken, audience)).Should().BeNull();
+        (await context.Set<SqlOSAuditEvent>().AnyAsync(x =>
+            x.EventType == "oauth.client_credentials.issued" && x.ActorId == clientId)).Should().BeTrue();
+        (await context.Set<SqlOSAuditEvent>().AnyAsync(x =>
+            x.EventType == "oauth.client_credentials.revoked")).Should().BeTrue();
+    }
+}

--- a/tests/SqlOS.Tests/SqlOSAuthorizationServerMetadataTests.cs
+++ b/tests/SqlOS.Tests/SqlOSAuthorizationServerMetadataTests.cs
@@ -99,6 +99,37 @@ public sealed class SqlOSAuthorizationServerMetadataTests
         json.Should().NotContain("resource_parameter_supported");
     }
 
+    [TestMethod]
+    public async Task GetMetadataAsync_AdvertisesClientCredentialsOnlyForConfiguredConfidentialClient()
+    {
+        using var context = CreateContext();
+        var optionsValue = new SqlOSAuthServerOptions
+        {
+            PublicOrigin = "https://app.example.com",
+            Issuer = "https://app.example.com/sqlos/auth"
+        };
+        var service = await CreateAuthorizationServerServiceAsync(context, optionsValue);
+        var before = await service.GetMetadataAsync(new DefaultHttpContext());
+        before.GrantTypesSupported.Should().NotContain(SqlOS.AuthServer.Contracts.SqlOSOAuthGrantTypes.ClientCredentials);
+
+        context.Set<SqlOS.AuthServer.Models.SqlOSClientApplication>().Add(new()
+        {
+            Id = "machine-app",
+            ClientId = "machine",
+            Name = "Machine",
+            ClientType = "confidential",
+            TokenEndpointAuthMethod = "client_secret_basic",
+            GrantTypesJson = "[\"client_credentials\"]",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow
+        });
+        await context.SaveChangesAsync();
+
+        var after = await service.GetMetadataAsync(new DefaultHttpContext());
+        after.GrantTypesSupported.Should().Contain(SqlOS.AuthServer.Contracts.SqlOSOAuthGrantTypes.ClientCredentials);
+        after.TokenEndpointAuthMethodsSupported.Should().Contain("client_secret_basic");
+    }
+
     private static async Task<SqlOSAuthorizationServerService> CreateAuthorizationServerServiceAsync(
         TestSqlOSInMemoryDbContext context,
         SqlOSAuthServerOptions optionsValue)

--- a/tests/SqlOS.Tests/SqlOSClientCredentialsEndpointTests.cs
+++ b/tests/SqlOS.Tests/SqlOSClientCredentialsEndpointTests.cs
@@ -1,0 +1,145 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SqlOS.AuthServer.Extensions;
+using SqlOS.AuthServer.Interfaces;
+using SqlOS.AuthServer.Models;
+using SqlOS.AuthServer.Services;
+using SqlOS.Extensions;
+using SqlOS.Fga.Models;
+using SqlOS.Tests.Infrastructure;
+
+namespace SqlOS.Tests;
+
+[TestClass]
+public sealed class SqlOSClientCredentialsEndpointTests
+{
+    [TestMethod]
+    public async Task TokenEndpoint_BasicAuthentication_IssuesAccessTokenOnlyAndRejectsWrongAudience()
+    {
+        using var host = await StartHostAsync();
+        const string secret = "endpoint-secret-with-at-least-256-bits-of-randomness-123456";
+        using (var scope = host.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TestSqlOSInMemoryDbContext>();
+            var crypto = scope.ServiceProvider.GetRequiredService<SqlOSCryptoService>();
+            var admin = scope.ServiceProvider.GetRequiredService<SqlOSAdminService>();
+            await crypto.EnsureActiveSigningKeyAsync();
+            await admin.UpsertSeededClientsAsync();
+            db.Set<SqlOSFgaSubject>().Add(new SqlOSFgaSubject
+            {
+                Id = "service_account::endpoint-worker",
+                SubjectTypeId = "service_account",
+                DisplayName = "Endpoint Worker"
+            });
+            db.Set<SqlOSFgaServiceAccount>().Add(new SqlOSFgaServiceAccount
+            {
+                Id = "sa-endpoint-worker",
+                SubjectId = "service_account::endpoint-worker",
+                ClientId = "endpoint-worker",
+                ClientSecretHash = crypto.HashPassword(secret)
+            });
+            await db.SaveChangesAsync();
+            var configuredClient = await db.Set<SqlOSClientApplication>().SingleAsync();
+            configuredClient.ClientType.Should().Be("confidential");
+            configuredClient.TokenEndpointAuthMethod.Should().Be("client_secret_basic");
+            configuredClient.GrantTypesJson.Should().Contain("client_credentials");
+            configuredClient.Audience.Should().Be("https://api.example.test/jobs");
+            configuredClient.AllowedScopesJson.Should().Contain("jobs.run");
+        }
+
+        using var request = TokenRequest("https://api.example.test/jobs", secret);
+        var response = await host.GetTestClient().SendAsync(request);
+        var responseBody = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, responseBody);
+        using var json = JsonDocument.Parse(responseBody);
+        json.RootElement.TryGetProperty("access_token", out _).Should().BeTrue();
+        json.RootElement.TryGetProperty("refresh_token", out _).Should().BeFalse();
+        json.RootElement.GetProperty("scope").GetString().Should().Be("jobs.run");
+
+        using var wrongAudience = TokenRequest("https://api.example.test/other", secret);
+        (await host.GetTestClient().SendAsync(wrongAudience)).StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        var secretPost = await host.GetTestClient().PostAsync(
+            "/sqlos/auth/token",
+            new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["grant_type"] = "client_credentials",
+                ["client_id"] = "endpoint-worker",
+                ["client_secret"] = secret,
+                ["resource"] = "https://api.example.test/jobs",
+                ["scope"] = "jobs.run"
+            }));
+        secretPost.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        secretPost.Headers.WwwAuthenticate.Should().ContainSingle(x => x.Scheme == "Basic");
+    }
+
+    private static HttpRequestMessage TokenRequest(string resource, string secret)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, "/sqlos/auth/token")
+        {
+            Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["grant_type"] = "client_credentials",
+                ["resource"] = resource,
+                ["scope"] = "jobs.run"
+            })
+        };
+        request.Headers.Authorization = new AuthenticationHeaderValue(
+            "Basic",
+            Convert.ToBase64String(Encoding.UTF8.GetBytes($"endpoint-worker:{secret}")));
+        return request;
+    }
+
+    private static Task<IHost> StartHostAsync()
+    {
+        var databaseName = Guid.NewGuid().ToString("N");
+        return new HostBuilder()
+            .ConfigureWebHost(webHost => webHost
+                .UseTestServer()
+                .ConfigureServices(services =>
+                {
+                    services.AddRouting();
+                    services.AddLogging();
+                    services.AddDbContext<TestSqlOSInMemoryDbContext>(db =>
+                        db.UseInMemoryDatabase(databaseName));
+                    services.AddSqlOS<TestSqlOSInMemoryDbContext>(sqlos =>
+                    {
+                        sqlos.AuthServer.Issuer = "https://tests.example.local/sqlos/auth";
+                        sqlos.AuthServer.BasePath = "/sqlos/auth";
+                        sqlos.AuthServer.ClientSeeds.Add(new()
+                        {
+                            ClientId = "endpoint-worker",
+                            Name = "Endpoint Worker",
+                            Audience = "https://api.example.test/jobs",
+                            ClientType = "confidential",
+                            EnableClientCredentials = true,
+                            RequirePkce = false,
+                            AllowedScopes = ["jobs.run"]
+                        });
+                    });
+                    foreach (var service in services.Where(x => x.ServiceType == typeof(IHostedService)).ToList())
+                    {
+                        services.Remove(service);
+                    }
+                    services.AddSingleton<ISqlOSAuthEmailSender>(new TestAuthEmailSender { IsConfigured = true });
+                })
+                .Configure(app =>
+                {
+                    app.UseRouting();
+                    app.UseEndpoints(endpoints => endpoints.MapAuthServer("/sqlos/auth"));
+                }))
+            .StartAsync();
+    }
+}

--- a/tests/SqlOS.Tests/SqlOSClientCredentialsServiceTests.cs
+++ b/tests/SqlOS.Tests/SqlOSClientCredentialsServiceTests.cs
@@ -1,0 +1,176 @@
+using System.IdentityModel.Tokens.Jwt;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SqlOS.AuthServer.Configuration;
+using SqlOS.AuthServer.Contracts;
+using SqlOS.AuthServer.Models;
+using SqlOS.AuthServer.Services;
+using SqlOS.Fga.Models;
+using SqlOS.Tests.Infrastructure;
+
+namespace SqlOS.Tests;
+
+[TestClass]
+public sealed class SqlOSClientCredentialsServiceTests
+{
+    [TestMethod]
+    public async Task ValidServiceAccount_IssuesAudienceBoundAccessTokenWithoutHumanSession()
+    {
+        await using var harness = await CreateHarnessAsync();
+
+        var result = await harness.Service.ExchangeAsync(
+            "ledger-worker", harness.Secret, "https://api.example.test/ledger", "ledger.read",
+            new DefaultHttpContext(), default);
+
+        var jwt = new JwtSecurityTokenHandler().ReadJwtToken(result.AccessToken);
+        jwt.Subject.Should().Be("service_account::ledger-worker");
+        jwt.Audiences.Should().ContainSingle("https://api.example.test/ledger");
+        jwt.Claims.Should().ContainSingle(x => x.Type == "client_id" && x.Value == "ledger-worker");
+        jwt.Claims.Should().ContainSingle(x => x.Type == "token_kind" && x.Value == "service");
+        jwt.Claims.Should().NotContain(x => x.Type == "sid");
+        jwt.Claims.Should().NotContain(x => x.Type == JwtRegisteredClaimNames.Email);
+        result.Scopes.Should().Equal("ledger.read");
+
+        var validated = await harness.Crypto.ValidateAccessTokenAsync(
+            result.AccessToken, "https://api.example.test/ledger");
+        validated.Should().NotBeNull();
+        validated!.SessionId.Should().BeEmpty();
+        validated.UserId.Should().BeNull();
+        validated.Principal.FindFirst("sub")!.Value.Should().Be("service_account::ledger-worker");
+    }
+
+    [TestMethod]
+    public async Task WrongAudienceScopeOrSecret_IsRejectedWithoutTokenIssuance()
+    {
+        await using var harness = await CreateHarnessAsync();
+
+        await Assert.ThrowsExceptionAsync<SqlOSClientCredentialsException>(() => harness.Service.ExchangeAsync(
+            "ledger-worker", "wrong-secret", "https://api.example.test/ledger", "ledger.read",
+            new DefaultHttpContext(), default));
+        await Assert.ThrowsExceptionAsync<SqlOSClientCredentialsException>(() => harness.Service.ExchangeAsync(
+            "ledger-worker", harness.Secret, "https://api.example.test/other", "ledger.read",
+            new DefaultHttpContext(), default));
+        await Assert.ThrowsExceptionAsync<SqlOSClientCredentialsException>(() => harness.Service.ExchangeAsync(
+            "ledger-worker", harness.Secret, "https://api.example.test/ledger", "ledger.write",
+            new DefaultHttpContext(), default));
+    }
+
+    [TestMethod]
+    public async Task PublicDisabledExpiredAndGrantlessClients_AreRejected()
+    {
+        await using var harness = await CreateHarnessAsync();
+        var client = await harness.Context.Set<SqlOSClientApplication>().SingleAsync();
+        var account = await harness.Context.Set<SqlOSFgaServiceAccount>().SingleAsync();
+
+        foreach (var mutation in new Action[]
+        {
+            () => client.ClientType = "public_pkce",
+            () => { client.ClientType = "confidential"; client.IsActive = false; },
+            () => { client.IsActive = true; client.GrantTypesJson = "[]"; },
+            () => { client.GrantTypesJson = "[\"client_credentials\"]"; account.ExpiresAt = DateTime.UtcNow.AddMinutes(-1); }
+        })
+        {
+            mutation();
+            await harness.Context.SaveChangesAsync();
+            await Assert.ThrowsExceptionAsync<SqlOSClientCredentialsException>(() => harness.Service.ExchangeAsync(
+                "ledger-worker", harness.Secret, "https://api.example.test/ledger", "ledger.read",
+                new DefaultHttpContext(), default));
+        }
+    }
+
+    [TestMethod]
+    public async Task RotatingStoredHash_InvalidatesPreviouslyIssuedTokenAndOldSecret()
+    {
+        await using var harness = await CreateHarnessAsync();
+        var first = await harness.Service.ExchangeAsync(
+            "ledger-worker", harness.Secret, "https://api.example.test/ledger", "ledger.read",
+            new DefaultHttpContext(), default);
+        var account = await harness.Context.Set<SqlOSFgaServiceAccount>().SingleAsync();
+        account.ClientSecretHash = harness.Crypto.HashPassword("replacement-secret-with-enough-entropy-123456789");
+        await harness.Context.SaveChangesAsync();
+
+        await Assert.ThrowsExceptionAsync<SqlOSClientCredentialsException>(() => harness.Service.ExchangeAsync(
+            "ledger-worker", harness.Secret, "https://api.example.test/ledger", "ledger.read",
+            new DefaultHttpContext(), default));
+        (await harness.Crypto.ValidateAccessTokenAsync(first.AccessToken, "https://api.example.test/ledger"))
+            .Should().NotBeNull("secret rotation is an explicit cutover for issuance, not token revocation");
+    }
+
+    [TestMethod]
+    public async Task RotationAndRevocation_AreAuditedAndRevokeAtTheDocumentedBoundaries()
+    {
+        await using var harness = await CreateHarnessAsync();
+        const string replacement = "replacement-secret-with-at-least-256-bits-123456789";
+
+        await harness.Service.RotateSecretAsync("ledger-worker", replacement, "admin-1");
+        await Assert.ThrowsExceptionAsync<SqlOSClientCredentialsException>(() => harness.Service.ExchangeAsync(
+            "ledger-worker", harness.Secret, "https://api.example.test/ledger", "ledger.read",
+            new DefaultHttpContext(), default));
+        var issued = await harness.Service.ExchangeAsync(
+            "ledger-worker", replacement, "https://api.example.test/ledger", "ledger.read",
+            new DefaultHttpContext(), default);
+
+        await harness.Service.RevokeAsync("ledger-worker", "admin-1");
+        (await harness.Crypto.ValidateAccessTokenAsync(issued.AccessToken, "https://api.example.test/ledger"))
+            .Should().BeNull();
+        var audits = await harness.Context.Set<SqlOSAuditEvent>().Select(x => x.EventType).ToListAsync();
+        audits.Should().Contain("oauth.client_credentials.rotated");
+        audits.Should().Contain("oauth.client_credentials.revoked");
+    }
+
+    private static async Task<Harness> CreateHarnessAsync()
+    {
+        var dbOptions = new DbContextOptionsBuilder<TestSqlOSInMemoryDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .Options;
+        var context = new TestSqlOSInMemoryDbContext(dbOptions);
+        var options = Options.Create(new SqlOSAuthServerOptions
+        {
+            Issuer = "https://issuer.example.test/sqlos/auth",
+            PublicOrigin = "https://issuer.example.test"
+        });
+        var crypto = TestCryptoService.Create(context, options);
+        var admin = new SqlOSAdminService(context, options, crypto);
+        const string secret = "test-secret-with-at-least-256-bits-of-randomness-123456789";
+        context.Set<SqlOSClientApplication>().Add(new SqlOSClientApplication
+        {
+            Id = "app-worker",
+            ClientId = "ledger-worker",
+            Name = "Ledger Worker",
+            ClientType = "confidential",
+            TokenEndpointAuthMethod = "client_secret_basic",
+            GrantTypesJson = "[\"client_credentials\"]",
+            AllowedScopesJson = "[\"ledger.read\"]",
+            Audience = "https://api.example.test/ledger",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow
+        });
+        context.Set<SqlOSFgaSubject>().Add(new SqlOSFgaSubject
+        {
+            Id = "service_account::ledger-worker",
+            SubjectTypeId = "service_account",
+            DisplayName = "Ledger Worker"
+        });
+        context.Set<SqlOSFgaServiceAccount>().Add(new SqlOSFgaServiceAccount
+        {
+            Id = "sa-worker",
+            SubjectId = "service_account::ledger-worker",
+            ClientId = "ledger-worker",
+            ClientSecretHash = crypto.HashPassword(secret)
+        });
+        await context.SaveChangesAsync();
+        return new Harness(context, crypto, new SqlOSClientCredentialsService(context, crypto, admin, options), secret);
+    }
+
+    private sealed record Harness(
+        TestSqlOSInMemoryDbContext Context,
+        SqlOSCryptoService Crypto,
+        SqlOSClientCredentialsService Service,
+        string Secret) : IAsyncDisposable
+    {
+        public ValueTask DisposeAsync() => Context.DisposeAsync();
+    }
+}

--- a/tests/SqlOS.Tests/SqlOSClientCredentialsServiceTests.cs
+++ b/tests/SqlOS.Tests/SqlOSClientCredentialsServiceTests.cs
@@ -82,6 +82,26 @@ public sealed class SqlOSClientCredentialsServiceTests
     }
 
     [TestMethod]
+    public async Task UnknownClient_UsesProcessLocalDummyHashAndPersistsNoCredential()
+    {
+        await using var harness = await CreateHarnessAsync();
+
+        SqlOSClientCredentialsService.ResolveCredentialHashForVerification(null)
+            .Should().BeSameAs(SqlOSClientCredentialsService.DummyCredentialHash);
+        harness.Crypto.VerifyPassword(
+            SqlOSClientCredentialsService.DummyCredentialHash,
+            "unknown-client-secret-with-sufficient-length-123456789").Should().BeFalse();
+        await Assert.ThrowsExceptionAsync<SqlOSClientCredentialsException>(() => harness.Service.ExchangeAsync(
+            "unknown-client",
+            "unknown-client-secret-with-sufficient-length-123456789",
+            "https://api.example.test/ledger",
+            "ledger.read",
+            new DefaultHttpContext(),
+            default));
+        (await harness.Context.Set<SqlOSFgaServiceAccount>().CountAsync()).Should().Be(1);
+    }
+
+    [TestMethod]
     public async Task RotatingStoredHash_InvalidatesPreviouslyIssuedTokenAndOldSecret()
     {
         await using var harness = await CreateHarnessAsync();

--- a/tests/SqlOS.Tests/SqlOSClientStorageTests.cs
+++ b/tests/SqlOS.Tests/SqlOSClientStorageTests.cs
@@ -67,6 +67,33 @@ public sealed class SqlOSClientStorageTests
         client.ResponseTypesJson.Should().Contain("code");
     }
 
+    [TestMethod]
+    public async Task UpsertSeededClientsAsync_ConfiguresExplicitConfidentialServiceClientWithoutRedirects()
+    {
+        using var context = CreateContext();
+        var optionsValue = new SqlOSAuthServerOptions();
+        optionsValue.ClientSeeds.Add(new SqlOSClientSeedOptions
+        {
+            ClientId = "worker",
+            Name = "Worker",
+            Audience = "https://api.example.test/jobs",
+            ClientType = "confidential",
+            EnableClientCredentials = true,
+            RequirePkce = false,
+            AllowedScopes = ["jobs.run"]
+        });
+        var options = Options.Create(optionsValue);
+        var admin = new SqlOSAdminService(context, options, TestCryptoService.Create(context, options));
+
+        await admin.UpsertSeededClientsAsync();
+
+        var client = await context.Set<SqlOSClientApplication>().SingleAsync();
+        client.TokenEndpointAuthMethod.Should().Be("client_secret_basic");
+        client.GrantTypesJson.Should().Be("[\"client_credentials\"]");
+        client.RedirectUrisJson.Should().Be("[]");
+        client.RequirePkce.Should().BeFalse();
+    }
+
     private static TestSqlOSInMemoryDbContext CreateContext()
     {
         var options = new DbContextOptionsBuilder<TestSqlOSInMemoryDbContext>()

--- a/tests/SqlOS.Tests/SqlOSDynamicClientRegistrationServiceTests.cs
+++ b/tests/SqlOS.Tests/SqlOSDynamicClientRegistrationServiceTests.cs
@@ -69,6 +69,25 @@ public sealed class SqlOSDynamicClientRegistrationServiceTests
     }
 
     [TestMethod]
+    public async Task RegisterAsync_CannotCreateClientCredentialsClient()
+    {
+        using var context = CreateContext();
+        var service = CreateService(context, CreateOptions(), new SqlOSDynamicClientRegistrationRateLimiter());
+
+        var act = () => service.RegisterAsync(new SqlOSDynamicClientRegistrationRequest
+        {
+            ClientName = "Machine Client",
+            RedirectUris = ["https://client.example.test/callback"],
+            GrantTypes = ["client_credentials"],
+            TokenEndpointAuthMethod = "client_secret_basic"
+        }, CreateHttpContext("10.0.0.9"));
+
+        var ex = await act.Should().ThrowAsync<SqlOSClientRegistrationException>();
+        ex.Which.Error.Should().Be("invalid_client_metadata");
+        (await context.Set<SqlOSClientApplication>().CountAsync()).Should().Be(0);
+    }
+
+    [TestMethod]
     public async Task RegisterAsync_RejectsInvalidRedirectUris()
     {
         using var context = CreateContext();

--- a/web/content/docs/guides/service-account-jobs.mdx
+++ b/web/content/docs/guides/service-account-jobs.mdx
@@ -18,9 +18,63 @@ section: guides
 
 This guide builds **LedgerOps**, a fictional finance app whose nightly worker exports one organization's ledger. The worker receives a dedicated credential, resolves to `service_account::ledger-exporter`, and can perform only `LEDGER_EXPORT` on `ledger::northwind`.
 
-<Callout type="warning" title="SqlOS stores the identity; your app authenticates it">
-  `SqlOSFgaServiceAccount` and `ProvisionServiceAccountSubjectAsync` do not implement OAuth `client_credentials`, API-key middleware, secret verification, or rotation. Your trusted API boundary must perform those jobs and pass only the resolved `SubjectId` into FGA.
+<Callout type="info" title="Use OAuth client credentials for service-to-service access">
+  SqlOS can authenticate an explicitly configured confidential client with `client_secret_basic`, issue an audience-bound service token, and map its `sub` to the existing FGA service-account subject. Public clients and dynamic registration cannot enable this grant.
 </Callout>
+
+## Recommended: configure the OAuth service client
+
+Add a confidential client seed. The grant is off unless `EnableClientCredentials` is set, and no redirect URI or PKCE configuration is needed:
+
+```csharp
+options.AuthServer.ClientSeeds.Add(new SqlOSClientSeedOptions
+{
+    ClientId = "ledger-exporter",
+    Name = "Ledger Exporter",
+    Audience = "https://api.example.com/ledger",
+    ClientType = "confidential",
+    EnableClientCredentials = true,
+    RequirePkce = false,
+    AllowedScopes = ["ledger.export"]
+});
+```
+
+Provision the matching FGA service account once from an authenticated admin command. Store only the slow hash in SqlOS and deliver the raw secret directly to the worker's secret manager:
+
+```csharp
+var secret = Convert.ToHexString(RandomNumberGenerator.GetBytes(32));
+
+await db.ProvisionServiceAccountSubjectAsync(
+    subjectId: "service_account::ledger-exporter",
+    displayName: "Ledger Exporter",
+    clientId: "ledger-exporter",
+    clientSecretHash: crypto.HashPassword(secret),
+    organizationId: "northwind",
+    cancellationToken: ct);
+
+await db.GrantRoleAsync(
+    "service_account::ledger-exporter",
+    "ledger::northwind",
+    "export_reader",
+    ct);
+await db.SaveChangesAsync(ct);
+```
+
+Exchange the credential with HTTP Basic authentication. The `resource` must exactly match the seeded audience and every scope must be pre-authorized:
+
+```bash
+curl -u 'ledger-exporter:YOUR_SECRET' \
+  -d 'grant_type=client_credentials' \
+  -d 'resource=https://api.example.com/ledger' \
+  -d 'scope=ledger.export' \
+  https://identity.example.com/sqlos/auth/token
+```
+
+The response contains an access token only—never a refresh token. Its `sub` is `service_account::ledger-exporter`; it includes `client_id`, `azp`, `scope`, and `token_kind=service`, but no human email and no `sid` session claim. Normal audience validation remains mandatory at the resource server.
+
+Secret rotation is an explicit cutover: replace `ClientSecretHash` in one transaction, deliver the new secret, and restart or reconfigure the worker. The old secret immediately stops minting tokens. Already-issued short-lived access tokens remain valid until expiry; set the service account `ExpiresAt` to the current time to revoke those tokens immediately. Rotation, successful issuance, and failed authentication are recorded in the audit log.
+
+Public DCR intentionally cannot create confidential machine clients. Create them through trusted code/configuration and provision credentials through an authenticated administrative workflow.
 
 ## Goal
 
@@ -87,6 +141,10 @@ await db.SaveChangesAsync(ct);
 ```
 
 Never print the credential to stdout, especially from CI or a deployment job where output is retained. Never commit it, write it to normal application logs, or return it from a later read endpoint. If your secret manager has no SDK, use an explicitly interactive one-time admin command with shell history and session recording disabled.
+
+## Lower-level alternative: authenticate at your own API boundary
+
+If OAuth is not appropriate for an internal boundary, the following pattern remains available. It is application-owned and should not be combined with the OAuth credential for the same worker.
 
 ## 3. Authenticate at the API boundary
 


### PR DESCRIPTION
Closes #44

## Summary
- add an explicitly enabled `client_credentials` grant for confidential service clients using `client_secret_basic`
- reuse the existing slow-hashed `SqlOSFgaServiceAccount` credential and subject instead of creating a second machine-identity model
- issue short-lived audience/resource-bound access tokens with service `sub`, `client_id`, `azp`, scopes, and no human user/session claims or refresh token
- validate service-account/client lifecycle on every token validation and provide audited secret rotation and immediate account revocation
- advertise the grant and Basic authentication only when an active configured machine client exists
- keep public DCR, public clients, `none`, and `client_secret_post` unable to create/use machine credentials
- document the secure code-first setup, FGA mapping, cutover behavior, and operational boundaries

## Developer ergonomics
Nothing changes for existing browser, mobile, device, CIMD, or DCR clients. A developer opts in with one seeded confidential client (`EnableClientCredentials = true`) and provisions the matching existing FGA service account. No external key or credential service is required.

## Validation
- `./scripts/build.sh`
- `./scripts/unit-tests.sh` (621 + 2 passed)
- `./scripts/integration-tests.sh` (169 + 71 + 15 passed)
- `./scripts/docs-check.sh`
- protocol-level HTTP tests cover Basic success, access-token-only response, wrong audience, and rejected secret-post authentication
- real SQL test covers issuance, audience validation, non-human claims, audit, and immediate revocation
