### PR TITLE
Add code-first application access policy seeds

### DIFF
--- a/scripts/compile-doc-snippets.mjs
+++ b/scripts/compile-doc-snippets.mjs
@@ -90,6 +90,13 @@ const snippetSpecs = [
     marker: "var filter = await fga.GetAuthorizationFilterAsync<Workspace>",
     wrap: asFgaGroupListProgram,
   },
+  {
+    name: "code-first application access policy",
+    relativePath: "web/content/docs/authserver/application-access.mdx",
+    heading: "## Code-first policy",
+    marker: "client.AssignOrganization(",
+    wrap: asApplicationAccessSeedProgram,
+  },
 ];
 
 function extractCsharpBlock({ relativePath, heading, marker }) {
@@ -222,6 +229,16 @@ function asSecuritySettingsProgram(snippet) {
 using SqlOS.AuthServer.Services;
 
 SqlOSSettingsService settingsService = null!;
+
+${snippet}
+`;
+}
+
+function asApplicationAccessSeedProgram(snippet) {
+  return `using SqlOS.AuthServer.Configuration;
+using SqlOS.AuthServer.Contracts;
+
+var auth = new SqlOSAuthServerOptions();
 
 ${snippet}
 `;

--- a/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerModelConfiguration.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerModelConfiguration.cs
@@ -455,6 +455,13 @@ public static class SqlOSAuthServerModelConfiguration
             entity.Property(x => x.RoleKey).HasMaxLength(80);
             entity.Property(x => x.Access).HasMaxLength(20);
             entity.Property(x => x.Reason).HasMaxLength(500);
+            entity.Property(x => x.ConfigurationOwner).HasMaxLength(40);
+            entity.Property(x => x.ConfigurationSourceKey).HasMaxLength(160);
+            entity.Property(x => x.ConfigurationFingerprint).HasMaxLength(64);
+            entity.HasIndex(x => new { x.ClientApplicationId, x.ConfigurationOwner, x.ConfigurationSourceKey })
+                .IsUnique()
+                .HasFilter("[ConfigurationSourceKey] IS NOT NULL")
+                .HasDatabaseName("UX_SqlOSApplicationAssignments_Client_Owner_SourceKey");
             entity.Property(x => x.CreatedByActorType).HasMaxLength(80);
             entity.Property(x => x.CreatedByActorId).HasMaxLength(128);
             entity.Property(x => x.RevokedByActorType).HasMaxLength(80);

--- a/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerSeedOptions.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerSeedOptions.cs
@@ -108,6 +108,60 @@ public sealed class SqlOSClientSeedOptions
     /// <summary>Enables OAuth client credentials for this confidential, non-browser client.</summary>
     public bool EnableClientCredentials { get; set; }
     public bool IsActive { get; set; } = true;
+    /// <summary>
+    /// Controls which organizations and principals may use this application. When omitted, new
+    /// clients use <c>all_organizations</c> and existing clients retain their current access mode.
+    /// </summary>
+    public string? AccessMode { get; set; }
+    /// <summary>Gets the ownership-safe application access assignments reconciled for this client.</summary>
+    public List<SqlOSApplicationAssignmentSeedOptions> Assignments { get; } = [];
+
+    public SqlOSClientSeedOptions AssignOrganization(string key, string organizationIdOrSlug, string access = SqlOSApplicationAssignmentAccess.Allowed, string? description = null)
+        => Assign(key, SqlOSApplicationAssignmentPrincipalTypes.Organization, organizationIdOrSlug: organizationIdOrSlug, access: access, description: description);
+
+    public SqlOSClientSeedOptions AssignUser(string key, string userId, string? organizationIdOrSlug = null, string access = SqlOSApplicationAssignmentAccess.Allowed, string? description = null)
+        => Assign(key, SqlOSApplicationAssignmentPrincipalTypes.User, principalId: userId, organizationIdOrSlug: organizationIdOrSlug, access: access, description: description);
+
+    public SqlOSClientSeedOptions AssignGroup(string key, string groupId, string? organizationIdOrSlug = null, string access = SqlOSApplicationAssignmentAccess.Allowed, string? description = null)
+        => Assign(key, SqlOSApplicationAssignmentPrincipalTypes.Group, principalId: groupId, organizationIdOrSlug: organizationIdOrSlug, access: access, description: description);
+
+    public SqlOSClientSeedOptions AssignRole(string key, string organizationIdOrSlug, string roleKey, string access = SqlOSApplicationAssignmentAccess.Allowed, string? description = null)
+        => Assign(key, SqlOSApplicationAssignmentPrincipalTypes.Role, organizationIdOrSlug: organizationIdOrSlug, roleKey: roleKey, access: access, description: description);
+
+    public SqlOSClientSeedOptions AssignServiceAccount(string key, string serviceAccountId, string? organizationIdOrSlug = null, string access = SqlOSApplicationAssignmentAccess.Allowed, string? description = null)
+        => Assign(key, SqlOSApplicationAssignmentPrincipalTypes.ServiceAccount, principalId: serviceAccountId, organizationIdOrSlug: organizationIdOrSlug, access: access, description: description);
+
+    public SqlOSClientSeedOptions AssignAgent(string key, string agentId, string? organizationIdOrSlug = null, string access = SqlOSApplicationAssignmentAccess.Allowed, string? description = null)
+        => Assign(key, SqlOSApplicationAssignmentPrincipalTypes.Agent, principalId: agentId, organizationIdOrSlug: organizationIdOrSlug, access: access, description: description);
+
+    private SqlOSClientSeedOptions Assign(string key, string principalType, string? principalId = null, string? organizationIdOrSlug = null, string? roleKey = null, string access = SqlOSApplicationAssignmentAccess.Allowed, string? description = null)
+    {
+        if (string.IsNullOrWhiteSpace(key)) throw new InvalidOperationException("Seeded application assignments require a stable key.");
+        Assignments.Add(new SqlOSApplicationAssignmentSeedOptions
+        {
+            Key = key.Trim(),
+            PrincipalType = principalType,
+            PrincipalId = principalId,
+            OrganizationIdOrSlug = organizationIdOrSlug,
+            RoleKey = roleKey,
+            Access = access,
+            Description = description
+        });
+        return this;
+    }
+}
+
+/// <summary>Declarative, stable-keyed assignment owned by a client seed.</summary>
+public sealed class SqlOSApplicationAssignmentSeedOptions
+{
+    public string Key { get; set; } = string.Empty;
+    public string PrincipalType { get; set; } = string.Empty;
+    public string? PrincipalId { get; set; }
+    /// <summary>An organization stable ID or slug, resolved during startup.</summary>
+    public string? OrganizationIdOrSlug { get; set; }
+    public string? RoleKey { get; set; }
+    public string Access { get; set; } = SqlOSApplicationAssignmentAccess.Allowed;
+    public string? Description { get; set; }
 }
 
 /// <summary>

--- a/src/SqlOS/AuthServer/Endpoints/AdminIdentityEndpoints.cs
+++ b/src/SqlOS/AuthServer/Endpoints/AdminIdentityEndpoints.cs
@@ -392,7 +392,7 @@ public static partial class EndpointRouteBuilderExtensions
 
             try
             {
-                var client = await adminService.SetApplicationAccessModeAsync(applicationId, request, cancellationToken: cancellationToken);
+                var client = await adminService.SetApplicationAccessModeAsync(applicationId, request, actorType: "dashboard", cancellationToken: cancellationToken);
                 return Results.Ok(new { client.Id, client.ClientId, client.Name, client.AccessMode, client.IsActive, client.DisabledAt, client.DisabledReason });
             }
             catch (InvalidOperationException ex)
@@ -421,6 +421,13 @@ public static partial class EndpointRouteBuilderExtensions
                     assignment.RoleKey,
                     assignment.Access,
                     assignment.Reason,
+                    Ownership = SqlOSConfigurationOwnershipPolicy.ToDto(
+                        assignment.ConfigurationOwner,
+                        assignment.ConfigurationSourceKey,
+                        assignment.LastReconciledAt,
+                        assignment.ConfigurationFingerprint,
+                        assignment.ConfigurationOrphanedAt,
+                        false),
                     assignment.CreatedAt,
                     assignment.RevokedAt
                 });
@@ -441,7 +448,20 @@ public static partial class EndpointRouteBuilderExtensions
             try
             {
                 var assignment = await adminService.RevokeApplicationAssignmentAsync(applicationId, assignmentId, null, cancellationToken);
-                return Results.Ok(new { assignment.Id, assignment.RevokedAt, assignment.RevokedByActorType, assignment.RevokedByActorId });
+                return Results.Ok(new
+                {
+                    assignment.Id,
+                    assignment.RevokedAt,
+                    assignment.RevokedByActorType,
+                    assignment.RevokedByActorId,
+                    Ownership = SqlOSConfigurationOwnershipPolicy.ToDto(
+                        assignment.ConfigurationOwner,
+                        assignment.ConfigurationSourceKey,
+                        assignment.LastReconciledAt,
+                        assignment.ConfigurationFingerprint,
+                        assignment.ConfigurationOrphanedAt,
+                        false)
+                });
             }
             catch (InvalidOperationException ex)
             {

--- a/src/SqlOS/AuthServer/Models/SqlOSEntities.cs
+++ b/src/SqlOS/AuthServer/Models/SqlOSEntities.cs
@@ -520,6 +520,11 @@ public sealed class SqlOSApplicationAssignment
     public string? RoleKey { get; set; }
     public string Access { get; set; } = "allowed";
     public string? Reason { get; set; }
+    public string ConfigurationOwner { get; set; } = "dashboard";
+    public string? ConfigurationSourceKey { get; set; }
+    public string? ConfigurationFingerprint { get; set; }
+    public DateTime? LastReconciledAt { get; set; }
+    public DateTime? ConfigurationOrphanedAt { get; set; }
     public DateTime CreatedAt { get; set; }
     public string? CreatedByActorType { get; set; }
     public string? CreatedByActorId { get; set; }

--- a/src/SqlOS/AuthServer/Schema/035_ApplicationAssignmentOwnership.sql
+++ b/src/SqlOS/AuthServer/Schema/035_ApplicationAssignmentOwnership.sql
@@ -1,0 +1,6 @@
+IF OBJECT_ID(N'[{Schema}].[SqlOSApplicationAssignments]', N'U') IS NOT NULL AND COL_LENGTH('[{Schema}].[SqlOSApplicationAssignments]', 'ConfigurationOwner') IS NULL
+BEGIN
+    EXEC(N'ALTER TABLE [{Schema}].[SqlOSApplicationAssignments] ADD [ConfigurationOwner] NVARCHAR(40) NOT NULL CONSTRAINT [DF_SqlOSApplicationAssignments_ConfigurationOwner] DEFAULT N''dashboard'', [ConfigurationSourceKey] NVARCHAR(160) NULL, [ConfigurationFingerprint] NVARCHAR(64) NULL, [LastReconciledAt] DATETIME2 NULL, [ConfigurationOrphanedAt] DATETIME2 NULL;');
+END
+IF OBJECT_ID(N'[{Schema}].[SqlOSApplicationAssignments]', N'U') IS NOT NULL AND NOT EXISTS (SELECT 1 FROM sys.indexes WHERE [object_id] = OBJECT_ID(N'[{Schema}].[SqlOSApplicationAssignments]') AND [name] = N'UX_SqlOSApplicationAssignments_Client_Owner_SourceKey')
+    EXEC(N'CREATE UNIQUE INDEX [UX_SqlOSApplicationAssignments_Client_Owner_SourceKey] ON [{Schema}].[SqlOSApplicationAssignments]([ClientApplicationId], [ConfigurationOwner], [ConfigurationSourceKey]) WHERE [ConfigurationSourceKey] IS NOT NULL;');

--- a/src/SqlOS/AuthServer/Services/SqlOSAdminService.ApplicationAccessSeeds.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSAdminService.ApplicationAccessSeeds.cs
@@ -1,0 +1,252 @@
+using Microsoft.EntityFrameworkCore;
+using SqlOS.AuthServer.Configuration;
+using SqlOS.AuthServer.Contracts;
+using SqlOS.AuthServer.Models;
+using SqlOS.Fga.Models;
+
+namespace SqlOS.AuthServer.Services;
+
+public sealed partial class SqlOSAdminService
+{
+    private async Task ApplySeededApplicationAccessModeAsync(
+        SqlOSClientApplication client,
+        string accessMode,
+        bool seedIsActive,
+        CancellationToken cancellationToken)
+    {
+        var previousMode = NormalizeAccessMode(client.AccessMode);
+        client.AccessMode = accessMode;
+        if (accessMode == SqlOSApplicationAccessModes.Disabled)
+        {
+            client.IsActive = false;
+            client.DisabledAt ??= DateTime.UtcNow;
+            client.DisabledReason ??= "application_access_disabled";
+            if (previousMode != SqlOSApplicationAccessModes.Disabled)
+            {
+                await RevokeClientSessionsInternalAsync(client.Id, "application_access_disabled", cancellationToken);
+            }
+        }
+        else if (previousMode == SqlOSApplicationAccessModes.Disabled
+            && string.Equals(client.DisabledReason, "application_access_disabled", StringComparison.Ordinal))
+        {
+            client.DisabledAt = null;
+            client.DisabledReason = null;
+            client.IsActive = seedIsActive;
+        }
+    }
+
+    private async Task ReconcileSeededApplicationAssignmentsAsync(
+        IReadOnlyCollection<SqlOSClientSeedOptions> clientSeeds,
+        DateTime now,
+        CancellationToken cancellationToken)
+    {
+        var desired = new List<NormalizedSeedAssignment>();
+        foreach (var clientSeed in clientSeeds)
+        {
+            var client = await _context.Set<SqlOSClientApplication>()
+                .SingleAsync(x => x.ClientId == clientSeed.ClientId, cancellationToken);
+            var accessMode = NormalizeAccessMode(client.AccessMode);
+            var keys = new HashSet<string>(StringComparer.Ordinal);
+            var targets = new HashSet<string>(StringComparer.Ordinal);
+
+            foreach (var seed in clientSeed.Assignments)
+            {
+                var key = RequireBounded(seed.Key, "Application assignment seed key", 160);
+                if (!keys.Add(key))
+                {
+                    throw new InvalidOperationException($"Client '{client.ClientId}' contains duplicate application assignment seed key '{key}'.");
+                }
+
+                var organizationId = await ResolveSeedOrganizationIdAsync(seed.OrganizationIdOrSlug, cancellationToken);
+                var request = NormalizeAssignmentRequest(new SqlOSCreateApplicationAssignmentRequest(
+                    seed.PrincipalType,
+                    seed.PrincipalId,
+                    organizationId,
+                    seed.RoleKey,
+                    seed.Access,
+                    seed.Description));
+                ValidateAssignmentMode(accessMode, request);
+                await ValidateAssignmentPrincipalAsync(request, cancellationToken);
+
+                var target = $"{request.PrincipalType}\u001f{request.PrincipalId}\u001f{request.OrganizationId}\u001f{request.RoleKey}\u001f{request.Access}";
+                if (!targets.Add(target))
+                {
+                    throw new InvalidOperationException($"Client '{client.ClientId}' contains duplicate seeded assignment targets. Give each effective assignment only one stable key.");
+                }
+
+                var fingerprint = SqlOSConfigurationOwnershipPolicy.Fingerprint(new
+                {
+                    request.PrincipalType,
+                    request.PrincipalId,
+                    request.OrganizationId,
+                    request.RoleKey,
+                    request.Access,
+                    request.Reason
+                });
+                desired.Add(new NormalizedSeedAssignment(client, key, request, fingerprint));
+            }
+        }
+
+        var desiredKeys = desired.Select(x => $"{x.Client.Id}\u001f{x.Key}").ToHashSet(StringComparer.Ordinal);
+        var codeOwned = await _context.Set<SqlOSApplicationAssignment>()
+            .Where(x => x.ConfigurationOwner == SqlOSConfigurationOwners.Code && x.ConfigurationSourceKey != null)
+            .ToListAsync(cancellationToken);
+        var audit = new List<(SqlOSApplicationAssignment Assignment, string Outcome)>();
+
+        foreach (var orphan in codeOwned.Where(x => !desiredKeys.Contains($"{x.ClientApplicationId}\u001f{x.ConfigurationSourceKey}")))
+        {
+            if (orphan.RevokedAt == null || orphan.ConfigurationOrphanedAt == null)
+            {
+                orphan.RevokedAt ??= now;
+                orphan.RevokedByActorType = "system";
+                orphan.RevokedByActorId = "startup";
+                orphan.ConfigurationOrphanedAt = now;
+                orphan.LastReconciledAt = now;
+                audit.Add((orphan, "revoked"));
+            }
+        }
+
+        foreach (var item in desired)
+        {
+            var assignment = codeOwned.SingleOrDefault(x =>
+                x.ClientApplicationId == item.Client.Id
+                && string.Equals(x.ConfigurationSourceKey, item.Key, StringComparison.Ordinal));
+            var outcome = assignment == null ? "created" : assignment.ConfigurationFingerprint == item.Fingerprint && assignment.RevokedAt == null ? null : "updated";
+            if (assignment == null)
+            {
+                assignment = new SqlOSApplicationAssignment
+                {
+                    Id = _cryptoService.GenerateId("asa"),
+                    ClientApplicationId = item.Client.Id,
+                    ConfigurationOwner = SqlOSConfigurationOwners.Code,
+                    ConfigurationSourceKey = item.Key,
+                    CreatedAt = now,
+                    CreatedByActorType = "system",
+                    CreatedByActorId = "startup"
+                };
+                _context.Set<SqlOSApplicationAssignment>().Add(assignment);
+            }
+
+            assignment.OrganizationId = item.Request.OrganizationId;
+            assignment.PrincipalType = item.Request.PrincipalType;
+            assignment.PrincipalId = item.Request.PrincipalId;
+            assignment.RoleKey = item.Request.RoleKey;
+            assignment.Access = item.Request.Access;
+            assignment.Reason = item.Request.Reason;
+            assignment.ConfigurationFingerprint = item.Fingerprint;
+            assignment.LastReconciledAt = now;
+            assignment.ConfigurationOrphanedAt = null;
+            assignment.RevokedAt = null;
+            assignment.RevokedByActorType = null;
+            assignment.RevokedByActorId = null;
+            if (outcome != null) audit.Add((assignment, outcome));
+        }
+
+        await _context.SaveChangesAsync(cancellationToken);
+        foreach (var (assignment, outcome) in audit)
+        {
+            await RecordAuditAsync(
+                "configuration.reconciled",
+                "system",
+                "startup",
+                organizationId: assignment.OrganizationId,
+                data: new
+                {
+                    resourceType = "application_assignment",
+                    resourceId = assignment.Id,
+                    owner = SqlOSConfigurationOwners.Code,
+                    sourceKey = assignment.ConfigurationSourceKey,
+                    outcome,
+                    fingerprint = assignment.ConfigurationFingerprint,
+                    clientApplicationId = assignment.ClientApplicationId
+                },
+                cancellationToken: cancellationToken);
+        }
+    }
+
+    private async Task<string?> ResolveSeedOrganizationIdAsync(string? idOrSlug, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(idOrSlug)) return null;
+        var value = idOrSlug.Trim();
+        var organization = await _context.Set<SqlOSOrganization>()
+            .AsNoTracking()
+            .SingleOrDefaultAsync(x => x.Id == value || x.Slug == value, cancellationToken);
+        if (organization == null || !organization.IsActive)
+        {
+            throw new InvalidOperationException($"Seeded application assignment organization '{value}' was not found or is inactive.");
+        }
+        return organization.Id;
+    }
+
+    private async Task ValidateAssignmentPrincipalAsync(NormalizedAssignmentRequest request, CancellationToken cancellationToken)
+    {
+        if (request.OrganizationId != null)
+        {
+            var organizationActive = await _context.Set<SqlOSOrganization>()
+                .AnyAsync(x => x.Id == request.OrganizationId && x.IsActive, cancellationToken);
+            if (!organizationActive) throw new InvalidOperationException("Application assignments require an active organization.");
+        }
+
+        switch (request.PrincipalType)
+        {
+            case SqlOSApplicationAssignmentPrincipalTypes.User:
+                var userActive = await _context.Set<SqlOSUser>().AnyAsync(x => x.Id == request.PrincipalId && x.IsActive, cancellationToken);
+                if (!userActive) throw new InvalidOperationException($"Application assignment user '{request.PrincipalId}' was not found or is inactive.");
+                if (request.OrganizationId != null)
+                {
+                    var membershipActive = await _context.Set<SqlOSMembership>().AnyAsync(x => x.UserId == request.PrincipalId && x.OrganizationId == request.OrganizationId && x.IsActive, cancellationToken);
+                    if (!membershipActive) throw new InvalidOperationException("Application assignment user is not active in the selected organization.");
+                }
+                break;
+            case SqlOSApplicationAssignmentPrincipalTypes.Group:
+                var group = await _context.Set<SqlOSFgaUserGroup>().AsNoTracking().Include(x => x.Subject).SingleOrDefaultAsync(x => x.Id == request.PrincipalId, cancellationToken);
+                if (group == null || !group.IsActive) throw new InvalidOperationException($"Application assignment group '{request.PrincipalId}' was not found or is inactive.");
+                EnsureSubjectOrganization(group.Subject?.OrganizationId, request.OrganizationId, "group");
+                break;
+            case SqlOSApplicationAssignmentPrincipalTypes.ServiceAccount:
+                var serviceAccount = await _context.Set<SqlOSFgaServiceAccount>().AsNoTracking().Include(x => x.Subject).SingleOrDefaultAsync(x => x.Id == request.PrincipalId, cancellationToken);
+                if (serviceAccount == null || serviceAccount.ExpiresAt <= DateTime.UtcNow) throw new InvalidOperationException($"Application assignment service account '{request.PrincipalId}' was not found or is expired.");
+                EnsureSubjectOrganization(serviceAccount.Subject?.OrganizationId, request.OrganizationId, "service account");
+                break;
+            case SqlOSApplicationAssignmentPrincipalTypes.Agent:
+                var agent = await _context.Set<SqlOSFgaAgent>().AsNoTracking().Include(x => x.Subject).SingleOrDefaultAsync(x => x.Id == request.PrincipalId, cancellationToken);
+                if (agent == null) throw new InvalidOperationException($"Application assignment agent '{request.PrincipalId}' was not found.");
+                EnsureSubjectOrganization(agent.Subject?.OrganizationId, request.OrganizationId, "agent");
+                break;
+        }
+    }
+
+    private static void EnsureSubjectOrganization(string? subjectOrganizationId, string? requestedOrganizationId, string principal)
+    {
+        if (requestedOrganizationId != null && !string.Equals(subjectOrganizationId, requestedOrganizationId, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException($"Application assignment {principal} belongs to a different organization.");
+        }
+    }
+
+    private static void ValidateAssignmentMode(string accessMode, NormalizedAssignmentRequest request)
+    {
+        if (accessMode == SqlOSApplicationAccessModes.Disabled)
+        {
+            throw new InvalidOperationException("Disabled applications cannot declare active access assignments.");
+        }
+        if (accessMode == SqlOSApplicationAccessModes.SelectedOrganizations
+            && request.PrincipalType != SqlOSApplicationAssignmentPrincipalTypes.Organization)
+        {
+            throw new InvalidOperationException("selected_organizations applications may only declare organization assignments.");
+        }
+    }
+
+    private static string RequireBounded(string? value, string name, int maxLength)
+    {
+        var normalized = RequireText(value, name);
+        if (normalized.Length > maxLength) throw new InvalidOperationException($"{name} must be {maxLength} characters or fewer.");
+        return normalized;
+    }
+
+    private sealed record NormalizedSeedAssignment(
+        SqlOSClientApplication Client,
+        string Key,
+        NormalizedAssignmentRequest Request,
+        string Fingerprint);
+}

--- a/src/SqlOS/AuthServer/Services/SqlOSAdminService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSAdminService.cs
@@ -122,6 +122,40 @@ public sealed partial class SqlOSAdminService
 
     public async Task UpsertSeededClientsAsync(CancellationToken cancellationToken = default)
     {
+        if (!_context.Database.IsRelational() || _context.Database.CurrentTransaction != null)
+        {
+            await UpsertSeededClientsCoreAsync(cancellationToken);
+            return;
+        }
+
+        var strategy = _context.Database.CreateExecutionStrategy();
+        var attempt = 0;
+        await strategy.ExecuteAsync(async () =>
+        {
+            if (attempt++ > 0 && _context is DbContext retryContext)
+            {
+                retryContext.ChangeTracker.Clear();
+            }
+            await using var transaction = await _context.Database.BeginTransactionAsync(System.Data.IsolationLevel.Serializable, cancellationToken);
+            if (string.Equals(_context.Database.ProviderName, "Microsoft.EntityFrameworkCore.SqlServer", StringComparison.Ordinal))
+            {
+                await _context.Database.ExecuteSqlRawAsync("""
+                    DECLARE @result int;
+                    EXEC @result = sys.sp_getapplock
+                        @Resource = N'SqlOS:ClientSeedReconciliation',
+                        @LockMode = N'Exclusive',
+                        @LockOwner = N'Transaction',
+                        @LockTimeout = 30000;
+                    IF @result < 0 THROW 51000, 'Could not acquire the SqlOS client seed reconciliation lock.', 1;
+                    """, cancellationToken);
+            }
+            await UpsertSeededClientsCoreAsync(cancellationToken);
+            await transaction.CommitAsync(cancellationToken);
+        });
+    }
+
+    private async Task UpsertSeededClientsCoreAsync(CancellationToken cancellationToken)
+    {
         var seeds = BuildStartupClientSeeds();
         var sourceKeys = seeds.Select(x => x.ClientId.Trim()).ToHashSet(StringComparer.Ordinal);
         var now = DateTime.UtcNow;
@@ -147,9 +181,19 @@ public sealed partial class SqlOSAdminService
         {
             var normalized = NormalizeSeededClient(seed);
             var sourceKey = normalized.ClientId;
-            var fingerprint = SqlOSConfigurationOwnershipPolicy.Fingerprint(new { normalized.ClientId, normalized.Name, normalized.Description, normalized.Audience, normalized.ClientType, normalized.RequirePkce, normalized.AllowedScopes, normalized.IsFirstParty, normalized.AllowNativeHeadlessAuth, normalized.AllowDeviceAuthorization, normalized.EnableClientCredentials, normalized.RedirectUris, normalized.IsActive });
             var existing = await _context.Set<SqlOSClientApplication>()
                 .FirstOrDefaultAsync(x => x.ClientId == normalized.ClientId, cancellationToken);
+            if (seed.Assignments.Count > 0 && string.IsNullOrWhiteSpace(seed.AccessMode))
+            {
+                throw new InvalidOperationException($"Client '{normalized.ClientId}' must set AccessMode explicitly when declaring application assignments.");
+            }
+            var accessMode = string.IsNullOrWhiteSpace(seed.AccessMode)
+                ? existing == null ? SqlOSApplicationAccessModes.AllOrganizations : NormalizeAccessMode(existing.AccessMode)
+                : NormalizeAccessMode(seed.AccessMode);
+            var assignmentFingerprint = seed.Assignments
+                .OrderBy(x => x.Key, StringComparer.Ordinal)
+                .Select(x => new { x.Key, x.PrincipalType, x.PrincipalId, x.OrganizationIdOrSlug, x.RoleKey, x.Access, x.Description });
+            var fingerprint = SqlOSConfigurationOwnershipPolicy.Fingerprint(new { normalized.ClientId, normalized.Name, normalized.Description, normalized.Audience, normalized.ClientType, normalized.RequirePkce, normalized.AllowedScopes, normalized.IsFirstParty, normalized.AllowNativeHeadlessAuth, normalized.AllowDeviceAuthorization, normalized.EnableClientCredentials, normalized.RedirectUris, normalized.IsActive, AccessMode = accessMode, Assignments = assignmentFingerprint });
             var outcome = existing == null ? "created" : existing.ConfigurationFingerprint == fingerprint && existing.ConfigurationOrphanedAt == null ? null : "updated";
 
             if (existing != null && string.Equals(existing.RegistrationSource, "seeded", StringComparison.OrdinalIgnoreCase) && existing.ConfigurationSourceKey == null)
@@ -187,8 +231,10 @@ public sealed partial class SqlOSAdminService
                     RedirectUrisJson = JsonSerializer.Serialize(normalized.RedirectUris),
                     CreatedAt = DateTime.UtcNow,
                     IsFirstParty = normalized.IsFirstParty,
-                    IsActive = normalized.IsActive,
-                    AccessMode = SqlOSApplicationAccessModes.AllOrganizations
+                    IsActive = normalized.IsActive && accessMode != SqlOSApplicationAccessModes.Disabled,
+                    AccessMode = accessMode,
+                    DisabledAt = accessMode == SqlOSApplicationAccessModes.Disabled ? now : null,
+                    DisabledReason = accessMode == SqlOSApplicationAccessModes.Disabled ? "application_access_disabled" : null
                 });
                 auditOutcomes.Add((sourceKey, sourceKey, "created", fingerprint));
                 continue;
@@ -214,7 +260,7 @@ public sealed partial class SqlOSAdminService
             existing.AllowDeviceAuthorization = normalized.AllowDeviceAuthorization;
             existing.RedirectUrisJson = JsonSerializer.Serialize(normalized.RedirectUris);
             existing.IsFirstParty = normalized.IsFirstParty;
-            existing.AccessMode = NormalizeAccessMode(existing.AccessMode);
+            await ApplySeededApplicationAccessModeAsync(existing, accessMode, normalized.IsActive, cancellationToken);
             if (existing.DisabledAt != null)
             {
                 existing.IsActive = false;
@@ -226,6 +272,7 @@ public sealed partial class SqlOSAdminService
         }
 
         await _context.SaveChangesAsync(cancellationToken);
+        await ReconcileSeededApplicationAssignmentsAsync(seeds, now, cancellationToken);
         foreach (var audit in auditOutcomes)
         {
             await RecordAuditAsync("configuration.reconciled", "system", "startup", data: new { resourceType = "oauth_client", resourceId = audit.ResourceId, owner = SqlOSConfigurationOwners.Code, sourceKey = audit.SourceKey, outcome = audit.Outcome, fingerprint = audit.Fingerprint }, cancellationToken: cancellationToken);
@@ -1247,6 +1294,10 @@ public sealed partial class SqlOSAdminService
         CancellationToken cancellationToken = default)
     {
         var client = await GetRequiredClientByIdAsync(clientApplicationId, cancellationToken);
+        if (string.Equals(actorType, "dashboard", StringComparison.OrdinalIgnoreCase))
+        {
+            SqlOSConfigurationOwnershipPolicy.EnsureDashboardEditable(client.ConfigurationOwner, $"OAuth client '{client.ClientId}' access mode");
+        }
         var accessMode = NormalizeAccessMode(request.AccessMode);
         var previousMode = NormalizeAccessMode(client.AccessMode);
         client.AccessMode = accessMode;
@@ -1304,6 +1355,13 @@ public sealed partial class SqlOSAdminService
                 x.RoleKey,
                 x.Access,
                 x.Reason,
+                Ownership = SqlOSConfigurationOwnershipPolicy.ToDto(
+                    x.ConfigurationOwner,
+                    x.ConfigurationSourceKey,
+                    x.LastReconciledAt,
+                    x.ConfigurationFingerprint,
+                    x.ConfigurationOrphanedAt,
+                    false),
                 x.CreatedAt,
                 x.CreatedByActorType,
                 x.CreatedByActorId,
@@ -1332,6 +1390,7 @@ public sealed partial class SqlOSAdminService
     {
         var client = await GetRequiredClientByIdAsync(clientApplicationId, cancellationToken);
         var normalized = NormalizeAssignmentRequest(request);
+        await ValidateAssignmentPrincipalAsync(normalized, cancellationToken);
 
         var assignment = new SqlOSApplicationAssignment
         {
@@ -1343,6 +1402,7 @@ public sealed partial class SqlOSAdminService
             RoleKey = normalized.RoleKey,
             Access = normalized.Access,
             Reason = normalized.Reason,
+            ConfigurationOwner = SqlOSConfigurationOwners.Dashboard,
             CreatedAt = DateTime.UtcNow,
             CreatedByActorType = actorType,
             CreatedByActorId = actorId
@@ -1379,6 +1439,8 @@ public sealed partial class SqlOSAdminService
         var assignment = await _context.Set<SqlOSApplicationAssignment>()
             .FirstOrDefaultAsync(x => x.Id == assignmentId && x.ClientApplicationId == client.Id, cancellationToken)
             ?? throw new InvalidOperationException("Application assignment was not found.");
+
+        SqlOSConfigurationOwnershipPolicy.EnsureDashboardEditable(assignment.ConfigurationOwner, $"Application assignment '{assignment.Id}'");
 
         if (assignment.RevokedAt == null)
         {
@@ -2109,9 +2171,9 @@ public sealed partial class SqlOSAdminService
     {
         var principalType = NormalizePrincipalType(request.PrincipalType);
         var access = NormalizeAssignmentAccess(request.Access);
-        var principalId = string.IsNullOrWhiteSpace(request.PrincipalId) ? null : request.PrincipalId.Trim();
-        var organizationId = string.IsNullOrWhiteSpace(request.OrganizationId) ? null : request.OrganizationId.Trim();
-        var roleKey = string.IsNullOrWhiteSpace(request.RoleKey) ? null : request.RoleKey.Trim();
+        var principalId = NormalizeBoundedOptional(request.PrincipalId, "Application assignment principalId", 128);
+        var organizationId = NormalizeBoundedOptional(request.OrganizationId, "Application assignment organizationId", 64);
+        var roleKey = NormalizeBoundedOptional(request.RoleKey, "Application assignment roleKey", 80);
 
         switch (principalType)
         {
@@ -2150,7 +2212,15 @@ public sealed partial class SqlOSAdminService
             organizationId,
             roleKey,
             access,
-            string.IsNullOrWhiteSpace(request.Reason) ? null : request.Reason.Trim());
+            NormalizeBoundedOptional(request.Reason, "Application assignment reason", 500));
+    }
+
+    private static string? NormalizeBoundedOptional(string? value, string name, int maxLength)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return null;
+        var normalized = value.Trim();
+        if (normalized.Length > maxLength) throw new InvalidOperationException($"{name} must be {maxLength} characters or fewer.");
+        return normalized;
     }
 
     private static string NormalizePrincipalType(string value)

--- a/src/SqlOS/Dashboard/wwwroot/app.js
+++ b/src/SqlOS/Dashboard/wwwroot/app.js
@@ -2894,13 +2894,14 @@
                                 ])}
                                 <div>
                                     <h3>Access</h3>
+                                    ${clientDetail.ownership && !clientDetail.ownership.isEditable ? `<div class="callout"><strong>Code owned access mode:</strong> Change <span class="inline-code">AccessMode</span> in the client seed. Dashboard-created assignments remain available and survive reconciliation.</div>` : ""}
                                     <form id="application-access-mode-form" class="client-filter-form">
-                                        <select name="accessMode">
+                                        <select name="accessMode" ${clientDetail.ownership && !clientDetail.ownership.isEditable ? "disabled" : ""}>
                                             ${["all_organizations", "selected_organizations", "selected_users_groups_roles", "internal_only", "disabled"].map(mode => `
                                                 <option value="${esc(mode)}" ${(clientAccess?.accessMode || clientDetail.accessMode || "all_organizations") === mode ? "selected" : ""}>${esc(mode)}</option>
                                             `).join("")}
                                         </select>
-                                        <button type="submit">Save access mode</button>
+                                        <button type="submit" ${clientDetail.ownership && !clientDetail.ownership.isEditable ? "disabled" : ""}>Save access mode</button>
                                     </form>
                                     <form id="create-application-assignment-form" class="client-assignment-form">
                                         <select name="principalType">
@@ -2908,6 +2909,8 @@
                                             <option value="user">User</option>
                                             <option value="group">Group</option>
                                             <option value="role">Role</option>
+                                            <option value="service_account">Service account</option>
+                                            <option value="agent">Agent</option>
                                         </select>
                                         <input name="organizationId" placeholder="Organization ID">
                                         <input name="principalId" placeholder="User or group ID">
@@ -2929,9 +2932,10 @@
                                                         <div class="client-badge-row">
                                                             ${renderClientBadge(assignment.access, assignment.access === "denied" ? "danger" : "success")}
                                                             ${assignment.revokedAt ? renderClientBadge("Revoked", "muted") : ""}
+                                                            ${renderClientBadge(assignment.ownership?.owner === "code" ? "Code owned" : "Dashboard owned", assignment.ownership?.owner === "code" ? "info" : "muted")}
                                                         </div>
                                                     </div>
-                                                    ${assignment.revokedAt ? "" : `
+                                                    ${assignment.revokedAt || (assignment.ownership && !assignment.ownership.isEditable) ? "" : `
                                                         <button type="button" data-application-assignment-revoke="${esc(assignment.id)}">Revoke</button>
                                                     `}
                                                 </div>
@@ -2940,6 +2944,7 @@
                                                     { label: "Principal ID", value: assignment.principalId || "n/a" },
                                                     { label: "Role key", value: assignment.roleKey || "n/a" },
                                                     { label: "Reason", value: assignment.reason || "n/a" },
+                                                    { label: "Source key", value: assignment.ownership?.sourceKey || "n/a" },
                                                     { label: "Created", value: formatDate(assignment.createdAt) }
                                                 ])}
                                             </div>

