### PR TITLE
Add complete platform-admin session revocation workflows

### DIFF
--- a/scripts/compile-doc-snippets.mjs
+++ b/scripts/compile-doc-snippets.mjs
@@ -97,6 +97,13 @@ const snippetSpecs = [
     marker: "client.AssignOrganization(",
     wrap: asApplicationAccessSeedProgram,
   },
+  {
+    name: "platform-admin session revocation",
+    relativePath: "web/content/docs/authserver/sessions-and-tokens.mdx",
+    heading: "### Platform-admin revocation",
+    marker: "revocations.PreviewAsync(",
+    wrap: asSessionRevocationProgram,
+  },
 ];
 
 function extractCsharpBlock({ relativePath, heading, marker }) {
@@ -239,6 +246,19 @@ function asApplicationAccessSeedProgram(snippet) {
 using SqlOS.AuthServer.Contracts;
 
 var auth = new SqlOSAuthServerOptions();
+
+${snippet}
+`;
+}
+
+function asSessionRevocationProgram(snippet) {
+  return `using SqlOS.AuthServer.Contracts;
+using SqlOS.AuthServer.Services;
+
+SqlOSSessionRevocationService revocations = null!;
+var organizationId = "org_acme";
+var clientApplicationId = "client_portal";
+var ct = CancellationToken.None;
 
 ${snippet}
 `;

--- a/src/SqlOS/AuthServer/Contracts/SqlOSSessionRevocationContracts.cs
+++ b/src/SqlOS/AuthServer/Contracts/SqlOSSessionRevocationContracts.cs
@@ -11,7 +11,8 @@ public sealed record SqlOSAdminSessionRevocationRequest(
     string? ClientApplicationId = null,
     string? Reason = null,
     string? OperationId = null,
-    bool Confirm = false);
+    bool Confirm = false,
+    int? ExpectedMatchedSessions = null);
 
 public sealed record SqlOSAdminSessionRevocationResult(
     bool Preview,

--- a/src/SqlOS/AuthServer/Contracts/SqlOSSessionRevocationContracts.cs
+++ b/src/SqlOS/AuthServer/Contracts/SqlOSSessionRevocationContracts.cs
@@ -1,0 +1,25 @@
+namespace SqlOS.AuthServer.Contracts;
+
+/// <summary>
+/// Selects sessions for an administrative revocation. At least one selector is required;
+/// multiple selectors are combined with AND semantics.
+/// </summary>
+public sealed record SqlOSAdminSessionRevocationRequest(
+    string? SessionId = null,
+    string? UserId = null,
+    string? OrganizationId = null,
+    string? ClientApplicationId = null,
+    string? Reason = null,
+    string? OperationId = null,
+    bool Confirm = false);
+
+public sealed record SqlOSAdminSessionRevocationResult(
+    bool Preview,
+    string OperationId,
+    int MatchedSessions,
+    int NewlyRevokedSessions,
+    int AlreadyRevokedSessions,
+    int ActiveRefreshTokens,
+    int NewlyRevokedRefreshTokens,
+    DateTime? RevokedAt,
+    string? AuditEventId = null);

--- a/src/SqlOS/AuthServer/Endpoints/AdminConfigurationEndpoints.cs
+++ b/src/SqlOS/AuthServer/Endpoints/AdminConfigurationEndpoints.cs
@@ -393,6 +393,49 @@ public static partial class EndpointRouteBuilderExtensions
             return Results.Ok(await adminService.ListSessionsAsync(page, pageSize, cancellationToken));
         });
 
+        api.MapPost("/sessions/revocation/preview", async (HttpContext context, SqlOSAdminSessionRevocationRequest request, SqlOSSessionRevocationService revocations, IOptions<SqlOSAuthServerOptions> options, IHostEnvironment environment, CancellationToken cancellationToken) =>
+        {
+            if (!await IsAdminAuthorizedAsync(context, options.Value, environment))
+            {
+                return Results.NotFound();
+            }
+
+            try
+            {
+                return Results.Ok(await revocations.PreviewAsync(request, cancellationToken));
+            }
+            catch (ArgumentException exception)
+            {
+                return Results.BadRequest(new { message = exception.Message });
+            }
+            catch (InvalidOperationException exception)
+            {
+                return Results.BadRequest(new { message = exception.Message });
+            }
+        });
+
+        api.MapPost("/sessions/revocation", async (HttpContext context, SqlOSAdminSessionRevocationRequest request, SqlOSSessionRevocationService revocations, IOptions<SqlOSAuthServerOptions> options, IHostEnvironment environment, CancellationToken cancellationToken) =>
+        {
+            if (!await IsAdminAuthorizedAsync(context, options.Value, environment))
+            {
+                return Results.NotFound();
+            }
+
+            try
+            {
+                var result = await revocations.RevokeAsync(request, cancellationToken);
+                return result.MatchedSessions == 0 ? Results.NotFound() : Results.Ok(result);
+            }
+            catch (ArgumentException exception)
+            {
+                return Results.BadRequest(new { message = exception.Message });
+            }
+            catch (InvalidOperationException exception)
+            {
+                return Results.BadRequest(new { message = exception.Message });
+            }
+        });
+
         api.MapGet("/audit-events", async (HttpContext context, SqlOSAdminService adminService, IOptions<SqlOSAuthServerOptions> options, IHostEnvironment environment, CancellationToken cancellationToken) =>
         {
             if (!await IsAdminAuthorizedAsync(context, options.Value, environment))

--- a/src/SqlOS/AuthServer/Services/SqlOSAdminService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSAdminService.cs
@@ -1848,6 +1848,7 @@ public sealed partial class SqlOSAdminService
                 x.IdleExpiresAt,
                 x.AbsoluteExpiresAt,
                 x.RevokedAt,
+                x.RevocationReason,
                 x.UserAgent,
                 x.IpAddress
             });
@@ -1875,6 +1876,7 @@ public sealed partial class SqlOSAdminService
                 x.IdleExpiresAt,
                 x.AbsoluteExpiresAt,
                 x.RevokedAt,
+                x.RevocationReason,
                 x.UserAgent,
                 x.IpAddress
             });

--- a/src/SqlOS/AuthServer/Services/SqlOSSessionRevocationService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSSessionRevocationService.cs
@@ -1,4 +1,7 @@
 using System.Data;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using SqlOS.AuditLogs;
 using SqlOS.AuthServer.Contracts;
@@ -93,11 +96,33 @@ public sealed class SqlOSSessionRevocationService
                 """, cancellationToken);
         }
 
+        var selectorFingerprint = BuildSelectorFingerprint(normalized);
+        if (execute)
+        {
+            var priorOperation = await _context.Set<SqlOSAuditEvent>()
+                .AsNoTracking()
+                .Where(x => x.EventType == "session.admin-revoked" && x.CorrelationId == operationId)
+                .Select(x => x.DataJson)
+                .FirstOrDefaultAsync(cancellationToken);
+            if (priorOperation != null && !HasSelectorFingerprint(priorOperation, selectorFingerprint))
+            {
+                throw new InvalidOperationException("Operation ID has already been used for a different revocation scope.");
+            }
+        }
+
         var query = ApplySelectors(_context.Set<SqlOSSession>().AsQueryable(), normalized);
         var matched = await query.CountAsync(cancellationToken);
         if (matched > MaxMatches)
         {
             throw new InvalidOperationException($"The revocation matches more than {MaxMatches:N0} sessions. Add a narrower filter.");
+        }
+        if (execute && normalized.ExpectedMatchedSessions.HasValue && normalized.ExpectedMatchedSessions.Value != matched)
+        {
+            throw new InvalidOperationException("The revocation scope changed after preview. Preview the operation again before confirming.");
+        }
+        if (execute && normalized.SessionId == null && !normalized.ExpectedMatchedSessions.HasValue)
+        {
+            throw new ArgumentException("Broad revocation requires the matched-session count returned by preview.");
         }
 
         var alreadyRevoked = await query.CountAsync(x => x.RevokedAt != null, cancellationToken);
@@ -158,12 +183,13 @@ public sealed class SqlOSSessionRevocationService
                 Source: "authserver",
                 Actor: new SqlOSAuditActor("admin"),
                 Targets: targets,
-                Context: new SqlOSAuditContext(SessionId: normalized.SessionId),
+                Context: new SqlOSAuditContext(SessionId: normalized.SessionId, CorrelationId: operationId),
                 IdempotencyKey: $"admin-session-revocation:{operationId}",
                 Metadata: new Dictionary<string, object?>
                 {
                     ["operation_id"] = operationId,
                     ["reason"] = reason,
+                    ["selector_fingerprint"] = selectorFingerprint,
                     ["matched_sessions"] = matched,
                     ["newly_revoked_sessions"] = sessions.Count,
                     ["already_revoked_sessions"] = alreadyRevoked,
@@ -216,11 +242,41 @@ public sealed class SqlOSSessionRevocationService
         };
 
         if (normalized.Reason!.Length > MaxReasonLength) throw new ArgumentException("Reason is too long.");
+        if (normalized.OperationId?.Length > 128) throw new ArgumentException("OperationId is too long.");
+        if (normalized.ExpectedMatchedSessions < 0 || normalized.ExpectedMatchedSessions > MaxMatches)
+        {
+            throw new ArgumentException($"ExpectedMatchedSessions must be between 0 and {MaxMatches:N0}.");
+        }
         if (normalized.SessionId == null && normalized.UserId == null && normalized.OrganizationId == null && normalized.ClientApplicationId == null)
         {
             throw new ArgumentException("At least one session, user, organization, or client selector is required.");
         }
 
         return normalized;
+    }
+
+    private static string BuildSelectorFingerprint(SqlOSAdminSessionRevocationRequest request)
+    {
+        var canonical = string.Join('\n',
+            request.SessionId ?? string.Empty,
+            request.UserId ?? string.Empty,
+            request.OrganizationId ?? string.Empty,
+            request.ClientApplicationId ?? string.Empty,
+            request.Reason ?? string.Empty);
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(canonical)));
+    }
+
+    private static bool HasSelectorFingerprint(string metadataJson, string expected)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(metadataJson);
+            return document.RootElement.TryGetProperty("selector_fingerprint", out var value)
+                && string.Equals(value.GetString(), expected, StringComparison.Ordinal);
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
     }
 }

--- a/src/SqlOS/AuthServer/Services/SqlOSSessionRevocationService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSSessionRevocationService.cs
@@ -1,0 +1,226 @@
+using System.Data;
+using Microsoft.EntityFrameworkCore;
+using SqlOS.AuditLogs;
+using SqlOS.AuthServer.Contracts;
+using SqlOS.AuthServer.Interfaces;
+using SqlOS.AuthServer.Models;
+
+namespace SqlOS.AuthServer.Services;
+
+/// <summary>
+/// Authorized control-plane session revocation. This is deliberately an imperative
+/// administrative workflow and is not part of startup configuration reconciliation.
+/// </summary>
+public sealed class SqlOSSessionRevocationService
+{
+    private const int MaxMatches = 10_000;
+    private const int MaxIdentifierLength = 256;
+    private const int MaxReasonLength = 256;
+    private readonly ISqlOSAuthServerDbContext _context;
+    private readonly ISqlOSAuditLogService _auditLogs;
+
+    public SqlOSSessionRevocationService(ISqlOSAuthServerDbContext context, ISqlOSAuditLogService auditLogs)
+    {
+        _context = context;
+        _auditLogs = auditLogs;
+    }
+
+    public Task<SqlOSAdminSessionRevocationResult> PreviewAsync(
+        SqlOSAdminSessionRevocationRequest request,
+        CancellationToken cancellationToken = default)
+        => ProcessAsync(request with { Confirm = false }, execute: false, cancellationToken);
+
+    public Task<SqlOSAdminSessionRevocationResult> RevokeAsync(
+        SqlOSAdminSessionRevocationRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        if (!request.Confirm)
+        {
+            throw new ArgumentException("Explicit confirmation is required.", nameof(request));
+        }
+
+        return ProcessAsync(request, execute: true, cancellationToken);
+    }
+
+    private async Task<SqlOSAdminSessionRevocationResult> ProcessAsync(
+        SqlOSAdminSessionRevocationRequest request,
+        bool execute,
+        CancellationToken cancellationToken)
+    {
+        var normalized = Normalize(request);
+        var operationId = normalized.OperationId ?? $"session-revocation-{Guid.NewGuid():N}";
+
+        if (execute && _context.Database.IsRelational())
+        {
+            var strategy = _context.Database.CreateExecutionStrategy();
+            var attempt = 0;
+            return await strategy.ExecuteAsync(async () =>
+            {
+                if (attempt++ > 0 && _context is DbContext retryContext)
+                {
+                    retryContext.ChangeTracker.Clear();
+                }
+
+                return await ProcessCoreAsync(normalized, execute, operationId, cancellationToken);
+            });
+        }
+
+        return await ProcessCoreAsync(normalized, execute, operationId, cancellationToken);
+    }
+
+    private async Task<SqlOSAdminSessionRevocationResult> ProcessCoreAsync(
+        SqlOSAdminSessionRevocationRequest normalized,
+        bool execute,
+        string operationId,
+        CancellationToken cancellationToken)
+    {
+
+        await using var transaction = execute && _context.Database.IsRelational()
+            ? await _context.Database.BeginTransactionAsync(IsolationLevel.Serializable, cancellationToken)
+            : null;
+
+        if (execute && string.Equals(_context.Database.ProviderName, "Microsoft.EntityFrameworkCore.SqlServer", StringComparison.Ordinal))
+        {
+            const string resource = "SqlOS:admin-session-revocation";
+            await _context.Database.ExecuteSqlInterpolatedAsync($"""
+                DECLARE @result int;
+                EXEC @result = sys.sp_getapplock
+                    @Resource = {resource},
+                    @LockMode = 'Exclusive',
+                    @LockOwner = 'Transaction',
+                    @LockTimeout = 30000;
+                IF @result < 0 THROW 51000, 'Could not acquire the session revocation lock.', 1;
+                """, cancellationToken);
+        }
+
+        var query = ApplySelectors(_context.Set<SqlOSSession>().AsQueryable(), normalized);
+        var matched = await query.CountAsync(cancellationToken);
+        if (matched > MaxMatches)
+        {
+            throw new InvalidOperationException($"The revocation matches more than {MaxMatches:N0} sessions. Add a narrower filter.");
+        }
+
+        var alreadyRevoked = await query.CountAsync(x => x.RevokedAt != null, cancellationToken);
+        var sessionIds = await query.Select(x => x.Id).ToListAsync(cancellationToken);
+        var activeRefreshTokens = sessionIds.Count == 0
+            ? 0
+            : await _context.Set<SqlOSRefreshToken>()
+                .CountAsync(x => sessionIds.Contains(x.SessionId) && x.RevokedAt == null, cancellationToken);
+
+        if (!execute)
+        {
+            return new SqlOSAdminSessionRevocationResult(
+                true, operationId, matched, 0, alreadyRevoked, activeRefreshTokens, 0, null);
+        }
+
+        if (matched == 0)
+        {
+            return new SqlOSAdminSessionRevocationResult(
+                false, operationId, 0, 0, 0, 0, 0, null);
+        }
+
+        var now = DateTime.UtcNow;
+        var reason = normalized.Reason!;
+        var sessions = await query.Where(x => x.RevokedAt == null).ToListAsync(cancellationToken);
+        var refreshTokens = sessionIds.Count == 0
+            ? []
+            : await _context.Set<SqlOSRefreshToken>()
+                .Where(x => sessionIds.Contains(x.SessionId) && x.RevokedAt == null)
+                .ToListAsync(cancellationToken);
+
+        foreach (var session in sessions)
+        {
+            session.RevokedAt = now;
+            session.RevocationReason = reason;
+        }
+
+        foreach (var refreshToken in refreshTokens)
+        {
+            refreshToken.RevokedAt = now;
+            refreshToken.ReplacementTokenResponse = null;
+            refreshToken.ReplacementOrganizationId = null;
+            refreshToken.ReplacementAccessTokenExpiresAt = null;
+        }
+
+        await _context.SaveChangesAsync(cancellationToken);
+
+        var targets = new List<SqlOSAuditTarget>();
+        if (normalized.SessionId != null) targets.Add(new("session", normalized.SessionId));
+        if (normalized.UserId != null) targets.Add(new("user", normalized.UserId));
+        if (normalized.OrganizationId != null) targets.Add(new("organization", normalized.OrganizationId));
+        if (normalized.ClientApplicationId != null) targets.Add(new("client", normalized.ClientApplicationId));
+        var audit = await _auditLogs.RecordAsync(
+            new SqlOSAuditLogRecordRequest(
+                Action: "session.admin-revoked",
+                OrganizationId: normalized.OrganizationId,
+                UserId: normalized.UserId,
+                ApplicationKey: normalized.ClientApplicationId,
+                Source: "authserver",
+                Actor: new SqlOSAuditActor("admin"),
+                Targets: targets,
+                Context: new SqlOSAuditContext(SessionId: normalized.SessionId),
+                IdempotencyKey: $"admin-session-revocation:{operationId}",
+                Metadata: new Dictionary<string, object?>
+                {
+                    ["operation_id"] = operationId,
+                    ["reason"] = reason,
+                    ["matched_sessions"] = matched,
+                    ["newly_revoked_sessions"] = sessions.Count,
+                    ["already_revoked_sessions"] = alreadyRevoked,
+                    ["newly_revoked_refresh_credentials"] = refreshTokens.Count
+                }),
+            cancellationToken);
+
+        if (transaction != null)
+        {
+            await transaction.CommitAsync(cancellationToken);
+        }
+
+        return new SqlOSAdminSessionRevocationResult(
+            false, operationId, matched, sessions.Count, alreadyRevoked,
+            activeRefreshTokens, refreshTokens.Count, now, audit.EventId);
+    }
+
+    private static IQueryable<SqlOSSession> ApplySelectors(
+        IQueryable<SqlOSSession> query,
+        SqlOSAdminSessionRevocationRequest request)
+    {
+        if (request.SessionId != null) query = query.Where(x => x.Id == request.SessionId);
+        if (request.UserId != null) query = query.Where(x => x.UserId == request.UserId);
+        if (request.OrganizationId != null) query = query.Where(x => x.OrganizationId == request.OrganizationId);
+        if (request.ClientApplicationId != null)
+        {
+            query = query.Where(x => x.ClientApplicationId == request.ClientApplicationId
+                || x.ClientApplication!.ClientId == request.ClientApplicationId);
+        }
+        return query;
+    }
+
+    private static SqlOSAdminSessionRevocationRequest Normalize(SqlOSAdminSessionRevocationRequest request)
+    {
+        static string? Field(string? value, string name)
+        {
+            var normalized = string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+            if (normalized?.Length > MaxIdentifierLength) throw new ArgumentException($"{name} is too long.");
+            return normalized;
+        }
+
+        var normalized = request with
+        {
+            SessionId = Field(request.SessionId, nameof(request.SessionId)),
+            UserId = Field(request.UserId, nameof(request.UserId)),
+            OrganizationId = Field(request.OrganizationId, nameof(request.OrganizationId)),
+            ClientApplicationId = Field(request.ClientApplicationId, nameof(request.ClientApplicationId)),
+            OperationId = Field(request.OperationId, nameof(request.OperationId)),
+            Reason = string.IsNullOrWhiteSpace(request.Reason) ? "admin_revoked" : request.Reason.Trim()
+        };
+
+        if (normalized.Reason!.Length > MaxReasonLength) throw new ArgumentException("Reason is too long.");
+        if (normalized.SessionId == null && normalized.UserId == null && normalized.OrganizationId == null && normalized.ClientApplicationId == null)
+        {
+            throw new ArgumentException("At least one session, user, organization, or client selector is required.");
+        }
+
+        return normalized;
+    }
+}

--- a/src/SqlOS/Dashboard/wwwroot/app.js
+++ b/src/SqlOS/Dashboard/wwwroot/app.js
@@ -3836,7 +3836,12 @@
         if (!confirmed) return false;
         await fetchJson(`${authApiBasePath}/sessions/revocation`, {
             method: "POST",
-            body: JSON.stringify({ ...request, operationId: preview.operationId, confirm: true })
+            body: JSON.stringify({
+                ...request,
+                operationId: preview.operationId,
+                expectedMatchedSessions: preview.matchedSessions,
+                confirm: true
+            })
         });
         return true;
     }

--- a/src/SqlOS/Dashboard/wwwroot/app.js
+++ b/src/SqlOS/Dashboard/wwwroot/app.js
@@ -1554,6 +1554,7 @@
                             { label: "Pending invitations", value: pendingInvitations },
                             { label: "Enabled SSO", value: organization.enabledSsoConnections ?? 0 }
                         ])}
+                        <button type="button" id="revoke-organization-sessions">Revoke organization sessions</button>
                     </section>
                 </div>
             `;
@@ -2009,6 +2010,18 @@
                 });
                 setFlash("success", "Organization updated.");
             });
