### PR TITLE
Add shared configuration ownership and reconciliation

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,5 +1,7 @@
 # Configuration
 
+See [Configuration ownership and reconciliation](CONFIGURATION_OWNERSHIP.md) for the shared rules that keep code-first seeds, the admin API, dynamic registration, and dashboard edits from overwriting one another.
+
 This guide moved to the docs site:
 
 **https://sqlos.dev/docs/guides/configuration**

--- a/docs/CONFIGURATION_OWNERSHIP.md
+++ b/docs/CONFIGURATION_OWNERSHIP.md
@@ -1,0 +1,25 @@
+# Configuration ownership and reconciliation
+
+SqlOS configuration can come from code-first startup seeds, the authenticated administration API and dashboard, dynamic protocol registration, internal defaults, or an external authority. Persisted configuration records identify that owner so one control plane cannot silently overwrite another.
+
+## Ownership rules
+
+- `code`: reconciled from a stable startup seed. Dashboard and admin API views are read-only for controlled fields.
+- `dashboard`: created and edited through the dashboard or administration API.
+- `dynamic`: created by a protocol such as DCR or CIMD. Its protocol lifecycle remains authoritative.
+- `system`: an internal default that a first explicit operator edit may claim.
+- `external`: reserved for configurations whose source of truth is outside SqlOS.
+
+OAuth clients use their client ID as the seed key. SCIM connections use the required key passed to `SeedScimConnection`. Custom OIDC connections should use `SeedOidcConnection(key, configure)`; provider helpers assign deterministic keys automatically. Global MFA uses `mfa:default`.
+
+Reconciliation stores a SHA-256 fingerprint of canonical non-secret configuration and the last successful reconciliation time. Secret values are never part of the fingerprint or diagnostics. Re-running an unchanged seed is idempotent. A seed may update only a record with the same `code` owner and stable source key; a dashboard-owned collision fails startup with a clear conflict instead of adopting or overwriting it.
+
+## Operator controls
+
+Removing a seed marks its record as orphaned but does not delete, disable, or clear it. This avoids turning a deployment mistake into an outage. Operators review the `Seed missing` state and explicitly disable or remove the resource when intended.
+
+Code-owned resources keep a narrow emergency enable/disable control. The dashboard cannot edit their controlled fields, rotate their code-supplied material, or change ownership. Restore normal service by correcting the startup configuration; ownership transfer is intentionally explicit rather than inferred.
+
+## Migrated resource families
+
+The shared model is applied to startup-seeded OAuth clients, social/OIDC connections, SCIM directory connections, and global MFA settings. Operational rows such as sessions, tokens, challenges, and audit events are intentionally outside this model.

--- a/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerModelConfiguration.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerModelConfiguration.cs
@@ -182,6 +182,12 @@ public static class SqlOSAuthServerModelConfiguration
             entity.Property(x => x.TokenHash).HasMaxLength(128);
             entity.Property(x => x.TokenPrefix).HasMaxLength(24);
             entity.Property(x => x.Source).HasMaxLength(40);
+            entity.Property(x => x.ConfigurationOwner).HasMaxLength(40);
+            entity.Property(x => x.ConfigurationSourceKey).HasMaxLength(160);
+            entity.Property(x => x.ConfigurationFingerprint).HasMaxLength(64);
+            entity.HasIndex(x => new { x.OrganizationId, x.ConfigurationOwner, x.ConfigurationSourceKey })
+                .IsUnique()
+                .HasFilter("[ConfigurationSourceKey] IS NOT NULL");
             entity.HasOne(x => x.Organization)
                 .WithMany(x => x.ScimConnections)
                 .HasForeignKey(x => x.OrganizationId)
@@ -367,6 +373,12 @@ public static class SqlOSAuthServerModelConfiguration
             entity.Property(x => x.AppleKeyId).HasMaxLength(100);
             entity.Property(x => x.AcceptedAmrValuesJson).HasDefaultValue("[]");
             entity.Property(x => x.AcceptedAcrValuesJson).HasDefaultValue("[]");
+            entity.Property(x => x.ConfigurationOwner).HasMaxLength(40);
+            entity.Property(x => x.ConfigurationSourceKey).HasMaxLength(160);
+            entity.Property(x => x.ConfigurationFingerprint).HasMaxLength(64);
+            entity.HasIndex(x => new { x.ConfigurationOwner, x.ConfigurationSourceKey })
+                .IsUnique()
+                .HasFilter("[ConfigurationSourceKey] IS NOT NULL");
         });
 
         modelBuilder.Entity<SqlOSExternalIdentity>(entity =>
@@ -412,6 +424,12 @@ public static class SqlOSAuthServerModelConfiguration
             entity.Property(x => x.Description).HasMaxLength(500);
             entity.Property(x => x.ClientType).HasMaxLength(40);
             entity.Property(x => x.RegistrationSource).HasMaxLength(20);
+            entity.Property(x => x.ConfigurationOwner).HasMaxLength(40);
+            entity.Property(x => x.ConfigurationSourceKey).HasMaxLength(160);
+            entity.Property(x => x.ConfigurationFingerprint).HasMaxLength(64);
+            entity.HasIndex(x => new { x.ConfigurationOwner, x.ConfigurationSourceKey })
+                .IsUnique()
+                .HasFilter("[ConfigurationSourceKey] IS NOT NULL");
             entity.Property(x => x.TokenEndpointAuthMethod).HasMaxLength(60);
             entity.Property(x => x.MetadataDocumentUrl).HasMaxLength(850);
             entity.Property(x => x.ClientUri).HasMaxLength(850);
@@ -607,6 +625,9 @@ public static class SqlOSAuthServerModelConfiguration
             entity.Property(x => x.Id).HasMaxLength(64);
             entity.Property(x => x.RequiredRolesJson).HasColumnType("nvarchar(max)");
             entity.Property(x => x.AvailableFactorsJson).HasColumnType("nvarchar(max)");
+            entity.Property(x => x.ConfigurationOwner).HasMaxLength(40);
+            entity.Property(x => x.ConfigurationSourceKey).HasMaxLength(160);
+            entity.Property(x => x.ConfigurationFingerprint).HasMaxLength(64);
         });
 
         modelBuilder.Entity<SqlOSOrganizationMfaPolicy>(entity =>

--- a/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerOptions.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerOptions.cs
@@ -124,6 +124,16 @@ public class SqlOSAuthServerOptions
         return this;
     }
 
+    /// <summary>Seed a social/OIDC connection with a stable source key.</summary>
+    public SqlOSAuthServerOptions SeedOidcConnection(string key, Action<SqlOSOidcConnectionSeedOptions> configure)
+    {
+        if (string.IsNullOrWhiteSpace(key)) throw new InvalidOperationException("Seeded OIDC connections require a stable key.");
+        var seed = new SqlOSOidcConnectionSeedOptions { Key = key.Trim() };
+        configure(seed);
+        OidcConnectionSeeds.Add(seed);
+        return this;
+    }
+
     /// <summary>
     /// Seed an organization-scoped SCIM directory sync connection. Seeded connections are reconciled
     /// on startup by stable key; mapping rules are reconciled by source key.