--- a/src/SqlOS/Services/SqlOSBootstrapper.cs
+++ b/src/SqlOS/Services/SqlOSBootstrapper.cs
@@ -60,6 +60,23 @@ public sealed class SqlOSBootstrapper
         await _settingsService.UpsertSeededAuthEmailSettingsAsync(cancellationToken);
         await _settingsService.UpsertSeededMfaSettingsAsync(cancellationToken);
         await _emailAdminService.EnsureBuiltInTemplatesAsync(cancellationToken);
+
+        // Application access seeds may reference FGA groups, service accounts, agents, and roles.
+        // Make those stable principals available before client policy reconciliation.
+        await _fgaSchemaInitializer.EnsureSchemaAsync(cancellationToken);
+        if (_options.Fga.InitializeFunctions)
+        {
+            await _fgaFunctionInitializer.EnsureFunctionsExistAsync(cancellationToken);
+        }
+        if (_options.Fga.SeedCoreData)
+        {
+            await _fgaSeedService.SeedCoreAsync(cancellationToken);
+        }
+        if (_options.Fga.StartupSeedData != null)
+        {
+            await _fgaSeedService.SeedAuthorizationDataAsync(_options.Fga.StartupSeedData, cancellationToken);
+        }
+
         await _adminService.UpsertSeededClientsAsync(cancellationToken);
         await _adminService.UpsertSeededOidcConnectionsAsync(cancellationToken);
         await _adminService.UpsertSeededScimConnectionsAsync(cancellationToken);
