### PR TITLE
Add ownership-safe code-first SAML connection seeds

### DIFF
--- a/scripts/compile-doc-snippets.mjs
+++ b/scripts/compile-doc-snippets.mjs
@@ -104,6 +104,13 @@ const snippetSpecs = [
     marker: "revocations.PreviewAsync(",
     wrap: asSessionRevocationProgram,
   },
+  {
+    name: "code-first SAML connection",
+    relativePath: "web/content/docs/authserver/saml-sso.mdx",
+    heading: "### Code-first connection",
+    marker: "SeedSamlConnection(",
+    wrap: asSamlSeedProgram,
+  },
 ];
 
 function extractCsharpBlock({ relativePath, heading, marker }) {
@@ -259,6 +266,18 @@ SqlOSSessionRevocationService revocations = null!;
 var organizationId = "org_acme";
 var clientApplicationId = "client_portal";
 var ct = CancellationToken.None;
+
+${snippet}
+`;
+}
+
+function asSamlSeedProgram(snippet) {
+  return `using Microsoft.Extensions.Configuration;
+using SqlOS.AuthServer.Configuration;
+using SqlOS.Configuration;
+
+var builder = WebApplication.CreateBuilder(args);
+var options = new SqlOSOptions();
 
 ${snippet}
 `;

--- a/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerModelConfiguration.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerModelConfiguration.cs
@@ -155,7 +155,15 @@ public static class SqlOSAuthServerModelConfiguration
             entity.ToTable("SqlOSSsoConnections", schema, t => t.ExcludeFromMigrations());
             entity.HasKey(x => x.Id);
             entity.Property(x => x.DisplayName).HasMaxLength(200);
+            entity.Property(x => x.IdentityProviderEntityId).HasMaxLength(500);
+            entity.Property(x => x.SingleSignOnUrl).HasMaxLength(2000);
             entity.Property(x => x.AcceptedAuthnContextClassRefsJson).HasDefaultValue("[]");
+            entity.Property(x => x.ConfigurationOwner).HasMaxLength(40);
+            entity.Property(x => x.ConfigurationSourceKey).HasMaxLength(160);
+            entity.Property(x => x.ConfigurationFingerprint).HasMaxLength(64);
+            entity.HasIndex(x => new { x.ConfigurationOwner, x.ConfigurationSourceKey })
+                .IsUnique()
+                .HasFilter("[ConfigurationSourceKey] IS NOT NULL");
             entity.HasOne(x => x.Organization)
                 .WithMany(x => x.SsoConnections)
                 .HasForeignKey(x => x.OrganizationId)

--- a/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerOptions.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerOptions.cs
@@ -71,6 +71,7 @@ public class SqlOSAuthServerOptions
     public SqlOSSingleApplicationOptions? SingleApplication { get; private set; }
     public List<SqlOSClientSeedOptions> ClientSeeds { get; } = [];
     public List<SqlOSOidcConnectionSeedOptions> OidcConnectionSeeds { get; } = [];
+    public List<SqlOSSamlConnectionSeedOptions> SamlConnectionSeeds { get; } = [];
     public List<SqlOSScimConnectionSeedOptions> ScimConnectionSeeds { get; } = [];
 
     public SqlOSAuthServerOptions UseHeadlessAuthPage(Action<SqlOSHeadlessAuthOptions> configure)
@@ -149,6 +150,21 @@ public class SqlOSAuthServerOptions
         configure(seed);
         EnableScim = true;
         ScimConnectionSeeds.Add(seed);
+        return this;
+    }
+
+    /// <summary>Seed an organization-scoped upstream SAML identity-provider connection.</summary>
+    public SqlOSAuthServerOptions SeedSamlConnection(string key, Action<SqlOSSamlConnectionSeedOptions> configure)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            throw new InvalidOperationException("Seeded SAML connections require a stable key.");
+        }
+
+        var seed = new SqlOSSamlConnectionSeedOptions { Key = key.Trim() };
+        configure(seed);
+        EnableSaml = true;
+        SamlConnectionSeeds.Add(seed);
         return this;
     }
 

--- a/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerSeedOptions.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerSeedOptions.cs
@@ -267,6 +267,30 @@ public sealed class SqlOSScimConnectionSeedOptions
     }
 }
 
+/// <summary>Declarative upstream SAML connection reconciled by a stable source key.</summary>
+public sealed class SqlOSSamlConnectionSeedOptions
+{
+    public string Key { get; set; } = string.Empty;
+    public string? OrganizationId { get; set; }
+    public string? OrganizationSlug { get; set; }
+    public string DisplayName { get; set; } = string.Empty;
+    /// <summary>Optional federation metadata XML. Use this or the three explicit IdP fields below.</summary>
+    public string? MetadataXml { get; set; }
+    public string? IdentityProviderEntityId { get; set; }
+    public string? SingleSignOnUrl { get; set; }
+    public string? X509CertificatePem { get; set; }
+    public string? PrimaryDomain { get; set; }
+    public bool IsEnabled { get; set; } = true;
+    public bool AutoProvisionUsers { get; set; } = true;
+    public bool AutoLinkByEmail { get; set; }
+    public string? NameIdFormat { get; set; }
+    public string EmailAttributeName { get; set; } = "email";
+    public string FirstNameAttributeName { get; set; } = "first_name";
+    public string LastNameAttributeName { get; set; } = "last_name";
+    public bool TrustUpstreamMfa { get; set; }
+    public List<string> AcceptedAuthnContextClassRefs { get; } = [];
+}
+
 public sealed class SqlOSScimGroupMappingSeedOptions
 {
     public string SourceKey { get; set; } = string.Empty;

--- a/src/SqlOS/AuthServer/Endpoints/AdminConfigurationEndpoints.cs
+++ b/src/SqlOS/AuthServer/Endpoints/AdminConfigurationEndpoints.cs
@@ -202,6 +202,20 @@ public static partial class EndpointRouteBuilderExtensions
             });
         });
 
+        api.MapPost("/sso-connections/{connectionId}/enable", async (HttpContext context, string connectionId, SqlOSAdminService adminService, IOptions<SqlOSAuthServerOptions> options, IHostEnvironment environment, CancellationToken cancellationToken) =>
+        {
+            if (!await IsAdminAuthorizedAsync(context, options.Value, environment)) return Results.NotFound();
+            var connection = await adminService.SetSsoConnectionEnabledAsync(connectionId, true, cancellationToken);
+            return Results.Ok(new { connection.Id, connection.IsEnabled, connection.UpdatedAt });
+        });
+
+        api.MapPost("/sso-connections/{connectionId}/disable", async (HttpContext context, string connectionId, SqlOSAdminService adminService, IOptions<SqlOSAuthServerOptions> options, IHostEnvironment environment, CancellationToken cancellationToken) =>
+        {
+            if (!await IsAdminAuthorizedAsync(context, options.Value, environment)) return Results.NotFound();
+            var connection = await adminService.SetSsoConnectionEnabledAsync(connectionId, false, cancellationToken);
+            return Results.Ok(new { connection.Id, connection.IsEnabled, connection.UpdatedAt });
+        });
+
         api.MapPost("/sso-connections", async (HttpContext context, SqlOSCreateSsoConnectionRequest request, SqlOSAdminService adminService, IOptions<SqlOSAuthServerOptions> options, IHostEnvironment environment, CancellationToken cancellationToken) =>
         {
             if (!await IsAdminAuthorizedAsync(context, options.Value, environment))

--- a/src/SqlOS/AuthServer/Models/SqlOSEntities.cs
+++ b/src/SqlOS/AuthServer/Models/SqlOSEntities.cs
@@ -168,6 +168,11 @@ public sealed class SqlOSSsoConnection
     public bool AutoLinkByEmail { get; set; }
     public bool TrustUpstreamMfa { get; set; }
     public string AcceptedAuthnContextClassRefsJson { get; set; } = "[]";
+    public string ConfigurationOwner { get; set; } = "dashboard";
+    public string? ConfigurationSourceKey { get; set; }
+    public string? ConfigurationFingerprint { get; set; }
+    public DateTime? LastReconciledAt { get; set; }
+    public DateTime? ConfigurationOrphanedAt { get; set; }
     public DateTime CreatedAt { get; set; }
     public DateTime UpdatedAt { get; set; }
 

--- a/src/SqlOS/AuthServer/Schema/036_SamlConnectionOwnership.sql
+++ b/src/SqlOS/AuthServer/Schema/036_SamlConnectionOwnership.sql
@@ -1,0 +1,6 @@
+IF OBJECT_ID(N'[{Schema}].[SqlOSSsoConnections]', N'U') IS NOT NULL AND COL_LENGTH('[{Schema}].[SqlOSSsoConnections]', 'ConfigurationOwner') IS NULL
+BEGIN
+    EXEC(N'ALTER TABLE [{Schema}].[SqlOSSsoConnections] ADD [ConfigurationOwner] NVARCHAR(40) NOT NULL CONSTRAINT [DF_SqlOSSsoConnections_ConfigurationOwner] DEFAULT N''dashboard'', [ConfigurationSourceKey] NVARCHAR(160) NULL, [ConfigurationFingerprint] NVARCHAR(64) NULL, [LastReconciledAt] DATETIME2 NULL, [ConfigurationOrphanedAt] DATETIME2 NULL;');
+END
+IF OBJECT_ID(N'[{Schema}].[SqlOSSsoConnections]', N'U') IS NOT NULL AND NOT EXISTS (SELECT 1 FROM sys.indexes WHERE [object_id] = OBJECT_ID(N'[{Schema}].[SqlOSSsoConnections]') AND [name] = N'UX_SqlOSSsoConnections_ConfigurationOwner_SourceKey')
+    EXEC(N'CREATE UNIQUE INDEX [UX_SqlOSSsoConnections_ConfigurationOwner_SourceKey] ON [{Schema}].[SqlOSSsoConnections]([ConfigurationOwner], [ConfigurationSourceKey]) WHERE [ConfigurationSourceKey] IS NOT NULL;');

--- a/src/SqlOS/AuthServer/Services/SqlOSAdminService.SamlSeeds.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSAdminService.SamlSeeds.cs
@@ -71,7 +71,7 @@ public sealed partial class SqlOSAdminService
                 .FirstOrDefaultAsync(x => x.Id != (existing == null ? string.Empty : existing.Id)
                     && x.IdentityProviderEntityId == resolved.Definition.IdentityProviderEntityId,
                     cancellationToken);
-            if (existing == null && conflict != null)
+            if (conflict != null)
             {
                 throw new InvalidOperationException(
                     $"Cannot reconcile SAML seed '{resolved.SourceKey}' because an existing '{conflict.ConfigurationOwner}' connection uses the same IdP entity ID.");
@@ -83,6 +83,11 @@ public sealed partial class SqlOSAdminService
                     existing.ConfigurationSourceKey,
                     resolved.SourceKey,
                     $"SAML connection '{displayName}'");
+                if (!string.Equals(existing.OrganizationId, resolved.Organization.Id, StringComparison.Ordinal))
+                {
+                    throw new InvalidOperationException(
+                        $"SAML seed '{resolved.SourceKey}' is already bound to organization '{existing.OrganizationId}' and cannot be moved to '{resolved.Organization.Id}'. Use a new seed key or explicitly replace the connection.");
+                }
             }
 
             if (!string.IsNullOrWhiteSpace(seed.PrimaryDomain))

--- a/src/SqlOS/AuthServer/Services/SqlOSAdminService.SamlSeeds.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSAdminService.SamlSeeds.cs
@@ -1,0 +1,301 @@
+using System.Data;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using SqlOS.AuthServer.Configuration;
+using SqlOS.AuthServer.Contracts;
+using SqlOS.AuthServer.Models;
+
+namespace SqlOS.AuthServer.Services;
+
+public sealed partial class SqlOSAdminService
+{
+    public async Task UpsertSeededSamlConnectionsAsync(CancellationToken cancellationToken = default)
+    {
+        if (_options.SamlConnectionSeeds.Count == 0
+            && !await _context.Set<SqlOSSsoConnection>().AnyAsync(
+                x => x.ConfigurationOwner == SqlOSConfigurationOwners.Code,
+                cancellationToken))
+        {
+            return;
+        }
+
+        await RunSamlSeedAtomicAsync(() => UpsertSeededSamlConnectionsCoreAsync(cancellationToken), cancellationToken);
+    }
+
+    private async Task UpsertSeededSamlConnectionsCoreAsync(CancellationToken cancellationToken)
+    {
+        var seeds = new List<ResolvedSamlSeed>();
+        var sourceKeys = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var seed in _options.SamlConnectionSeeds)
+        {
+            var sourceKey = RequireSamlSeedValue(seed.Key, "SAML seed key is required.", 160);
+            if (!sourceKeys.Add(sourceKey))
+            {
+                throw new InvalidOperationException($"SAML seed '{sourceKey}' is configured more than once.");
+            }
+
+            var organization = await ResolveSamlSeedOrganizationAsync(seed, cancellationToken);
+            var definition = NormalizeSamlConnection(
+                seed.MetadataXml,
+                seed.IdentityProviderEntityId,
+                seed.SingleSignOnUrl,
+                seed.X509CertificatePem);
+            seeds.Add(new ResolvedSamlSeed(seed, sourceKey, organization, definition));
+        }
+
+        var now = DateTime.UtcNow;
+        var outcomes = new List<(string Id, string Key, string Outcome, string? Fingerprint, string OrganizationId)>();
+        var orphans = await _context.Set<SqlOSSsoConnection>()
+            .Where(x => x.ConfigurationOwner == SqlOSConfigurationOwners.Code
+                && x.ConfigurationSourceKey != null
+                && !sourceKeys.Contains(x.ConfigurationSourceKey))
+            .ToListAsync(cancellationToken);
+        foreach (var orphan in orphans)
+        {
+            if (orphan.ConfigurationOrphanedAt == null)
+            {
+                orphan.ConfigurationOrphanedAt = now;
+                outcomes.Add((orphan.Id, orphan.ConfigurationSourceKey!, "orphaned", orphan.ConfigurationFingerprint, orphan.OrganizationId));
+            }
+        }
+
+        foreach (var resolved in seeds)
+        {
+            var seed = resolved.Seed;
+            var displayName = RequireSamlSeedValue(seed.DisplayName, $"SAML seed '{resolved.SourceKey}' requires a display name.", 200);
+            var existing = await _context.Set<SqlOSSsoConnection>()
+                .FirstOrDefaultAsync(x => x.ConfigurationSourceKey == resolved.SourceKey, cancellationToken);
+            var conflict = await _context.Set<SqlOSSsoConnection>()
+                .FirstOrDefaultAsync(x => x.Id != (existing == null ? string.Empty : existing.Id)
+                    && x.IdentityProviderEntityId == resolved.Definition.IdentityProviderEntityId,
+                    cancellationToken);
+            if (existing == null && conflict != null)
+            {
+                throw new InvalidOperationException(
+                    $"Cannot reconcile SAML seed '{resolved.SourceKey}' because an existing '{conflict.ConfigurationOwner}' connection uses the same IdP entity ID.");
+            }
+            if (existing != null)
+            {
+                SqlOSConfigurationOwnershipPolicy.EnsureCodeOwnership(
+                    existing.ConfigurationOwner,
+                    existing.ConfigurationSourceKey,
+                    resolved.SourceKey,
+                    $"SAML connection '{displayName}'");
+            }
+
+            if (!string.IsNullOrWhiteSpace(seed.PrimaryDomain))
+            {
+                var domain = NormalizeDomain(seed.PrimaryDomain);
+                if (string.IsNullOrWhiteSpace(resolved.Organization.PrimaryDomain))
+                {
+                    resolved.Organization.PrimaryDomain = domain;
+                }
+                else if (!string.Equals(resolved.Organization.PrimaryDomain, domain, StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new InvalidOperationException(
+                        $"SAML seed '{resolved.SourceKey}' cannot replace organization '{resolved.Organization.Id}' primary domain '{resolved.Organization.PrimaryDomain}'. Change it explicitly in the dashboard or API first.");
+                }
+            }
+
+            var acceptedContexts = NormalizeTrustValues(seed.AcceptedAuthnContextClassRefs);
+            var fingerprint = SqlOSConfigurationOwnershipPolicy.Fingerprint(new
+            {
+                resolved.SourceKey,
+                OrganizationId = resolved.Organization.Id,
+                DisplayName = displayName,
+                resolved.Definition.IdentityProviderEntityId,
+                resolved.Definition.SingleSignOnUrl,
+                resolved.Definition.X509CertificatePem,
+                seed.PrimaryDomain,
+                seed.AutoProvisionUsers,
+                seed.AutoLinkByEmail,
+                seed.NameIdFormat,
+                seed.EmailAttributeName,
+                seed.FirstNameAttributeName,
+                seed.LastNameAttributeName,
+                seed.TrustUpstreamMfa,
+                AcceptedAuthnContextClassRefs = acceptedContexts,
+                seed.IsEnabled
+            });
+            var outcome = existing == null
+                ? "created"
+                : existing.ConfigurationFingerprint == fingerprint && existing.ConfigurationOrphanedAt == null ? null : "updated";
+
+            var isNew = existing == null;
+            existing ??= new SqlOSSsoConnection
+            {
+                Id = _cryptoService.GenerateId("sso"),
+                CreatedAt = now,
+                IsEnabled = seed.IsEnabled,
+                ConfigurationOwner = SqlOSConfigurationOwners.Code,
+                ConfigurationSourceKey = resolved.SourceKey
+            };
+            if (isNew)
+            {
+                _context.Set<SqlOSSsoConnection>().Add(existing);
+            }
+
+            existing.OrganizationId = resolved.Organization.Id;
+            existing.DisplayName = displayName;
+            existing.IdentityProviderEntityId = resolved.Definition.IdentityProviderEntityId;
+            existing.SingleSignOnUrl = resolved.Definition.SingleSignOnUrl;
+            existing.X509CertificatePem = resolved.Definition.X509CertificatePem;
+            existing.AutoProvisionUsers = seed.AutoProvisionUsers;
+            existing.AutoLinkByEmail = seed.AutoLinkByEmail;
+            existing.NameIdFormat = NormalizeOptionalSamlValue(seed.NameIdFormat, 200);
+            existing.EmailAttributeName = NormalizeSamlAttribute(seed.EmailAttributeName, "email");
+            existing.FirstNameAttributeName = NormalizeSamlAttribute(seed.FirstNameAttributeName, "first_name");
+            existing.LastNameAttributeName = NormalizeSamlAttribute(seed.LastNameAttributeName, "last_name");
+            existing.TrustUpstreamMfa = seed.TrustUpstreamMfa;
+            existing.AcceptedAuthnContextClassRefsJson = JsonSerializer.Serialize(acceptedContexts);
+            existing.ConfigurationFingerprint = fingerprint;
+            existing.LastReconciledAt = now;
+            existing.ConfigurationOrphanedAt = null;
+            existing.UpdatedAt = now;
+            // Preserve an operator emergency disable. Code can disable, but does not
+            // silently re-enable an existing enterprise connection on restart.
+            if (!seed.IsEnabled) existing.IsEnabled = false;
+            if (outcome != null) outcomes.Add((existing.Id, resolved.SourceKey, outcome, fingerprint, resolved.Organization.Id));
+        }
+
+        await _context.SaveChangesAsync(cancellationToken);
+        foreach (var outcome in outcomes)
+        {
+            await RecordAuditAsync(
+                "configuration.reconciled",
+                "system",
+                "startup",
+                organizationId: outcome.OrganizationId,
+                data: new
+                {
+                    resourceType = "saml_connection",
+                    resourceId = outcome.Id,
+                    owner = SqlOSConfigurationOwners.Code,
+                    sourceKey = outcome.Key,
+                    outcome = outcome.Outcome,
+                    fingerprint = outcome.Fingerprint
+                },
+                cancellationToken: cancellationToken);
+        }
+    }
+
+    private async Task RunSamlSeedAtomicAsync(Func<Task> action, CancellationToken cancellationToken)
+    {
+        if (!_context.Database.IsRelational())
+        {
+            await action();
+            return;
+        }
+
+        var strategy = _context.Database.CreateExecutionStrategy();
+        var attempt = 0;
+        await strategy.ExecuteAsync(async () =>
+        {
+            if (attempt++ > 0 && _context is DbContext retryContext) retryContext.ChangeTracker.Clear();
+            await using var transaction = await _context.Database.BeginTransactionAsync(IsolationLevel.Serializable, cancellationToken);
+            if (string.Equals(_context.Database.ProviderName, "Microsoft.EntityFrameworkCore.SqlServer", StringComparison.Ordinal))
+            {
+                const string resource = "SqlOS:SamlSeedReconciliation";
+                await _context.Database.ExecuteSqlInterpolatedAsync($"""
+                    DECLARE @result int;
+                    EXEC @result = sys.sp_getapplock @Resource = {resource}, @LockMode = 'Exclusive', @LockOwner = 'Transaction', @LockTimeout = 30000;
+                    IF @result < 0 THROW 51000, 'Could not acquire the SAML seed reconciliation lock.', 1;
+                    """, cancellationToken);
+            }
+            await action();
+            await transaction.CommitAsync(cancellationToken);
+        });
+    }
+
+    private async Task<SqlOSOrganization> ResolveSamlSeedOrganizationAsync(
+        SqlOSSamlConnectionSeedOptions seed,
+        CancellationToken cancellationToken)
+    {
+        if (!string.IsNullOrWhiteSpace(seed.OrganizationId))
+        {
+            var id = seed.OrganizationId.Trim();
+            return await _context.Set<SqlOSOrganization>().FirstOrDefaultAsync(x => x.Id == id, cancellationToken)
+                ?? throw new InvalidOperationException($"Seeded SAML organization '{id}' was not found.");
+        }
+
+        var slug = RequireSamlSeedValue(seed.OrganizationSlug, $"SAML seed '{seed.Key}' requires OrganizationId or OrganizationSlug.", 160);
+        return await _context.Set<SqlOSOrganization>().FirstOrDefaultAsync(x => x.Slug == slug, cancellationToken)
+            ?? throw new InvalidOperationException($"Seeded SAML organization slug '{slug}' was not found.");
+    }
+
+    private static NormalizedSamlConnection NormalizeSamlConnection(
+        string? metadataXml,
+        string? identityProviderEntityId,
+        string? singleSignOnUrl,
+        string? certificatePem)
+    {
+        if (!string.IsNullOrWhiteSpace(metadataXml))
+        {
+            if (!string.IsNullOrWhiteSpace(identityProviderEntityId)
+                || !string.IsNullOrWhiteSpace(singleSignOnUrl)
+                || !string.IsNullOrWhiteSpace(certificatePem))
+            {
+                throw new InvalidOperationException("Configure SAML federation metadata XML or explicit IdP fields, not both.");
+            }
+            var metadata = ParseFederationMetadata(metadataXml);
+            identityProviderEntityId = metadata.IdentityProviderEntityId;
+            singleSignOnUrl = metadata.SingleSignOnUrl;
+            certificatePem = metadata.X509CertificatePem;
+        }
+
+        var entityId = RequireSamlSeedValue(identityProviderEntityId, "SAML IdP entity ID is required.", 500);
+        var ssoUrl = RequireSamlSeedValue(singleSignOnUrl, "SAML SSO URL is required.", 2000);
+        if (!Uri.TryCreate(ssoUrl, UriKind.Absolute, out var uri) || uri.Scheme != Uri.UriSchemeHttps)
+        {
+            throw new InvalidOperationException("SAML SSO URL must be an absolute HTTPS URL.");
+        }
+
+        var rawCertificate = RequireSamlSeedValue(certificatePem, "SAML signing certificate is required.", 20_000);
+        X509Certificate2 certificate;
+        try
+        {
+            certificate = X509Certificate2.CreateFromPem(rawCertificate);
+        }
+        catch (CryptographicException exception)
+        {
+            throw new InvalidOperationException("SAML signing certificate is malformed.", exception);
+        }
+        using (certificate)
+        {
+            var now = DateTime.UtcNow;
+            if (certificate.NotBefore.ToUniversalTime() > now.AddMinutes(5))
+                throw new InvalidOperationException("SAML signing certificate is not valid yet.");
+            if (certificate.NotAfter.ToUniversalTime() <= now)
+                throw new InvalidOperationException("SAML signing certificate is expired.");
+            rawCertificate = ToPem(certificate.Export(X509ContentType.Cert));
+        }
+
+        return new NormalizedSamlConnection(entityId, uri.AbsoluteUri, rawCertificate);
+    }
+
+    private static string RequireSamlSeedValue(string? value, string message, int maxLength)
+    {
+        var normalized = string.IsNullOrWhiteSpace(value) ? throw new InvalidOperationException(message) : value.Trim();
+        if (normalized.Length > maxLength) throw new InvalidOperationException(message.Replace("required", $"limited to {maxLength} characters", StringComparison.OrdinalIgnoreCase));
+        return normalized;
+    }
+
+    private static string NormalizeSamlAttribute(string? value, string fallback)
+        => RequireSamlSeedValue(string.IsNullOrWhiteSpace(value) ? fallback : value, "SAML attribute name is required.", 500);
+
+    private static string? NormalizeOptionalSamlValue(string? value, int maxLength)
+        => string.IsNullOrWhiteSpace(value) ? null : RequireSamlSeedValue(value, "SAML value is required.", maxLength);
+
+    private sealed record NormalizedSamlConnection(
+        string IdentityProviderEntityId,
+        string SingleSignOnUrl,
+        string X509CertificatePem);
+
+    private sealed record ResolvedSamlSeed(
+        SqlOSSamlConnectionSeedOptions Seed,
+        string SourceKey,
+        SqlOSOrganization Organization,
+        NormalizedSamlConnection Definition);
+}

--- a/src/SqlOS/AuthServer/Services/SqlOSAdminService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSAdminService.cs
@@ -769,22 +769,37 @@ public sealed partial class SqlOSAdminService
 
     public async Task<SqlOSSsoConnection> CreateSsoConnectionAsync(SqlOSCreateSsoConnectionRequest request, CancellationToken cancellationToken = default)
     {
+        _ = await _context.Set<SqlOSOrganization>()
+            .FirstOrDefaultAsync(x => x.Id == request.OrganizationId, cancellationToken)
+            ?? throw new InvalidOperationException("Organization not found.");
+        var normalized = NormalizeSamlConnection(
+            null,
+            request.IdentityProviderEntityId,
+            request.SingleSignOnUrl,
+            request.X509CertificatePem);
+        if (await _context.Set<SqlOSSsoConnection>().AnyAsync(
+            x => x.IdentityProviderEntityId == normalized.IdentityProviderEntityId,
+            cancellationToken))
+        {
+            throw new InvalidOperationException("A SAML connection already uses this IdP entity ID.");
+        }
         var connection = new SqlOSSsoConnection
         {
             Id = _cryptoService.GenerateId("sso"),
             OrganizationId = request.OrganizationId,
-            DisplayName = request.DisplayName,
-            IdentityProviderEntityId = request.IdentityProviderEntityId,
-            SingleSignOnUrl = request.SingleSignOnUrl,
-            X509CertificatePem = request.X509CertificatePem,
+            DisplayName = RequireSamlSeedValue(request.DisplayName, "SAML display name is required.", 200),
+            IdentityProviderEntityId = normalized.IdentityProviderEntityId,
+            SingleSignOnUrl = normalized.SingleSignOnUrl,
+            X509CertificatePem = normalized.X509CertificatePem,
             AutoProvisionUsers = request.AutoProvisionUsers,
             AutoLinkByEmail = request.AutoLinkByEmail,
             TrustUpstreamMfa = request.TrustUpstreamMfa,
             AcceptedAuthnContextClassRefsJson = JsonSerializer.Serialize(
                 NormalizeTrustValues(request.AcceptedAuthnContextClassRefs)),
-            EmailAttributeName = request.EmailAttributeName ?? "email",
-            FirstNameAttributeName = request.FirstNameAttributeName ?? "first_name",
-            LastNameAttributeName = request.LastNameAttributeName ?? "last_name",
+            EmailAttributeName = NormalizeSamlAttribute(request.EmailAttributeName, "email"),
+            FirstNameAttributeName = NormalizeSamlAttribute(request.FirstNameAttributeName, "first_name"),
+            LastNameAttributeName = NormalizeSamlAttribute(request.LastNameAttributeName, "last_name"),
+            ConfigurationOwner = SqlOSConfigurationOwners.Dashboard,
             CreatedAt = DateTime.UtcNow,
             UpdatedAt = DateTime.UtcNow,
             IsEnabled = true
@@ -792,6 +807,7 @@ public sealed partial class SqlOSAdminService
 
         _context.Set<SqlOSSsoConnection>().Add(connection);
         await _context.SaveChangesAsync(cancellationToken);
+        await RecordAuditAsync("saml.connection.created", "admin", null, organizationId: connection.OrganizationId, data: new { connection.Id, connection.IdentityProviderEntityId }, cancellationToken: cancellationToken);
         return connection;
     }
 
@@ -847,7 +863,15 @@ public sealed partial class SqlOSAdminService
             .FirstOrDefaultAsync(x => x.Id == connectionId, cancellationToken)
             ?? throw new InvalidOperationException("SAML connection not found.");
 
-        var metadata = ParseFederationMetadata(request.MetadataXml);
+        SqlOSConfigurationOwnershipPolicy.EnsureDashboardEditable(connection.ConfigurationOwner, "SAML connection metadata");
+
+        var metadata = NormalizeSamlConnection(request.MetadataXml, null, null, null);
+        if (await _context.Set<SqlOSSsoConnection>().AnyAsync(
+            x => x.Id != connection.Id && x.IdentityProviderEntityId == metadata.IdentityProviderEntityId,
+            cancellationToken))
+        {
+            throw new InvalidOperationException("A SAML connection already uses this IdP entity ID.");
+        }
         connection.IdentityProviderEntityId = metadata.IdentityProviderEntityId;
         connection.SingleSignOnUrl = metadata.SingleSignOnUrl;
         connection.X509CertificatePem = metadata.X509CertificatePem;
@@ -855,6 +879,7 @@ public sealed partial class SqlOSAdminService
         connection.UpdatedAt = DateTime.UtcNow;
 
         await _context.SaveChangesAsync(cancellationToken);
+        await RecordAuditAsync("saml.connection.metadata-imported", "admin", null, organizationId: connection.OrganizationId, data: new { connection.Id, connection.IdentityProviderEntityId }, cancellationToken: cancellationToken);
         return connection;
     }
 
@@ -862,7 +887,7 @@ public sealed partial class SqlOSAdminService
     {
         try
         {
-            var metadata = ParseFederationMetadata(request.MetadataXml);
+            var metadata = NormalizeSamlConnection(request.MetadataXml, null, null, null);
             return new SqlOSSsoMetadataValidationResult(
                 true,
                 null,
@@ -874,6 +899,31 @@ public sealed partial class SqlOSAdminService
         {
             return new SqlOSSsoMetadataValidationResult(false, ex.Message, null, null, false);
         }
+    }
+
+    public async Task<SqlOSSsoConnection> SetSsoConnectionEnabledAsync(
+        string connectionId,
+        bool enabled,
+        CancellationToken cancellationToken = default)
+    {
+        var connection = await _context.Set<SqlOSSsoConnection>()
+            .FirstOrDefaultAsync(x => x.Id == connectionId, cancellationToken)
+            ?? throw new InvalidOperationException("SAML connection not found.");
+        if (enabled && GetSsoSetupStatus(connection) == "draft")
+        {
+            throw new InvalidOperationException("Import valid SAML metadata before enabling this connection.");
+        }
+        connection.IsEnabled = enabled;
+        connection.UpdatedAt = DateTime.UtcNow;
+        await _context.SaveChangesAsync(cancellationToken);
+        await RecordAuditAsync(
+            enabled ? "saml.connection.enabled" : "saml.connection.disabled",
+            "admin",
+            null,
+            organizationId: connection.OrganizationId,
+            data: new { connection.Id, connection.ConfigurationOwner },
+            cancellationToken: cancellationToken);
+        return connection;
     }
 
     public async Task<SqlOSClientApplication> RequireClientAsync(
@@ -1735,7 +1785,12 @@ public sealed partial class SqlOSAdminService
                 x.AppleTeamId,
                 x.AppleKeyId,
                 x.IsEnabled,
-                Ownership = SqlOSConfigurationOwnershipPolicy.ToDto(x.ConfigurationOwner, x.ConfigurationSourceKey, x.LastReconciledAt, x.ConfigurationFingerprint, x.ConfigurationOrphanedAt),
+                Ownership = SqlOSConfigurationOwnershipPolicy.ToDto(
+                    x.ConfigurationOwner,
+                    x.ConfigurationSourceKey,
+                    x.LastReconciledAt,
+                    x.ConfigurationFingerprint,
+                    x.ConfigurationOrphanedAt),
                 x.CreatedAt,
                 x.UpdatedAt
             })
@@ -1763,6 +1818,7 @@ public sealed partial class SqlOSAdminService
                 x.Organization!.PrimaryDomain,
                 x.AutoProvisionUsers,
                 x.AutoLinkByEmail,
+                Ownership = SqlOSConfigurationOwnershipPolicy.ToDto(x.ConfigurationOwner, x.ConfigurationSourceKey, x.LastReconciledAt, x.ConfigurationFingerprint, x.ConfigurationOrphanedAt),
                 SetupStatus = GetSsoSetupStatus(x),
                 ServiceProviderEntityId = GetServiceProviderEntityId(),
                 AssertionConsumerServiceUrl = GetAssertionConsumerServiceUrl(x.Id)
@@ -1791,6 +1847,11 @@ public sealed partial class SqlOSAdminService
                 PrimaryDomain = x.Organization!.PrimaryDomain,
                 x.AutoProvisionUsers,
                 x.AutoLinkByEmail,
+                x.ConfigurationOwner,
+                x.ConfigurationSourceKey,
+                x.LastReconciledAt,
+                x.ConfigurationFingerprint,
+                x.ConfigurationOrphanedAt,
                 SetupStatus = string.IsNullOrWhiteSpace(x.IdentityProviderEntityId) || string.IsNullOrWhiteSpace(x.SingleSignOnUrl) || string.IsNullOrWhiteSpace(x.X509CertificatePem)
                     ? "draft"
                     : x.IsEnabled ? "active" : "ready_to_activate"
@@ -1818,6 +1879,7 @@ public sealed partial class SqlOSAdminService
                 PrimaryDomain = x.PrimaryDomain,
                 x.AutoProvisionUsers,
                 x.AutoLinkByEmail,
+                Ownership = SqlOSConfigurationOwnershipPolicy.ToDto(x.ConfigurationOwner, x.ConfigurationSourceKey, x.LastReconciledAt, x.ConfigurationFingerprint, x.ConfigurationOrphanedAt),
                 x.SetupStatus,
                 ServiceProviderEntityId = serviceProviderEntityId,
                 AssertionConsumerServiceUrl = GetAssertionConsumerServiceUrl(x.Id)

--- a/src/SqlOS/Dashboard/wwwroot/app.js
+++ b/src/SqlOS/Dashboard/wwwroot/app.js
@@ -1745,13 +1745,17 @@
                                     { label: "Connection ID", value: item.id },
                                     { label: "Primary domain", value: item.primaryDomain || "n/a" },
                                     { label: "Enabled", value: item.isEnabled ? "Yes" : "No" },
+                                    { label: "Configuration owner", value: item.ownership?.owner || "dashboard" },
+                                    { label: "Source key", value: item.ownership?.sourceKey || "n/a" },
                                     { label: "SP Entity ID", value: item.serviceProviderEntityId },
                                     { label: "ACS URL", value: item.assertionConsumerServiceUrl }
                                 ])}
+                                ${item.ownership && !item.ownership.isEditable ? `<div class="callout"><strong>Code owned:</strong> Update federation metadata and policy in the SAML seed. Emergency enable/disable remains available.</div>` : ""}
                                 <form id="import-sso-metadata-${esc(item.id)}" class="nested-form">
                                     <textarea name="metadataXml" placeholder="Paste the Entra federation metadata XML" required></textarea>
-                                    <button type="submit">Import metadata</button>
+                                    <button type="submit" ${item.ownership && !item.ownership.isEditable ? "disabled" : ""}>Import metadata</button>
                                 </form>
+                                <button type="button" data-saml-toggle="${esc(item.id)}" data-enabled="${item.isEnabled ? "true" : "false"}">${item.isEnabled ? "Emergency disable" : "Enable"}</button>
                             `,
                             "No SSO connections yet."
                         )}