@@ -154,6 +164,7 @@ public class SqlOSAuthServerOptions
         params string[] allowedCallbackUris)
         => SeedOidcConnection(oidc =>
         {
+            oidc.Key = "microsoft";
             oidc.ProviderType = SqlOSOidcProviderType.Microsoft;
             oidc.DisplayName = "Microsoft";
             oidc.ClientId = clientId;
@@ -174,6 +185,7 @@ public class SqlOSAuthServerOptions
         params string[] allowedCallbackUris)
         => SeedOidcConnection(oidc =>
         {
+            oidc.Key = "google";
             oidc.ProviderType = SqlOSOidcProviderType.Google;
             oidc.DisplayName = "Google";
             oidc.ClientId = clientId;
@@ -195,6 +207,7 @@ public class SqlOSAuthServerOptions
         params string[] allowedCallbackUris)
         => SeedOidcConnection(oidc =>
         {
+            oidc.Key = "github";
             oidc.ProviderType = SqlOSOidcProviderType.GitHub;
             oidc.DisplayName = "GitHub";
             oidc.ClientId = clientId;

--- a/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerSeedOptions.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerSeedOptions.cs
@@ -119,6 +119,8 @@ public sealed class SqlOSClientSeedOptions
 /// </summary>
 public sealed class SqlOSOidcConnectionSeedOptions
 {
+    /// <summary>Stable source key used to reconcile this connection across renames.</summary>
+    public string? Key { get; set; }
     public SqlOSOidcProviderType ProviderType { get; set; } = SqlOSOidcProviderType.Custom;
     public string DisplayName { get; set; } = string.Empty;
     public string ClientId { get; set; } = string.Empty;

--- a/src/SqlOS/AuthServer/Contracts/SqlOSConfigurationOwnership.cs
+++ b/src/SqlOS/AuthServer/Contracts/SqlOSConfigurationOwnership.cs
@@ -1,0 +1,21 @@
+namespace SqlOS.AuthServer.Contracts;
+
+/// <summary>Identifies the control plane that owns a persisted configuration record.</summary>
+public static class SqlOSConfigurationOwners
+{
+    public const string Code = "code";
+    public const string Dashboard = "dashboard";
+    public const string Dynamic = "dynamic";
+    public const string System = "system";
+    public const string External = "external";
+}
+
+/// <summary>Ownership and reconciliation state exposed consistently by administration surfaces.</summary>
+public sealed record SqlOSConfigurationOwnershipDto(
+    string Owner,
+    string? SourceKey,
+    DateTime? LastReconciledAt,
+    string? ConfigurationFingerprint,
+    bool IsEditable,
+    bool CanEmergencyDisable,
+    bool IsOrphaned);

--- a/src/SqlOS/AuthServer/Contracts/SqlOSMfaContracts.cs
+++ b/src/SqlOS/AuthServer/Contracts/SqlOSMfaContracts.cs
@@ -16,7 +16,8 @@ public sealed record SqlOSMfaSettingsDto(
     IReadOnlyList<string> RequiredRoles,
     IReadOnlyList<string> AvailableFactors,
     DateTime UpdatedAt,
-    bool ManagedByStartupSeed);
+    bool ManagedByStartupSeed,
+    SqlOSConfigurationOwnershipDto Ownership);
 
 public sealed record SqlOSUpdateMfaSettingsRequest(
     bool Enabled,

--- a/src/SqlOS/AuthServer/Endpoints/EndpointContracts.cs
+++ b/src/SqlOS/AuthServer/Endpoints/EndpointContracts.cs
@@ -86,6 +86,7 @@ public static partial class EndpointRouteBuilderExtensions
         AcceptedAmrValues = SqlOSAdminService.DeserializeJsonList(connection.AcceptedAmrValuesJson),
         AcceptedAcrValues = SqlOSAdminService.DeserializeJsonList(connection.AcceptedAcrValuesJson),
         connection.IsEnabled,
+        Ownership = SqlOSConfigurationOwnershipPolicy.ToDto(connection.ConfigurationOwner, connection.ConfigurationSourceKey, connection.LastReconciledAt, connection.ConfigurationFingerprint, connection.ConfigurationOrphanedAt),
         connection.CreatedAt,
         connection.UpdatedAt
     };

--- a/src/SqlOS/AuthServer/Endpoints/ScimEndpointSupport.cs
+++ b/src/SqlOS/AuthServer/Endpoints/ScimEndpointSupport.cs
@@ -220,6 +220,7 @@ public static partial class EndpointRouteBuilderExtensions
         connection.IsEnabled,
         connection.Source,
         connection.SeedKey,
+        Ownership = SqlOSConfigurationOwnershipPolicy.ToDto(connection.ConfigurationOwner, connection.ConfigurationSourceKey, connection.LastReconciledAt, connection.ConfigurationFingerprint, connection.ConfigurationOrphanedAt),
         connection.TokenPrefix,
         connection.TokenRotatedAt,
         connection.TokenLastUsedAt,

--- a/src/SqlOS/AuthServer/Models/SqlOSEntities.cs
+++ b/src/SqlOS/AuthServer/Models/SqlOSEntities.cs
@@ -189,6 +189,11 @@ public sealed class SqlOSScimConnection
     public DateTime? TokenLastUsedAt { get; set; }
     public DateTime? LastSyncAt { get; set; }
     public string Source { get; set; } = "dashboard";
+    public string ConfigurationOwner { get; set; } = "dashboard";
+    public string? ConfigurationSourceKey { get; set; }
+    public string? ConfigurationFingerprint { get; set; }
+    public DateTime? LastReconciledAt { get; set; }
+    public DateTime? ConfigurationOrphanedAt { get; set; }
     public DateTime CreatedAt { get; set; }
     public DateTime UpdatedAt { get; set; }
 
@@ -368,6 +373,11 @@ public sealed class SqlOSOidcConnection
     public bool TrustUpstreamMfa { get; set; }
     public string AcceptedAmrValuesJson { get; set; } = "[]";
     public string AcceptedAcrValuesJson { get; set; } = "[]";
+    public string ConfigurationOwner { get; set; } = "dashboard";
+    public string? ConfigurationSourceKey { get; set; }
+    public string? ConfigurationFingerprint { get; set; }
+    public DateTime? LastReconciledAt { get; set; }
+    public DateTime? ConfigurationOrphanedAt { get; set; }
     public DateTime CreatedAt { get; set; }
     public DateTime UpdatedAt { get; set; }
 
@@ -467,6 +477,11 @@ public sealed class SqlOSClientApplication
     public string AccessMode { get; set; } = "all_organizations";
     public string ClientType { get; set; } = "public_pkce";
     public string RegistrationSource { get; set; } = "manual";
+    public string ConfigurationOwner { get; set; } = "dashboard";
+    public string? ConfigurationSourceKey { get; set; }
+    public string? ConfigurationFingerprint { get; set; }
+    public DateTime? LastReconciledAt { get; set; }
+    public DateTime? ConfigurationOrphanedAt { get; set; }
     public string TokenEndpointAuthMethod { get; set; } = "none";
     public string GrantTypesJson { get; set; } = "[\"authorization_code\",\"refresh_token\"]";
     public string ResponseTypesJson { get; set; } = "[\"code\"]";
@@ -642,6 +657,11 @@ public sealed class SqlOSMfaSettings
     public bool RequireForOwnersAndAdmins { get; set; }
     public string RequiredRolesJson { get; set; } = "[\"owner\",\"admin\"]";
     public string AvailableFactorsJson { get; set; } = "[\"totp\",\"recovery_code\"]";
+    public string ConfigurationOwner { get; set; } = "system";
+    public string? ConfigurationSourceKey { get; set; }
+    public string? ConfigurationFingerprint { get; set; }
+    public DateTime? LastReconciledAt { get; set; }
+    public DateTime? ConfigurationOrphanedAt { get; set; }
     public DateTime UpdatedAt { get; set; }
 }
 

--- a/src/SqlOS/AuthServer/Schema/034_ConfigurationOwnership.sql
+++ b/src/SqlOS/AuthServer/Schema/034_ConfigurationOwnership.sql
@@ -1,0 +1,26 @@
+IF OBJECT_ID(N'[{Schema}].[SqlOSClientApplications]', N'U') IS NOT NULL AND COL_LENGTH('[{Schema}].[SqlOSClientApplications]', 'ConfigurationOwner') IS NULL
+BEGIN
+    EXEC(N'ALTER TABLE [{Schema}].[SqlOSClientApplications] ADD [ConfigurationOwner] NVARCHAR(40) NOT NULL CONSTRAINT [DF_SqlOSClientApplications_ConfigurationOwner] DEFAULT N''dashboard'', [ConfigurationSourceKey] NVARCHAR(160) NULL, [ConfigurationFingerprint] NVARCHAR(64) NULL, [LastReconciledAt] DATETIME2 NULL, [ConfigurationOrphanedAt] DATETIME2 NULL;');
+    IF COL_LENGTH('[{Schema}].[SqlOSClientApplications]', 'RegistrationSource') IS NOT NULL
+        AND COL_LENGTH('[{Schema}].[SqlOSClientApplications]', 'ClientId') IS NOT NULL
+        EXEC(N'UPDATE [{Schema}].[SqlOSClientApplications] SET [ConfigurationOwner] = CASE WHEN [RegistrationSource] = N''seeded'' THEN N''code'' WHEN [RegistrationSource] IN (N''dcr'', N''cimd'') THEN N''dynamic'' ELSE N''dashboard'' END, [ConfigurationSourceKey] = CASE WHEN [RegistrationSource] = N''seeded'' THEN [ClientId] ELSE NULL END;');
+END
+IF OBJECT_ID(N'[{Schema}].[SqlOSClientApplications]', N'U') IS NOT NULL AND NOT EXISTS (SELECT 1 FROM sys.indexes WHERE [object_id] = OBJECT_ID(N'[{Schema}].[SqlOSClientApplications]') AND [name] = N'UX_SqlOSClientApplications_ConfigurationOwner_SourceKey')
+    EXEC(N'CREATE UNIQUE INDEX [UX_SqlOSClientApplications_ConfigurationOwner_SourceKey] ON [{Schema}].[SqlOSClientApplications]([ConfigurationOwner], [ConfigurationSourceKey]) WHERE [ConfigurationSourceKey] IS NOT NULL;');
+IF OBJECT_ID(N'[{Schema}].[SqlOSAuthOidcConnections]', N'U') IS NOT NULL AND COL_LENGTH('[{Schema}].[SqlOSAuthOidcConnections]', 'ConfigurationOwner') IS NULL
+BEGIN
+    EXEC(N'ALTER TABLE [{Schema}].[SqlOSAuthOidcConnections] ADD [ConfigurationOwner] NVARCHAR(40) NOT NULL CONSTRAINT [DF_SqlOSAuthOidcConnections_ConfigurationOwner] DEFAULT N''dashboard'', [ConfigurationSourceKey] NVARCHAR(160) NULL, [ConfigurationFingerprint] NVARCHAR(64) NULL, [LastReconciledAt] DATETIME2 NULL, [ConfigurationOrphanedAt] DATETIME2 NULL;');
+END
+IF OBJECT_ID(N'[{Schema}].[SqlOSAuthOidcConnections]', N'U') IS NOT NULL AND NOT EXISTS (SELECT 1 FROM sys.indexes WHERE [object_id] = OBJECT_ID(N'[{Schema}].[SqlOSAuthOidcConnections]') AND [name] = N'UX_SqlOSAuthOidcConnections_ConfigurationOwner_SourceKey')
+    EXEC(N'CREATE UNIQUE INDEX [UX_SqlOSAuthOidcConnections_ConfigurationOwner_SourceKey] ON [{Schema}].[SqlOSAuthOidcConnections]([ConfigurationOwner], [ConfigurationSourceKey]) WHERE [ConfigurationSourceKey] IS NOT NULL;');
+IF OBJECT_ID(N'[{Schema}].[SqlOSScimConnections]', N'U') IS NOT NULL AND COL_LENGTH('[{Schema}].[SqlOSScimConnections]', 'ConfigurationOwner') IS NULL
+BEGIN
+    EXEC(N'ALTER TABLE [{Schema}].[SqlOSScimConnections] ADD [ConfigurationOwner] NVARCHAR(40) NOT NULL CONSTRAINT [DF_SqlOSScimConnections_ConfigurationOwner] DEFAULT N''dashboard'', [ConfigurationSourceKey] NVARCHAR(160) NULL, [ConfigurationFingerprint] NVARCHAR(64) NULL, [LastReconciledAt] DATETIME2 NULL, [ConfigurationOrphanedAt] DATETIME2 NULL;');
+    EXEC(N'UPDATE [{Schema}].[SqlOSScimConnections] SET [ConfigurationOwner] = CASE WHEN [Source] = N''seeded'' THEN N''code'' ELSE N''dashboard'' END, [ConfigurationSourceKey] = CASE WHEN [Source] = N''seeded'' THEN [SeedKey] ELSE NULL END;');
+END
+IF OBJECT_ID(N'[{Schema}].[SqlOSScimConnections]', N'U') IS NOT NULL AND NOT EXISTS (SELECT 1 FROM sys.indexes WHERE [object_id] = OBJECT_ID(N'[{Schema}].[SqlOSScimConnections]') AND [name] = N'UX_SqlOSScimConnections_Organization_Owner_SourceKey')
+    EXEC(N'CREATE UNIQUE INDEX [UX_SqlOSScimConnections_Organization_Owner_SourceKey] ON [{Schema}].[SqlOSScimConnections]([OrganizationId], [ConfigurationOwner], [ConfigurationSourceKey]) WHERE [ConfigurationSourceKey] IS NOT NULL;');
+IF OBJECT_ID(N'[{Schema}].[SqlOSMfaSettings]', N'U') IS NOT NULL AND COL_LENGTH('[{Schema}].[SqlOSMfaSettings]', 'ConfigurationOwner') IS NULL
+BEGIN
+    EXEC(N'ALTER TABLE [{Schema}].[SqlOSMfaSettings] ADD [ConfigurationOwner] NVARCHAR(40) NOT NULL CONSTRAINT [DF_SqlOSMfaSettings_ConfigurationOwner] DEFAULT N''system'', [ConfigurationSourceKey] NVARCHAR(160) NULL, [ConfigurationFingerprint] NVARCHAR(64) NULL, [LastReconciledAt] DATETIME2 NULL, [ConfigurationOrphanedAt] DATETIME2 NULL;');
+END

--- a/src/SqlOS/AuthServer/Services/SqlOSAdminService.Scim.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSAdminService.Scim.cs
@@ -117,13 +117,7 @@ public sealed partial class SqlOSAdminService
             string.IsNullOrWhiteSpace(connection.SeedKey)
                 || !configuredConnections.Contains(BuildConfiguredScimConnectionKey(connection.OrganizationId, connection.SeedKey))))
         {
-            await RevokeManagedGrantsAsync(orphaned.Id, mappingId: null, cancellationToken: cancellationToken);
-            orphaned.IsEnabled = false;
-            orphaned.TokenHash = null;
-            orphaned.TokenPrefix = null;
-            orphaned.TokenRotatedAt = null;
-            orphaned.TokenLastUsedAt = null;
-            orphaned.UpdatedAt = DateTime.UtcNow;
+            orphaned.ConfigurationOrphanedAt ??= DateTime.UtcNow;
         }
         await _context.SaveChangesAsync(cancellationToken);
 
@@ -176,6 +170,8 @@ public sealed partial class SqlOSAdminService
                     DisplayName = displayName,
                     IsEnabled = seed.Enabled,
                     Source = SqlOSScimSources.Seeded,
+                    ConfigurationOwner = SqlOSConfigurationOwners.Code,
+                    ConfigurationSourceKey = seedKey,
                     CreatedAt = now,
                     UpdatedAt = now
                 };