@@ -70,23 +87,7 @@ public sealed class SqlOSBootstrapper
         await _adminService.CleanupExpiredRefreshTokensAsync(cancellationToken);
         await _adminService.CleanupStaleDynamicClientsAsync(cancellationToken);
 
-        await _fgaSchemaInitializer.EnsureSchemaAsync(cancellationToken);
         await _adminService.ReconcileDisabledScimManagedGrantsAsync(cancellationToken);
-
-        if (_options.Fga.InitializeFunctions)
-        {
-            await _fgaFunctionInitializer.EnsureFunctionsExistAsync(cancellationToken);
-        }
-
-        if (_options.Fga.SeedCoreData)
-        {
-            await _fgaSeedService.SeedCoreAsync(cancellationToken);
-        }
-
-        if (_options.Fga.StartupSeedData != null)
-        {
-            await _fgaSeedService.SeedAuthorizationDataAsync(_options.Fga.StartupSeedData, cancellationToken);
-        }
 
         await _fgaHierarchyValidator.ValidateExistingDataAsync(cancellationToken);
 

--- a/tests/SqlOS.IntegrationTests/ApplicationAccessSeedIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/ApplicationAccessSeedIntegrationTests.cs
@@ -1,0 +1,80 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SqlOS.AuthServer.Configuration;
+using SqlOS.AuthServer.Contracts;
+using SqlOS.AuthServer.Models;
+using SqlOS.AuthServer.Services;
+using SqlOS.IntegrationTests.Infrastructure;
+
+namespace SqlOS.IntegrationTests;
+
+[TestClass]
+public sealed class ApplicationAccessSeedIntegrationTests
+{
+    [TestMethod]
+    public async Task ApplicationAccessSeeds_ConcurrentRealSqlStartupIsIdempotentAndPreservesDashboardRows()
+    {
+        await using var setupContext = await AspireFixture.CreateIsolatedAuthContextAsync("AppAccessSeed");
+        try
+        {
+            var connectionString = setupContext.Database.GetConnectionString()!;
+            var optionsValue = new SqlOSAuthServerOptions();
+            var setupOptions = Options.Create(optionsValue);
+            var setupAdmin = new SqlOSAdminService(setupContext, setupOptions, new SqlOSCryptoService(setupContext, setupOptions));
+            var organization = await setupAdmin.CreateOrganizationAsync(new SqlOSCreateOrganizationRequest("Seeded access", "seeded-access"));
+            optionsValue.SeedClient(client =>
+            {
+                client.ClientId = "real-sql-seeded-app";
+                client.Name = "Real SQL seeded app";
+                client.RedirectUris = ["https://app.example.test/callback"];
+                client.AccessMode = SqlOSApplicationAccessModes.SelectedOrganizations;
+                client.AssignOrganization("primary-org", organization.Slug, description: "seeded entitlement");
+            });
+            await setupAdmin.UpsertSeededClientsAsync();
+            var dashboard = await setupAdmin.AssignApplicationAsync(
+                "real-sql-seeded-app",
+                new SqlOSCreateApplicationAssignmentRequest(
+                    SqlOSApplicationAssignmentPrincipalTypes.Organization,
+                    OrganizationId: organization.Id,
+                    Access: SqlOSApplicationAssignmentAccess.Denied,
+                    Reason: "operator exception"));
+
+            var contexts = Enumerable.Range(0, 4)
+                .Select(_ => new TestSqlOSDbContext(new DbContextOptionsBuilder<TestSqlOSDbContext>().UseSqlServer(connectionString).Options))
+                .ToList();
+            try
+            {
+                var ready = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                var runs = contexts.Select(context => Task.Run(async () =>
+                {
+                    await ready.Task;
+                    var options = Options.Create(optionsValue);
+                    var admin = new SqlOSAdminService(context, options, new SqlOSCryptoService(context, options));
+                    await admin.UpsertSeededClientsAsync();
+                })).ToArray();
+                ready.SetResult();
+                await Task.WhenAll(runs).WaitAsync(TimeSpan.FromSeconds(45));
+            }
+            finally
+            {
+                foreach (var context in contexts) await context.DisposeAsync();
+            }
+
+            setupContext.ChangeTracker.Clear();
+            var client = await setupContext.Set<SqlOSClientApplication>().AsNoTracking().SingleAsync(x => x.ClientId == "real-sql-seeded-app");
+            client.AccessMode.Should().Be(SqlOSApplicationAccessModes.SelectedOrganizations);
+            var assignments = await setupContext.Set<SqlOSApplicationAssignment>().AsNoTracking().Where(x => x.ClientApplicationId == client.Id).ToListAsync();
+            assignments.Should().HaveCount(2);
+            assignments.Single(x => x.ConfigurationSourceKey == "primary-org").ConfigurationOwner.Should().Be(SqlOSConfigurationOwners.Code);
+            assignments.Single(x => x.Id == dashboard.Id).ConfigurationOwner.Should().Be(SqlOSConfigurationOwners.Dashboard);
+            (await setupContext.Set<SqlOSAuditEvent>().CountAsync(x => x.EventType == "configuration.reconciled" && x.DataJson != null && x.DataJson.Contains("application_assignment")))
+                .Should().Be(1, "no-op concurrent startup must not duplicate assignment reconciliation evidence");
+        }
+        finally
+        {
+            await setupContext.Database.EnsureDeletedAsync();
+        }
+    }
+}

