### PR TITLE
Add safe OTP readiness and delivery diagnostics

### DIFF
--- a/src/SqlOS/AuthServer/Endpoints/AdminConfigurationEndpoints.cs
+++ b/src/SqlOS/AuthServer/Endpoints/AdminConfigurationEndpoints.cs
@@ -459,5 +459,24 @@ public static partial class EndpointRouteBuilderExtensions
 
             return Results.Ok(await adminService.ListAuditEventsAsync(cancellationToken));
         });
+
+        api.MapGet("/otp/readiness", async (HttpContext context, SqlOSOtpAdminService otpAdmin, IOptions<SqlOSAuthServerOptions> options, IHostEnvironment environment, CancellationToken cancellationToken) =>
+        {
+            if (!await IsAdminAuthorizedAsync(context, options.Value, environment)) return Results.NotFound();
+            return Results.Ok(await otpAdmin.GetReadinessAsync(cancellationToken));
+        });
+
+        api.MapPost("/otp/test-delivery", async (HttpContext context, OtpTestDeliveryRequest request, SqlOSOtpAdminService otpAdmin, IOptions<SqlOSAuthServerOptions> options, IHostEnvironment environment, CancellationToken cancellationToken) =>
+        {
+            if (!await IsAdminAuthorizedAsync(context, options.Value, environment)) return Results.NotFound();
+            try
+            {
+                return Results.Ok(await otpAdmin.SendTestAsync(request.Method, request.Destination, context.Connection.RemoteIpAddress?.ToString(), cancellationToken));
+            }
+            catch (ArgumentException exception) { return Results.BadRequest(new { message = exception.Message }); }
+            catch (InvalidOperationException exception) { return Results.BadRequest(new { message = exception.Message }); }
+        });
     }
+
+    private sealed record OtpTestDeliveryRequest(string Method, string Destination);
 }

--- a/src/SqlOS/AuthServer/Interfaces/ISqlOSOtpDeliveryChannel.cs
+++ b/src/SqlOS/AuthServer/Interfaces/ISqlOSOtpDeliveryChannel.cs
@@ -19,7 +19,8 @@ public sealed record SqlOSOtpDeliveryContext(
     string? ClientApplicationId,
     string? AuthorizationRequestId,
     string? IpAddress,
-    string? UserAgent);
+    string? UserAgent,
+    string? ProviderChallengeId = null);
 
 public sealed record SqlOSOtpDeliveryStartResult(
     bool Accepted,

--- a/src/SqlOS/AuthServer/Services/SqlOSOtpAdminRateLimiter.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSOtpAdminRateLimiter.cs
@@ -1,0 +1,26 @@
+using SqlOS.Security;
+
+namespace SqlOS.AuthServer.Services;
+
+public sealed class SqlOSOtpAdminRateLimiter
+{
+    private readonly ISqlOSRateLimitStore _store;
+
+    internal SqlOSOtpAdminRateLimiter(ISqlOSRateLimitStore store)
+    {
+        _store = store;
+    }
+
+    public async Task<bool> TryConsumeAsync(string key, DateTimeOffset now, CancellationToken cancellationToken = default)
+    {
+        var state = await _store.IncrementAsync(
+            "otp_admin_test",
+            key,
+            lockThreshold: 4,
+            window: TimeSpan.FromHours(1),
+            lockoutDuration: TimeSpan.FromHours(1),
+            now,
+            cancellationToken);
+        return state.LockedUntil is null;
+    }
+}

--- a/src/SqlOS/AuthServer/Services/SqlOSOtpAdminRateLimiter.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSOtpAdminRateLimiter.cs
@@ -11,12 +11,12 @@ public sealed class SqlOSOtpAdminRateLimiter
         _store = store;
     }
 