@@ -183,15 +179,30 @@ public sealed partial class SqlOSAdminService
             }
             else
             {
+                if (existing.ConfigurationSourceKey == null && existing.Source == SqlOSScimSources.Seeded)
+                {
+                    existing.ConfigurationOwner = SqlOSConfigurationOwners.Code;
+                    existing.ConfigurationSourceKey = seedKey;
+                }
+                SqlOSConfigurationOwnershipPolicy.EnsureCodeOwnership(existing.ConfigurationOwner, existing.ConfigurationSourceKey, seedKey, $"SCIM connection '{displayName}'");
                 if (existing.IsEnabled && !seed.Enabled)
                 {
                     await RevokeManagedGrantsAsync(existing.Id, mappingId: null, cancellationToken: cancellationToken);
                 }
                 existing.DisplayName = displayName;
-                existing.IsEnabled = seed.Enabled;
+                // Preserve an operator emergency disable. Code may disable an existing
+                // connection, but does not silently re-enable one at startup.
+                if (!seed.Enabled)
+                {
+                    existing.IsEnabled = false;
+                }
                 existing.Source = SqlOSScimSources.Seeded;
                 existing.UpdatedAt = now;
             }
+
+            existing.ConfigurationFingerprint = SqlOSConfigurationOwnershipPolicy.Fingerprint(new { OrganizationId = organization.Id, SourceKey = seedKey, DisplayName = displayName, seed.Enabled, Mappings = seed.GroupMappings.Select(mapping => new { mapping.SourceKey, mapping.MatchType, mapping.GroupDisplayName, mapping.GroupExternalId, mapping.GroupPattern, mapping.RoleKey, mapping.ResourceId, mapping.ResourceIdTemplate, mapping.Description, mapping.Enabled }).ToArray() });
+            existing.LastReconciledAt = now;
+            existing.ConfigurationOrphanedAt = null;
 
             if (rawToken != null)
             {
@@ -248,6 +259,28 @@ public sealed partial class SqlOSAdminService
         }
 
         await _context.SaveChangesAsync(cancellationToken);