+            document.getElementById("revoke-organization-sessions")?.addEventListener("click", async () => {
+                try {
+                    const reason = window.prompt("Why are you revoking sessions for this organization?", "organization_revoked");
+                    if (reason === null) return;
+                    if (await revokeSessionsWithPreview({ organizationId, reason })) {
+                        setFlash("success", "Organization sessions revoked.");
+                    }
+                } catch (error) {
+                    setFlash("error", error.message || String(error));
+                }
+                await render();
+            });
         } else if (tab === "users") {
             bindForm("create-org-membership-form", async form => {
                 await fetchJson(`${authApiBasePath}/organizations/${organizationId}/memberships`, {
@@ -2462,6 +2475,7 @@
                             <input name="resetUrlTemplate" placeholder="Optional reset URL template with {token}">
                             <button type="submit" ${user.defaultEmail ? "" : "disabled"}>Send password reset email</button>
                         </form>
+                        <button type="button" id="revoke-user-sessions">Sign out all user sessions</button>
                     </section>
                 </div>
             `;
@@ -2506,8 +2520,11 @@
                                 { label: "Client", value: item.clientApplicationId || "n/a" },
                                 { label: "Created", value: formatDate(item.createdAt) },
                                 { label: "Last seen", value: formatDate(item.lastSeenAt) },
-                                { label: "Revoked", value: formatDate(item.revokedAt) }
+                                { label: "Revoked", value: item.revokedAt ? formatDate(item.revokedAt) : "Active" },
+                                { label: "Revocation reason", value: item.revocationReason || "n/a" }
                             ])}
+                            ${item.revokedAt ? "" : `<button type="button" class="js-revoke-user-session" data-session-id="${esc(item.id)}">Revoke session</button>`}
+                            ${item.revokedAt ? `<a class="inline-link" href="${esc(pathForRoute("auth-audit"))}">Open audit history</a>` : ""}
                         `,
                         "No sessions yet."
                     )}
@@ -2542,6 +2559,16 @@
                 });
                 setFlash("success", "Password reset email queued.");
             });