--- a/tests/SqlOS.IntegrationTests/SchemaInitializerIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/SchemaInitializerIntegrationTests.cs
@@ -14,7 +14,7 @@ namespace SqlOS.IntegrationTests;
 [TestClass]
 public sealed class SchemaInitializerIntegrationTests
 {
-    private const int CurrentSchemaVersion = 34;
+    private const int CurrentSchemaVersion = 35;
 
     [TestMethod]
     public async Task EnsureSchema_CreatesCoreTables()

--- a/tests/SqlOS.Tests/SqlOSApplicationAssignmentsTests.cs
+++ b/tests/SqlOS.Tests/SqlOSApplicationAssignmentsTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using System.Text.Json;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
@@ -237,6 +238,175 @@ public sealed class SqlOSApplicationAssignmentsTests
         failure.Message.Should().NotContain("selected_organizations");
     }
 
+    [TestMethod]
+    public async Task SeededAssignments_ResolveOrganizationSlugAndAuthorizeWithoutSetupScript()
+    {
+        await using var harness = await Harness.CreateAsync(options =>
+        {
+            var client = options.ClientSeeds.Single(x => x.ClientId == "test-client");
+            client.AccessMode = SqlOSApplicationAccessModes.SelectedOrganizations;
+            client.AssignOrganization("primary-org", "allowed", description: "production tenant");
+        });
+
+        var client = await harness.Context.Set<SqlOSClientApplication>().SingleAsync(x => x.ClientId == "test-client");
+        client.AccessMode.Should().Be(SqlOSApplicationAccessModes.SelectedOrganizations);
+        var assignment = await harness.Context.Set<SqlOSApplicationAssignment>().SingleAsync(x => x.ClientApplicationId == client.Id);
+        assignment.OrganizationId.Should().Be("org_allowed");
+        assignment.ConfigurationOwner.Should().Be(SqlOSConfigurationOwners.Code);
+        assignment.ConfigurationSourceKey.Should().Be("primary-org");
+        JsonSerializer.Serialize(await harness.Admin.ListApplicationAssignmentsAsync(client.Id)).Should()
+            .Contain("\"Owner\":\"code\"").And.Contain("\"IsEditable\":false");
+
+        var result = await harness.Auth.LoginWithPasswordAsync(
+            new SqlOSPasswordLoginRequest("ada@example.com", "P@ssword123!", "test-client", "org_allowed"),
+            harness.Http);
+        result.Tokens.Should().NotBeNull();
+    }
+
+    [TestMethod]
+    public async Task SeededAssignments_RerunIsIdempotentAndPreservesDashboardAssignments()
+    {
+        await using var harness = await Harness.CreateAsync(options =>
+        {
+            var client = options.ClientSeeds.Single(x => x.ClientId == "test-client");
+            client.AccessMode = SqlOSApplicationAccessModes.SelectedOrganizations;
+            client.AssignOrganization("primary-org", "allowed");
+        });
+        var dashboard = await harness.Admin.AssignApplicationAsync("test-client", new SqlOSCreateApplicationAssignmentRequest(
+            SqlOSApplicationAssignmentPrincipalTypes.Organization,
+            OrganizationId: "org_blocked"));
+
+        await harness.Admin.UpsertSeededClientsAsync();
+
+        var assignments = await harness.Context.Set<SqlOSApplicationAssignment>().ToListAsync();
+        assignments.Should().HaveCount(2);
+        assignments.Single(x => x.Id == dashboard.Id).ConfigurationOwner.Should().Be(SqlOSConfigurationOwners.Dashboard);
+        assignments.Single(x => x.ConfigurationSourceKey == "primary-org").RevokedAt.Should().BeNull();
+    }
+
+    [TestMethod]
+    public async Task SeededClient_OmittedAccessModePreservesExistingStoredPolicy()
+    {
+        await using var harness = await Harness.CreateAsync();
+        await harness.Admin.SetApplicationAccessModeAsync(
+            "test-client",
+            new SqlOSSetApplicationAccessModeRequest(SqlOSApplicationAccessModes.SelectedOrganizations));
+
+        await harness.Admin.UpsertSeededClientsAsync();
+
+        (await harness.Context.Set<SqlOSClientApplication>().SingleAsync(x => x.ClientId == "test-client"))
+            .AccessMode.Should().Be(SqlOSApplicationAccessModes.SelectedOrganizations);
+    }
+
+    [TestMethod]
+    public async Task SeededClient_AssignmentsRequireExplicitAccessMode()
+    {
+        var act = () => Harness.CreateAsync(options =>
+            options.ClientSeeds.Single(x => x.ClientId == "test-client")
+                .AssignOrganization("primary-org", "allowed"));
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*must set AccessMode explicitly*");
+    }
+
+    [TestMethod]
+    public async Task SeededAssignments_RemovalRevokesOnlyCodeOwnedAssignmentAndAuditsOutcome()
+    {
+        await using var harness = await Harness.CreateAsync(options =>
+        {
+            var client = options.ClientSeeds.Single(x => x.ClientId == "test-client");
+            client.AccessMode = SqlOSApplicationAccessModes.SelectedOrganizations;
+            client.AssignOrganization("primary-org", "allowed");
+        });
+        var dashboard = await harness.Admin.AssignApplicationAsync("test-client", new SqlOSCreateApplicationAssignmentRequest(
+            SqlOSApplicationAssignmentPrincipalTypes.Organization,
+            OrganizationId: "org_blocked"));
+        harness.Options.ClientSeeds.Single(x => x.ClientId == "test-client").Assignments.Clear();
+
+        await harness.Admin.UpsertSeededClientsAsync();
+
+        var codeOwned = await harness.Context.Set<SqlOSApplicationAssignment>().SingleAsync(x => x.ConfigurationOwner == SqlOSConfigurationOwners.Code);
+        codeOwned.RevokedAt.Should().NotBeNull();
+        codeOwned.ConfigurationOrphanedAt.Should().NotBeNull();
+        (await harness.Context.Set<SqlOSApplicationAssignment>().SingleAsync(x => x.Id == dashboard.Id)).RevokedAt.Should().BeNull();
+        (await harness.Context.Set<SqlOSAuditEvent>().Where(x => x.EventType == "configuration.reconciled").Select(x => x.DataJson).ToListAsync())
+            .Should().Contain(x => x.Contains("application_assignment") && x.Contains("revoked"));
+    }
+
+    [TestMethod]
+    public async Task SeededAssignments_InvalidOrCrossTenantPrincipalFailsClosed()
+    {
+        var act = () => Harness.CreateAsync(options =>
+        {
+            var client = options.ClientSeeds.Single(x => x.ClientId == "test-client");
+            client.AccessMode = SqlOSApplicationAccessModes.SelectedUsersGroupsRoles;
+            client.AssignUser("wrong-tenant", "missing-user", "allowed");
+        });
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*was not found or is inactive*");
+    }
+
+    [TestMethod]
+    public async Task ApplicationAssignments_RejectOverlongFieldsBeforePersistence()
+    {
+        await using var harness = await Harness.CreateAsync();
+        var act = () => harness.Admin.AssignApplicationAsync(
+            "test-client",
+            new SqlOSCreateApplicationAssignmentRequest(
+                SqlOSApplicationAssignmentPrincipalTypes.User,
+                PrincipalId: new string('u', 129)));
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*principalId must be 128 characters or fewer*");
+        (await harness.Context.Set<SqlOSApplicationAssignment>().CountAsync()).Should().Be(0);
+    }
+
+    [TestMethod]
+    public async Task SeededAssignments_CodeOwnedRowsAreReadOnlyThroughDashboardService()
+    {
+        await using var harness = await Harness.CreateAsync(options =>
+        {
+            var client = options.ClientSeeds.Single(x => x.ClientId == "test-client");
+            client.AccessMode = SqlOSApplicationAccessModes.SelectedOrganizations;
+            client.AssignOrganization("primary-org", "allowed");
+        });
+        var assignment = await harness.Context.Set<SqlOSApplicationAssignment>().SingleAsync();
+
+        var revoke = () => harness.Admin.RevokeApplicationAssignmentAsync("test-client", assignment.Id);
+        await revoke.Should().ThrowAsync<InvalidOperationException>().WithMessage("*owned by the 'code' configuration source*");
+    }
+
+    [TestMethod]
+    public async Task SeededAssignments_AllSupportedPrincipalBuildersUseSharedValidation()
+    {
+        await using var harness = await Harness.CreateAsync();
+        var group = await harness.SeedFgaGroupMembershipAsync();
+        var (serviceAccountId, agentId) = await harness.SeedFgaMachinePrincipalsAsync();
+        var client = harness.Options.ClientSeeds.Single(x => x.ClientId == "test-client");
+        client.AccessMode = SqlOSApplicationAccessModes.SelectedUsersGroupsRoles;
+        client.AssignOrganization("organization", "allowed")
+            .AssignUser("user", harness.User.Id)
+            .AssignGroup("group", group.Id)
+            .AssignRole("role", "allowed", "admin")
+            .AssignServiceAccount("service-account", serviceAccountId, "allowed")
+            .AssignAgent("agent", agentId, "allowed");
+
+        await harness.Admin.UpsertSeededClientsAsync();
+
+        var assignments = await harness.Context.Set<SqlOSApplicationAssignment>()
+            .Where(x => x.ConfigurationOwner == SqlOSConfigurationOwners.Code && x.RevokedAt == null)
+            .ToListAsync();
+        assignments.Should().HaveCount(6);
+        assignments.Select(x => x.PrincipalType).Should().BeEquivalentTo(
+            SqlOSApplicationAssignmentPrincipalTypes.Organization,
+            SqlOSApplicationAssignmentPrincipalTypes.User,
+            SqlOSApplicationAssignmentPrincipalTypes.Group,
+            SqlOSApplicationAssignmentPrincipalTypes.Role,
+            SqlOSApplicationAssignmentPrincipalTypes.ServiceAccount,
+            SqlOSApplicationAssignmentPrincipalTypes.Agent);
+    }
+
     private sealed class Harness : IAsyncDisposable
     {
         private readonly SqlOSCryptoService _crypto;
@@ -268,8 +438,9 @@ public sealed class SqlOSApplicationAssignmentsTests
         public SqlOSDeviceAuthorizationService Device { get; }
         public SqlOSUser User { get; }
         public DefaultHttpContext Http { get; }
+        public SqlOSAuthServerOptions Options { get; private init; } = null!;
 
-        public static async Task<Harness> CreateAsync()
+        public static async Task<Harness> CreateAsync(Action<SqlOSAuthServerOptions>? configure = null)
         {
             var context = new TestSqlOSInMemoryDbContext(
                 new DbContextOptionsBuilder<TestSqlOSInMemoryDbContext>()
@@ -284,8 +455,9 @@ public sealed class SqlOSApplicationAssignmentsTests
             authOptions.ResourceIndicators.Enabled = true;
             authOptions.SeedBrowserClient("test-client", "Test Client", "https://client.example.test/callback");
             authOptions.SeedCliClient("test-cli", "Test CLI", "test-cli", "openid", "offline_access");
+            configure?.Invoke(authOptions);
 
-            var options = Options.Create(authOptions);
+            var options = Microsoft.Extensions.Options.Options.Create(authOptions);
             var crypto = TestCryptoService.Create(context, options);
             var admin = new SqlOSAdminService(context, options, crypto);
             var emailSender = new TestAuthEmailSender();
@@ -302,8 +474,6 @@ public sealed class SqlOSApplicationAssignmentsTests
 
             await crypto.EnsureActiveSigningKeyAsync();
             await settings.EnsureDefaultAuthPageSettingsAsync();
-            await admin.UpsertSeededClientsAsync();
-
             var user = await admin.CreateUserAsync(new SqlOSCreateUserRequest("Ada Lovelace", "ada@example.com", "P@ssword123!"));
             context.Set<SqlOSOrganization>().AddRange(
                 new SqlOSOrganization { Id = "org_allowed", Slug = "allowed", Name = "Allowed Org", CreatedAt = DateTime.UtcNow, IsActive = true },
@@ -313,7 +483,9 @@ public sealed class SqlOSApplicationAssignmentsTests
                 new SqlOSMembership { OrganizationId = "org_blocked", UserId = user.Id, Role = "member", CreatedAt = DateTime.UtcNow, IsActive = true });
             await context.SaveChangesAsync();
 
-            return new Harness(context, admin, auth, authorization, device, crypto, user, http);
+            await admin.UpsertSeededClientsAsync();
+
+            return new Harness(context, admin, auth, authorization, device, crypto, user, http) { Options = authOptions };
         }
 
         public async Task<SqlOSAuthorizationRequest> CreateAuthorizationRequestAsync()
@@ -381,6 +553,49 @@ public sealed class SqlOSApplicationAssignmentsTests
             });
             await Context.SaveChangesAsync();
             return group;