+
+        foreach (var (seed, organization, seedKey) in resolvedSeeds)
+        {
+            var reconciled = await _context.Set<SqlOSScimConnection>()
+                .AsNoTracking()
+                .SingleAsync(x => x.OrganizationId == organization.Id && x.ConfigurationSourceKey == seedKey, cancellationToken);
+            await RecordAuditAsync(
+                "configuration.reconciled",
+                "system",
+                "startup",
+                organizationId: organization.Id,
+                data: new
+                {
+                    resourceType = "scim_connection",
+                    resourceId = reconciled.Id,
+                    owner = SqlOSConfigurationOwners.Code,
+                    sourceKey = seedKey,
+                    outcome = "reconciled",
+                    fingerprint = reconciled.ConfigurationFingerprint
+                },
+                cancellationToken: cancellationToken);
+        }
     }
 
     private async Task<List<SqlOSScimConnection>> LockSeededScimConnectionsForReconciliationAsync(
@@ -439,7 +472,7 @@ public sealed partial class SqlOSAdminService
         => await RunScimAdminAtomicAsync(async () =>
         {
             var connection = await GetRequiredScimConnectionForUpdateAsync(connectionId, cancellationToken);
-            EnsureScimConnectionIsDashboardManaged(connection);
+            // Enable/disable is the explicit emergency control available for every owner.
             if (enabled)
             {
                 EnsureScimConnectionHasToken(connection);

--- a/src/SqlOS/AuthServer/Services/SqlOSAdminService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSAdminService.cs
@@ -123,7 +123,22 @@ public sealed partial class SqlOSAdminService
     public async Task UpsertSeededClientsAsync(CancellationToken cancellationToken = default)
     {
         var seeds = BuildStartupClientSeeds();
-        if (seeds.Count == 0)
+        var sourceKeys = seeds.Select(x => x.ClientId.Trim()).ToHashSet(StringComparer.Ordinal);
+        var now = DateTime.UtcNow;
+        var auditOutcomes = new List<(string ResourceId, string SourceKey, string Outcome, string? Fingerprint)>();
+        var orphans = await _context.Set<SqlOSClientApplication>()
+            .Where(x => x.ConfigurationOwner == SqlOSConfigurationOwners.Code && x.ConfigurationSourceKey != null && !sourceKeys.Contains(x.ConfigurationSourceKey))
+            .ToListAsync(cancellationToken);
+        foreach (var orphan in orphans)
+        {
+            if (orphan.ConfigurationOrphanedAt == null)
+            {
+                orphan.ConfigurationOrphanedAt = now;
+                auditOutcomes.Add((orphan.Id, orphan.ConfigurationSourceKey!, "orphaned", orphan.ConfigurationFingerprint));
+            }
+        }
+
+        if (seeds.Count == 0 && orphans.Count == 0)
         {
             return;
         }
@@ -131,14 +146,20 @@ public sealed partial class SqlOSAdminService
         foreach (var seed in seeds)
         {
             var normalized = NormalizeSeededClient(seed);
+            var sourceKey = normalized.ClientId;
+            var fingerprint = SqlOSConfigurationOwnershipPolicy.Fingerprint(new { normalized.ClientId, normalized.Name, normalized.Description, normalized.Audience, normalized.ClientType, normalized.RequirePkce, normalized.AllowedScopes, normalized.IsFirstParty, normalized.AllowNativeHeadlessAuth, normalized.AllowDeviceAuthorization, normalized.EnableClientCredentials, normalized.RedirectUris, normalized.IsActive });
             var existing = await _context.Set<SqlOSClientApplication>()
                 .FirstOrDefaultAsync(x => x.ClientId == normalized.ClientId, cancellationToken);
+            var outcome = existing == null ? "created" : existing.ConfigurationFingerprint == fingerprint && existing.ConfigurationOrphanedAt == null ? null : "updated";
 
-            if (_options.SingleApplication != null
-                && existing != null
-                && !string.Equals(existing.RegistrationSource, "seeded", StringComparison.OrdinalIgnoreCase))
+            if (existing != null && string.Equals(existing.RegistrationSource, "seeded", StringComparison.OrdinalIgnoreCase) && existing.ConfigurationSourceKey == null)
             {
-                throw new InvalidOperationException($"Single-application client id '{normalized.ClientId}' already exists. Choose a different ClientId or remove the existing manual client.");
+                existing.ConfigurationOwner = SqlOSConfigurationOwners.Code;
+                existing.ConfigurationSourceKey = sourceKey;
+            }
+            if (existing != null)
+            {
+                SqlOSConfigurationOwnershipPolicy.EnsureCodeOwnership(existing.ConfigurationOwner, existing.ConfigurationSourceKey, sourceKey, $"OAuth client '{sourceKey}'");
             }
 
             if (existing == null)
@@ -152,6 +173,10 @@ public sealed partial class SqlOSAdminService
                     Audience = normalized.Audience,
                     ClientType = normalized.ClientType,
                     RegistrationSource = "seeded",
+                    ConfigurationOwner = SqlOSConfigurationOwners.Code,
+                    ConfigurationSourceKey = sourceKey,
+                    ConfigurationFingerprint = fingerprint,
+                    LastReconciledAt = now,
                     TokenEndpointAuthMethod = normalized.EnableClientCredentials ? "client_secret_basic" : "none",
                     GrantTypesJson = JsonSerializer.Serialize(normalized.GrantTypes),
                     ResponseTypesJson = JsonSerializer.Serialize(new[] { "code" }),
@@ -165,6 +190,7 @@ public sealed partial class SqlOSAdminService
                     IsActive = normalized.IsActive,
                     AccessMode = SqlOSApplicationAccessModes.AllOrganizations
                 });
+                auditOutcomes.Add((sourceKey, sourceKey, "created", fingerprint));
                 continue;
             }
 
@@ -173,6 +199,10 @@ public sealed partial class SqlOSAdminService
             existing.Audience = normalized.Audience;
             existing.ClientType = normalized.ClientType;
             existing.RegistrationSource = "seeded";
+            existing.ConfigurationFingerprint = fingerprint;
+            existing.LastReconciledAt = now;
+            existing.ConfigurationOrphanedAt = null;
+            if (outcome != null) auditOutcomes.Add((existing.Id, sourceKey, outcome, fingerprint));
             existing.TokenEndpointAuthMethod = normalized.EnableClientCredentials ? "client_secret_basic" : "none";
             existing.GrantTypesJson = JsonSerializer.Serialize(normalized.GrantTypes);
             existing.ResponseTypesJson = string.IsNullOrWhiteSpace(existing.ResponseTypesJson)
@@ -196,11 +226,29 @@ public sealed partial class SqlOSAdminService
         }
 
         await _context.SaveChangesAsync(cancellationToken);
+        foreach (var audit in auditOutcomes)
+        {
+            await RecordAuditAsync("configuration.reconciled", "system", "startup", data: new { resourceType = "oauth_client", resourceId = audit.ResourceId, owner = SqlOSConfigurationOwners.Code, sourceKey = audit.SourceKey, outcome = audit.Outcome, fingerprint = audit.Fingerprint }, cancellationToken: cancellationToken);
+        }
     }
 
     public async Task UpsertSeededOidcConnectionsAsync(CancellationToken cancellationToken = default)
     {
-        if (_options.OidcConnectionSeeds.Count == 0)
+        var sourceKeys = _options.OidcConnectionSeeds.Select(ResolveOidcSeedKey).ToHashSet(StringComparer.Ordinal);
+        var now = DateTime.UtcNow;
+        var auditOutcomes = new List<(string ResourceId, string SourceKey, string Outcome, string? Fingerprint)>();
+        var orphans = await _context.Set<SqlOSOidcConnection>()
+            .Where(x => x.ConfigurationOwner == SqlOSConfigurationOwners.Code && x.ConfigurationSourceKey != null && !sourceKeys.Contains(x.ConfigurationSourceKey))
+            .ToListAsync(cancellationToken);
+        foreach (var orphan in orphans)
+        {
+            if (orphan.ConfigurationOrphanedAt == null)
+            {
+                orphan.ConfigurationOrphanedAt = now;
+                auditOutcomes.Add((orphan.Id, orphan.ConfigurationSourceKey!, "orphaned", orphan.ConfigurationFingerprint));
+            }
+        }
+        if (_options.OidcConnectionSeeds.Count == 0 && orphans.Count == 0)
         {
             return;
         }
@@ -208,20 +256,16 @@ public sealed partial class SqlOSAdminService
         foreach (var seed in _options.OidcConnectionSeeds)
         {
             var displayName = (seed.DisplayName ?? string.Empty).Trim();
+            var sourceKey = ResolveOidcSeedKey(seed);
 
-            SqlOSOidcConnection? existing;
-            if (seed.ProviderType == SqlOSOidcProviderType.Custom)
+            var existing = await _context.Set<SqlOSOidcConnection>().FirstOrDefaultAsync(x => x.ConfigurationSourceKey == sourceKey, cancellationToken);
+            var conflicting = await _context.Set<SqlOSOidcConnection>().FirstOrDefaultAsync(x => x.Id != (existing == null ? string.Empty : existing.Id)
+                && (seed.ProviderType == SqlOSOidcProviderType.Custom ? x.ProviderType == SqlOSOidcProviderType.Custom && x.DisplayName == displayName : x.ProviderType == seed.ProviderType), cancellationToken);
+            if (existing == null && conflicting != null)
             {
-                existing = await _context.Set<SqlOSOidcConnection>()
-                    .FirstOrDefaultAsync(
-                        x => x.ProviderType == SqlOSOidcProviderType.Custom && x.DisplayName == displayName,
-                        cancellationToken);
+                throw new InvalidOperationException($"Cannot reconcile OIDC connection '{displayName}' from code because an existing '{conflicting.ConfigurationOwner}' connection uses the same provider identity. Remove or rename the conflicting record explicitly.");
             }
-            else
-            {
-                existing = await _context.Set<SqlOSOidcConnection>()
-                    .FirstOrDefaultAsync(x => x.ProviderType == seed.ProviderType, cancellationToken);
-            }
+            if (existing != null) SqlOSConfigurationOwnershipPolicy.EnsureCodeOwnership(existing.ConfigurationOwner, existing.ConfigurationSourceKey, sourceKey, $"OIDC connection '{displayName}'");
 
             var connectionId = existing?.Id ?? _cryptoService.GenerateId("oidc");
             var callbacks = NormalizeCallbackUris(seed.AllowedCallbackUris, connectionId);
@@ -247,6 +291,8 @@ public sealed partial class SqlOSAdminService
                 seed.UseUserInfo,
                 seed.AppleTeamId,
                 seed.AppleKeyId);
+            var fingerprint = SqlOSConfigurationOwnershipPolicy.Fingerprint(new { SourceKey = sourceKey, seed.ProviderType, DisplayName = displayName, seed.ClientId, Callbacks = callbacks, normalized.Protocol, normalized.UseDiscovery, normalized.DiscoveryUrl, normalized.Issuer, normalized.AuthorizationEndpoint, normalized.TokenEndpoint, normalized.UserInfoEndpoint, normalized.JwksUri, normalized.MicrosoftTenant, normalized.Scopes, normalized.ClaimMapping, normalized.ClientAuthMethod, normalized.UseUserInfo, normalized.AppleTeamId, normalized.AppleKeyId, seed.TrustUpstreamMfa, AcceptedAmrValues = NormalizeTrustValues(seed.AcceptedAmrValues), AcceptedAcrValues = NormalizeTrustValues(seed.AcceptedAcrValues) });
+            var outcome = existing == null ? "created" : existing.ConfigurationFingerprint == fingerprint && existing.ConfigurationOrphanedAt == null ? null : "updated";
 
             if (existing == null)
             {
@@ -278,6 +324,10 @@ public sealed partial class SqlOSAdminService
                     TrustUpstreamMfa = seed.TrustUpstreamMfa,
                     AcceptedAmrValuesJson = JsonSerializer.Serialize(NormalizeTrustValues(seed.AcceptedAmrValues)),
                     AcceptedAcrValuesJson = JsonSerializer.Serialize(NormalizeTrustValues(seed.AcceptedAcrValues)),
+                    ConfigurationOwner = SqlOSConfigurationOwners.Code,
+                    ConfigurationSourceKey = sourceKey,
+                    ConfigurationFingerprint = fingerprint,
+                    LastReconciledAt = now,
                     IsEnabled = seed.IsEnabled,
                     CreatedAt = DateTime.UtcNow,
                     UpdatedAt = DateTime.UtcNow
@@ -285,6 +335,7 @@ public sealed partial class SqlOSAdminService
 
                 ValidateOidcSecretRequirements(connection);
                 _context.Set<SqlOSOidcConnection>().Add(connection);
+                auditOutcomes.Add((connection.Id, sourceKey, "created", fingerprint));
                 continue;
             }
 
@@ -310,6 +361,10 @@ public sealed partial class SqlOSAdminService
             existing.TrustUpstreamMfa = seed.TrustUpstreamMfa;
             existing.AcceptedAmrValuesJson = JsonSerializer.Serialize(NormalizeTrustValues(seed.AcceptedAmrValues));
             existing.AcceptedAcrValuesJson = JsonSerializer.Serialize(NormalizeTrustValues(seed.AcceptedAcrValues));
+            existing.ConfigurationFingerprint = fingerprint;
+            existing.LastReconciledAt = now;
+            existing.ConfigurationOrphanedAt = null;
+            if (outcome != null) auditOutcomes.Add((existing.Id, sourceKey, outcome, fingerprint));
             existing.UpdatedAt = DateTime.UtcNow;
 
             // Only overwrite secrets when the seed supplies them, so config without a secret
@@ -330,6 +385,17 @@ public sealed partial class SqlOSAdminService
         }
 
         await _context.SaveChangesAsync(cancellationToken);
+        foreach (var audit in auditOutcomes)
+        {
+            await RecordAuditAsync("configuration.reconciled", "system", "startup", data: new { resourceType = "oidc_connection", resourceId = audit.ResourceId, owner = SqlOSConfigurationOwners.Code, sourceKey = audit.SourceKey, outcome = audit.Outcome, fingerprint = audit.Fingerprint }, cancellationToken: cancellationToken);
+        }
+    }
+
+    private static string ResolveOidcSeedKey(SqlOSOidcConnectionSeedOptions seed)
+    {
+        if (!string.IsNullOrWhiteSpace(seed.Key)) return seed.Key.Trim();
+        if (seed.ProviderType != SqlOSOidcProviderType.Custom) return seed.ProviderType.ToString().ToLowerInvariant();
+        throw new InvalidOperationException("Custom seeded OIDC connections require a stable key. Use SeedOidcConnection(key, configure).");
     }
 
     public async Task<SqlOSUser> CreateUserAsync(SqlOSCreateUserRequest request, CancellationToken cancellationToken = default)
@@ -576,6 +642,8 @@ public sealed partial class SqlOSAdminService
         var connection = await _context.Set<SqlOSOidcConnection>()
             .FirstOrDefaultAsync(x => x.Id == connectionId, cancellationToken)
             ?? throw new InvalidOperationException("OIDC connection not found.");