+            document.getElementById("revoke-user-sessions")?.addEventListener("click", async () => {
+                try {
+                    const reason = window.prompt("Why are you signing out this user?", "user_sessions_revoked");
+                    if (reason === null) return;
+                    if (await revokeSessionsWithPreview({ userId, reason })) setFlash("success", "User sessions revoked.");
+                } catch (error) {
+                    setFlash("error", error.message || String(error));
+                }
+                await render();
+            });
         } else if (tab === "organizations") {
             bindPagination("#user-memberships-pagination-top", async page => {
                 setPagerPage(`auth-user-${userId}-memberships`, page);
@@ -2551,6 +2578,20 @@
             bindPagination("#user-sessions-pagination-top", async page => {
                 setPagerPage(`auth-user-${userId}-sessions`, page);
                 await render();
+            });
+            document.querySelectorAll(".js-revoke-user-session").forEach(button => {
+                button.addEventListener("click", async () => {
+                    try {
+                        const reason = window.prompt("Why are you revoking this session?", "admin_revoked");
+                        if (reason === null) return;
+                        if (await revokeSessionsWithPreview({ sessionId: button.dataset.sessionId, userId, reason })) {
+                            setFlash("success", "Session revoked.");
+                        }
+                    } catch (error) {
+                        setFlash("error", error.message || String(error));
+                    }
+                    await render();
+                });
             });
         }
     }
@@ -3169,11 +3210,9 @@
                             return;
                         }
 