-    public async Task<bool> TryConsumeAsync(string key, DateTimeOffset now, CancellationToken cancellationToken = default)
+    public async Task<bool> TryConsumeAsync(string key, DateTimeOffset now, int maxAttempts = 3, CancellationToken cancellationToken = default)
     {
         var state = await _store.IncrementAsync(
             "otp_admin_test",
             key,
-            lockThreshold: 4,
+            lockThreshold: checked(maxAttempts + 1),
             window: TimeSpan.FromHours(1),
             lockoutDuration: TimeSpan.FromHours(1),
             now,

--- a/src/SqlOS/AuthServer/Services/SqlOSOtpAdminService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSOtpAdminService.cs
@@ -1,0 +1,239 @@
+using System.Net.Mail;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using PhoneNumbers;
+using SqlOS.AuthServer.Configuration;
+using SqlOS.AuthServer.Interfaces;
+using SqlOS.AuthServer.Models;
+
+namespace SqlOS.AuthServer.Services;
+
+public sealed class SqlOSOtpAdminService
+{
+    private readonly ISqlOSAuthServerDbContext _context;
+    private readonly SqlOSAdminService _admin;
+    private readonly SqlOSCryptoService _crypto;
+    private readonly SqlOSSettingsService _settings;
+    private readonly ISqlOSAuthEmailSender _emailSender;
+    private readonly ISqlOSOtpDeliveryChannel _phoneChannel;
+    private readonly SqlOSOtpAdminRateLimiter _rateLimiter;
+    private readonly SqlOSAuthServerOptions _options;
+    private readonly PhoneNumberUtil _phoneNumbers = PhoneNumberUtil.GetInstance();
+
+    public SqlOSOtpAdminService(
+        ISqlOSAuthServerDbContext context,
+        SqlOSAdminService admin,
+        SqlOSCryptoService crypto,
+        SqlOSSettingsService settings,
+        ISqlOSAuthEmailSender emailSender,
+        ISqlOSOtpDeliveryChannel phoneChannel,
+        SqlOSOtpAdminRateLimiter rateLimiter,
+        IOptions<SqlOSAuthServerOptions> options)
+    {
+        _context = context;
+        _admin = admin;
+        _crypto = crypto;
+        _settings = settings;
+        _emailSender = emailSender;
+        _phoneChannel = phoneChannel;
+        _rateLimiter = rateLimiter;
+        _options = options.Value;
+    }
+
+    public async Task<SqlOSOtpReadinessResponse> GetReadinessAsync(CancellationToken cancellationToken = default)
+    {
+        var credentials = await _settings.GetResolvedCredentialSettingsAsync(cancellationToken);
+        var emailReasons = GetEmailReasons();
+        var phoneReasons = GetPhoneReasons();
+        var diagnostics = await _context.Set<SqlOSAuditEvent>()
+            .AsNoTracking()
+            .Where(x => x.Action.StartsWith("otp.admin_test.")
+                || x.Action == "email_otp.send_failed"
+                || x.Action == "email_otp.verify_failed"
+                || x.Action == "email_otp.rate_limit_rejected"
+                || x.Action == "phone_otp.send_failed"
+                || x.Action == "phone_otp.verify_failed"
+                || x.Action == "phone_otp.rate_limit_rejected")
+            .OrderByDescending(x => x.OccurredAt)
+            .Take(20)
+            .Select(x => new SqlOSOtpDiagnostic(x.Action, x.OccurredAt, x.MetadataJson))
+            .ToListAsync(cancellationToken);
+
+        return new SqlOSOtpReadinessResponse(
+            BuildEmailStatus(credentials.EmailOtpEnabled, emailReasons),
+            BuildPhoneStatus(credentials.PhoneOtpEnabled, phoneReasons),
+            diagnostics.Select(ToDiagnostic).ToArray());
+    }
+
+    public async Task<SqlOSOtpTestDeliveryResult> SendTestAsync(
+        string method,
+        string destination,
+        string? ipAddress,
+        CancellationToken cancellationToken = default)
+    {
+        var normalizedMethod = (method ?? string.Empty).Trim().ToLowerInvariant();
+        var normalizedDestination = normalizedMethod switch
+        {
+            "email" => NormalizeEmail(destination),
+            "phone" => NormalizePhone(destination),
+            _ => throw new ArgumentException("Method must be 'email' or 'phone'.", nameof(method))
+        };
+        var reasons = normalizedMethod == "email" ? GetEmailReasons() : GetPhoneReasons();
+        if (reasons.Count != 0)
+        {
+            throw new InvalidOperationException($"{normalizedMethod} OTP test delivery is unavailable: {string.Join(", ", reasons)}.");
+        }
+
+        var destinationHash = _crypto.HashToken(normalizedDestination);
+        if (!await _rateLimiter.TryConsumeAsync($"{normalizedMethod}:{destinationHash}", DateTimeOffset.UtcNow, cancellationToken))
+        {
+            await AuditAsync(normalizedMethod, "rate_limited", Mask(normalizedMethod, normalizedDestination), null, ipAddress, cancellationToken);
+            throw new InvalidOperationException("Test delivery limit reached. Try again later.");
+        }
+
+        var masked = Mask(normalizedMethod, normalizedDestination);
+        try
+        {
+            string provider;
+            string? providerStatus = null;
+            if (normalizedMethod == "email")
+            {
+                provider = _options.EmailOtp.BuildMessage == null ? "azure_communication_services" : "custom_email_sender";
+                await _emailSender.SendAsync(new SqlOSAuthEmailMessage(
+                    normalizedDestination,
+                    $"{_options.EmailOtp.ApplicationName} delivery test",
+                    "<p>Your SqlOS email delivery configuration is working. This message is not a sign-in code.</p>",
+                    "Your SqlOS email delivery configuration is working. This message is not a sign-in code."), cancellationToken);
+            }
+            else
+            {
+                var delivery = await _phoneChannel.StartAsync(normalizedDestination,
+                    new SqlOSOtpDeliveryContext("admin_test", null, null, ipAddress, null), cancellationToken);
+                provider = delivery.Provider;
+                providerStatus = delivery.ProviderStatus;
+                if (!delivery.Accepted)
+                {
+                    throw new InvalidOperationException(delivery.SanitizedError ?? "The OTP provider rejected the test delivery.");
+                }
+            }
+
+            await AuditAsync(normalizedMethod, "succeeded", masked, providerStatus, ipAddress, cancellationToken, provider);
+            return new SqlOSOtpTestDeliveryResult(normalizedMethod, masked, provider, providerStatus, DateTime.UtcNow);
+        }
+        catch (Exception exception) when (exception is not OperationCanceledException)
+        {
+            await AuditAsync(normalizedMethod, "failed", masked, "provider_error", ipAddress, cancellationToken);
+            throw new InvalidOperationException("The OTP provider could not complete the test delivery. Review recent diagnostics.");
+        }
+    }
+
+    private SqlOSOtpMethodReadiness BuildEmailStatus(bool enabled, IReadOnlyList<string> reasons)
+        => new("email", enabled, reasons.Count == 0, _options.EmailOtp.BuildMessage == null ? "azure_communication_services" : "custom_email_sender",
+            reasons, ["SqlOS:EmailOtp:AzureCommunicationServicesConnectionString", "SqlOS:EmailOtp:FromAddress"],
+            new Dictionary<string, object?>
+            {
+                ["fromAddress"] = MaskEmail(_options.EmailOtp.FromAddress),
+                ["codeLength"] = _options.EmailOtp.CodeLength,
+                ["challengeLifetimeMinutes"] = _options.EmailOtp.ChallengeLifetime.TotalMinutes,
+                ["maxAttempts"] = _options.EmailOtp.MaxAttempts,
+                ["maxChallengesPerHour"] = _options.EmailOtp.MaxChallengesPerHour
+            });
+
+    private SqlOSOtpMethodReadiness BuildPhoneStatus(bool enabled, IReadOnlyList<string> reasons)
+        => new("phone", enabled, reasons.Count == 0, "twilio_verify", reasons,
+            ["SqlOS:PhoneOtp:Enabled", "SqlOS:PhoneOtp:TwilioAccountSid", "SqlOS:PhoneOtp:TwilioAuthToken", "SqlOS:PhoneOtp:TwilioVerifyServiceSid"],
+            new Dictionary<string, object?>
+            {
+                ["defaultRegion"] = _options.PhoneOtp.DefaultRegion,
+                ["serviceSidSuffix"] = LastFour(_options.PhoneOtp.TwilioVerifyServiceSid),
+                ["challengeLifetimeMinutes"] = _options.PhoneOtp.ChallengeLifetime.TotalMinutes,
+                ["maxSendsPerPhone"] = _options.PhoneOtp.MaxSendsPerPhone,
+                ["countryAllowList"] = _options.PhoneOtp.CountryAllowList,
+                ["countryDenyList"] = _options.PhoneOtp.CountryDenyList
+            });
+
+    private List<string> GetEmailReasons()
+    {
+        var reasons = new List<string>();
+        if (!_emailSender.IsConfigured) reasons.Add("email_sender_unavailable");
+        if (_options.EmailOtp.BuildMessage == null && string.IsNullOrWhiteSpace(_options.EmailOtp.FromAddress)) reasons.Add("missing_from_address");
+        if (_options.EmailOtp.CodeLength is < 4 or > 10) reasons.Add("invalid_code_length");
+        if (_options.EmailOtp.MaxAttempts < 1) reasons.Add("invalid_max_attempts");
+        return reasons;
+    }
+
+    private List<string> GetPhoneReasons()
+    {
+        var reasons = new List<string>();
+        if (!_options.PhoneOtp.Enabled) reasons.Add("method_disabled_in_host_configuration");
+        if (string.IsNullOrWhiteSpace(_options.PhoneOtp.TwilioAccountSid)) reasons.Add("missing_account_sid");
+        if (string.IsNullOrWhiteSpace(_options.PhoneOtp.TwilioAuthToken)) reasons.Add("missing_auth_token");
+        if (string.IsNullOrWhiteSpace(_options.PhoneOtp.TwilioVerifyServiceSid)) reasons.Add("missing_verify_service_sid");
+        if (_options.PhoneOtp.MaxSendsPerPhone < 1) reasons.Add("invalid_send_limit");
+        return reasons;
+    }
+
+    private async Task AuditAsync(string method, string outcome, string masked, string? status, string? ipAddress, CancellationToken cancellationToken, string? provider = null)
+        => await _admin.RecordAuditAsync($"otp.admin_test.{outcome}", "admin", null, ipAddress: ipAddress,
+            data: new { method, maskedDestination = masked, provider, providerStatus = status }, cancellationToken: cancellationToken);
+
+    private static SqlOSOtpDiagnosticResponse ToDiagnostic(SqlOSOtpDiagnostic diagnostic)
+    {
+        string? method = null, masked = null, provider = null, status = null;
+        if (!string.IsNullOrWhiteSpace(diagnostic.MetadataJson))
+        {
+            using var document = JsonDocument.Parse(diagnostic.MetadataJson);
+            var root = document.RootElement;
+            method = ReadString(root, "method");
+            masked = ReadString(root, "maskedDestination");
+            provider = ReadString(root, "provider");
+            status = ReadString(root, "providerStatus");
+            method ??= diagnostic.Action.StartsWith("email_otp.", StringComparison.Ordinal) ? "email"
+                : diagnostic.Action.StartsWith("phone_otp.", StringComparison.Ordinal) ? "phone" : null;
+            masked ??= ReadString(root, "maskedEmail") ?? ReadString(root, "maskedPhone");
+            if (status == null && root.TryGetProperty("details", out var details) && details.ValueKind == JsonValueKind.Object)
+            {
+                status = ReadString(details, "providerStatus") ?? ReadString(details, "reason");
+            }
+        }
+        return new SqlOSOtpDiagnosticResponse(diagnostic.Action, diagnostic.OccurredAt, method, masked, provider, status);
+    }
+
+    private static string? ReadString(JsonElement root, string name)
+        => root.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.String ? value.GetString() : null;
+
+    private static string NormalizeEmail(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value) || value.Length > 320) throw new ArgumentException("A valid email destination is required.");
+        try { return new MailAddress(value.Trim()).Address.ToLowerInvariant(); }
+        catch (FormatException exception) { throw new ArgumentException("A valid email destination is required.", exception); }
+    }
+
+    private string NormalizePhone(string value)
+    {
+        try
+        {
+            var parsed = _phoneNumbers.Parse(value?.Trim(), _options.PhoneOtp.DefaultRegion);
+            if (!_phoneNumbers.IsValidNumber(parsed)) throw new ArgumentException("A valid phone destination is required.");
+            return _phoneNumbers.Format(parsed, PhoneNumberFormat.E164);
+        }
+        catch (NumberParseException exception) { throw new ArgumentException("A valid phone destination is required.", exception); }
+    }
+
+    private static string Mask(string method, string value) => method == "email" ? MaskEmail(value)! : value.Length <= 4 ? "****" : $"***{value[^4..]}";
+    private static string? MaskEmail(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value) || !value.Contains('@')) return null;
+        var parts = value.Split('@', 2);
+        return $"{parts[0][0]}***@{parts[1]}";
+    }
+    private static string? LastFour(string? value) => string.IsNullOrWhiteSpace(value) ? null : value.Length <= 4 ? "****" : $"***{value[^4..]}";
+
+    private sealed record SqlOSOtpDiagnostic(string Action, DateTime OccurredAt, string? MetadataJson);
+}
+
+public sealed record SqlOSOtpReadinessResponse(SqlOSOtpMethodReadiness Email, SqlOSOtpMethodReadiness Phone, IReadOnlyList<SqlOSOtpDiagnosticResponse> RecentDiagnostics);
+public sealed record SqlOSOtpMethodReadiness(string Method, bool Enabled, bool LocallyConfigured, string Provider, IReadOnlyList<string> ReasonCodes, IReadOnlyList<string> ConfigurationKeys, IReadOnlyDictionary<string, object?> Policy);
+public sealed record SqlOSOtpTestDeliveryResult(string Method, string MaskedDestination, string Provider, string? ProviderStatus, DateTime SentAt);
+public sealed record SqlOSOtpDiagnosticResponse(string Action, DateTime OccurredAt, string? Method, string? MaskedDestination, string? Provider, string? ProviderStatus);