+
+        SqlOSConfigurationOwnershipPolicy.EnsureDashboardEditable(connection.ConfigurationOwner, "OIDC connection");
 
         var callbacks = NormalizeCallbackUris(request.AllowedCallbackUris, connectionId);
         if (callbacks.Count == 0)
@@ -1604,6 +1672,7 @@ public sealed partial class SqlOSAdminService
                 x.AppleTeamId,
                 x.AppleKeyId,
                 x.IsEnabled,
+                Ownership = SqlOSConfigurationOwnershipPolicy.ToDto(x.ConfigurationOwner, x.ConfigurationSourceKey, x.LastReconciledAt, x.ConfigurationFingerprint, x.ConfigurationOrphanedAt),
                 x.CreatedAt,
                 x.UpdatedAt
             })
@@ -2652,6 +2721,7 @@ public sealed partial class SqlOSAdminService
             client.DisabledAt,
             client.DisabledReason,
             managedByStartupSeed,
+            SqlOSConfigurationOwnershipPolicy.ToDto(client.ConfigurationOwner, client.ConfigurationSourceKey, client.LastReconciledAt, client.ConfigurationFingerprint, client.ConfigurationOrphanedAt),
             string.Equals(client.RegistrationSource, "manual", StringComparison.OrdinalIgnoreCase)
                 || string.Equals(client.RegistrationSource, "seeded", StringComparison.OrdinalIgnoreCase),
             duplicateFingerprint,
@@ -2966,6 +3036,7 @@ public sealed partial class SqlOSAdminService
         DateTime? DisabledAt,
         string? DisabledReason,
         bool ManagedByStartupSeed,
+        SqlOSConfigurationOwnershipDto Ownership,
         bool CoreMetadataEditable,
         string? DuplicateFingerprint,
         int DuplicateCount,

--- a/src/SqlOS/AuthServer/Services/SqlOSCimdClientService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSCimdClientService.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using SqlOS.AuthServer.Configuration;
+using SqlOS.AuthServer.Contracts;
 using SqlOS.AuthServer.Interfaces;
 using SqlOS.AuthServer.Models;
 
@@ -297,6 +298,7 @@ public sealed class SqlOSCimdClientService
         client.Audience = string.IsNullOrWhiteSpace(client.Audience) ? _options.DefaultAudience : client.Audience;
         client.ClientType = "public_pkce";
         client.RegistrationSource = "cimd";
+        client.ConfigurationOwner = SqlOSConfigurationOwners.Dynamic;
         client.TokenEndpointAuthMethod = parsed.TokenEndpointAuthMethod;
         client.GrantTypesJson = JsonSerializer.Serialize(parsed.GrantTypes);
         client.ResponseTypesJson = JsonSerializer.Serialize(parsed.ResponseTypes);

--- a/src/SqlOS/AuthServer/Services/SqlOSConfigurationOwnershipPolicy.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSConfigurationOwnershipPolicy.cs
@@ -1,0 +1,40 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using SqlOS.AuthServer.Contracts;
+
+namespace SqlOS.AuthServer.Services;
+
+internal static class SqlOSConfigurationOwnershipPolicy
+{
+    public static SqlOSConfigurationOwnershipDto ToDto(string owner, string? sourceKey, DateTime? lastReconciledAt, string? fingerprint, DateTime? orphanedAt, bool canEmergencyDisable = true)
+        => new(owner, sourceKey, lastReconciledAt, fingerprint, IsEditable(owner), canEmergencyDisable, orphanedAt != null);
+
+    public static bool IsEditable(string owner)
+        => string.Equals(owner, SqlOSConfigurationOwners.Dashboard, StringComparison.OrdinalIgnoreCase);
+
+    public static void EnsureDashboardEditable(string owner, string resource)
+    {
+        if (!IsEditable(owner))
+        {
+            throw new InvalidOperationException($"{resource} is owned by the '{owner}' configuration source. Change its source configuration instead.");
+        }
+    }
+
+    public static void EnsureCodeOwnership(string owner, string? sourceKey, string expectedSourceKey, string resource)
+    {
+        if (!string.Equals(owner, SqlOSConfigurationOwners.Code, StringComparison.OrdinalIgnoreCase)
+            || !string.Equals(sourceKey, expectedSourceKey, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException($"Cannot reconcile {resource} from code because it is owned by '{owner}'"
+                + (string.IsNullOrWhiteSpace(sourceKey) ? "." : $" with source key '{sourceKey}'.")
+                + " Use a different stable key or remove the conflicting record explicitly.");
+        }
+    }
+
+    public static string Fingerprint(object nonSecretConfiguration)
+    {
+        var json = JsonSerializer.Serialize(nonSecretConfiguration);
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(json))).ToLowerInvariant();
+    }
+}

--- a/src/SqlOS/AuthServer/Services/SqlOSDynamicClientRegistrationService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSDynamicClientRegistrationService.cs
@@ -61,6 +61,7 @@ public sealed class SqlOSDynamicClientRegistrationService
                 Audience = _options.DefaultAudience,
                 ClientType = "public_pkce",
                 RegistrationSource = "dcr",
+                ConfigurationOwner = SqlOSConfigurationOwners.Dynamic,
                 TokenEndpointAuthMethod = normalized.TokenEndpointAuthMethod,
                 GrantTypesJson = JsonSerializer.Serialize(normalized.GrantTypes),
                 ResponseTypesJson = JsonSerializer.Serialize(normalized.ResponseTypes),

--- a/src/SqlOS/AuthServer/Services/SqlOSSettingsService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSSettingsService.cs
@@ -4,6 +4,7 @@ using SqlOS.AuthServer.Configuration;
 using SqlOS.AuthServer.Contracts;
 using SqlOS.AuthServer.Interfaces;
 using SqlOS.AuthServer.Models;
+using SqlOS.AuditLogs;
 using System.Text.Json;
 
 namespace SqlOS.AuthServer.Services;
@@ -13,15 +14,18 @@ public sealed class SqlOSSettingsService
     private readonly ISqlOSAuthServerDbContext _context;
     private readonly SqlOSAuthServerOptions _options;
     private readonly ISqlOSAuthEmailSender _emailSender;
+    private readonly SqlOSCryptoService? _cryptoService;
 
     public SqlOSSettingsService(
         ISqlOSAuthServerDbContext context,
         IOptions<SqlOSAuthServerOptions> options,
-        ISqlOSAuthEmailSender emailSender)
+        ISqlOSAuthEmailSender emailSender,
+        SqlOSCryptoService? cryptoService = null)
     {
         _context = context;
         _options = options.Value;
         _emailSender = emailSender;
+        _cryptoService = cryptoService;
     }
 
     public async Task EnsureDefaultSettingsAsync(CancellationToken cancellationToken = default)
@@ -146,6 +150,7 @@ public sealed class SqlOSSettingsService
             RequireForOwnersAndAdmins = _options.Mfa.RequireForOwnersAndAdminsByDefault,
             RequiredRolesJson = JsonSerializer.Serialize(NormalizeList(_options.Mfa.RequiredRolesByDefault, ["owner", "admin"])),
             AvailableFactorsJson = JsonSerializer.Serialize(NormalizeAvailableFactors(_options.Mfa.AvailableFactorsByDefault)),
+            ConfigurationOwner = SqlOSConfigurationOwners.System,
             UpdatedAt = DateTime.UtcNow
         });
         await _context.SaveChangesAsync(cancellationToken);
