### PR TITLE
Release SqlOS 3.23.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![NuGet](https://img.shields.io/nuget/v/SqlOS)](https://www.nuget.org/packages/SqlOS)
 [![.NET 9](https://img.shields.io/badge/.NET-9.0-purple)](https://dotnet.microsoft.com)
 
-SqlOS 3.22.0 provides a hosted OAuth server, branded login, organizations, sessions, and optional fine-grained authorization to an ASP.NET Core application. It runs in your process and stores its data in your SQL Server database, so you do not need a separate identity or authorization service to get started.
+SqlOS 3.23.0 provides a hosted OAuth server, branded login, organizations, sessions, and optional fine-grained authorization to an ASP.NET Core application. It runs in your process and stores its data in your SQL Server database, so you do not need a separate identity or authorization service to get started.
 
 Start with one application and hosted login. Add SAML SSO, social login, Email OTP, audit logs, calendar connections, or hierarchical authorization when your product needs them.
 
@@ -35,10 +35,10 @@ Requirements:
 Install the package:
 
 ```bash
-dotnet add package SqlOS --version 3.22.0
+dotnet add package SqlOS --version 3.23.0
 ```
 
-> The `main` branch is staged for the 3.22.0 package contract. If NuGet does not list 3.22.0 yet, run the repository examples from source or wait for the package release; do not pair these source docs with an older package.
+> The `main` branch is staged for the 3.23.0 package contract. If NuGet does not list 3.23.0 yet, run the repository examples from source or wait for the package release; do not pair these source docs with an older package.
 
 Use `SqlOSDbContext<TContext>` so SqlOS can register its EF Core model, then declare one application with `UseSingleApplication`:
 

--- a/src/SqlOS/SqlOS.csproj
+++ b/src/SqlOS/SqlOS.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>SqlOS</PackageId>
-    <Version>3.22.0</Version>
+    <Version>3.23.0</Version>
     <Authors>Ross Slaney</Authors>
     <Description>Embedded auth server and fine-grained authorization runtime for .NET + SQL Server + EF Core.</Description>
     <PackageTags>authentication;authorization;fga;saml;jwt;sessions;efcore;sqlserver</PackageTags>

--- a/web/content/blog/hierarchical-authorization-native-ef-core.mdx
+++ b/web/content/blog/hierarchical-authorization-native-ef-core.mdx
@@ -128,7 +128,7 @@ Create the host and install the same package version used to compile this articl
 ```bash
 dotnet new web --framework net9.0 --name HierarchicalEf
 cd HierarchicalEf
-dotnet add package SqlOS --version 3.22.0
+dotnet add package SqlOS --version 3.23.0
 ```
 
 Replace `Program.cs` with the program below. It assumes SQL Server is running and that callers obtain an audience-bound access token through the [Protect an API quickstart](/docs/quickstarts/protect-api). That keeps the sample focused on upgrading the EF model rather than rebuilding the OAuth client flow in the same file.

--- a/web/content/blog/sqlos-3-23-service-identities-without-an-identity-platform.mdx
+++ b/web/content/blog/sqlos-3-23-service-identities-without-an-identity-platform.mdx
@@ -1,0 +1,92 @@
+---
+title: "SqlOS 3.23: Service Identities Without an Identity Platform"
+description: "Use OAuth client credentials and SqlOS FGA for background workers while keeping credentials, policy, and revocation inside your application and SQL Server."
+date: "2026-07-16"
+author: "Ross Slaney"
+tags: ["AuthServer", "OAuth", "Client Credentials", "Service Accounts", "FGA", "SqlOS"]
+---
+
+SqlOS 3.23 adds a standards-based path for service-to-service authentication without turning an embedded .NET library into another identity platform you have to operate.
+
+A background worker can now exchange its own credential at the normal token endpoint, receive a short-lived audience-bound access token, and arrive at your API as an existing SqlOS FGA service-account subject. The secret hash, client policy, grants, and lifecycle state remain in your application's SQL Server database. There is no cloud key vault integration, extra authorization service, or new middleware order to learn.
+
+## The normal setup stays code-owned
+
+Explicitly seed a confidential client and opt it into the grant:
+
+```csharp
+options.AuthServer.ClientSeeds.Add(new SqlOSClientSeedOptions
+{
+    ClientId = "ledger-exporter",
+    Name = "Ledger Exporter",
+    Audience = "https://api.example.com/ledger",
+    ClientType = "confidential",
+    EnableClientCredentials = true,
+    RequirePkce = false,
+    AllowedScopes = ["ledger.export"]
+});
+```
+
+The opt-in matters. Existing browser and native clients do not silently become machine clients, public dynamic registration cannot request the grant, and discovery advertises it only when an active configured client can use it.
+
+Provision the corresponding FGA service account from a trusted administrative command. Generate at least 256 random bits, retain only the slow hash in SqlOS, and deliver the raw value directly to the worker's existing secret store:
+
+```csharp
+var secret = Convert.ToHexString(RandomNumberGenerator.GetBytes(32));
+
+await db.ProvisionServiceAccountSubjectAsync(
+    subjectId: "service_account::ledger-exporter",
+    displayName: "Ledger Exporter",
+    clientId: "ledger-exporter",
+    clientSecretHash: crypto.HashPassword(secret),
+    organizationId: "northwind",
+    cancellationToken: ct);
+
+await db.GrantRoleAsync(
+    "service_account::ledger-exporter",
+    "ledger::northwind",
+    "export_reader",
+    ct);
+await db.SaveChangesAsync(ct);
+```
+
+Do not print that secret or return it from a later read endpoint. SqlOS cannot recover it because the database contains only the password hash.
+
+## Exchange the credential using the OAuth protocol
+
+The worker authenticates with HTTP Basic and asks for the exact configured resource and an allowed scope:
+
+```bash
+curl -u 'ledger-exporter:YOUR_SECRET' \
+  -d 'grant_type=client_credentials' \
+  -d 'resource=https://api.example.com/ledger' \
+  -d 'scope=ledger.export' \
+  https://identity.example.com/sqlos/auth/token
+```
+
+The response contains a short-lived access token and no refresh token. The token carries `sub=service_account::ledger-exporter`, `client_id`, `azp`, `scope`, and `token_kind=service`. It deliberately has no human email or browser-session claim. Your API continues to validate the issuer and its own audience before applying the same FGA checks it uses for other subject types.
+
+SqlOS rejects credentials in the request body, scopes that were not seeded, and resources that do not exactly match the client's audience. Unknown and known client IDs also follow the same lookup and slow-hash verification shape so a caller cannot cheaply probe which machine identities exist.
+
+## Rotation and revocation are local operations
+
+Rotation is an explicit cutover: generate a new secret, replace the stored hash in one transaction, deliver the new value to the worker, and restart or reconfigure it. The previous credential immediately stops minting tokens.
+
+Already-issued access tokens remain useful only for their short lifetime. For immediate revocation, expire the service account; database-backed token validation and FGA lifecycle enforcement then reject the identity. Issuance, failed authentication, rotation, and revocation are written to the SqlOS audit log.
+
+There is no automatic dependency on Azure, AWS, or any platform key service. A deployment can still store the worker's one-time raw secret in whatever secret mechanism it already trusts, but SqlOS itself remains portable across modern .NET environments.
+
+## More security work in 3.23
+
+The release also closes several less-visible authorization and federation edges:
+
+- admin APIs now share one explicit authorization policy;
+- FGA hierarchy depth and lifecycle rules are consistent across point checks and SQL query filtering;
+- FGA SQL functions deploy safely across upgrades and reject cycles;
+- public throttling can coordinate through SQL across application instances;
+- AuthServer endpoint mapping is split into auditable protocol modules; and
+- upstream MFA is trusted only when both the provider and the individual claim mapping are explicitly configured.
+
+Each change went through an adversarial review and follow-up iteration with negative-path, protocol-level, and real-SQL integration coverage. The result is a higher security floor without adding production infrastructure to the everyday developer experience.
+
+For the complete setup, including a lower-level application-owned alternative, see [Background jobs with service accounts](/docs/guides/service-account-jobs).

--- a/web/content/docs/docs-index.mdx
+++ b/web/content/docs/docs-index.mdx
@@ -5,7 +5,7 @@ order: 0
 ---
 
 <Callout type="info" title="Version contract">
-  These docs target **SqlOS 3.22.0**, **.NET 9**, **EF Core 9**, and **SQL Server**. Use the same package version as the docs; older releases do not include the complete current schema and source/reference contract.
+  These docs target **SqlOS 3.23.0**, **.NET 9**, **EF Core 9**, and **SQL Server**. Use the same package version as the docs; older releases do not include the complete current schema and source/reference contract.
 </Callout>
 
 ## Get useful proof first

--- a/web/content/docs/getting-started.mdx
+++ b/web/content/docs/getting-started.mdx
@@ -14,7 +14,7 @@ order: 0
 </Banner>
 
 <Callout type="info" title="Supported stack">
-  - **SqlOS 3.22.0**
+  - **SqlOS 3.23.0**
   - **.NET 9** (`net9.0`)
   - **EF Core 9**
   - **SQL Server**

--- a/web/content/docs/quickstarts/add-to-app.mdx
+++ b/web/content/docs/quickstarts/add-to-app.mdx
@@ -11,7 +11,7 @@ section: quickstarts
   href="#complete-program"
   actionLabel="View the code"
 >
-  Install SqlOS 3.22.0, register one SQL Server `DbContext`, declare one application, and map the routes. FGA modeling and advanced client registration can wait.
+  Install SqlOS 3.23.0, register one SQL Server `DbContext`, declare one application, and map the routes. FGA modeling and advanced client registration can wait.
 </Banner>
 
 ## Goal
@@ -30,16 +30,16 @@ Start an ASP.NET Core application with:
 - EF Core 9;
 - an existing SQL Server database and a login allowed to create tables, indexes, and functions.
 
-SqlOS 3.22.0 targets `net9.0`; it is not compatible with a `net8.0` host.
+SqlOS 3.23.0 targets `net9.0`; it is not compatible with a `net8.0` host.
 
 ## Install
 
 ```bash
-dotnet add package SqlOS --version 3.22.0
+dotnet add package SqlOS --version 3.23.0
 ```
 
 <Callout type="warning" title="Use the matching package version">
-  The `3.22.0` package is the version contract for this guide. If NuGet does not list it yet, run the source examples from this repository or wait for the release; older packages may not contain the schema and APIs documented here.
+  The `3.23.0` package is the version contract for this guide. If NuGet does not list it yet, run the source examples from this repository or wait for the release; older packages may not contain the schema and APIs documented here.
 </Callout>
 
 For a new project, store local values with user secrets:

--- a/web/content/docs/quickstarts/ef-authorization.mdx
+++ b/web/content/docs/quickstarts/ef-authorization.mdx
@@ -20,7 +20,7 @@ Create projects through an audience-protected API and return only projects the s
 
 ## Prerequisites
 
-- SqlOS 3.22.0;
+- SqlOS 3.23.0;
 - .NET 9, EF Core 9, and SQL Server;
 - a completed [Protect an API](/docs/quickstarts/protect-api) flow;
 - a valid access token whose `aud` is `http://localhost:5050/api`.

--- a/web/content/docs/quickstarts/protect-api.mdx
+++ b/web/content/docs/quickstarts/protect-api.mdx
@@ -20,7 +20,7 @@ Add `/api/me` to a one-application SqlOS host. Requests without a bearer token r
 
 ## Prerequisites
 
-- SqlOS 3.22.0;
+- SqlOS 3.23.0;
 - .NET 9 and EF Core 9;
 - the [Add SqlOS to one app](/docs/quickstarts/add-to-app) setup;
 - the working [.NET hosted-login flow](/docs/quickstarts/aspnet-core-login), adapted so its registered callback matches your handler and its audience is `http://localhost:5050/api`, or another PKCE client that does the same.

--- a/web/content/docs/quickstarts/run-example-stack.mdx
+++ b/web/content/docs/quickstarts/run-example-stack.mdx
@@ -20,7 +20,7 @@ Compare hosted and headless auth, organization workflows, SSO, sessions, audit l
 
 ## Prerequisites
 
-- SqlOS repository checked out at version 3.22.0;
+- SqlOS repository checked out at version 3.23.0;
 - .NET 9 SDK;
 - Node.js and npm;
 - Docker running with enough memory for SQL Server;

--- a/web/content/docs/quickstarts/run-todo.mdx
+++ b/web/content/docs/quickstarts/run-todo.mdx
@@ -25,7 +25,7 @@ Create an account through the SqlOS hosted AuthPage, return to a secure ASP.NET 
 - Docker running with enough memory for SQL Server;
 - ports `1435`, `5080`, `5090`, `18890`, and `18891` available.
 
-This quickstart uses the source at **SqlOS 3.22.0**. Local password authentication is the default, so the first run does not require Azure Communication Services, Twilio, or an OIDC provider.
+This quickstart uses the source at **SqlOS 3.23.0**. Local password authentication is the default, so the first run does not require Azure Communication Services, Twilio, or an OIDC provider.
 
 ## Run
 

--- a/web/content/docs/reference/index.mdx
+++ b/web/content/docs/reference/index.mdx
@@ -1,13 +1,13 @@
 ---
 title: "Reference"
-description: "Source-aligned reference for SqlOS 3.22.0 hosting, authentication, authorization, and integration APIs."
+description: "Source-aligned reference for SqlOS 3.23.0 hosting, authentication, authorization, and integration APIs."
 order: 7
 section: reference
 ---
 
 <Banner
   eyebrow="Reference"
-  title="SqlOS 3.22.0 application API"
+  title="SqlOS 3.23.0 application API"
   href="/docs/getting-started"
   actionLabel="Start with a guide"
 >
@@ -19,7 +19,7 @@ section: reference
 | Item | Value |
 | --- | --- |
 | Package | `SqlOS` |
-| Current source version | `3.22.0` |
+| Current source version | `3.23.0` |
 | Assembly | `SqlOS.dll` |
 | Target framework | `net9.0` |
 | EF Core provider | SQL Server, EF Core 9 |


### PR DESCRIPTION
## Summary

- bump the SqlOS package and all source-aligned install examples from 3.22.0 to 3.23.0
- publish a practical client-credentials article covering code-owned setup, token exchange, FGA, rotation, revocation, and secure defaults
- release the BV3 security and operability work merged in #203 through #209

## Developer impact

Client credentials are opt-in per confidential client. Existing browser/native clients, dynamic registration, middleware ordering, and application startup require no changes. Service identities reuse SqlOS SQL storage and FGA subjects; there is no cloud key service or new infrastructure dependency.

## Validation

- solution build: 0 warnings, 0 errors
- library unit tests: 622 passed
- docs source contracts, snippets, lint, TypeScript, production build, images, and links passed
- package created and inspected as `SqlOS.3.23.0.nupkg`
- the complete real SQL/protocol integration and coverage matrix will run in PR CI before merge

## Included work

- #203 / #106 centralized admin API authorization
- #204 / #135 unified FGA hierarchy depth
- #205 / #139 deployment-safe, cycle-tolerant FGA TVFs
- #206 / #107 distributed public throttling
- #207 / #32 auditable AuthServer endpoint modules
- #208 / #43 explicit upstream MFA trust policy
- #209 / #44 OAuth client credentials for FGA service accounts