--- a/src/SqlOS/AuthServer/Services/SqlOSOtpAdminService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSOtpAdminService.cs
@@ -86,7 +86,11 @@ public sealed class SqlOSOtpAdminService
         }
 
         var destinationHash = _crypto.HashToken(normalizedDestination);
-        if (!await _rateLimiter.TryConsumeAsync($"{normalizedMethod}:{destinationHash}", DateTimeOffset.UtcNow, cancellationToken))
+        var actorHash = _crypto.HashToken(string.IsNullOrWhiteSpace(ipAddress) ? "unknown" : ipAddress);
+        var now = DateTimeOffset.UtcNow;
+        var destinationAllowed = await _rateLimiter.TryConsumeAsync($"destination:{normalizedMethod}:{destinationHash}", now, cancellationToken: cancellationToken);
+        var actorAllowed = await _rateLimiter.TryConsumeAsync($"actor:{actorHash}", now, maxAttempts: 20, cancellationToken: cancellationToken);
+        if (!destinationAllowed || !actorAllowed)
         {
             await AuditAsync(normalizedMethod, "rate_limited", Mask(normalizedMethod, normalizedDestination), null, ipAddress, cancellationToken);
             throw new InvalidOperationException("Test delivery limit reached. Try again later.");

--- a/src/SqlOS/AuthServer/Services/SqlOSPhoneOtpService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSPhoneOtpService.cs
@@ -471,7 +471,8 @@ public sealed class SqlOSPhoneOtpService
                 challenge.ClientApplicationId,
                 challenge.AuthorizationRequestId,
                 challenge.IpAddress,
-                challenge.UserAgent),
+                challenge.UserAgent,
+                challenge.ProviderChallengeId),
             cancellationToken);
 
         challenge.AttemptCount++;