-                        await fetchJson(`${authApiBasePath}/clients/${encodeURIComponent(clientId)}/revoke`, {
-                            method: "POST",
-                            body: JSON.stringify({ reason })
-                        });
-                        setFlash("success", "Client sessions revoked.");
+                        if (await revokeSessionsWithPreview({ clientApplicationId: clientId, reason })) {
+                            setFlash("success", "Client sessions revoked.");
+                        }
                     }
                 } catch (error) {
                     setFlash("error", error.message || String(error));
@@ -3782,6 +3821,26 @@
         });
     }
 
+    async function revokeSessionsWithPreview(request) {
+        const preview = await fetchJson(`${authApiBasePath}/sessions/revocation/preview`, {
+            method: "POST",
+            body: JSON.stringify(request)
+        });
+        if (preview.matchedSessions === 0) {
+            setFlash("info", "No sessions matched this scope.");
+            return false;
+        }
+        const confirmed = window.confirm(
+            `Revoke ${preview.matchedSessions} session(s) and ${preview.activeRefreshTokens} active refresh token(s)? Already-revoked sessions will be left unchanged.`
+        );
+        if (!confirmed) return false;
+        await fetchJson(`${authApiBasePath}/sessions/revocation`, {
+            method: "POST",
+            body: JSON.stringify({ ...request, operationId: preview.operationId, confirm: true })
+        });
+        return true;
+    }
+
     async function renderAuthSessions() {
         const config = authViews.sessions;
         setHeader("Auth Server", config.title, config.description);
@@ -3797,6 +3856,14 @@
                     <h2>Sessions</h2>
                     <div id="sessions-pagination-top">${renderPagination(sessions.page, sessions.totalPages, sessions.totalCount)}</div>
                 </div>
+                <form id="session-revocation-form" class="client-filter-form">
+                    <input name="userId" placeholder="User ID (optional)">
+                    <input name="organizationId" placeholder="Organization ID (optional)">
+                    <input name="clientApplicationId" placeholder="Client application ID (optional)">
+                    <input name="reason" placeholder="Reason" value="admin_revoked" required>
+                    <button type="submit">Preview and revoke</button>
+                </form>
+                <p>Use one or more filters. Combined filters use AND semantics, and you will see the affected session and refresh-token count before confirmation.</p>
                 ${renderList(
                     sessions.data,
                     item => `
@@ -3810,8 +3877,12 @@
                             { label: "Client", value: item.clientApplicationId || "n/a" },
                             { label: "Created", value: formatDate(item.createdAt) },
                             { label: "Idle expires", value: formatDate(item.idleExpiresAt) },
-                            { label: "Absolute expires", value: formatDate(item.absoluteExpiresAt) }
+                            { label: "Absolute expires", value: formatDate(item.absoluteExpiresAt) },
+                            { label: "Revoked", value: item.revokedAt ? formatDate(item.revokedAt) : "Active" },
+                            { label: "Revocation reason", value: item.revocationReason || "n/a" }
                         ])}
+                        ${item.revokedAt ? "" : `<button type="button" class="js-revoke-session" data-session-id="${esc(item.id)}">Revoke session</button>`}
+                        ${item.revokedAt ? `<a class="inline-link" href="${esc(pathForRoute("auth-audit"))}">Open audit history</a>` : ""}
                     `,
                     "No sessions yet."
                 )}
@@ -3821,6 +3892,31 @@
         bindPagination("#sessions-pagination-top", async page => {
             setPagerPage("auth-sessions", page);
             await render();
+        });
+
+        bindForm("session-revocation-form", async form => {
+            const request = {
+                userId: form.get("userId") || null,
+                organizationId: form.get("organizationId") || null,
+                clientApplicationId: form.get("clientApplicationId") || null,
+                reason: form.get("reason")
+            };
+            if (await revokeSessionsWithPreview(request)) setFlash("success", "Sessions revoked.");
+        });
+
+        document.querySelectorAll(".js-revoke-session").forEach(button => {
+            button.addEventListener("click", async () => {
+                try {
+                    const reason = window.prompt("Why are you revoking this session?", "admin_revoked");
+                    if (reason === null) return;
+                    if (await revokeSessionsWithPreview({ sessionId: button.dataset.sessionId, reason })) {
+                        setFlash("success", "Session revoked.");
+                    }
+                } catch (error) {
+                    setFlash("error", error.message || String(error));
+                }
+                await render();
+            });
         });
     }
 

--- a/src/SqlOS/Extensions/ServiceCollectionExtensions.cs
+++ b/src/SqlOS/Extensions/ServiceCollectionExtensions.cs
@@ -110,6 +110,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<SqlOSDynamicClientRegistrationService>();
         services.AddScoped<SqlOSClientResolutionService>();
         services.AddScoped<SqlOSAdminService>();