@@ -2159,6 +2163,7 @@
             });
 
             organizationSsoConnections.forEach(item => {
+                if (item.ownership && !item.ownership.isEditable) return;
                 bindForm(`import-sso-metadata-${item.id}`, async form => {
                     await fetchJson(`${authApiBasePath}/sso-connections/${item.id}/metadata`, {
                         method: "POST",
@@ -2167,6 +2172,16 @@
                         })
                     });
                     setFlash("success", "Federation metadata imported.");
+                });
+            });
+
+            document.querySelectorAll("[data-saml-toggle]").forEach(button => {
+                button.addEventListener("click", async () => {
+                    const enabled = button.dataset.enabled === "true";
+                    if (enabled && !window.confirm("Disable this SAML connection? New SSO sign-ins will stop until it is enabled again.")) return;
+                    await fetchJson(`${authApiBasePath}/sso-connections/${encodeURIComponent(button.dataset.samlToggle)}/${enabled ? "disable" : "enable"}`, { method: "POST" });
+                    setFlash("success", enabled ? "SAML connection disabled." : "SAML connection enabled.");
+                    await render();
                 });
             });
 
@@ -3497,9 +3512,13 @@
                                 { label: "Organization", value: item.organization },
                                 { label: "Primary domain", value: item.primaryDomain || "n/a" },
                                 { label: "Status", value: `${item.setupStatus} | Enabled: ${item.isEnabled}` },