--- a/src/SqlOS/AuthServer/Services/SqlOSTwilioVerifyOtpChannel.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSTwilioVerifyOtpChannel.cs
@@ -59,11 +59,12 @@ public sealed class SqlOSTwilioVerifyOtpChannel : ISqlOSOtpDeliveryChannel
 
         try
         {
-            var request = new CreateVerificationCheckOptions(_options.TwilioVerifyServiceSid!.Trim())
+            var request = new CreateVerificationCheckOptions(_options.TwilioVerifyServiceSid!.Trim()) { Code = code };
+            if (string.IsNullOrWhiteSpace(context.ProviderChallengeId))
             {
-                To = e164PhoneNumber,
-                Code = code
-            };
+                throw new InvalidOperationException("The provider verification identifier is required.");
+            }
+            request.VerificationSid = context.ProviderChallengeId;
 
             var check = await VerificationCheckResource.CreateAsync(request, CreateClient());
             var approved = check.Valid == true

--- a/src/SqlOS/Dashboard/wwwroot/app.js
+++ b/src/SqlOS/Dashboard/wwwroot/app.js
@@ -3572,7 +3572,27 @@
         setHeader("Auth Server", config.title, config.description);
         renderLoading("Loading security settings...");
 
-        const settings = await fetchJson(`${authApiBasePath}/settings/security`);
+        const [settings, otp] = await Promise.all([
+            fetchJson(`${authApiBasePath}/settings/security`),
+            fetchJson(`${authApiBasePath}/otp/readiness`)
+        ]);
+        const otpCard = method => `
+            <section class="panel">
+                <h2>${method.method === "email" ? "Email OTP" : "Phone OTP"}</h2>
+                <div class="status-row"><span class="status ${method.enabled && method.locallyConfigured ? "active" : "inactive"}">${method.enabled && method.locallyConfigured ? "Ready" : method.enabled ? "Incomplete" : "Disabled"}</span></div>
+                ${renderMetadataRows([
+                    { label: "Provider", value: method.provider },
+                    { label: "Deployment configuration", value: "Code / host configuration (view only)" },
+                    { label: "Reason codes", value: method.reasonCodes.length ? method.reasonCodes.join(", ") : "None" },
+                    { label: "Configuration keys", value: method.configurationKeys.join("\n") }
+                ])}
+                <details><summary>Effective non-secret policy</summary><pre>${esc(JSON.stringify(method.policy, null, 2))}</pre></details>
+                <form class="otp-test-form" data-method="${method.method}">
+                    <input name="destination" type="${method.method === "email" ? "email" : "tel"}" maxlength="320" placeholder="${method.method === "email" ? "operator@example.com" : "+14155550123"}" required>
+                    <button type="submit" ${method.locallyConfigured ? "" : "disabled"}>Send test delivery</button>
+                </form>
+                <small>Tests are limited to three sends per destination per hour and never create a user, session, or login challenge.</small>
+            </section>`;
 
         content.innerHTML = `
             ${consumeFlashHtml()}
@@ -3599,6 +3619,16 @@
                     ])}
                 </section>
             </div>
+            <h2>OTP communications readiness</h2>
+            <p>Provider secrets remain deployment-owned and are never returned here. These checks validate local configuration only; startup never calls a provider.</p>
+            <div class="panel-grid">
+                ${otpCard(otp.email)}
+                ${otpCard(otp.phone)}
+            </div>
+            <section class="panel">
+                <h2>Recent OTP test diagnostics</h2>
+                ${otp.recentDiagnostics.length ? `<div class="table-wrap"><table><thead><tr><th>Time</th><th>Method</th><th>Outcome</th><th>Destination</th><th>Provider status</th></tr></thead><tbody>${otp.recentDiagnostics.map(item => `<tr><td>${esc(formatDate(item.occurredAt))}</td><td>${esc(item.method || "-")}</td><td>${esc(item.action)}</td><td>${esc(item.maskedDestination || "-")}</td><td>${esc(item.providerStatus || "-")}</td></tr>`).join("")}</tbody></table></div>` : "<p>No administrative OTP test deliveries have been attempted.</p>"}
+            </section>
         `;
 
         bindForm("security-settings-form", async form => {
@@ -3619,6 +3649,21 @@
                 })
             });
             setFlash("success", "Security settings saved.");
+        });
+
+        document.querySelectorAll(".otp-test-form").forEach(form => {
+            form.addEventListener("submit", async event => {
+                event.preventDefault();
+                const method = form.dataset.method;
+                const destination = new FormData(form).get("destination");
+                if (!window.confirm(`Send a ${method} OTP delivery test to ${destination}? This may incur provider charges.`)) return;
+                await fetchJson(`${authApiBasePath}/otp/test-delivery`, {
+                    method: "POST",
+                    body: JSON.stringify({ method, destination })
+                });
+                setFlash("success", `${method === "email" ? "Email" : "Phone"} test accepted. No login challenge was created.`);
+                await renderAuthSecurity();
+            });
         });
     }
 