+        services.AddScoped<SqlOSSessionRevocationService>();
         services.AddScoped<SqlOSAuthService>();
         services.AddScoped<SqlOSAuthPageSessionService>();
         services.AddScoped<SqlOSAuthorizationServerService>();

--- a/tests/SqlOS.IntegrationTests/SessionRevocationIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/SessionRevocationIntegrationTests.cs
@@ -59,7 +59,8 @@ public sealed class SessionRevocationIntegrationTests
                 var service = new SqlOSSessionRevocationService(context, new SqlOSAuditLogService(context, crypto));
                 await ready.Task;
                 return await service.RevokeAsync(new SqlOSAdminSessionRevocationRequest(
-                    UserId: "user-concurrent", Reason: "incident", OperationId: operationId, Confirm: true));
+                    UserId: "user-concurrent", Reason: "incident", OperationId: operationId, Confirm: true,
+                    ExpectedMatchedSessions: 1));
             }
 
             var first = RunAsync("operation-a");

--- a/tests/SqlOS.IntegrationTests/SessionRevocationIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/SessionRevocationIntegrationTests.cs
@@ -1,0 +1,82 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SqlOS.AuthServer.Configuration;
+using SqlOS.AuthServer.Contracts;
+using SqlOS.AuthServer.Models;
+using SqlOS.AuthServer.Services;
+using SqlOS.AuditLogs;
+using SqlOS.IntegrationTests.Infrastructure;
+
+namespace SqlOS.IntegrationTests;
+
+[TestClass]
+public sealed class SessionRevocationIntegrationTests
+{
+    [TestMethod]
+    public async Task ConcurrentRealSqlRevocation_CountsEachSessionAndRefreshTokenAsNewOnce()
+    {
+        await using var setup = await AspireFixture.CreateIsolatedAuthContextAsync("SessionRevoke");
+        try
+        {
+            var now = DateTime.UtcNow;
+            setup.Set<SqlOSOrganization>().Add(new SqlOSOrganization
+            {
+                Id = "org-concurrent", Slug = "org-concurrent", Name = "Concurrent org", CreatedAt = now
+            });
+            setup.Set<SqlOSUser>().Add(new SqlOSUser
+            {
+                Id = "user-concurrent", DisplayName = "Concurrent user", CreatedAt = now, UpdatedAt = now
+            });
+            setup.Set<SqlOSClientApplication>().Add(new SqlOSClientApplication
+            {
+                Id = "client-concurrent", ClientId = "client-concurrent", Name = "Concurrent client",
+                Audience = "sqlos", RedirectUrisJson = "[]", CreatedAt = now
+            });
+            setup.Set<SqlOSSession>().Add(new SqlOSSession
+            {
+                Id = "session-concurrent", UserId = "user-concurrent", OrganizationId = "org-concurrent",
+                ClientApplicationId = "client-concurrent", CreatedAt = now, LastSeenAt = now,
+                IdleExpiresAt = now.AddHours(1), AbsoluteExpiresAt = now.AddDays(1)
+            });
+            setup.Set<SqlOSRefreshToken>().Add(new SqlOSRefreshToken
+            {
+                Id = "refresh-concurrent", SessionId = "session-concurrent", TokenHash = "hash",
+                FamilyId = "family", CreatedAt = now, ExpiresAt = now.AddDays(1),
+                ReplacementTokenResponse = "sensitive-cache"
+            });
+            await setup.SaveChangesAsync();
+            var connectionString = setup.Database.GetConnectionString()!;
+            var ready = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            async Task<SqlOSAdminSessionRevocationResult> RunAsync(string operationId)
+            {
+                await using var context = new TestSqlOSDbContext(
+                    new DbContextOptionsBuilder<TestSqlOSDbContext>().UseSqlServer(connectionString).Options);
+                var options = Options.Create(new SqlOSAuthServerOptions());
+                var crypto = new SqlOSCryptoService(context, options);
+                var service = new SqlOSSessionRevocationService(context, new SqlOSAuditLogService(context, crypto));
+                await ready.Task;
+                return await service.RevokeAsync(new SqlOSAdminSessionRevocationRequest(
+                    UserId: "user-concurrent", Reason: "incident", OperationId: operationId, Confirm: true));
+            }
+
+            var first = RunAsync("operation-a");
+            var second = RunAsync("operation-b");
+            ready.SetResult();
+            var results = await Task.WhenAll(first, second).WaitAsync(TimeSpan.FromSeconds(45));
+
+            results.Sum(x => x.NewlyRevokedSessions).Should().Be(1);
+            results.Sum(x => x.NewlyRevokedRefreshTokens).Should().Be(1);
+            results.Should().ContainSingle(x => x.AlreadyRevokedSessions == 1);
+            setup.ChangeTracker.Clear();
+            (await setup.Set<SqlOSRefreshToken>().AsNoTracking().SingleAsync()).ReplacementTokenResponse.Should().BeNull();
+            (await setup.Set<SqlOSAuditEvent>().CountAsync(x => x.EventType == "session.admin-revoked")).Should().Be(2);
+        }
+        finally
+        {
+            await setup.Database.EnsureDeletedAsync();
+        }
+    }
+}

--- a/tests/SqlOS.Tests/SqlOSAdminAuthorizationMetadataTests.cs
+++ b/tests/SqlOS.Tests/SqlOSAdminAuthorizationMetadataTests.cs
@@ -83,6 +83,8 @@ public sealed class SqlOSAdminAuthorizationMetadataTests
         {
             await client.GetAsync("/sqlos/admin/auth/api/stats"),
             await client.PostAsJsonAsync("/sqlos/admin/auth/api/users", new { }),
+            await client.PostAsJsonAsync("/sqlos/admin/auth/api/sessions/revocation/preview", new { userId = "victim" }),
+            await client.PostAsJsonAsync("/sqlos/admin/auth/api/sessions/revocation", new { userId = "victim", confirm = true }),
             await client.PutAsJsonAsync("/sqlos/admin/email/api/templates/missing", new { }),
             await client.DeleteAsync("/sqlos/admin/email/api/templates/missing")
         };

--- a/tests/SqlOS.Tests/SqlOSAuthEndpointRouteInventoryTests.cs
+++ b/tests/SqlOS.Tests/SqlOSAuthEndpointRouteInventoryTests.cs
@@ -45,6 +45,8 @@ public class SqlOSAuthEndpointRouteInventoryTests
             "GET /sqlos/admin/auth/api/users",
             "GET /sqlos/admin/auth/api/clients",
             "GET /sqlos/admin/auth/api/sessions",
+            "POST /sqlos/admin/auth/api/sessions/revocation/preview",
+            "POST /sqlos/admin/auth/api/sessions/revocation",
             "GET /sqlos/admin/auth/api/settings/security"
         };
 

--- a/tests/SqlOS.Tests/SqlOSAuthLifecycleTests.cs
+++ b/tests/SqlOS.Tests/SqlOSAuthLifecycleTests.cs
@@ -423,6 +423,27 @@ public sealed class SqlOSAuthLifecycleTests
     }
 
     [TestMethod]