+                                { label: "Configuration owner", value: item.ownership?.owner || "dashboard" },
+                                { label: "Source key", value: item.ownership?.sourceKey || "n/a" },
                                 { label: "SP Entity ID", value: item.serviceProviderEntityId },
                                 { label: "ACS URL", value: item.assertionConsumerServiceUrl }
                             ])}
+                            ${item.ownership && !item.ownership.isEditable ? `<div class="callout"><strong>Code owned:</strong> Change connection fields in startup configuration. Emergency enable/disable remains available.</div>` : ""}
+                            <button type="button" data-saml-toggle="${esc(item.id)}" data-enabled="${item.isEnabled ? "true" : "false"}">${item.isEnabled ? "Emergency disable" : "Enable"}</button>
                         `,
                         "No SSO connections yet."
                     )}
@@ -3535,6 +3554,16 @@
                 })
             });
             setFlash("success", "Federation metadata imported.");
+        });
+
+        document.querySelectorAll("[data-saml-toggle]").forEach(button => {
+            button.addEventListener("click", async () => {
+                const enabled = button.dataset.enabled === "true";
+                if (enabled && !window.confirm("Disable this SAML connection? New SSO sign-ins will stop until it is enabled again.")) return;
+                await fetchJson(`${authApiBasePath}/sso-connections/${encodeURIComponent(button.dataset.samlToggle)}/${enabled ? "disable" : "enable"}`, { method: "POST" });
+                setFlash("success", enabled ? "SAML connection disabled." : "SAML connection enabled.");
+                await render();
+            });
         });
     }
 

--- a/src/SqlOS/Services/SqlOSBootstrapper.cs
+++ b/src/SqlOS/Services/SqlOSBootstrapper.cs
@@ -79,6 +79,7 @@ public sealed class SqlOSBootstrapper
 
         await _adminService.UpsertSeededClientsAsync(cancellationToken);
         await _adminService.UpsertSeededOidcConnectionsAsync(cancellationToken);
+        await _adminService.UpsertSeededSamlConnectionsAsync(cancellationToken);
         await _adminService.UpsertSeededScimConnectionsAsync(cancellationToken);
         await _adminService.CleanupExpiredScimOperationCommitsAsync(cancellationToken);
         await _adminService.CleanupExpiredTemporaryTokensAsync(cancellationToken);

--- a/tests/SqlOS.IntegrationTests/SamlSeedReconciliationIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/SamlSeedReconciliationIntegrationTests.cs
@@ -1,0 +1,77 @@
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SqlOS.AuthServer.Configuration;
+using SqlOS.AuthServer.Contracts;
+using SqlOS.AuthServer.Models;
+using SqlOS.AuthServer.Services;
+using SqlOS.IntegrationTests.Infrastructure;
+
+namespace SqlOS.IntegrationTests;
+
+[TestClass]
+public sealed class SamlSeedReconciliationIntegrationTests
+{
+    [TestMethod]
+    public async Task ConcurrentRealSqlStartup_CreatesOneSeededSamlConnectionAndOneAudit()
+    {
+        await using var setup = await AspireFixture.CreateIsolatedAuthContextAsync("SamlSeedRace");
+        try
+        {
+            var setupOptions = Options.Create(new SqlOSAuthServerOptions());
+            var setupAdmin = new SqlOSAdminService(setup, setupOptions, new SqlOSCryptoService(setup, setupOptions));
+            var organization = await setupAdmin.CreateOrganizationAsync(new SqlOSCreateOrganizationRequest("Concurrent SAML", "concurrent-saml"));
+            var optionsValue = new SqlOSAuthServerOptions();
+            optionsValue.SeedSamlConnection("workforce", seed =>
+            {
+                seed.OrganizationId = organization.Id;
+                seed.DisplayName = "Concurrent workforce";
+                seed.IdentityProviderEntityId = "urn:concurrent-workforce:idp";
+                seed.SingleSignOnUrl = "https://idp.example.test/sso";
+                seed.X509CertificatePem = CreateCertificatePem();
+            });
+            var connectionString = setup.Database.GetConnectionString()!;
+            var contexts = Enumerable.Range(0, 4).Select(_ => new TestSqlOSDbContext(
+                new DbContextOptionsBuilder<TestSqlOSDbContext>().UseSqlServer(connectionString).Options)).ToList();
+            try
+            {
+                var ready = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                var tasks = contexts.Select(context => Task.Run(async () =>
+                {
+                    var options = Options.Create(optionsValue);
+                    var admin = new SqlOSAdminService(context, options, new SqlOSCryptoService(context, options));
+                    await ready.Task;
+                    await admin.UpsertSeededSamlConnectionsAsync();
+                })).ToArray();
+                ready.SetResult();
+                await Task.WhenAll(tasks).WaitAsync(TimeSpan.FromSeconds(45));
+            }
+            finally
+            {
+                foreach (var context in contexts) await context.DisposeAsync();
+            }
+
+            setup.ChangeTracker.Clear();
+            var connection = await setup.Set<SqlOSSsoConnection>().AsNoTracking().SingleAsync();
+            connection.ConfigurationOwner.Should().Be(SqlOSConfigurationOwners.Code);
+            connection.ConfigurationSourceKey.Should().Be("workforce");
+            (await setup.Set<SqlOSAuditEvent>().CountAsync(x => x.EventType == "configuration.reconciled"
+                && x.DataJson != null && x.DataJson.Contains("saml_connection"))).Should().Be(1);
+        }
+        finally
+        {
+            await setup.Database.EnsureDeletedAsync();
+        }
+    }
+
+    private static string CreateCertificatePem()
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest("CN=ConcurrentSamlSeed", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        using var certificate = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(30));
+        return certificate.ExportCertificatePem();
+    }
+}

--- a/tests/SqlOS.IntegrationTests/SamlServiceIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/SamlServiceIntegrationTests.cs
@@ -12,6 +12,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SqlOS.AuthServer.Configuration;
 using SqlOS.AuthServer.Contracts;
 using SqlOS.AuthServer.Models;
 using SqlOS.AuthServer.Services;
@@ -24,6 +25,57 @@ public sealed class SamlServiceIntegrationTests
 {
     private const string TrustedSamlMfaContext =
         "urn:oasis:names:tc:SAML:2.0:ac:classes:TimeSyncToken";
+
+    [TestMethod]
+    public async Task SeededSamlConnection_CompletesRealSignedLogin()
+    {
+        await using var context = await AspireFixture.CreateIsolatedAuthContextAsync("SeededSamlLogin");
+        try
+        {
+            var optionsValue = new SqlOSAuthServerOptions
+            {
+                Issuer = AspireFixture.Options.Issuer,
+                BasePath = AspireFixture.Options.BasePath
+            };
+            var options = Options.Create(optionsValue);
+            var crypto = new SqlOSCryptoService(context, options, AspireFixture.DataProtectionProvider);
+            var admin = new SqlOSAdminService(context, options, crypto);
+            var saml = new SqlOSSamlService(context, options, admin, crypto);
+            var organization = await admin.CreateOrganizationAsync(new SqlOSCreateOrganizationRequest("Seeded signed login", "seeded-signed-login"));
+            var client = await CreateSamlClientAsync(admin, "seeded-signed");
+            using var rsa = RSA.Create(2048);
+            var certificateRequest = new CertificateRequest("CN=SeededSamlLogin", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+            using var certificate = certificateRequest.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(30));
+            optionsValue.SeedSamlConnection("signed-login", seed =>
+            {
+                seed.OrganizationId = organization.Id;
+                seed.DisplayName = "Seeded signed login";
+                seed.IdentityProviderEntityId = "urn:seeded-signed-login:idp";
+                seed.SingleSignOnUrl = "https://idp.example.test/sso";
+                seed.X509CertificatePem = certificate.ExportCertificatePem();
+                seed.AutoProvisionUsers = true;
+            });
+            await admin.UpsertSeededSamlConnectionsAsync();
+            var connection = await context.Set<SqlOSSsoConnection>().SingleAsync();
+            var flow = await StartSamlRequestAsync(saml, connection.Id, client.ClientId);
+            var response = BuildSignedSamlResponse(
+                certificate,
+                connection.IdentityProviderEntityId,
+                "seeded-user@example.test",
+                "Seeded",
+                "User",
+                flow);
+
+            var redirect = await saml.HandleAcsAsync(connection.Id, response, flow.RelayState, default);
+
+            redirect.Should().StartWith("https://client.example.local/callback");
+            (await context.Set<SqlOSUserEmail>().AnyAsync(x => x.NormalizedEmail == "SEEDED-USER@EXAMPLE.TEST")).Should().BeTrue();
+        }
+        finally
+        {
+            await context.Database.EnsureDeletedAsync();
+        }
+    }
 
     [TestMethod]
     public async Task SamlAuthnContext_WithoutTrustPolicy_DoesNotSatisfyMfa()

--- a/tests/SqlOS.IntegrationTests/SchemaInitializerIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/SchemaInitializerIntegrationTests.cs
@@ -14,7 +14,7 @@ namespace SqlOS.IntegrationTests;
 [TestClass]
 public sealed class SchemaInitializerIntegrationTests
 {
-    private const int CurrentSchemaVersion = 35;
+    private const int CurrentSchemaVersion = 36;
 
     [TestMethod]
     public async Task EnsureSchema_CreatesCoreTables()

--- a/tests/SqlOS.Tests/SqlOSDiscoveryAndSettingsTests.cs
+++ b/tests/SqlOS.Tests/SqlOSDiscoveryAndSettingsTests.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
@@ -28,7 +30,7 @@ public sealed class SqlOSDiscoveryAndSettingsTests
             "Contoso SSO",
             "urn:test:idp",
             "https://idp.example.test/sso",
-            "-----BEGIN CERTIFICATE-----\nTEST\n-----END CERTIFICATE-----",
+            CreateCertificatePem(),
             true,
             false,
             "email",
@@ -67,7 +69,7 @@ public sealed class SqlOSDiscoveryAndSettingsTests
             "Member SSO",
             "urn:member:idp",
             "https://idp.member.test/sso",
-            "-----BEGIN CERTIFICATE-----\nTEST\n-----END CERTIFICATE-----",
+            CreateCertificatePem(),
             false,
             true,
             "email",
@@ -96,7 +98,7 @@ public sealed class SqlOSDiscoveryAndSettingsTests
             "No JIT SSO",
             "urn:nojit:idp",
             "https://idp.nojit.test/sso",
-            "-----BEGIN CERTIFICATE-----\nTEST\n-----END CERTIFICATE-----",
+            CreateCertificatePem(),
             false,
             true,
             "email",
@@ -133,7 +135,7 @@ public sealed class SqlOSDiscoveryAndSettingsTests
             "Password SSO",
             "urn:password:idp",
             "https://idp.password.test/sso",
-            "-----BEGIN CERTIFICATE-----\nTEST\n-----END CERTIFICATE-----",
+            CreateCertificatePem(),
             false,
             false,
             "email",
@@ -207,5 +209,13 @@ public sealed class SqlOSDiscoveryAndSettingsTests
         userEmail.VerifiedAt = DateTime.UtcNow;
         await context.SaveChangesAsync();
         return user;
+    }
+
+    private static string CreateCertificatePem()
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest("CN=SqlOSDiscoveryIdP", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        using var certificate = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(30));
+        return certificate.ExportCertificatePem();
     }
 }

--- a/tests/SqlOS.Tests/SqlOSSamlConnectionSeedingTests.cs
+++ b/tests/SqlOS.Tests/SqlOSSamlConnectionSeedingTests.cs
@@ -89,6 +89,45 @@ public sealed class SqlOSSamlConnectionSeedingTests
     }
 
     [TestMethod]
+    public async Task Seed_UpdateCannotCollideWithAnotherEntityIdOrMoveOrganizations()
+    {
+        await using var context = CreateContext();
+        var certificate = CreateCertificatePem();
+        var optionsValue = new SqlOSAuthServerOptions();
+        var options = Options.Create(optionsValue);
+        var admin = new SqlOSAdminService(context, options, TestCryptoService.Create(context, options));
+        var firstOrganization = await admin.CreateOrganizationAsync(new SqlOSCreateOrganizationRequest("First", "first"));
+        var secondOrganization = await admin.CreateOrganizationAsync(new SqlOSCreateOrganizationRequest("Second", "second"));
+        optionsValue.SeedSamlConnection("first", seed =>
+        {
+            seed.OrganizationId = firstOrganization.Id;
+            seed.DisplayName = "First SSO";
+            seed.IdentityProviderEntityId = "urn:first:idp";
+            seed.SingleSignOnUrl = "https://first.example.test/sso";
+            seed.X509CertificatePem = certificate;
+        });
+        await admin.UpsertSeededSamlConnectionsAsync();
+        await admin.CreateSsoConnectionAsync(new SqlOSCreateSsoConnectionRequest(
+            secondOrganization.Id, "Second SSO", "urn:second:idp", "https://second.example.test/sso", certificate,
+            true, false, "email", "first_name", "last_name"));
+
+        optionsValue.SamlConnectionSeeds[0].IdentityProviderEntityId = "urn:second:idp";
+        await FluentActions.Invoking(() => admin.UpsertSeededSamlConnectionsAsync())
+            .Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*same IdP entity ID*");
+
+        optionsValue.SamlConnectionSeeds[0].IdentityProviderEntityId = "urn:first:idp";
+        optionsValue.SamlConnectionSeeds[0].OrganizationId = secondOrganization.Id;
+        await FluentActions.Invoking(() => admin.UpsertSeededSamlConnectionsAsync())
+            .Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*cannot be moved*");
+
+        var original = await context.Set<SqlOSSsoConnection>().SingleAsync(x => x.ConfigurationSourceKey == "first");
+        original.OrganizationId.Should().Be(firstOrganization.Id);
+        original.IdentityProviderEntityId.Should().Be("urn:first:idp");
+    }
+
+    [TestMethod]
     public async Task Seed_RejectsExpiredCertificateAndMixedMetadataModes()
     {
         await using var context = CreateContext();

--- a/tests/SqlOS.Tests/SqlOSSamlConnectionSeedingTests.cs
+++ b/tests/SqlOS.Tests/SqlOSSamlConnectionSeedingTests.cs
@@ -1,0 +1,128 @@
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SqlOS.AuthServer.Configuration;
+using SqlOS.AuthServer.Contracts;
+using SqlOS.AuthServer.Models;
+using SqlOS.AuthServer.Services;
+using SqlOS.Tests.Infrastructure;
+
+namespace SqlOS.Tests;
+
+[TestClass]
+public sealed class SqlOSSamlConnectionSeedingTests
+{
+    [TestMethod]
+    public async Task Seed_CreateRerunRenameAndOrphan_AreOwnershipSafe()
+    {
+        await using var context = CreateContext();
+        var certificate = CreateCertificatePem();
+        var optionsValue = new SqlOSAuthServerOptions();
+        var options = Options.Create(optionsValue);
+        var admin = new SqlOSAdminService(context, options, TestCryptoService.Create(context, options));
+        var organization = await admin.CreateOrganizationAsync(new SqlOSCreateOrganizationRequest("Seed org", "seed-org"));
+        var dashboardOrganization = await admin.CreateOrganizationAsync(new SqlOSCreateOrganizationRequest("Dashboard org", "dashboard-org"));
+        var dashboard = await admin.CreateSsoConnectionAsync(new SqlOSCreateSsoConnectionRequest(
+            dashboardOrganization.Id, "Dashboard SSO", "urn:dashboard:idp", "https://dashboard-idp.example.test/sso",
+            certificate, true, false, "email", "first_name", "last_name"));
+        optionsValue.SeedSamlConnection("workforce", seed =>
+        {
+            seed.OrganizationSlug = organization.Slug;
+            seed.DisplayName = "Workforce SSO";
+            seed.IdentityProviderEntityId = "urn:workforce:idp";
+            seed.SingleSignOnUrl = "https://idp.example.test/sso";
+            seed.X509CertificatePem = certificate;
+            seed.PrimaryDomain = "example.test";
+        });
+
+        await admin.UpsertSeededSamlConnectionsAsync();
+        await admin.UpsertSeededSamlConnectionsAsync();
+        var seeded = await context.Set<SqlOSSsoConnection>().SingleAsync(x => x.ConfigurationSourceKey == "workforce");
+        seeded.ConfigurationOwner.Should().Be(SqlOSConfigurationOwners.Code);
+        seeded.DisplayName.Should().Be("Workforce SSO");
+        organization.PrimaryDomain.Should().Be("example.test");
+        (await context.Set<SqlOSSsoConnection>().CountAsync()).Should().Be(2);
+        (await context.Set<SqlOSAuditEvent>().CountAsync(x => x.EventType == "configuration.reconciled")).Should().Be(1);
+
+        seeded.IsEnabled = false;
+        optionsValue.SamlConnectionSeeds[0].DisplayName = "Renamed Workforce SSO";
+        await context.SaveChangesAsync();
+        await admin.UpsertSeededSamlConnectionsAsync();
+        seeded.DisplayName.Should().Be("Renamed Workforce SSO");
+        seeded.IsEnabled.Should().BeFalse("operator emergency disable survives restart");
+        (await context.Set<SqlOSSsoConnection>().SingleAsync(x => x.Id == dashboard.Id)).DisplayName.Should().Be("Dashboard SSO");
+
+        optionsValue.SamlConnectionSeeds.Clear();
+        await admin.UpsertSeededSamlConnectionsAsync();
+        seeded.ConfigurationOrphanedAt.Should().NotBeNull();
+        seeded.IsEnabled.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public async Task Seed_DoesNotAdoptDashboardConnectionWithSameEntityId()
+    {
+        await using var context = CreateContext();
+        var certificate = CreateCertificatePem();
+        var optionsValue = new SqlOSAuthServerOptions();
+        var options = Options.Create(optionsValue);
+        var admin = new SqlOSAdminService(context, options, TestCryptoService.Create(context, options));
+        var organization = await admin.CreateOrganizationAsync(new SqlOSCreateOrganizationRequest("Org", "org"));
+        await admin.CreateSsoConnectionAsync(new SqlOSCreateSsoConnectionRequest(
+            organization.Id, "Manual", "urn:collision:idp", "https://idp.example.test/sso", certificate,
+            true, false, "email", "first_name", "last_name"));
+        optionsValue.SeedSamlConnection("collision", seed =>
+        {
+            seed.OrganizationId = organization.Id;
+            seed.DisplayName = "Seeded";
+            seed.IdentityProviderEntityId = "urn:collision:idp";
+            seed.SingleSignOnUrl = "https://idp.example.test/sso";
+            seed.X509CertificatePem = certificate;
+        });
+
+        await FluentActions.Invoking(() => admin.UpsertSeededSamlConnectionsAsync())
+            .Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*existing 'dashboard' connection*");
+        (await context.Set<SqlOSSsoConnection>().SingleAsync()).ConfigurationOwner.Should().Be(SqlOSConfigurationOwners.Dashboard);
+    }
+
+    [TestMethod]
+    public async Task Seed_RejectsExpiredCertificateAndMixedMetadataModes()
+    {
+        await using var context = CreateContext();
+        var optionsValue = new SqlOSAuthServerOptions();
+        var options = Options.Create(optionsValue);
+        var admin = new SqlOSAdminService(context, options, TestCryptoService.Create(context, options));
+        var organization = await admin.CreateOrganizationAsync(new SqlOSCreateOrganizationRequest("Org", "org"));
+        optionsValue.SeedSamlConnection("expired", seed =>
+        {
+            seed.OrganizationId = organization.Id;
+            seed.DisplayName = "Expired";
+            seed.IdentityProviderEntityId = "urn:expired:idp";
+            seed.SingleSignOnUrl = "https://idp.example.test/sso";
+            seed.X509CertificatePem = CreateCertificatePem(DateTimeOffset.UtcNow.AddDays(-10), DateTimeOffset.UtcNow.AddDays(-1));
+        });
+
+        await FluentActions.Invoking(() => admin.UpsertSeededSamlConnectionsAsync())
+            .Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*expired*");
+    }
+
+    private static string CreateCertificatePem(
+        DateTimeOffset? notBefore = null,
+        DateTimeOffset? notAfter = null)
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest("CN=SqlOSSamlSeed", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        using var certificate = request.CreateSelfSigned(
+            notBefore ?? DateTimeOffset.UtcNow.AddDays(-1),
+            notAfter ?? DateTimeOffset.UtcNow.AddDays(30));
+        return certificate.ExportCertificatePem();
+    }
+
+    private static TestSqlOSInMemoryDbContext CreateContext()
+        => new(new DbContextOptionsBuilder<TestSqlOSInMemoryDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N")).Options);
+}

--- a/web/content/docs/authserver/saml-sso.mdx
+++ b/web/content/docs/authserver/saml-sso.mdx
@@ -11,10 +11,36 @@ For a complete customer IT administrator journey, use [Let customer admins set u
 
 ## Setup
 
-You can configure SAML in two ways:
+You can configure SAML in three ways:
 
+- **Code-first setup**: your application declares a stable-keyed connection that SqlOS reconciles on startup.
 - **Platform-admin setup**: your operator creates the draft and imports metadata from the dashboard or admin API.
 - **Delegated org-admin setup**: your operator or host app creates a one-organization portal session, sends the setup link to the customer IT admin, and lets that admin complete the same SAML setup without access to the global dashboard.
+
+### Code-first connection
+
+Use a seed when the organization and IdP configuration are deployment topology that should be reproducible in source control. Keep the public signing certificate or metadata in host configuration; SqlOS does not call a cloud key service or fetch a remote metadata URL.
+
+```csharp
+var metadataXml = builder.Configuration["SqlOS:Saml:Acme:MetadataXml"]
+    ?? throw new InvalidOperationException("Acme SAML metadata is not configured.");
+
+options.AuthServer.SeedSamlConnection("acme-workforce", saml =>
+{
+    saml.OrganizationSlug = "acme";
+    saml.DisplayName = "Acme workforce SSO";
+    saml.MetadataXml = metadataXml;
+    saml.PrimaryDomain = "acme.com";
+    saml.AutoProvisionUsers = false;
+    saml.AutoLinkByEmail = true;
+});
+```
+
+You can provide `IdentityProviderEntityId`, `SingleSignOnUrl`, and `X509CertificatePem` instead of `MetadataXml`. Do not provide both modes. The certificate is public verification material, but treating deployment-specific metadata as configuration keeps customer topology out of a shared source tree.
+
+The stable key—not the display name—owns reconciliation. Code-owned fields update on restart, renames preserve the same record, and unrelated dashboard-owned connections are never adopted. Removing a seed marks the record orphaned without deleting or silently disabling a live enterprise connection. A dashboard emergency disable survives restart; setting `IsEnabled = false` in code can disable an existing connection, while `true` only controls initial creation and does not undo an operator disable.
+
+The dashboard labels code-owned connections and makes their metadata editor read-only. Operators can still emergency-disable or re-enable the connection. Metadata changes are normalized through the same parser used by the dashboard/API, must contain an absolute HTTPS SSO URL and a currently valid X.509 certificate, and are written to the audit log without certificate contents.
 
 ### 1. Create an SSO draft
 
@@ -220,6 +246,7 @@ When `/test` includes `clientId` and `redirectUri`, it must also include a fresh
 | `autoLinkByEmail` | `true` for portal-created connections | Require existing verified org members to enroll and sign in through SSO |
 | `trustUpstreamMfa` | `false` | Allow this connection to satisfy MFA only through accepted signed `AuthnContextClassRef` values |
 | `acceptedAuthnContextClassRefs` | empty | Exact SAML authentication-context URIs accepted as upstream MFA |
+| `SamlConnectionSeeds` | empty | Stable-keyed code-first upstream SAML connections; configured with `SeedSamlConnection` |
 | `SsoPortal.EnableApi` | `true` | Expose portal and headless setup APIs |
 | `SsoPortal.UseHostedPortal` | `true` | Serve the bundled setup portal |
 | `SsoPortal.BuildUiUrl` | `null` | Redirect opened setup sessions to a host-owned UI |

--- a/web/content/docs/guides/saml-sso.mdx
+++ b/web/content/docs/guides/saml-sso.mdx
@@ -15,8 +15,10 @@ section: guides
 You'll learn how to create a SAML connection, share metadata with your customer’s IdP, and route users by email domain.
 
 <Callout type="info" title="Choose who runs setup">
-  This guide is the **operator-managed** path: your platform team uses the protected SqlOS dashboard. To give a customer IT admin a one-time, one-organization portal instead, follow [Let customer admins set up enterprise SSO](/docs/guides/customer-managed-sso).
+  Use code-first seeds for repeatable deployment-owned connections, this **operator-managed** dashboard path for platform-owned setup, or the [customer-managed SSO guide](/docs/guides/customer-managed-sso) for a one-time organization-scoped portal. All three use the same SAML runtime and validation.
 </Callout>
+
+For code-first setup, call `options.AuthServer.SeedSamlConnection("stable-key", ...)` and provide either metadata XML from host configuration or explicit entity ID, HTTPS SSO URL, and public signing certificate. The dashboard shows the result as code owned and leaves emergency enable/disable available; edit other fields in the seed. See [SAML SSO: Code-first connection](/docs/authserver/saml-sso#code-first-connection) for the compiled example and reconciliation rules.
 
 <Callout type="info" title="Prerequisites">
   - An organization in SqlOS with a **primary email domain** set


### PR DESCRIPTION
Closes #212.

## What changed
- adds stable-keyed, organization-bound SAML connection seeds with metadata XML or explicit IdP settings
- reconciles code-owned records transactionally and surfaces ownership/orphans without overwriting dashboard-owned connections
- preserves emergency dashboard disablement across restarts and exposes audited enable/disable actions
- shares normalization and certificate validation between code, service, and dashboard paths
- documents the code-first, programmable administration, and dashboard control planes with a compiled example

## Security and ergonomics
- no external key, metadata-fetching, or cloud-service dependency
- seeded SAML is opt-in; existing dashboard configuration continues to work
- invalid, expired, or not-yet-valid IdP certificates fail startup clearly
- missing seeds become visible orphans rather than being silently deleted or disabled

## Validation
- 654 unit tests (one pre-existing OIDC parity projection failure discovered and repaired in this PR; focused rerun green)
- real SQL concurrent reconciliation test (4 startup contexts)
- real signed SAML login through a seeded connection
- `./scripts/docs-check.sh`
- compiled documentation snippet and dashboard JavaScript syntax check

An adversarial review round will be recorded on this PR before merge.