--- a/src/SqlOS/Dashboard/wwwroot/app.js
+++ b/src/SqlOS/Dashboard/wwwroot/app.js
@@ -3591,7 +3591,7 @@
                     <input name="destination" type="${method.method === "email" ? "email" : "tel"}" maxlength="320" placeholder="${method.method === "email" ? "operator@example.com" : "+14155550123"}" required>
                     <button type="submit" ${method.locallyConfigured ? "" : "disabled"}>Send test delivery</button>
                 </form>
-                <small>Tests are limited to three sends per destination per hour and never create a user, session, or login challenge.</small>
+                <small>Tests are limited to three sends per destination and 20 per operator source per hour. They never create a user, session, or SqlOS login challenge.</small>
             </section>`;
 
         content.innerHTML = `

--- a/src/SqlOS/Extensions/ServiceCollectionExtensions.cs
+++ b/src/SqlOS/Extensions/ServiceCollectionExtensions.cs
@@ -100,6 +100,9 @@ public static class ServiceCollectionExtensions
         services.AddScoped<SqlOSMagicLinkService>();
         services.AddSingleton<ISqlOSOtpDeliveryChannel, SqlOSTwilioVerifyOtpChannel>();
         services.AddScoped<SqlOSPhoneOtpService>();
+        services.AddScoped(sp => new SqlOSOtpAdminRateLimiter(
+            sp.GetRequiredService<SqlOSDistributedRateLimitStore>()));
+        services.AddScoped<SqlOSOtpAdminService>();
         services.AddScoped<SqlOSMfaPolicyService>();
         services.AddScoped<SqlOSTotpMfaService>();
         services.AddScoped<SqlOSPasswordLoginAbuseService>();

--- a/tests/SqlOS.IntegrationTests/DistributedRateLimitIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/DistributedRateLimitIntegrationTests.cs
@@ -15,6 +15,32 @@ namespace SqlOS.IntegrationTests;
 public class DistributedRateLimitIntegrationTests
 {
     [TestMethod]
+    public async Task OtpAdministrativeTestLimit_IsSharedAcrossApplicationInstances()
+    {
+        var connectionString = GetConnectionString();
+        await using var firstContext = CreateContext(connectionString);
+        await using var secondContext = CreateContext(connectionString);
+        var options = Options.Create(new SqlOSAuthServerOptions());
+        var firstStore = new SqlOSDistributedRateLimitStore(firstContext, options);
+        var secondStore = new SqlOSDistributedRateLimitStore(secondContext, options);
+        var first = new SqlOSOtpAdminRateLimiter(firstStore);
+        var second = new SqlOSOtpAdminRateLimiter(secondStore);
+        var key = $"email-{Guid.NewGuid():N}";
+
+        try
+        {
+            (await first.TryConsumeAsync(key, DateTimeOffset.UtcNow)).Should().BeTrue();
+            (await second.TryConsumeAsync(key, DateTimeOffset.UtcNow.AddSeconds(1))).Should().BeTrue();
+            (await first.TryConsumeAsync(key, DateTimeOffset.UtcNow.AddSeconds(2))).Should().BeTrue();
+            (await second.TryConsumeAsync(key, DateTimeOffset.UtcNow.AddSeconds(3))).Should().BeFalse();
+        }
+        finally
+        {
+            await firstStore.DeleteAsync("otp_admin_test", key);
+        }
+    }
+
+    [TestMethod]
     public async Task DcrLimit_IsSharedAcrossApplicationInstances()
     {
         var connectionString = GetConnectionString();

--- a/tests/SqlOS.Tests/SqlOSAdminAuthorizationMetadataTests.cs
+++ b/tests/SqlOS.Tests/SqlOSAdminAuthorizationMetadataTests.cs
@@ -85,6 +85,8 @@ public sealed class SqlOSAdminAuthorizationMetadataTests
             await client.PostAsJsonAsync("/sqlos/admin/auth/api/users", new { }),
             await client.PostAsJsonAsync("/sqlos/admin/auth/api/sessions/revocation/preview", new { userId = "victim" }),
             await client.PostAsJsonAsync("/sqlos/admin/auth/api/sessions/revocation", new { userId = "victim", confirm = true }),
+            await client.GetAsync("/sqlos/admin/auth/api/otp/readiness"),
+            await client.PostAsJsonAsync("/sqlos/admin/auth/api/otp/test-delivery", new { method = "email", destination = "operator@example.test" }),
             await client.PutAsJsonAsync("/sqlos/admin/email/api/templates/missing", new { }),
             await client.DeleteAsync("/sqlos/admin/email/api/templates/missing")
         };

--- a/tests/SqlOS.Tests/SqlOSAuthEndpointRouteInventoryTests.cs
+++ b/tests/SqlOS.Tests/SqlOSAuthEndpointRouteInventoryTests.cs
@@ -47,7 +47,9 @@ public class SqlOSAuthEndpointRouteInventoryTests
             "GET /sqlos/admin/auth/api/sessions",
             "POST /sqlos/admin/auth/api/sessions/revocation/preview",
             "POST /sqlos/admin/auth/api/sessions/revocation",
-            "GET /sqlos/admin/auth/api/settings/security"
+            "GET /sqlos/admin/auth/api/settings/security",
+            "GET /sqlos/admin/auth/api/otp/readiness",
+            "POST /sqlos/admin/auth/api/otp/test-delivery"
         };
 
         actual.Should().Contain(expected);