+    public async Task AdminRevocation_ImmediatelyInvalidatesAccessAndRefreshTokens()
+    {
+        await using var harness = await LifecycleHarness.CreateAsync();
+        var subject = await harness.CreateOrganizationSubjectAsync("admin-revoke");
+        var tokens = await harness.IssueTokensAsync(subject);
+        var revocations = new SqlOSSessionRevocationService(
+            harness.Context,
+            new SqlOS.AuditLogs.SqlOSAuditLogService(harness.Context, harness.Crypto));
+
+        await revocations.RevokeAsync(new SqlOSAdminSessionRevocationRequest(
+            SessionId: tokens.SessionId,
+            Reason: "compromised_device",
+            Confirm: true));
+
+        (await harness.Auth.ValidateAccessTokenAsync(tokens.AccessToken, subject.Client.Audience)).Should().BeNull();
+        await FluentActions.Invoking(() => harness.Auth.RefreshAsync(
+                new SqlOSRefreshRequest(tokens.RefreshToken, subject.Organization.Id)))
+            .Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [TestMethod]
     public async Task InactiveUser_PasswordAuthenticationUsesGenericFailure()
     {
         await using var harness = await LifecycleHarness.CreateAsync();

--- a/tests/SqlOS.Tests/SqlOSSessionRevocationServiceTests.cs
+++ b/tests/SqlOS.Tests/SqlOSSessionRevocationServiceTests.cs
@@ -1,0 +1,158 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SqlOS.AuthServer.Configuration;
+using SqlOS.AuthServer.Contracts;
+using SqlOS.AuthServer.Models;
+using SqlOS.AuthServer.Services;
+using SqlOS.AuditLogs;
+using SqlOS.Tests.Infrastructure;
+
+namespace SqlOS.Tests;
+
+[TestClass]
+public sealed class SqlOSSessionRevocationServiceTests
+{
+    [TestMethod]
+    public async Task Preview_ThenExecute_WithCombinedFilters_IsBoundedAndIdempotent()
+    {
+        await using var context = CreateContext();
+        var service = CreateService(context);
+        Seed(context);
+        await context.SaveChangesAsync();
+        var request = new SqlOSAdminSessionRevocationRequest(
+            UserId: "user-1",
+            OrganizationId: "org-1",
+            ClientApplicationId: "client-1",
+            Reason: "incident-42",
+            OperationId: "op-42");
+
+        var preview = await service.PreviewAsync(request);
+        preview.Preview.Should().BeTrue();
+        preview.MatchedSessions.Should().Be(2);
+        preview.AlreadyRevokedSessions.Should().Be(1);
+        preview.ActiveRefreshTokens.Should().Be(1);
+
+        var executed = await service.RevokeAsync(request with { Confirm = true });
+        executed.NewlyRevokedSessions.Should().Be(1);
+        executed.NewlyRevokedRefreshTokens.Should().Be(1);
+        executed.OperationId.Should().Be("op-42");
+
+        var repeated = await service.RevokeAsync(request with { Confirm = true });
+        repeated.NewlyRevokedSessions.Should().Be(0);
+        repeated.NewlyRevokedRefreshTokens.Should().Be(0);
+        repeated.AlreadyRevokedSessions.Should().Be(2);
+
+        (await context.Set<SqlOSSession>().SingleAsync(x => x.Id == "matching-active"))
+            .RevocationReason.Should().Be("incident-42");
+        (await context.Set<SqlOSRefreshToken>().SingleAsync(x => x.SessionId == "matching-active"))
+            .ReplacementTokenResponse.Should().BeNull();
+        (await context.Set<SqlOSSession>().SingleAsync(x => x.Id == "other-org"))
+            .RevokedAt.Should().BeNull();
+    }
+
+    [TestMethod]
+    public async Task Execute_RequiresConfirmationAndSelector()
+    {
+        await using var context = CreateContext();
+        var service = CreateService(context);
+
+        await FluentActions.Invoking(() => service.RevokeAsync(
+                new SqlOSAdminSessionRevocationRequest(UserId: "user-1")))
+            .Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*confirmation*");
+        await FluentActions.Invoking(() => service.PreviewAsync(
+                new SqlOSAdminSessionRevocationRequest()))
+            .Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*selector*");
+    }
+
+    [TestMethod]
+    public async Task Execute_RecordsRedactedAuditMetadata()
+    {
+        await using var context = CreateContext();
+        var service = CreateService(context);
+        Seed(context);
+        await context.SaveChangesAsync();
+
+        await service.RevokeAsync(new SqlOSAdminSessionRevocationRequest(
+            SessionId: "matching-active",
+            Reason: "compromised device",
+            OperationId: "incident-op",
+            Confirm: true));
+
+        var audit = await context.Set<SqlOSAuditEvent>().SingleAsync(x => x.EventType == "session.admin-revoked");
+        audit.DataJson.Should().Contain("incident-op");
+        audit.DataJson.Should().Contain("compromised device");
+        audit.DataJson.Should().NotContain("cached-token-response");
+    }
+
+    [TestMethod]
+    public async Task Preview_RejectsAnUnboundedBulkOperation()
+    {
+        await using var context = CreateContext();
+        var now = DateTime.UtcNow;
+        context.Set<SqlOSSession>().AddRange(Enumerable.Range(0, 10_001).Select(index => new SqlOSSession
+        {
+            Id = $"bulk-{index}", UserId = "bulk-user", CreatedAt = now, LastSeenAt = now,
+            IdleExpiresAt = now.AddHours(1), AbsoluteExpiresAt = now.AddDays(1)
+        }));
+        await context.SaveChangesAsync();
+
+        await FluentActions.Invoking(() => CreateService(context).PreviewAsync(
+                new SqlOSAdminSessionRevocationRequest(UserId: "bulk-user")))
+            .Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*10,000*");
+    }
+
+    [TestMethod]
+    public async Task Execute_MissingCrossTenantSelectors_ReturnsGenericZeroWithoutAudit()
+    {
+        await using var context = CreateContext();
+        var result = await CreateService(context).RevokeAsync(new SqlOSAdminSessionRevocationRequest(
+            UserId: "unknown-user",
+            OrganizationId: "unknown-organization",
+            Confirm: true));
+
+        result.MatchedSessions.Should().Be(0);
+        result.AuditEventId.Should().BeNull();
+        (await context.Set<SqlOSAuditEvent>().CountAsync()).Should().Be(0);
+    }
+
+    private static SqlOSSessionRevocationService CreateService(TestSqlOSInMemoryDbContext context)
+    {
+        var options = Options.Create(new SqlOSAuthServerOptions());
+        var crypto = TestCryptoService.Create(context, options);
+        return new SqlOSSessionRevocationService(context, new SqlOSAuditLogService(context, crypto));
+    }
+
+    private static void Seed(TestSqlOSInMemoryDbContext context)
+    {
+        var now = DateTime.UtcNow;
+        context.Set<SqlOSSession>().AddRange(
+            Session("matching-active", "org-1", "client-1"),
+            Session("matching-revoked", "org-1", "client-1", now.AddMinutes(-2)),
+            Session("other-org", "org-2", "client-1"),
+            Session("other-client", "org-1", "client-2"));
+        context.Set<SqlOSRefreshToken>().Add(new SqlOSRefreshToken
+        {
+            Id = "refresh-1", SessionId = "matching-active", TokenHash = "hash", FamilyId = "family",
+            CreatedAt = now, ExpiresAt = now.AddDays(1), ReplacementTokenResponse = "cached-token-response",
+            ReplacementOrganizationId = "org-1", ReplacementAccessTokenExpiresAt = now.AddMinutes(5)
+        });
+    }
+
+    private static SqlOSSession Session(string id, string organizationId, string clientId, DateTime? revokedAt = null)
+        => new()
+        {
+            Id = id, UserId = "user-1", OrganizationId = organizationId, ClientApplicationId = clientId,
+            CreatedAt = DateTime.UtcNow, LastSeenAt = DateTime.UtcNow,
+            IdleExpiresAt = DateTime.UtcNow.AddHours(1), AbsoluteExpiresAt = DateTime.UtcNow.AddDays(1),
+            RevokedAt = revokedAt, RevocationReason = revokedAt == null ? null : "previous"
+        };
+
+    private static TestSqlOSInMemoryDbContext CreateContext()
+        => new(new DbContextOptionsBuilder<TestSqlOSInMemoryDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N")).Options);
+}

--- a/tests/SqlOS.Tests/SqlOSSessionRevocationServiceTests.cs
+++ b/tests/SqlOS.Tests/SqlOSSessionRevocationServiceTests.cs
@@ -34,12 +34,12 @@ public sealed class SqlOSSessionRevocationServiceTests
         preview.AlreadyRevokedSessions.Should().Be(1);
         preview.ActiveRefreshTokens.Should().Be(1);
 
-        var executed = await service.RevokeAsync(request with { Confirm = true });
+        var executed = await service.RevokeAsync(request with { Confirm = true, ExpectedMatchedSessions = preview.MatchedSessions });
         executed.NewlyRevokedSessions.Should().Be(1);
         executed.NewlyRevokedRefreshTokens.Should().Be(1);
         executed.OperationId.Should().Be("op-42");
 
-        var repeated = await service.RevokeAsync(request with { Confirm = true });
+        var repeated = await service.RevokeAsync(request with { Confirm = true, ExpectedMatchedSessions = preview.MatchedSessions });
         repeated.NewlyRevokedSessions.Should().Be(0);
         repeated.NewlyRevokedRefreshTokens.Should().Be(0);
         repeated.AlreadyRevokedSessions.Should().Be(2);
@@ -113,11 +113,48 @@ public sealed class SqlOSSessionRevocationServiceTests
         var result = await CreateService(context).RevokeAsync(new SqlOSAdminSessionRevocationRequest(
             UserId: "unknown-user",
             OrganizationId: "unknown-organization",
-            Confirm: true));
+            Confirm: true,
+            ExpectedMatchedSessions: 0));
 
         result.MatchedSessions.Should().Be(0);
         result.AuditEventId.Should().BeNull();
         (await context.Set<SqlOSAuditEvent>().CountAsync()).Should().Be(0);
+    }
+
+    [TestMethod]
+    public async Task Execute_RejectsWhenBroadScopeChangedAfterPreview()
+    {
+        await using var context = CreateContext();
+        var service = CreateService(context);
+        Seed(context);
+        await context.SaveChangesAsync();
+        var preview = await service.PreviewAsync(new SqlOSAdminSessionRevocationRequest(UserId: "user-1"));
+        context.Set<SqlOSSession>().Add(Session("arrived-after-preview", "org-1", "client-1"));
+        await context.SaveChangesAsync();
+
+        await FluentActions.Invoking(() => service.RevokeAsync(new SqlOSAdminSessionRevocationRequest(
+                UserId: "user-1", OperationId: preview.OperationId, Confirm: true,
+                ExpectedMatchedSessions: preview.MatchedSessions)))
+            .Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*changed after preview*");
+        (await context.Set<SqlOSSession>().CountAsync(x => x.RevokedAt == null)).Should().Be(4);
+    }
+
+    [TestMethod]
+    public async Task Execute_RejectsOperationIdReusedForDifferentScope()
+    {
+        await using var context = CreateContext();
+        var service = CreateService(context);
+        Seed(context);
+        await context.SaveChangesAsync();
+        await service.RevokeAsync(new SqlOSAdminSessionRevocationRequest(
+            SessionId: "matching-active", OperationId: "unique-operation", Confirm: true));
+
+        await FluentActions.Invoking(() => service.RevokeAsync(new SqlOSAdminSessionRevocationRequest(
+                SessionId: "other-org", OperationId: "unique-operation", Confirm: true)))
+            .Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*different revocation scope*");
+        (await context.Set<SqlOSSession>().SingleAsync(x => x.Id == "other-org")).RevokedAt.Should().BeNull();
     }
 
     private static SqlOSSessionRevocationService CreateService(TestSqlOSInMemoryDbContext context)