+        }
+
+        public async Task<(string ServiceAccountId, string AgentId)> SeedFgaMachinePrincipalsAsync()
+        {
+            var serviceSubject = new SqlOSFgaSubject
+            {
+                Id = "subj_service_app",
+                SubjectTypeId = "service_account",
+                OrganizationId = "org_allowed",
+                DisplayName = "Application worker",
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            };
+            var agentSubject = new SqlOSFgaSubject
+            {
+                Id = "subj_agent_app",
+                SubjectTypeId = "agent",
+                OrganizationId = "org_allowed",
+                DisplayName = "Application agent",
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            };
+            var serviceAccount = new SqlOSFgaServiceAccount
+            {
+                Id = "sa_app",
+                SubjectId = serviceSubject.Id,
+                ClientId = "sa-app",
+                ClientSecretHash = "not-used-in-assignment-test",
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            };
+            var agent = new SqlOSFgaAgent
+            {
+                Id = "agt_app",
+                SubjectId = agentSubject.Id,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            };
+            Context.Set<SqlOSFgaSubject>().AddRange(serviceSubject, agentSubject);
+            Context.Set<SqlOSFgaServiceAccount>().Add(serviceAccount);
+            Context.Set<SqlOSFgaAgent>().Add(agent);
+            await Context.SaveChangesAsync();
+            return (serviceAccount.Id, agent.Id);
         }
 
         public async ValueTask DisposeAsync()