--- a/tests/SqlOS.Tests/SqlOSOtpAdminServiceTests.cs
+++ b/tests/SqlOS.Tests/SqlOSOtpAdminServiceTests.cs
@@ -1,0 +1,149 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SqlOS.AuthServer.Configuration;
+using SqlOS.AuthServer.Interfaces;
+using SqlOS.AuthServer.Models;
+using SqlOS.AuthServer.Services;
+using SqlOS.Security;
+using SqlOS.Tests.Infrastructure;
+
+namespace SqlOS.Tests;
+
+[TestClass]
+public sealed class SqlOSOtpAdminServiceTests
+{
+    [TestMethod]
+    public async Task ReadinessAndTestDelivery_AreRedactedAndCreateNoAuthenticationState()
+    {
+        await using var context = CreateContext();
+        var optionsValue = ReadyOptions();
+        var options = Options.Create(optionsValue);
+        var email = new TestAuthEmailSender { IsConfigured = true };
+        var phone = new FakePhoneChannel();
+        var crypto = TestCryptoService.Create(context, options);
+        var admin = new SqlOSAdminService(context, options, crypto);
+        var settings = new SqlOSSettingsService(context, options, email, crypto);
+        await settings.UpsertSeededAuthPageSettingsAsync();
+        var service = CreateService(context, admin, crypto, settings, email, phone, options);
+
+        var readiness = await service.GetReadinessAsync();
+        readiness.Email.Enabled.Should().BeTrue();
+        readiness.Email.LocallyConfigured.Should().BeTrue();
+        readiness.Phone.Enabled.Should().BeTrue();
+        readiness.Phone.LocallyConfigured.Should().BeTrue();
+        var serialized = JsonSerializer.Serialize(readiness);
+        serialized.Should().NotContain("super-secret-email-connection");
+        serialized.Should().NotContain("super-secret-twilio-token");
+
+        var emailResult = await service.SendTestAsync("email", "operator@example.test", "127.0.0.1");
+        var phoneResult = await service.SendTestAsync("phone", "+14155550123", "127.0.0.1");
+
+        emailResult.MaskedDestination.Should().Be("o***@example.test");
+        phoneResult.MaskedDestination.Should().EndWith("0123");
+        email.Messages.Should().ContainSingle().Which.TextBody.Should().NotContain("code:");
+        phone.Starts.Should().ContainSingle().Which.Context.Purpose.Should().Be("admin_test");
+        (await context.Set<SqlOSUser>().CountAsync()).Should().Be(0);
+        (await context.Set<SqlOSSession>().CountAsync()).Should().Be(0);
+        (await context.Set<SqlOSEmailOtpChallenge>().CountAsync()).Should().Be(0);
+        (await context.Set<SqlOSPhoneOtpChallenge>().CountAsync()).Should().Be(0);
+        var audits = await context.Set<SqlOSAuditEvent>().ToListAsync();
+        audits.Should().HaveCount(2);
+        JsonSerializer.Serialize(audits).Should().NotContain("operator@example.test");
+        JsonSerializer.Serialize(audits).Should().NotContain("+14155550123");
+    }
+
+    [TestMethod]
+    public async Task TestDelivery_UsesGenericProviderFailureAndDistributedRateLimit()
+    {
+        await using var context = CreateContext();
+        var optionsValue = ReadyOptions();
+        var options = Options.Create(optionsValue);
+        var email = new TestAuthEmailSender { IsConfigured = true };
+        var phone = new FakePhoneChannel { Reject = true };
+        var crypto = TestCryptoService.Create(context, options);
+        var admin = new SqlOSAdminService(context, options, crypto);
+        var settings = new SqlOSSettingsService(context, options, email, crypto);
+        await settings.UpsertSeededAuthPageSettingsAsync();
+        var limiter = new SqlOSOtpAdminRateLimiter(new SqlOSInMemoryRateLimitStore());
+        var service = new SqlOSOtpAdminService(context, admin, crypto, settings, email, phone, limiter, options);
+
+        await FluentActions.Invoking(() => service.SendTestAsync("phone", "+14155550123", null))
+            .Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*could not complete*");
+        phone.Reject = false;
+        await service.SendTestAsync("phone", "+14155550123", null);
+        await service.SendTestAsync("phone", "+14155550123", null);
+        await FluentActions.Invoking(() => service.SendTestAsync("phone", "+14155550123", null))
+            .Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*limit reached*");
+    }
+
+    [TestMethod]
+    public async Task Readiness_ExplainsIncompleteConfigurationWithoutSecrets()
+    {
+        await using var context = CreateContext();
+        var optionsValue = new SqlOSAuthServerOptions();
+        optionsValue.SeedAuthPage(page => page.EnabledCredentialTypes = ["email_otp", "phone_otp"]);
+        var options = Options.Create(optionsValue);
+        var email = new TestAuthEmailSender { IsConfigured = false };
+        var crypto = TestCryptoService.Create(context, options);
+        var admin = new SqlOSAdminService(context, options, crypto);
+        var settings = new SqlOSSettingsService(context, options, email, crypto);
+        await settings.UpsertSeededAuthPageSettingsAsync();
+        var service = CreateService(context, admin, crypto, settings, email, new FakePhoneChannel(), options);
+
+        var readiness = await service.GetReadinessAsync();
+
+        readiness.Email.ReasonCodes.Should().Contain("email_sender_unavailable");
+        readiness.Phone.ReasonCodes.Should().Contain(["method_disabled_in_host_configuration", "missing_auth_token", "missing_verify_service_sid"]);
+    }
+
+    private static SqlOSOtpAdminService CreateService(
+        TestSqlOSInMemoryDbContext context,
+        SqlOSAdminService admin,
+        SqlOSCryptoService crypto,
+        SqlOSSettingsService settings,
+        ISqlOSAuthEmailSender email,
+        ISqlOSOtpDeliveryChannel phone,
+        IOptions<SqlOSAuthServerOptions> options)
+        => new(context, admin, crypto, settings, email, phone,
+            new SqlOSOtpAdminRateLimiter(new SqlOSInMemoryRateLimitStore()), options);
+
+    private static SqlOSAuthServerOptions ReadyOptions()
+    {
+        var options = new SqlOSAuthServerOptions();
+        options.SeedAuthPage(page => page.EnabledCredentialTypes = ["email_otp", "phone_otp"]);
+        options.EmailOtp.AzureCommunicationServicesConnectionString = "super-secret-email-connection";
+        options.EmailOtp.FromAddress = "signin@example.test";
+        options.ConfigurePhoneOtp(phone =>
+        {
+            phone.Enabled = true;
+            phone.TwilioAccountSid = "AC00000000000000000000000000000000";
+            phone.TwilioAuthToken = "super-secret-twilio-token";
+            phone.TwilioVerifyServiceSid = "VA00000000000000000000000000000000";
+        });
+        return options;
+    }
+
+    private static TestSqlOSInMemoryDbContext CreateContext()
+        => new(new DbContextOptionsBuilder<TestSqlOSInMemoryDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N")).Options);
+
+    private sealed class FakePhoneChannel : ISqlOSOtpDeliveryChannel
+    {
+        public bool Reject { get; set; }
+        public List<(string Phone, SqlOSOtpDeliveryContext Context)> Starts { get; } = [];
+
+        public Task<SqlOSOtpDeliveryStartResult> StartAsync(string e164PhoneNumber, SqlOSOtpDeliveryContext context, CancellationToken cancellationToken = default)
+        {
+            Starts.Add((e164PhoneNumber, context));
+            return Task.FromResult(new SqlOSOtpDeliveryStartResult(!Reject, "fake_twilio", null, Reject ? "rejected" : "pending", Reject ? "sensitive provider detail" : null));
+        }
+
+        public Task<SqlOSOtpDeliveryCheckResult> CheckAsync(string e164PhoneNumber, string code, SqlOSOtpDeliveryContext context, CancellationToken cancellationToken = default)
+            => Task.FromResult(new SqlOSOtpDeliveryCheckResult(false, "fake_twilio", null, "unused"));
+    }
+}

--- a/tests/SqlOS.Tests/SqlOSPhoneOtpServiceTests.cs
+++ b/tests/SqlOS.Tests/SqlOSPhoneOtpServiceTests.cs
@@ -147,6 +147,8 @@ public sealed class SqlOSPhoneOtpServiceTests
 
         result.User.Id.Should().Be(user.Id);
         result.AuthenticationMethod.Should().Be("phone_otp");
+        harness.Channel.CheckRequests.Should().ContainSingle()
+            .Which.Context.ProviderChallengeId.Should().Be("ve-1");
         new SqlOSMfaPolicyService(harness.Options).SatisfiesStrongMfa(result.AuthenticationMethod).Should().BeTrue();
     }
 