@@ -155,11 +160,43 @@ public sealed class SqlOSSettingsService
     {
         if (_options.MfaSeed == null)
         {
+            var existingSeed = await _context.Set<SqlOSMfaSettings>().FirstOrDefaultAsync(x => x.Id == "default" && x.ConfigurationOwner == SqlOSConfigurationOwners.Code, cancellationToken);
+            if (existingSeed != null && existingSeed.ConfigurationOrphanedAt == null)
+            {
+                existingSeed.ConfigurationOrphanedAt = DateTime.UtcNow;
+                await _context.SaveChangesAsync(cancellationToken);
+                if (_cryptoService != null)
+                {
+                    var audit = new SqlOSAuditLogService(_context, _cryptoService);
+                    await audit.RecordAsync(new SqlOSAuditLogRecordRequest(
+                        Action: "configuration.reconciled",
+                        Source: "authserver",
+                        Actor: new SqlOSAuditActor("system", "startup"),
+                        Targets: [new SqlOSAuditTarget("mfa_settings", existingSeed.Id)],
+                        Metadata: new Dictionary<string, object?>
+                        {
+                            ["resourceType"] = "mfa_settings",
+                            ["resourceId"] = existingSeed.Id,
+                            ["owner"] = SqlOSConfigurationOwners.Code,
+                            ["sourceKey"] = existingSeed.ConfigurationSourceKey,
+                            ["outcome"] = "orphaned",
+                            ["fingerprint"] = existingSeed.ConfigurationFingerprint
+                        }), cancellationToken);
+                }
+            }
             return;
         }
 
         await EnsureDefaultMfaSettingsAsync(cancellationToken);
         var settings = await _context.Set<SqlOSMfaSettings>().FirstAsync(x => x.Id == "default", cancellationToken);
+        var previousFingerprint = settings.ConfigurationFingerprint;
+        var wasOrphaned = settings.ConfigurationOrphanedAt != null;
+        if (string.Equals(settings.ConfigurationOwner, SqlOSConfigurationOwners.System, StringComparison.OrdinalIgnoreCase))
+        {
+            settings.ConfigurationOwner = SqlOSConfigurationOwners.Code;
+            settings.ConfigurationSourceKey = "mfa:default";
+        }
+        else SqlOSConfigurationOwnershipPolicy.EnsureCodeOwnership(settings.ConfigurationOwner, settings.ConfigurationSourceKey, "mfa:default", "global MFA settings");
 
         settings.Enabled = _options.MfaSeed.Enabled;
         settings.TotpEnabled = _options.MfaSeed.TotpEnabled;
@@ -169,7 +206,11 @@ public sealed class SqlOSSettingsService
         settings.RequireForOwnersAndAdmins = _options.MfaSeed.RequireForOwnersAndAdmins;
         settings.RequiredRolesJson = JsonSerializer.Serialize(NormalizeList(_options.MfaSeed.RequiredRoles, ["owner", "admin"]));
         settings.AvailableFactorsJson = JsonSerializer.Serialize(NormalizeAvailableFactors(_options.MfaSeed.AvailableFactors));
-        settings.UpdatedAt = DateTime.UtcNow;
+        var now = DateTime.UtcNow;
+        settings.UpdatedAt = now;
+        settings.LastReconciledAt = now;
+        settings.ConfigurationOrphanedAt = null;
+        settings.ConfigurationFingerprint = SqlOSConfigurationOwnershipPolicy.Fingerprint(new { _options.MfaSeed.Enabled, _options.MfaSeed.TotpEnabled, _options.MfaSeed.UserSelfEnrollmentEnabled, _options.MfaSeed.RecoveryCodesEnabled, _options.MfaSeed.RequireForAllUsers, _options.MfaSeed.RequireForOwnersAndAdmins, RequiredRoles = NormalizeList(_options.MfaSeed.RequiredRoles, ["owner", "admin"]), AvailableFactors = NormalizeAvailableFactors(_options.MfaSeed.AvailableFactors) });
 
         foreach (var organizationSeed in _options.MfaSeed.Organizations)
         {
@@ -206,12 +247,32 @@ public sealed class SqlOSSettingsService
         }
 
         await _context.SaveChangesAsync(cancellationToken);
+
+        if (_cryptoService != null && (previousFingerprint != settings.ConfigurationFingerprint || wasOrphaned))
+        {
+            var audit = new SqlOSAuditLogService(_context, _cryptoService);
+            await audit.RecordAsync(new SqlOSAuditLogRecordRequest(
+                Action: "configuration.reconciled",
+                Source: "authserver",
+                Actor: new SqlOSAuditActor("system", "startup"),
+                Targets: [new SqlOSAuditTarget("mfa_settings", settings.Id)],
+                Metadata: new Dictionary<string, object?>
+                {
+                    ["resourceType"] = "mfa_settings",
+                    ["resourceId"] = settings.Id,
+                    ["owner"] = SqlOSConfigurationOwners.Code,
+                    ["sourceKey"] = settings.ConfigurationSourceKey,
+                    ["outcome"] = previousFingerprint == null ? "created" : "updated",
+                    ["fingerprint"] = settings.ConfigurationFingerprint
+                }), cancellationToken);
+        }
     }
 
     public async Task<SqlOSMfaSettingsDto> GetMfaSettingsAsync(CancellationToken cancellationToken = default)
     {
         await EnsureDefaultMfaSettingsAsync(cancellationToken);
         var settings = await _context.Set<SqlOSMfaSettings>().FirstAsync(x => x.Id == "default", cancellationToken);
+
         return ToMfaSettingsDto(settings, _options.MfaSeed != null);
     }
 