--- a/web/content/docs/authserver/application-access.mdx
+++ b/web/content/docs/authserver/application-access.mdx
@@ -27,6 +27,28 @@ Two apps can mint tokens for the same API audience. Assignments decide whether a
 
 Explicit `denied` assignments take precedence over allowed assignments.
 
+## Code-first policy
+
+Declare reproducible application policy on the client seed. Stable assignment keys let SqlOS update or revoke only the rows owned by that source configuration.
+
+```csharp
+auth.SeedClient(client =>
+{
+    client.ClientId = "customer-portal";
+    client.Name = "Customer Portal";
+    client.RedirectUris = ["https://portal.example.com/auth/callback"];
+    client.AccessMode = SqlOSApplicationAccessModes.SelectedOrganizations;
+    client.AssignOrganization(
+        "northwind-access",
+        "northwind", // stable organization ID or slug
+        description: "Contracted customer");
+});
+```
+
+Use `AssignOrganization`, `AssignUser`, `AssignGroup`, `AssignRole`, `AssignServiceAccount`, or `AssignAgent`. Referenced organizations and principals must already exist and be active; FGA startup seeds are applied before client policy. Invalid, cross-organization, duplicate-key, and mode-incompatible assignments stop startup without opening access.
+
+Code-owned access modes and assignments are visible but read-only in the dashboard. Emergency client disablement remains available. Dashboard-owned assignments may coexist as operator exceptions and are never deleted by seed reconciliation.
+
 ## Admin API
 
 Set an application access mode:

--- a/web/content/docs/guides/configuration.mdx
+++ b/web/content/docs/guides/configuration.mdx
@@ -43,6 +43,23 @@ builder.AddSqlOS<AppDbContext>(
 
 Single-application mode creates one first-party PKCE client and keeps CIMD, DCR, resource indicators, and multi-application policy out of the starting path.
 
+## Reproducible multi-application access
+
+Multi-application hosts can keep access policy beside each client seed. When `AccessMode` is omitted, new clients default to `all_organizations` and existing seeded clients retain their stored mode. Declare it explicitly whenever you add keyed assignments.
+
+```csharp
+options.AuthServer.SeedClient(client =>
+{
+    client.ClientId = "admin-console";
+    client.Name = "Admin Console";
+    client.RedirectUris = ["https://admin.example.com/auth/callback"];
+    client.AccessMode = SqlOSApplicationAccessModes.SelectedUsersGroupsRoles;
+    client.AssignRole("tenant-admins", "northwind", "admin");
+});
+```
+
+The organization ID/slug and referenced principals must already exist. Reconciliation is idempotent and source-owned: code changes affect only the keyed rows above, while dashboard-created assignments remain operator-owned. See [Application Access](/docs/authserver/application-access) and [Assign access across multiple apps](/docs/guides/multi-app-access).
+
 ## FGA seeding
 
 Keep auth and FGA seeding in the same `AddSqlOS` call:

--- a/web/content/docs/guides/multi-app-access.mdx
+++ b/web/content/docs/guides/multi-app-access.mdx
@@ -56,6 +56,9 @@ builder.AddSqlOS<AppDbContext>(options =>
         client.AllowedScopes = ["openid", "profile", "email", "offline_access"];
         client.RequirePkce = true;
         client.IsFirstParty = true;
+        client.AccessMode = SqlOSApplicationAccessModes.SelectedOrganizations;
+        client.AssignOrganization("northwind-subscription", "northwind",
+            description: "Northwind enterprise subscription");
     });
 
     auth.SeedClient(client =>
@@ -68,6 +71,9 @@ builder.AddSqlOS<AppDbContext>(options =>
         client.RequirePkce = true;
         client.IsFirstParty = true;
         client.AllowNativeHeadlessAuth = true;
+        client.AccessMode = SqlOSApplicationAccessModes.SelectedOrganizations;
+        client.AssignOrganization("northwind-mobile", "northwind",
+            description: "Northwind mobile entitlement");
     });
 
     auth.SeedClient(client =>
@@ -79,15 +85,20 @@ builder.AddSqlOS<AppDbContext>(options =>
         client.AllowedScopes = ["openid", "profile", "email", "offline_access"];
         client.RequirePkce = true;
         client.IsFirstParty = true;
+        client.AccessMode = SqlOSApplicationAccessModes.SelectedUsersGroupsRoles;
+        client.AssignRole("northwind-admins", "northwind", "admin",
+            description: "Northwind administrators");
     });
 });
 ```
 
-New seeded clients start in `all_organizations`. Startup reconciliation preserves an existing client's access mode, and client seed options do not currently contain assignments. Apply the restrictive policy explicitly after the clients exist.
+`northwind` is a stable organization ID or slug that must already exist. Startup resolves it, applies the restrictive mode before the host accepts traffic, and fails closed if the organization or principal is missing or inactive. If you omit `AccessMode` and assignments, new clients use `all_organizations` and existing seeded clients retain their stored mode.
+
+Assignment keys such as `northwind-mobile` are application-owned identities, not database row IDs. SqlOS reconciles only rows owned by that key. Dashboard-created assignments coexist with them and survive restart; removing a keyed seed revokes only its code-owned row and records an audit event.
 
 ## 2. Choose the access mode
 
-Open **Auth Server > Clients**, select each app, and use its **Access** section. For Atlas Suite:
+Open **Auth Server > Clients** and select each app to inspect the effective policy. For Atlas Suite:
 
 | Client | Mode | Meaning |
 | --- | --- | --- |
@@ -95,7 +106,7 @@ Open **Auth Server > Clients**, select each app, and use its **Access** section.
 | `atlas-field-mobile` | `selected_organizations` | Mobile-entitled organizations only |
 | `atlas-ops-console` | `selected_users_groups_roles` | Only explicit people, groups, or org roles |
 
-The same change is available from a trusted admin process:
+For dashboard-owned clients, the same change is available from a trusted admin process:
 
 ```csharp
 await admin.SetApplicationAccessModeAsync(
@@ -107,7 +118,7 @@ await admin.SetApplicationAccessModeAsync(
     cancellationToken: ct);
 ```
 
-Run assignment automation as an idempotent, versioned deployment step. `AssignApplicationAsync` creates an assignment; it does not deduplicate repeated calls for you.
+Code-owned access modes are read-only in the dashboard. Operators may still add dashboard-owned exception assignments; startup reconciliation never adopts or removes them. For fully programmable, operator-owned policy, `AssignApplicationAsync` remains available and creates a new dashboard-owned assignment on each call.
 
 ## 3. Assign Northwind to the customer apps
 

--- a/web/content/docs/guides/standalone-identity-server.mdx
+++ b/web/content/docs/guides/standalone-identity-server.mdx
@@ -148,7 +148,20 @@ See [Headless Auth](/docs/authserver/headless-auth) and [Hosted vs Headless](/do
 
 ## 4. Configure application access
 
-Start with open access for the customer-facing app. Restrict sensitive surfaces.
+For reproducible deployments, set `AccessMode` and stable keyed assignments directly on `SeedClient`. Referenced organizations and principals must already exist. The dashboard/API workflow below is the operator-owned alternative and remains useful for runtime exceptions.
+
+```csharp
+auth.SeedClient(client =>
+{
+    client.ClientId = "admin-console";
+    client.Name = "Admin Console";
+    client.RedirectUris = ["https://admin.example.com/auth/callback"];
+    client.AccessMode = SqlOSApplicationAccessModes.SelectedUsersGroupsRoles;
+    client.AssignRole("tenant-admins", "org_123", "admin");
+});
+```
+
+Or restrict a dashboard-owned client through the admin API:
 
 ```bash
 curl -X POST https://auth.example.com/sqlos/admin/auth/api/applications/admin-console/access-mode \


### PR DESCRIPTION
Closes #214

## What changed
- adds typed access-mode and stable-key assignment builders for organizations, users, FGA groups, roles, service accounts, and agents
- reconciles assignment ownership safely without touching dashboard-owned operator exceptions
- resolves active organizations by stable ID/slug and validates principal lifecycle/tenancy before accepting policy
- serializes multi-instance startup reconciliation with a SQL Server application lock
- makes code-owned access modes/assignments visible and read-only in the dashboard while retaining emergency disablement and dashboard-owned assignments
- initializes FGA schema/seeds before client policy so fresh-start FGA references are valid
- adds schema migration 035, protocol/real-SQL concurrency coverage, dashboard projections, and compiled documentation examples

## Adversarial review iteration
- fixed silent broadening risk: omitted AccessMode now preserves an existing stored mode and defaults only new clients to all_organizations
- keyed assignments require an explicit access mode
- shared seed/admin validation enforces database field bounds before persistence
- both inline review threads are replied to and resolved

## Validation
- solution build and dashboard JavaScript syntax
- full unit suite: 643/643
- focused real SQL/Aspire concurrency test: 1/1 with four simultaneous reconcilers
- docs/site build and 170-link validation
- compiled code-first application-access documentation snippet

## Compatibility and ergonomics
Existing client seeds require no changes. Omitted AccessMode preserves an existing seeded client policy; a brand-new client retains the all_organizations default. No external service, post-start script, generated database ID, or dashboard setup is required. Invalid restrictive policy fails closed at startup.