@@ -162,6 +164,24 @@ public sealed class SqlOSPhoneOtpServiceTests
         await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("The sign-in code is invalid or expired.");
         harness.Channel.CheckRequests.Should().ContainSingle(x => x.Code == "000000");
+    }
+
+    [TestMethod]
+    public async Task PhoneOtp_Verify_CannotCrossSatisfyAnotherProviderChallenge()
+    {
+        using var harness = await PhoneOtpHarness.CreateAsync();
+        await harness.CreateUserWithPhoneAsync("+12025550137");
+        var start = await harness.Service.StartForClientAsync(new SqlOSPhoneOtpStartRequest("+12025550137", "test-client", null));
+        var challenge = await harness.Context.Set<SqlOSPhoneOtpChallenge>()
+            .SingleAsync(x => x.ChallengeTokenHash == harness.Crypto.HashToken(start.ChallengeToken));
+        challenge.ProviderChallengeId = "ve-from-admin-test";
+        await harness.Context.SaveChangesAsync();
+
+        await FluentActions.Invoking(() => harness.Service.VerifyAsync(new SqlOSPhoneOtpVerifyRequest(start.ChallengeToken, "123456")))
+            .Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("The sign-in code is invalid or expired.");
+        harness.Channel.CheckRequests.Should().ContainSingle()
+            .Which.Context.ProviderChallengeId.Should().Be("ve-from-admin-test");
     }
 
     [TestMethod]
