### PR TITLE
Document SqlOS control-plane parity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# SqlOS contributor guidance
+
+These instructions apply to the entire repository.
+
+## Product control-plane parity
+
+Administrative product capabilities should be designed as one domain model exposed through three control planes. Do not build separate policy or validation implementations for code, HTTP APIs, and the dashboard.
+
+### Code-first configuration
+
+- Provide strongly typed options and seeds when configuration should be reproducible in source control.
+- Make startup reconciliation deterministic and idempotent.
+- Track configuration ownership explicitly. Code-owned records may be reconciled authoritatively, but startup must not overwrite dashboard-owned records or silently change their ownership.
+- Keep credentials out of committed configuration. Resolve protected values through the host application's existing configuration or secret mechanism and fail closed when required material is unavailable.
+
+### Programmable administration
+
+- Provide authenticated application services/SDKs and admin APIs for operations developers reasonably need to automate, such as creating connections, rotating credentials, previewing policies, triggering synchronization, and inspecting outcomes.
+- Route programmatic operations through the same domain services, normalization, validation, authorization, tenancy, secret handling, and audit behavior used by every other control plane.
+- Return stable, machine-readable results and typed failures without exposing stored secrets or internal security material.
+
+### Dashboard workflow
+
+- Treat the embedded dashboard as a first-class operator experience, not a later wrapper around incomplete APIs.
+- Support the relevant setup, validation, testing, troubleshooting, rotation, disablement, audit history, ownership/source visibility, and copy-ready integration values for the capability.
+- Make code-owned records observable and testable while clearly identifying fields that must be changed in source control.
+- Keep secrets write-only or one-time reveal and never render protected credential material after creation.
+
+### Definition of done
+
+- Code-first, API-created, and dashboard-created configuration must produce equivalent runtime behavior when all three control planes apply.
+- Add parity tests that exercise realistic paths through each applicable control plane and prove they share behavior rather than merely sharing data shapes.
+- Document ownership and reconciliation semantics, especially how code-owned and dashboard-owned records coexist.
+- Internal secure defaults do not need artificial configuration or dashboard switches. Apply this standard to product capabilities operators manage, not invisible protocol hardening such as token validation rules.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,24 @@ SqlOS 3.23.0 provides a hosted OAuth server, branded login, organizations, sessi
 
 Start with one application and hosted login. Add SAML SSO, social login, Email OTP, audit logs, calendar connections, or hierarchical authorization when your product needs them.
 
+## One capability, three control planes
+
+SqlOS keeps infrastructure optional without making operations opaque. Administrative capabilities are designed as one underlying implementation exposed in three ways:
+
+### Code-first configuration
+
+Use strongly typed options and seeds when configuration should be reproducible in source control. Startup reconciliation is deterministic and idempotent: code-owned records can be kept aligned with code without silently overwriting records owned by dashboard operators.
+
+### Programmable administration
+
+Use authenticated services/SDKs and admin APIs to automate work such as creating connections, rotating credentials, previewing policies, triggering synchronization, and inspecting outcomes. These operations share the same validation, authorization, tenancy, secret handling, and audit behavior as every other control plane.
+
+### Dashboard workflow
+
+Use the embedded dashboard for complete operator workflows: setup, validation, testing, troubleshooting, rotation, disablement, audit history, ownership visibility, and copy-ready integration values. Code-owned records remain visible and testable while clearly identifying fields controlled by source code.
+
+The three paths do not implement separate policy. When a capability supports all three, code-first, API-created, and dashboard-created configuration must produce equivalent runtime behavior. Invisible security defaults remain automatic; they do not gain unnecessary switches merely to appear in the dashboard.
+
 ## Choose your starting point
 
 ### See SqlOS work first


### PR DESCRIPTION
## Summary

- add repository-wide contributor guidance for code-first configuration, programmable administration, and complete dashboard workflows
- document ownership and idempotent reconciliation requirements so code-owned configuration cannot silently overwrite dashboard-owned records
- make runtime parity, shared domain services, audit behavior, secret handling, and cross-control-plane tests part of the definition of done
- explain the same product principle to README readers while preserving automatic, switch-free internal security defaults

## Why

SqlOS should remain fully programmable while also providing a first-class embedded operator dashboard. These surfaces must be equivalent ways into the same implementation, not separate policy systems or an SDK-first feature with UI deferred indefinitely.

## Validation

- source-aligned docs validation passed
- image validation passed
- compiled documentation snippets passed
- ESLint passed
- Next.js production build passed
- 169 markdown files passed local-link validation
- `git diff --check` passed

The first aggregate docs run encountered an environment-only `ENOSPC` during Next build. Generated dependencies from completed release worktrees were removed, then the production build and link validation passed.