--- a/web/content/docs/authserver/sessions-and-tokens.mdx
+++ b/web/content/docs/authserver/sessions-and-tokens.mdx
@@ -132,6 +132,30 @@ await authService.LogoutAllAsync(userId, ct);
 
 `LogoutAllAsync` invalidates both OAuth sessions and hosted AuthPage sessions. A successful password reset does the same. Organization deactivation invalidates organization-bound OAuth and AuthPage sessions, and the SSO portal's organization-session revocation action invalidates matching-domain AuthPage sessions along with OAuth sessions.
 
+### Platform-admin revocation
+
+The dashboard's **Auth Server > Sessions** page supports incident-response revocation by session, user, organization, client application, or an AND-combination of those filters. It always previews the matched sessions and active refresh tokens before asking for confirmation. The Applications page uses the same preview-and-confirm workflow when an operator revokes a client's sessions.
+
+Trusted backend administration can use the same strongly typed service:
+
+```csharp
+var preview = await revocations.PreviewAsync(new SqlOSAdminSessionRevocationRequest(
+    OrganizationId: organizationId,
+    ClientApplicationId: clientApplicationId,
+    Reason: "incident-2026-07"), ct);
+
+var result = await revocations.RevokeAsync(new SqlOSAdminSessionRevocationRequest(
+    OrganizationId: organizationId,
+    ClientApplicationId: clientApplicationId,
+    Reason: "incident-2026-07",
+    OperationId: preview.OperationId,
+    Confirm: true), ct);
+```
+
+The authenticated admin API exposes `POST /sqlos/admin/auth/api/sessions/revocation/preview` and `POST /sqlos/admin/auth/api/sessions/revocation`. At least one selector is required, multiple selectors narrow the result, and execution requires `confirm: true`. A single operation is capped at 10,000 sessions; narrow broader incident queries instead of loading an unbounded tenant history. Revocation immediately marks matching sessions and active refresh tokens as revoked, removes cached refresh responses, preserves unrelated sessions, and writes an audit record containing the actor, reason, selectors, operation ID, and counts—never token material.
+
+Repeat execution is safe: already-revoked sessions and tokens are counted but not rewritten. On SQL Server, matching execution is serialized so concurrent incident responders cannot count the same active sessions as newly revoked.
+
 ## Session lifetimes
 
 Configured via the dashboard (Auth Server > Security) or the admin API:
@@ -161,8 +185,8 @@ builder.AddSqlOS<AppDbContext>(options =>
 
 Idle timeout does not retroactively shorten a JWT that has already been issued. Session-aware access-token validation rejects a missing, revoked, or absolutely expired session; the access token's own `exp` remains its time boundary. Idle expiry is enforced on refresh, and a successful refresh extends the idle deadline without moving the absolute deadline.
 
-## Viewing active sessions
+## Viewing sessions
 
-The dashboard Sessions page shows all active sessions with authentication method, client, and expiration.
+The dashboard Sessions page shows session history with authentication method, client, expiration, revocation time, and revocation reason. Use its user, organization, and client filters to preview and revoke a bounded set during incident response.
 
 ![Active sessions](/docs/dashboard-sessions.png)

--- a/web/content/docs/authserver/sessions-and-tokens.mdx
+++ b/web/content/docs/authserver/sessions-and-tokens.mdx
@@ -149,10 +149,11 @@ var result = await revocations.RevokeAsync(new SqlOSAdminSessionRevocationReques
     ClientApplicationId: clientApplicationId,
     Reason: "incident-2026-07",
     OperationId: preview.OperationId,
-    Confirm: true), ct);
+    Confirm: true,
+    ExpectedMatchedSessions: preview.MatchedSessions), ct);
 ```
 
-The authenticated admin API exposes `POST /sqlos/admin/auth/api/sessions/revocation/preview` and `POST /sqlos/admin/auth/api/sessions/revocation`. At least one selector is required, multiple selectors narrow the result, and execution requires `confirm: true`. A single operation is capped at 10,000 sessions; narrow broader incident queries instead of loading an unbounded tenant history. Revocation immediately marks matching sessions and active refresh tokens as revoked, removes cached refresh responses, preserves unrelated sessions, and writes an audit record containing the actor, reason, selectors, operation ID, and counts—never token material.
+The authenticated admin API exposes `POST /sqlos/admin/auth/api/sessions/revocation/preview` and `POST /sqlos/admin/auth/api/sessions/revocation`. At least one selector is required, multiple selectors narrow the result, and execution requires `confirm: true`. Broad execution also requires `expectedMatchedSessions` from the preview; if the scope changes between preview and confirmation, the caller must preview again. A single operation is capped at 10,000 sessions; narrow broader incident queries instead of loading an unbounded tenant history. Revocation immediately marks matching sessions and active refresh tokens as revoked, removes cached refresh responses, preserves unrelated sessions, and writes an audit record containing the actor, reason, selectors, operation ID, and counts—never token material. Reusing an operation ID with a different scope or reason is rejected.
 
 Repeat execution is safe: already-revoked sessions and tokens are counted but not rewritten. On SQL Server, matching execution is serialized so concurrent incident responders cannot count the same active sessions as newly revoked.
 

--- a/web/content/docs/guides/account-recovery-sessions.mdx
+++ b/web/content/docs/guides/account-recovery-sessions.mdx
@@ -198,6 +198,8 @@ Place this middleware before the account endpoints. Do not use user ids from rou
 
 `SqlOSAdminService.ListUserSessionsAsync` is useful for trusted admin/server surfaces, but it returns session history—including revoked or expired rows—and raw user-agent/IP fields. A user-facing endpoint should project only the fields Harbor intends to display and compute active state explicitly.
 
+For a platform-operator workflow, use `SqlOSSessionRevocationService` or the dashboard Sessions page instead. Those surfaces provide bounded preview, explicit confirmation, idempotent execution, refresh-token invalidation, and audit records. They are platform-admin capabilities; do not expose their arbitrary user/organization/client selectors to an end-user account page.
+
 ```csharp
 using Microsoft.EntityFrameworkCore;
 using SqlOS.AuthServer.Extensions;

--- a/web/content/docs/reference/api-reference.mdx
+++ b/web/content/docs/reference/api-reference.mdx
@@ -223,6 +223,17 @@ Account-management routes are secure by default without adding a blanket ASP.NET
 
 Trusted backend code can still call `SqlOSAuthService.LogoutAsync(..., sessionId: ...)`, `LogoutAllAsync(userId)`, or `CreateEmailVerificationTokenAsync(...)` after applying its own ownership/admin policy. Do not expose those service methods by mapping caller-supplied IDs or raw tokens directly into a public route.
 
+## Platform-admin session revocation
+
+The dashboard admin API has two authenticated platform-operator routes. Unauthorized requests receive the same not-found response used by the rest of the admin control plane.
+
+| Method and route | JSON request | Success response |
+| --- | --- | --- |
+| `POST /sqlos/admin/auth/api/sessions/revocation/preview` | `SqlOSAdminSessionRevocationRequest` | Match and active refresh-token counts; no mutation |
+| `POST /sqlos/admin/auth/api/sessions/revocation` | Same request with `confirm: true` | Newly/already-revoked session counts and revoked refresh-token count |
+
+Supply at least one of `sessionId`, `userId`, `organizationId`, or `clientApplicationId`. Multiple values are combined with AND semantics. `reason` and `operationId` are bounded strings, and operations matching more than 10,000 sessions are rejected so callers must narrow the incident scope. The API returns a generic not-found result when execution matches no records and does not expose cross-tenant record details.
+
 ## Headless AuthPage API
 
 The default headless base is `/sqlos/auth/headless`. It can be moved with `AuthServer.Headless.HeadlessApiBasePath`. `AuthServer.Headless.EnableApi` defaults to `true`; disabling it leaves the routes unavailable with `404`. These endpoints use JSON and operate on SqlOS authorization-request state.

--- a/web/content/docs/reference/api-reference.mdx
+++ b/web/content/docs/reference/api-reference.mdx
@@ -232,7 +232,7 @@ The dashboard admin API has two authenticated platform-operator routes. Unauthor
 | `POST /sqlos/admin/auth/api/sessions/revocation/preview` | `SqlOSAdminSessionRevocationRequest` | Match and active refresh-token counts; no mutation |
 | `POST /sqlos/admin/auth/api/sessions/revocation` | Same request with `confirm: true` | Newly/already-revoked session counts and revoked refresh-token count |
 
-Supply at least one of `sessionId`, `userId`, `organizationId`, or `clientApplicationId`. Multiple values are combined with AND semantics. `reason` and `operationId` are bounded strings, and operations matching more than 10,000 sessions are rejected so callers must narrow the incident scope. The API returns a generic not-found result when execution matches no records and does not expose cross-tenant record details.
+Supply at least one of `sessionId`, `userId`, `organizationId`, or `clientApplicationId`. Multiple values are combined with AND semantics. For a broad operation, copy the preview's `matchedSessions` into `expectedMatchedSessions`; execution rejects a changed count so the operator must preview and confirm the current scope again. `reason` and `operationId` are bounded strings, operation IDs cannot be reused for a different selector/reason, and operations matching more than 10,000 sessions are rejected so callers must narrow the incident scope. The API returns a generic not-found result when execution matches no records and does not expose cross-tenant record details.
 
 ## Headless AuthPage API
 


### PR DESCRIPTION
Closes #216

## What changed
- adds one typed preview/execute service for session, user, organization, client, and combined revocation scopes
- requires explicit confirmation, caps operations at 10,000 sessions, serializes real-SQL execution, clears refresh rotation caches, and keeps repeated operations idempotent
- exposes centrally authorized admin API routes with generic zero-match behavior
- adds Sessions, User, Organization, and Application dashboard actions with count preview and confirmation
- records idempotent, redacted audit evidence and surfaces revocation reason/time plus audit navigation
- documents platform-admin incident response and compiles the shared example

## Validation
- `dotnet test tests/SqlOS.Tests/SqlOS.Tests.csproj` (649 passed)
- real SQL: `SessionRevocationIntegrationTests` (passed; concurrent execution)
- `node --check src/SqlOS/Dashboard/wwwroot/app.js`
- `node scripts/compile-doc-snippets.mjs`
- `./scripts/docs-check.sh`