@@ -402,7 +422,9 @@ public sealed class SqlOSPhoneOtpServiceTests
             CancellationToken cancellationToken = default)
         {
             CheckRequests.Add((e164PhoneNumber, code, context));
-            var approved = string.Equals(code, ApprovedCode, StringComparison.Ordinal);
+            var expectedProviderChallengeId = $"ve-{StartRequests.Count}";
+            var approved = string.Equals(code, ApprovedCode, StringComparison.Ordinal)
+                && string.Equals(context.ProviderChallengeId, expectedProviderChallengeId, StringComparison.Ordinal);
             return Task.FromResult(new SqlOSOtpDeliveryCheckResult(
                 approved,
                 "test_verify",

--- a/web/content/docs/authserver/email-otp.mdx
+++ b/web/content/docs/authserver/email-otp.mdx
@@ -34,6 +34,18 @@ dotnet run
 
 Use `scripts/azure/setup-acs-email.sh` to create the ACS Email resources and DNS verification records.
 
+## Readiness and safe test delivery
+
+Open **Auth Server > Security > OTP communications readiness** after configuring the host. The dashboard reports whether Email OTP is enabled, whether the local sender is configured, bounded reason codes, and non-secret policy values. Connection strings remain in your deployment secret store and are never returned by the admin API.
+
+An authenticated administrator can retrieve the same model from `GET /sqlos/admin/auth/api/otp/readiness` or send a bounded test with `POST /sqlos/admin/auth/api/otp/test-delivery`:
+
+```json
+{ "method": "email", "destination": "operator@example.com" }
+```
+
+The test uses the configured auth email sender, is limited to three sends per destination per hour, and records only a masked destination. It does not create a user, session, OTP challenge, or reusable login credential. A successful local readiness check does not call ACS; use the explicit test only when you intend to incur a provider request.
+
 ## Enable AuthPage Email OTP
 
 Seed or configure the AuthPage credential types:

--- a/web/content/docs/authserver/email-otp.mdx
+++ b/web/content/docs/authserver/email-otp.mdx
@@ -44,7 +44,7 @@ An authenticated administrator can retrieve the same model from `GET /sqlos/admi
 { "method": "email", "destination": "operator@example.com" }
 ```
 
-The test uses the configured auth email sender, is limited to three sends per destination per hour, and records only a masked destination. It does not create a user, session, OTP challenge, or reusable login credential. A successful local readiness check does not call ACS; use the explicit test only when you intend to incur a provider request.
+The test uses the configured auth email sender, is limited to three sends per destination and 20 per operator source per hour, and records only a masked destination. It does not create a user, session, OTP challenge, or reusable login credential. A successful local readiness check does not call ACS; use the explicit test only when you intend to incur a provider request.
 
 ## Enable AuthPage Email OTP
 

--- a/web/content/docs/authserver/phone-otp.mdx
+++ b/web/content/docs/authserver/phone-otp.mdx
@@ -101,7 +101,7 @@ Content-Type: application/json
 { "method": "phone", "destination": "+14155550123" }
 ```
 
-The operation validates and normalizes the number, applies a three-per-destination hourly test limit, calls the same `ISqlOSOtpDeliveryChannel` used by login, and audits a masked destination with a bounded provider status. It deliberately creates no SqlOS user, session, or login challenge, so a code delivered by this operational test cannot complete a SqlOS sign-in. Startup never performs this active provider check.
+The operation validates and normalizes the number, applies three-per-destination and 20-per-operator-source hourly limits, calls the same `ISqlOSOtpDeliveryChannel` used by login, and audits a masked destination with a bounded provider status. It deliberately creates no SqlOS user, session, or login challenge. Runtime verification is bound to its stored Twilio verification SID, so a code from an administrative test cannot satisfy a different login challenge. Startup never performs this active provider check.
 
 ### Runtime defaults
 

--- a/web/content/docs/authserver/phone-otp.mdx
+++ b/web/content/docs/authserver/phone-otp.mdx
@@ -88,6 +88,21 @@ builder.AddSqlOS<AppDbContext>(options =>
 
 When `Enabled` is `true`, startup validation requires all three Twilio values. An incomplete configuration fails startup with a direct validation error instead of exposing a broken login button.
 
+### Dashboard readiness and provider test
+
+**Auth Server > Security > OTP communications readiness** shows the enabled state, local configuration reason codes, effective non-secret limits, and only the last four characters of the Verify service SID. It never returns the Account SID credential or Auth Token.
+
+The authenticated admin API exposes the same status at `GET /sqlos/admin/auth/api/otp/readiness`. An operator can explicitly test delivery from the dashboard or with:
+
+```http
+POST /sqlos/admin/auth/api/otp/test-delivery
+Content-Type: application/json
+
+{ "method": "phone", "destination": "+14155550123" }
+```
+
+The operation validates and normalizes the number, applies a three-per-destination hourly test limit, calls the same `ISqlOSOtpDeliveryChannel` used by login, and audits a masked destination with a bounded provider status. It deliberately creates no SqlOS user, session, or login challenge, so a code delivered by this operational test cannot complete a SqlOS sign-in. Startup never performs this active provider check.
+
 ### Runtime defaults
 
 | Option | Default | Meaning |

--- a/web/content/docs/guides/email-otp-onboarding.mdx
+++ b/web/content/docs/guides/email-otp-onboarding.mdx
@@ -302,6 +302,7 @@ A new challenge supersedes the previous active challenge in that signup context.
 
 ## Production checklist
 
+- Open **Auth Server > Security > OTP communications readiness**, confirm Email OTP is ready, and perform one explicit test delivery to an operator-controlled inbox. The readiness read is local-only; the test is the provider proof.
 - Use HTTPS, PKCE S256, high-entropy state, and an exact redirect URI.
 - Keep signup and challenge tokens in ephemeral state and clear them after completion.
 - Treat existing-account disclosure as an explicit threat-model decision: the current signup endpoint is not account-enumeration resistant, so add bot controls, rate limits, and monitoring rather than claiming a generic response.

--- a/web/content/docs/guides/production-readiness.mdx
+++ b/web/content/docs/guides/production-readiness.mdx
@@ -313,6 +313,7 @@ Run this against the public origin through the real proxy, not directly against 
 ### User journeys
 
 - [ ] Hosted password or passwordless sign-in works through the external HTTPS origin.
+- [ ] The dashboard OTP readiness view reports every enabled method ready, and an explicit test reaches operator-controlled email/phone destinations without exposing provider secrets in the response or audit log.
 - [ ] Each enabled OIDC or SAML provider returns through its production callback.
 - [ ] Invitation, password-reset, OTP, and MFA messages contain production—not internal—URLs.
 - [ ] Multi-organization selection and organization-scoped claims behave as expected.

--- a/web/content/docs/guides/troubleshooting.mdx
+++ b/web/content/docs/guides/troubleshooting.mdx
@@ -59,6 +59,12 @@ You'll learn how to diagnose connection, OAuth callback, SAML, and migration pro
 - Domain on the org must match the email entered at login.
 - SAML connection must be **enabled**, not draft-only.
 
+## Email or phone OTP delivery
+
+Open **Auth Server > Security > OTP communications readiness** first. The status returns bounded reason codes such as `missing_from_address`, `missing_auth_token`, or `missing_verify_service_sid` without exposing provider credentials. Deployment-owned values must be corrected in host configuration and the application restarted; the dashboard intentionally does not persist them.
+
+Use **Send test delivery** only with an operator-controlled destination. A test is limited to three sends per destination per hour and creates no SqlOS login challenge. Recent rows distinguish a local configuration problem, provider rejection, and administrative test throttling while retaining only a masked destination. Runtime user-facing OTP errors remain generic.
+
 ## FGA filters return empty lists
 
 - Confirm resources were created for domain rows and grants exist for the subject.


### PR DESCRIPTION
Closes #213.

## What changed
- adds authenticated, redacted Email OTP and Phone OTP readiness models
- adds explicit test-delivery operations using the existing email sender and Twilio delivery abstraction
- enforces a distributed three-per-destination hourly test limit
- shows deployment-owned configuration keys, non-secret policy, tests, and bounded recent failures in the dashboard
- keeps runtime and administrative errors generic while auditing only masked destinations
- documents readiness, test delivery, troubleshooting, and production proof

## Security and ergonomics
- provider secrets remain host-owned and are never persisted or returned
- readiness is local-only and does not make startup depend on a provider
- tests create no user, session, or SqlOS OTP/login challenge
- existing hosted/headless flows and configuration behavior are unchanged

## Validation
- 658 unit tests
- real-SQL distributed rate-limit integration test across application contexts
- admin route authorization and API inventory tests
- dashboard JavaScript syntax check
- full docs lint/build/link/snippet gate

An adversarial review round will be recorded on this PR before merge.