@@ -219,6 +280,27 @@ public sealed class SqlOSSettingsService
     {
         await EnsureDefaultMfaSettingsAsync(cancellationToken);
         var settings = await _context.Set<SqlOSMfaSettings>().FirstAsync(x => x.Id == "default", cancellationToken);
+
+        if (string.Equals(settings.ConfigurationOwner, SqlOSConfigurationOwners.Code, StringComparison.OrdinalIgnoreCase))
+        {
+            var onlyEnabledChanged = request.TotpEnabled == settings.TotpEnabled
+                && request.UserSelfEnrollmentEnabled == settings.UserSelfEnrollmentEnabled
+                && request.RecoveryCodesEnabled == settings.RecoveryCodesEnabled
+                && request.RequireForAllUsers == settings.RequireForAllUsers
+                && request.RequireForOwnersAndAdmins == settings.RequireForOwnersAndAdmins
+                && NormalizeList(request.RequiredRoles, ["owner", "admin"]).SequenceEqual(DeserializeStringArray(settings.RequiredRolesJson, ["owner", "admin"]), StringComparer.OrdinalIgnoreCase)
+                && NormalizeAvailableFactors(request.AvailableFactors).SequenceEqual(DeserializeStringArray(settings.AvailableFactorsJson, [SqlOSMfaFactorTypes.Totp, SqlOSMfaFactorTypes.RecoveryCode]), StringComparer.OrdinalIgnoreCase);
+            if (!onlyEnabledChanged) SqlOSConfigurationOwnershipPolicy.EnsureDashboardEditable(settings.ConfigurationOwner, "Global MFA settings");
+            settings.Enabled = request.Enabled;
+            settings.UpdatedAt = DateTime.UtcNow;
+            await _context.SaveChangesAsync(cancellationToken);
+            return ToMfaSettingsDto(settings, true);
+        }
+        if (string.Equals(settings.ConfigurationOwner, SqlOSConfigurationOwners.System, StringComparison.OrdinalIgnoreCase))
+        {
+            settings.ConfigurationOwner = SqlOSConfigurationOwners.Dashboard;
+            settings.ConfigurationSourceKey = null;
+        }
 
         settings.Enabled = request.Enabled;
         settings.TotpEnabled = request.TotpEnabled;
@@ -565,7 +647,8 @@ public sealed class SqlOSSettingsService
             DeserializeStringArray(settings.RequiredRolesJson, ["owner", "admin"]),
             DeserializeStringArray(settings.AvailableFactorsJson, [SqlOSMfaFactorTypes.Totp, SqlOSMfaFactorTypes.RecoveryCode]),
             settings.UpdatedAt,
-            managedByStartupSeed);
+            managedByStartupSeed,
+            SqlOSConfigurationOwnershipPolicy.ToDto(settings.ConfigurationOwner, settings.ConfigurationSourceKey, settings.LastReconciledAt, settings.ConfigurationFingerprint, settings.ConfigurationOrphanedAt));
 
     private static SqlOSOrganizationMfaPolicyDto ToOrganizationMfaPolicyDto(
         SqlOSOrganization organization,

--- a/src/SqlOS/Dashboard/wwwroot/app.js
+++ b/src/SqlOS/Dashboard/wwwroot/app.js
@@ -723,7 +723,10 @@
         ];
 
         if (client.managedByStartupSeed) {
-            badges.push(renderClientBadge("Startup managed", "muted"));
+            badges.push(renderClientBadge("Code owned", "muted"));
+        }
+        if (client.ownership?.isOrphaned) {
+            badges.push(renderClientBadge("Seed missing", "warning"));
         }
 
         if (client.metadataCacheState === "fresh") {
@@ -1852,6 +1855,8 @@
                                 ${renderMetadataRows([
                                     { label: "Connection ID", value: item.connection.id },
                                     { label: "Source", value: item.connection.source || "dashboard" },
+                                    { label: "Configuration owner", value: item.connection.ownership?.owner || item.connection.source || "dashboard" },
+                                    { label: "Source key", value: item.connection.ownership?.sourceKey },
                                     { label: "Base URL", html: `<span class="inline-code">${esc(item.connection.baseUrl || "n/a")}</span>` },
                                     { label: "Users URL", html: `<span class="inline-code">${esc(item.connection.usersUrl || "n/a")}</span>` },
                                     { label: "Groups URL", html: `<span class="inline-code">${esc(item.connection.groupsUrl || "n/a")}</span>` },
@@ -1862,8 +1867,13 @@
                                 ])}
                                 ${item.connection.source === "seeded" ? `
                                     <div class="callout">
-                                        <strong>Managed by startup configuration.</strong>
-                                        Change this connection's display name, enabled state, or token secret in <span class="inline-code">SeedScimConnection</span>, then restart SqlOS. Dashboard token and lifecycle actions are intentionally disabled so a restart cannot silently undo an emergency rotation.
+                                        <strong>Code owned.</strong>
+                                        Change this connection's fields or token secret in <span class="inline-code">SeedScimConnection</span>. Emergency enable/disable remains available here and is preserved across restart.
+                                    </div>
+                                    <div class="form-actions">
+                                        ${item.connection.isEnabled
+                                            ? `<button type="button" class="js-disable-scim-connection" data-id="${esc(item.connection.id)}">Disable</button>`
+                                            : `<button type="button" class="js-enable-scim-connection" data-id="${esc(item.connection.id)}">Enable</button>`}
                                     </div>
                                 ` : `
                                     <form id="update-scim-connection-${esc(item.connection.id)}" class="nested-form">
@@ -3288,7 +3298,11 @@
                                     html: `<pre>${esc(JSON.stringify(parseJsonObject(item.claimMapping), null, 2))}</pre>`
                                 },
                                 { label: "Enabled", value: item.isEnabled ? "Yes" : "No" }
+                                ,{ label: "Configuration owner", value: item.ownership?.owner || "dashboard" }
+                                ,{ label: "Source key", value: item.ownership?.sourceKey }
+                                ,{ label: "Reconciliation", value: item.ownership?.isOrphaned ? "Seed missing" : item.ownership?.lastReconciledAt ? `Reconciled ${formatDate(item.ownership.lastReconciledAt)}` : "Not reconciled" }
                             ])}
+                            ${item.ownership && !item.ownership.isEditable ? `<div class="callout"><strong>Code owned:</strong> Edit this connection in startup configuration. Emergency enable/disable remains available here.</div>` : ""}
                             <form id="edit-oidc-${esc(item.id)}" class="nested-form">
                                 <input name="displayName" value="${esc(item.displayName)}" required>
                                 <label>Logo upload<input type="file" accept="image/*,.svg" data-dataurl-target="logoDataUrl"></label>
@@ -3352,6 +3366,10 @@
         });
 
         oidcConnections.forEach(item => {
+            if (item.ownership && !item.ownership.isEditable) {
+                const form = document.getElementById(`edit-oidc-${item.id}`);
+                form?.querySelectorAll("input, textarea, select, button[type='submit']").forEach(field => { field.disabled = true; });
+            }
             bindForm(`edit-oidc-${item.id}`, async form => {
                 await fetchJson(`${authApiBasePath}/oidc-connections/${item.id}`, {
                     method: "PUT",
@@ -3545,7 +3563,7 @@
             <div class="panel-grid">
                 <section class="panel">
                     <h2>MFA Settings</h2>
-                    ${settings.managedByStartupSeed ? `<div class="callout"><strong>Startup managed:</strong> These values are seeded from application startup and will be reapplied on restart.</div>` : ""}
+                    ${settings.ownership && !settings.ownership.isEditable ? `<div class="callout"><strong>Code owned:</strong> Policy fields come from startup configuration. The master Enable MFA switch remains available for emergency shutdown.</div>` : ""}
                     <form id="mfa-settings-form">
                         <label><input type="checkbox" name="enabled" ${settings.enabled ? "checked" : ""}> Enable MFA</label>
                         <label><input type="checkbox" name="totpEnabled" ${settings.totpEnabled ? "checked" : ""}> Enable authenticator apps</label>
@@ -3572,6 +3590,10 @@
                 </section>
             </div>
         `;
+
+        if (settings.ownership && !settings.ownership.isEditable) {
+            content.querySelectorAll("#mfa-settings-form input:not([name='enabled'])").forEach(field => { field.disabled = true; });
+        }
 
         bindForm("mfa-settings-form", async form => {
             const splitList = value => String(value || "")

--- a/tests/SqlOS.IntegrationTests/SchemaInitializerIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/SchemaInitializerIntegrationTests.cs
@@ -14,7 +14,7 @@ namespace SqlOS.IntegrationTests;
 [TestClass]
 public sealed class SchemaInitializerIntegrationTests
 {
-    private const int CurrentSchemaVersion = 33;
+    private const int CurrentSchemaVersion = 34;
 
     [TestMethod]
     public async Task EnsureSchema_CreatesCoreTables()
@@ -71,6 +71,13 @@ public sealed class SchemaInitializerIntegrationTests
         Assert.IsTrue(await ColumnExistsAsync(
             "SqlOSAuthOidcConnections",
             "AcceptedAcrValuesJson"));
+        foreach (var table in new[] { "SqlOSClientApplications", "SqlOSAuthOidcConnections", "SqlOSScimConnections", "SqlOSMfaSettings" })
+        {
+            foreach (var column in new[] { "ConfigurationOwner", "ConfigurationSourceKey", "ConfigurationFingerprint", "LastReconciledAt", "ConfigurationOrphanedAt" })
+            {
+                Assert.IsTrue(await ColumnExistsAsync(table, column), $"Column {table}.{column} should exist.");
+            }
+        }
     }
 
     [TestMethod]

--- a/tests/SqlOS.Tests/SqlOSClientStorageTests.cs
+++ b/tests/SqlOS.Tests/SqlOSClientStorageTests.cs
@@ -35,7 +35,7 @@ public sealed class SqlOSClientStorageTests
     }
 
     [TestMethod]
-    public async Task UpsertSeededClientsAsync_BackfillsSeededRegistrationSource()
+    public async Task UpsertSeededClientsAsync_DoesNotAdoptDashboardOwnedClient()
     {
         using var context = CreateContext();
         var optionsValue = new SqlOSAuthServerOptions();
@@ -56,15 +56,13 @@ public sealed class SqlOSClientStorageTests
         });
         await context.SaveChangesAsync();
 
-        await admin.UpsertSeededClientsAsync();
+        var act = () => admin.UpsertSeededClientsAsync();
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*owned by 'dashboard'*");
 
-        var client = await context.Set<SqlOSClientApplication>()
-            .SingleAsync(x => x.ClientId == "seeded-client");
-
-        client.RegistrationSource.Should().Be("seeded");
-        client.TokenEndpointAuthMethod.Should().Be("none");
-        client.GrantTypesJson.Should().Contain("authorization_code");
-        client.ResponseTypesJson.Should().Contain("code");
+        var client = await context.Set<SqlOSClientApplication>().SingleAsync();
+        client.Name.Should().Be("Existing Client");
+        client.RegistrationSource.Should().Be("manual");
     }
 
     [TestMethod]

--- a/tests/SqlOS.Tests/SqlOSConfigurationOwnershipTests.cs
+++ b/tests/SqlOS.Tests/SqlOSConfigurationOwnershipTests.cs
@@ -1,0 +1,65 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SqlOS.AuthServer.Configuration;
+using SqlOS.AuthServer.Contracts;
+using SqlOS.AuthServer.Models;
+using SqlOS.AuthServer.Services;
+using SqlOS.Tests.Infrastructure;
+
+namespace SqlOS.Tests;
+
+[TestClass]
+public sealed class SqlOSConfigurationOwnershipTests
+{
+    [TestMethod]
+    public async Task MfaSeed_IsIdempotent_ReadOnlyExceptEmergencyState_AndNonDestructiveWhenRemoved()
+    {
+        using var context = CreateContext();
+        var optionsValue = new SqlOSAuthServerOptions();
+        optionsValue.SeedMfaPolicy(seed => seed.RequireForOwnersAndAdmins = true);
+        var crypto = TestCryptoService.Create(context, Options.Create(optionsValue));
+        var service = new SqlOSSettingsService(context, Options.Create(optionsValue), new TestAuthEmailSender(), crypto);
+
+        await service.UpsertSeededMfaSettingsAsync();
+        await service.UpsertSeededMfaSettingsAsync();
+        var seeded = await context.Set<SqlOSMfaSettings>().SingleAsync();
+        seeded.ConfigurationOwner.Should().Be(SqlOSConfigurationOwners.Code);
+        seeded.ConfigurationSourceKey.Should().Be("mfa:default");
+        seeded.ConfigurationFingerprint.Should().HaveLength(64);
+        (await context.Set<SqlOSAuditEvent>().CountAsync(x => x.EventType == "configuration.reconciled")).Should().Be(1, "an idempotent rerun must not create duplicate reconciliation outcomes");
+
+        var mutate = () => service.UpdateMfaSettingsAsync(new SqlOSUpdateMfaSettingsRequest(
+            false, false, true, true, false, true, ["owner", "admin"], ["totp", "recovery_code"]));
+        await mutate.Should().ThrowAsync<InvalidOperationException>().WithMessage("*owned by the 'code'*");
+
+        var disable = await service.UpdateMfaSettingsAsync(new SqlOSUpdateMfaSettingsRequest(
+            false, true, true, true, false, true, ["owner", "admin"], ["totp", "recovery_code"]));
+        disable.Enabled.Should().BeFalse();
+
+        var noSeedService = new SqlOSSettingsService(context, Options.Create(new SqlOSAuthServerOptions()), new TestAuthEmailSender(), crypto);
+        await noSeedService.UpsertSeededMfaSettingsAsync();
+        seeded.ConfigurationOrphanedAt.Should().NotBeNull();
+        seeded.RequireForOwnersAndAdmins.Should().BeTrue();
+        (await context.Set<SqlOSAuditEvent>().CountAsync(x => x.EventType == "configuration.reconciled")).Should().Be(2);
+    }
+
+    [TestMethod]
+    public async Task DashboardUpdate_ClaimsOnlySystemDefault()
+    {
+        using var context = CreateContext();
+        var service = new SqlOSSettingsService(context, Options.Create(new SqlOSAuthServerOptions()), new TestAuthEmailSender());
+        await service.EnsureDefaultMfaSettingsAsync();
+
+        var updated = await service.UpdateMfaSettingsAsync(new SqlOSUpdateMfaSettingsRequest(
+            true, true, true, true, false, false, ["owner"], ["totp"]));
+
+        updated.Ownership.Owner.Should().Be(SqlOSConfigurationOwners.Dashboard);
+        updated.Ownership.IsEditable.Should().BeTrue();
+    }
+
+    private static TestSqlOSInMemoryDbContext CreateContext()
+        => new(new DbContextOptionsBuilder<TestSqlOSInMemoryDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N")).Options);
+}

--- a/tests/SqlOS.Tests/SqlOSOidcConnectionSeedingTests.cs
+++ b/tests/SqlOS.Tests/SqlOSOidcConnectionSeedingTests.cs
@@ -206,7 +206,7 @@ public sealed class SqlOSOidcConnectionSeedingTests
         using var context = CreateContext();
         var optionsValue = new SqlOSAuthServerOptions();
         optionsValue
-            .SeedOidcConnection(oidc =>
+            .SeedOidcConnection("acme", oidc =>
             {
                 oidc.ProviderType = SqlOSOidcProviderType.Custom;
                 oidc.DisplayName = "Acme Identity";
@@ -216,7 +216,7 @@ public sealed class SqlOSOidcConnectionSeedingTests
                 oidc.DiscoveryUrl = "https://oidc.example.local/.well-known/openid-configuration";
                 oidc.AllowedCallbackUris = ["https://app.example.local/callback/{connectionId}"];
             })
-            .SeedOidcConnection(oidc =>
+            .SeedOidcConnection("globex", oidc =>
             {
                 oidc.ProviderType = SqlOSOidcProviderType.Custom;
                 oidc.DisplayName = "Globex Identity";
@@ -259,6 +259,27 @@ public sealed class SqlOSOidcConnectionSeedingTests
     }
 
     [TestMethod]
+    public async Task CustomSeed_WithoutStableKey_IsRejectedBeforePersistence()
+    {
+        using var context = CreateContext();
+        var options = new SqlOSAuthServerOptions();
+        options.SeedOidcConnection(seed =>
+        {
+            seed.DisplayName = "Display names can change";
+            seed.ClientId = "client";
+            seed.ClientSecret = "secret";
+            seed.DiscoveryUrl = "https://id.example.test/.well-known/openid-configuration";
+            seed.AllowedCallbackUris = ["https://app.example.test/callback/{connectionId}"];
+        });
+        var (admin, _) = CreateServices(context, options);
+
+        await FluentActions.Awaiting(() => admin.UpsertSeededOidcConnectionsAsync())
+            .Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*require a stable key*SeedOidcConnection(key, configure)*");
+        (await context.Set<SqlOSOidcConnection>().CountAsync()).Should().Be(0);
+    }
+
+    [TestMethod]
     public async Task UpsertSeededOidcConnectionsAsync_ThrowsWhenSecretMissing()
     {
         using var context = CreateContext();
@@ -288,6 +309,60 @@ public sealed class SqlOSOidcConnectionSeedingTests
         await admin.UpsertSeededOidcConnectionsAsync();
 
         (await context.Set<SqlOSOidcConnection>().CountAsync()).Should().Be(0);
+    }
+
+    [TestMethod]
+    public async Task StableSourceKey_ReconcilesRename_AndFingerprintExcludesSecret()
+    {
+        using var context = CreateContext();
+        var options = new SqlOSAuthServerOptions();
+        options.SeedOidcConnection("workforce", seed =>
+        {
+            seed.DisplayName = "Acme";
+            seed.ClientId = "acme-client";
+            seed.ClientSecret = "secret-one";
+            seed.DiscoveryUrl = "https://id.acme.test/.well-known/openid-configuration";
+            seed.AllowedCallbackUris = ["https://app.acme.test/callback/{connectionId}"];
+        });
+        var (admin, _) = CreateServices(context, options);
+
+        await admin.UpsertSeededOidcConnectionsAsync();
+        var first = await context.Set<SqlOSOidcConnection>().SingleAsync();
+        var id = first.Id;
+        var fingerprint = first.ConfigurationFingerprint;
+
+        options.OidcConnectionSeeds[0].DisplayName = "Acme Workforce";
+        options.OidcConnectionSeeds[0].ClientSecret = "secret-two";
+        await admin.UpsertSeededOidcConnectionsAsync();
+
+        var renamed = await context.Set<SqlOSOidcConnection>().SingleAsync();
+        renamed.Id.Should().Be(id);
+        renamed.DisplayName.Should().Be("Acme Workforce");
+        renamed.ConfigurationOwner.Should().Be(SqlOSConfigurationOwners.Code);
+        renamed.ConfigurationSourceKey.Should().Be("workforce");
+        renamed.ConfigurationFingerprint.Should().NotBe(fingerprint, "the display name changed");
+
+        var renamedFingerprint = renamed.ConfigurationFingerprint;
+        options.OidcConnectionSeeds[0].ClientSecret = "secret-three";
+        await admin.UpsertSeededOidcConnectionsAsync();
+        (await context.Set<SqlOSOidcConnection>().SingleAsync()).ConfigurationFingerprint.Should().Be(renamedFingerprint, "secret values must never affect diagnostic fingerprints");
+    }
+
+    [TestMethod]
+    public async Task RemovedSeed_IsMarkedOrphaned_WithoutDisablingConnection()
+    {
+        using var context = CreateContext();
+        var options = new SqlOSAuthServerOptions();
+        options.SeedGoogleConnection("client", "secret", "https://app.test/callback/{connectionId}");
+        var (admin, _) = CreateServices(context, options);
+        await admin.UpsertSeededOidcConnectionsAsync();
+
+        options.OidcConnectionSeeds.Clear();
+        await admin.UpsertSeededOidcConnectionsAsync();
+
+        var connection = await context.Set<SqlOSOidcConnection>().SingleAsync();
+        connection.ConfigurationOrphanedAt.Should().NotBeNull();
+        connection.IsEnabled.Should().BeTrue();
     }
 
     private static (SqlOSAdminService admin, SqlOSOidcAuthService oidc) CreateServices(

--- a/tests/SqlOS.Tests/SqlOSScimServiceTests.cs
+++ b/tests/SqlOS.Tests/SqlOSScimServiceTests.cs
@@ -140,9 +140,9 @@ public sealed class SqlOSScimServiceTests
         var connection = await context.Set<SqlOSScimConnection>().SingleAsync();
 
         var rotate = async () => await harness.Admin.RotateScimTokenAsync(connection.Id);
-        var disable = async () => await harness.Admin.SetScimConnectionEnabledAsync(connection.Id, false);
         await rotate.Should().ThrowAsync<InvalidOperationException>().WithMessage("*startup configuration*");
-        await disable.Should().ThrowAsync<InvalidOperationException>().WithMessage("*startup configuration*");
+        (await harness.Admin.SetScimConnectionEnabledAsync(connection.Id, false)).IsEnabled.Should().BeFalse();
+        (await harness.Admin.SetScimConnectionEnabledAsync(connection.Id, true)).IsEnabled.Should().BeTrue();
 
         var configuredSeed = optionsValue.ScimConnectionSeeds.Single();
         configuredSeed.Token = null;
@@ -169,20 +169,25 @@ public sealed class SqlOSScimServiceTests
             seed.OrganizationSlug = "acme";
             seed.Token = replacement;
         });
+        var renamedConflict = () => harness.Admin.UpsertSeededScimConnectionsAsync();
+        await renamedConflict.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Only one SCIM directory connection can be enabled*");
+        connection.ConfigurationOrphanedAt.Should().NotBeNull();
+        connection.IsEnabled.Should().BeTrue();
+
+        await harness.Admin.SetScimConnectionEnabledAsync(connection.Id, false);
         await harness.Admin.UpsertSeededScimConnectionsAsync();
         var renamedConnections = await context.Set<SqlOSScimConnection>().OrderBy(item => item.CreatedAt).ToListAsync();
         renamedConnections.Should().HaveCount(2);
         renamedConnections[0].IsEnabled.Should().BeFalse();
-        renamedConnections[0].TokenHash.Should().BeNull();
+        renamedConnections[0].TokenHash.Should().NotBeNull();
         renamedConnections[1].IsEnabled.Should().BeTrue();
         (await harness.Scim.AuthenticateAsync(replacementContext)).Id.Should().Be(renamedConnections[1].Id);
 
         optionsValue.ScimConnectionSeeds.Clear();
         await harness.Admin.UpsertSeededScimConnectionsAsync();
-        var orphanedAuth = async () => await harness.Scim.AuthenticateAsync(replacementContext);
-        var orphanedError = await orphanedAuth.Should().ThrowAsync<SqlOSScimException>();
-        orphanedError.Which.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
-        (await context.Set<SqlOSScimConnection>().CountAsync(item => item.IsEnabled)).Should().Be(0);
+        (await harness.Scim.AuthenticateAsync(replacementContext)).Id.Should().Be(renamedConnections[1].Id);
+        (await context.Set<SqlOSScimConnection>().CountAsync(item => item.IsEnabled)).Should().Be(1);
 
         optionsValue.SeedScimConnection("acme-renamed", seed => seed.OrganizationSlug = "acme");
         var resurrectWithoutSecret = async () => await harness.Admin.UpsertSeededScimConnectionsAsync();

--- a/tests/SqlOS.Tests/SqlOSSingleApplicationTests.cs
+++ b/tests/SqlOS.Tests/SqlOSSingleApplicationTests.cs
@@ -102,7 +102,7 @@ public sealed class SqlOSSingleApplicationTests
         var act = async () => await harness.Admin.UpsertSeededClientsAsync();
 
         await act.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("Single-application client id 'todo' already exists. Choose a different ClientId or remove the existing manual client.");
+            .WithMessage("*owned by 'dashboard'*");
     }
 
     [TestMethod]

--- a/web/content/docs/authserver/oidc-auth.mdx
+++ b/web/content/docs/authserver/oidc-auth.mdx
@@ -109,7 +109,7 @@ An OIDC login proves the configured provider authenticated the user; it does not
 Code-owned OIDC seeds can configure the policy without adding runtime infrastructure:
 
 ```csharp
-options.AuthServer.SeedOidcConnection(oidc =>
+options.AuthServer.SeedOidcConnection("workforce", oidc =>
 {
     oidc.ProviderType = SqlOSOidcProviderType.Microsoft;
     oidc.DisplayName = "Workforce Entra ID";

--- a/web/content/docs/guides/social-oidc.mdx
+++ b/web/content/docs/guides/social-oidc.mdx
@@ -89,7 +89,7 @@ builder.AddSqlOS<AppDbContext>(options =>
 For Apple or fully custom providers, use the general form:
 
 ```csharp
-auth.SeedOidcConnection(oidc =>
+auth.SeedOidcConnection("workforce", oidc =>
 {
     oidc.ProviderType = SqlOSOidcProviderType.Custom;
     oidc.DisplayName = "Acme Identity";


### PR DESCRIPTION
Closes #217.

## What changed

- adds a persisted shared ownership model for code, dashboard, dynamic, system, and external configuration sources
- migrates startup-seeded OAuth clients, social/OIDC connections, SCIM connections, and global MFA settings
- reconciles by stable source key, records non-secret fingerprints and timestamps, and refuses silent cross-owner adoption
- marks removed seeds as orphaned without deleting, disabling, or clearing live configuration
- keeps explicit emergency enable/disable controls while making code-owned fields read-only in services and dashboard workflows
- exposes ownership consistently in admin responses and records reconciliation audit outcomes
- adds filtered unique indexes to guard concurrent source-key claims
- documents ownership, conflict, orphan, secret-redaction, and operator semantics

## Developer ergonomics

- existing provider helpers supply deterministic OIDC keys automatically
- custom OIDC connections gain an additive `SeedOidcConnection(key, ...)` overload for rename-safe reconciliation
- no external service or new runtime dependency is required
- ordinary dashboard-owned configuration remains editable as before
- internal defaults become dashboard-owned on the first explicit operator edit

## Validation

- `dotnet build SqlOS.sln --no-restore`
- `dotnet test tests/SqlOS.Tests/SqlOS.Tests.csproj --no-build` (626 passed)
- `dotnet test tests/SqlOS.IntegrationTests/SqlOS.IntegrationTests.csproj --no-build` (169 passed against Aspire-hosted SQL Server)
- `node --check src/SqlOS/Dashboard/wwwroot/app.js`

The SQL Server run covers fresh schema creation, historical partial-schema upgrades, OAuth/SCIM/MFA behavior, and the migration's idempotence.
