### PR TITLE
Unify OAuth machine-client and FGA administration

### DIFF
--- a/scripts/compile-doc-snippets.mjs
+++ b/scripts/compile-doc-snippets.mjs
@@ -111,6 +111,13 @@ const snippetSpecs = [
     marker: "SeedSamlConnection(",
     wrap: asSamlSeedProgram,
   },
+  {
+    name: "unified machine-client seed",
+    relativePath: "web/content/docs/guides/service-account-jobs.mdx",
+    heading: "## Recommended: declare one machine client",
+    marker: "SeedMachineClient(",
+    wrap: asMachineClientSeedProgram,
+  },
 ];
 
 function extractCsharpBlock({ relativePath, heading, marker }) {
@@ -272,6 +279,18 @@ ${snippet}
 }
 
 function asSamlSeedProgram(snippet) {
+  return `using Microsoft.Extensions.Configuration;
+using SqlOS.AuthServer.Configuration;
+using SqlOS.Configuration;
+
+var builder = WebApplication.CreateBuilder(args);
+var options = new SqlOSOptions();
+
+${snippet}
+`;
+}
+
+function asMachineClientSeedProgram(snippet) {
   return `using Microsoft.Extensions.Configuration;
 using SqlOS.AuthServer.Configuration;
 using SqlOS.Configuration;

--- a/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerOptions.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerOptions.cs
@@ -112,6 +112,24 @@ public class SqlOSAuthServerOptions
         return this;
     }
 
+    public SqlOSAuthServerOptions SeedMachineClient(string clientId, Action<SqlOSClientSeedOptions, SqlOSMachineClientSeedOptions> configure)
+    {
+        if (string.IsNullOrWhiteSpace(clientId)) throw new InvalidOperationException("Machine clients require a stable client ID.");
+        var machine = new SqlOSMachineClientSeedOptions();
+        var client = new SqlOSClientSeedOptions
+        {
+            ClientId = clientId.Trim(),
+            Name = clientId.Trim(),
+            ClientType = "confidential",
+            RequirePkce = false,
+            EnableClientCredentials = true,
+            MachineClient = machine
+        };
+        configure(client, machine);
+        ClientSeeds.Add(client);
+        return this;
+    }
+
     /// <summary>
     /// Seed a social/OIDC login connection (Google, Microsoft, Apple, or custom). The connection is
     /// reconciled into the database on startup, matched by provider type (and display name for custom

--- a/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerSeedOptions.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerSeedOptions.cs
@@ -115,6 +115,8 @@ public sealed class SqlOSClientSeedOptions
     public string? AccessMode { get; set; }
     /// <summary>Gets the ownership-safe application access assignments reconciled for this client.</summary>
     public List<SqlOSApplicationAssignmentSeedOptions> Assignments { get; } = [];
+    /// <summary>Optional unified OAuth client and FGA service-account declaration.</summary>
+    public SqlOSMachineClientSeedOptions? MachineClient { get; set; }
 
     public SqlOSClientSeedOptions AssignOrganization(string key, string organizationIdOrSlug, string access = SqlOSApplicationAssignmentAccess.Allowed, string? description = null)
         => Assign(key, SqlOSApplicationAssignmentPrincipalTypes.Organization, organizationIdOrSlug: organizationIdOrSlug, access: access, description: description);
@@ -150,6 +152,26 @@ public sealed class SqlOSClientSeedOptions
         return this;
     }
 }
+
+public sealed class SqlOSMachineClientSeedOptions
+{
+    public string? OrganizationId { get; set; }
+    public string? OrganizationSlug { get; set; }
+    public DateTime? ExpiresAt { get; set; }
+    /// <summary>Resolves secret material from the host secret provider. Never commit the returned value.</summary>
+    public Func<string?>? SecretResolver { get; set; }
+    /// <summary>Alternatively resolves an ASP.NET Core PasswordHasher-compatible hash.</summary>
+    public Func<string?>? SecretHashResolver { get; set; }
+    public List<SqlOSMachineClientGrantSeedOptions> Grants { get; } = [];
+
+    public SqlOSMachineClientSeedOptions Grant(string resourceId, string roleId, string? description = null)
+    {
+        Grants.Add(new SqlOSMachineClientGrantSeedOptions(resourceId, roleId, description));
+        return this;
+    }
+}
+
+public sealed record SqlOSMachineClientGrantSeedOptions(string ResourceId, string RoleId, string? Description = null);
 
 /// <summary>Declarative, stable-keyed assignment owned by a client seed.</summary>
 public sealed class SqlOSApplicationAssignmentSeedOptions

--- a/src/SqlOS/AuthServer/Endpoints/AdminIdentityEndpoints.cs
+++ b/src/SqlOS/AuthServer/Endpoints/AdminIdentityEndpoints.cs
@@ -583,5 +583,55 @@ public static partial class EndpointRouteBuilderExtensions
                 return Results.BadRequest(new { message = ex.Message });
             }
         });
+
+        api.MapGet("/machine-clients", async (HttpContext context, SqlOSMachineClientAdminService machines, IOptions<SqlOSAuthServerOptions> options, IHostEnvironment environment, CancellationToken cancellationToken) =>
+        {
+            if (!await IsAdminAuthorizedAsync(context, options.Value, environment)) return Results.NotFound();
+            return Results.Ok(await machines.ListAsync(cancellationToken));
+        });
+
+        api.MapPost("/machine-clients", async (HttpContext context, SqlOSCreateMachineClientRequest request, SqlOSMachineClientAdminService machines, IOptions<SqlOSAuthServerOptions> options, IHostEnvironment environment, CancellationToken cancellationToken) =>
+        {
+            if (!await IsAdminAuthorizedAsync(context, options.Value, environment)) return Results.NotFound();
+            try { return Results.Ok(await machines.CreateAsync(request, cancellationToken)); }
+            catch (InvalidOperationException exception) { return Results.BadRequest(new { message = exception.Message }); }
+        });
+
+        api.MapPost("/machine-clients/{clientId}/rotate", async (HttpContext context, string clientId, SqlOSMachineClientAdminService machines, IOptions<SqlOSAuthServerOptions> options, IHostEnvironment environment, CancellationToken cancellationToken) =>
+        {
+            if (!await IsAdminAuthorizedAsync(context, options.Value, environment)) return Results.NotFound();
+            try { return Results.Ok(await machines.RotateAsync(clientId, cancellationToken)); }
+            catch (InvalidOperationException exception) { return Results.BadRequest(new { message = exception.Message }); }
+        });
+
+        api.MapPost("/machine-clients/{clientId}/validate", async (HttpContext context, string clientId, MachineClientValidationRequest request, SqlOSMachineClientAdminService machines, IOptions<SqlOSAuthServerOptions> options, IHostEnvironment environment, CancellationToken cancellationToken) =>
+        {
+            if (!await IsAdminAuthorizedAsync(context, options.Value, environment)) return Results.NotFound();
+            try { return Results.Ok(await machines.ValidateCredentialAsync(clientId, request.ClientSecret, request.Resource, request.Scopes, cancellationToken)); }
+            catch (InvalidOperationException exception) { return Results.BadRequest(new { message = exception.Message }); }
+        });
+
+        api.MapPost("/machine-clients/{clientId}/revoke", async (HttpContext context, string clientId, SqlOSMachineClientAdminService machines, IOptions<SqlOSAuthServerOptions> options, IHostEnvironment environment, CancellationToken cancellationToken) =>
+        {
+            if (!await IsAdminAuthorizedAsync(context, options.Value, environment)) return Results.NotFound();
+            try { await machines.RevokeAsync(clientId, cancellationToken); return Results.Ok(new { revoked = true }); }
+            catch (InvalidOperationException exception) { return Results.BadRequest(new { message = exception.Message }); }
+        });
+
+        api.MapPost("/machine-clients/{clientId}/grants", async (HttpContext context, string clientId, SqlOSMachineClientGrantRequest request, SqlOSMachineClientAdminService machines, IOptions<SqlOSAuthServerOptions> options, IHostEnvironment environment, CancellationToken cancellationToken) =>
+        {
+            if (!await IsAdminAuthorizedAsync(context, options.Value, environment)) return Results.NotFound();
+            try { await machines.AddGrantAsync(clientId, request, cancellationToken); return Results.Ok(new { added = true }); }
+            catch (InvalidOperationException exception) { return Results.BadRequest(new { message = exception.Message }); }
+        });
+
+        api.MapDelete("/machine-clients/{clientId}/grants/{grantId}", async (HttpContext context, string clientId, string grantId, SqlOSMachineClientAdminService machines, IOptions<SqlOSAuthServerOptions> options, IHostEnvironment environment, CancellationToken cancellationToken) =>
+        {
+            if (!await IsAdminAuthorizedAsync(context, options.Value, environment)) return Results.NotFound();
+            try { await machines.RemoveGrantAsync(clientId, grantId, cancellationToken); return Results.Ok(new { removed = true }); }
+            catch (InvalidOperationException exception) { return Results.BadRequest(new { message = exception.Message }); }
+        });
     }
+
+    private sealed record MachineClientValidationRequest(string ClientSecret, string Resource, IReadOnlyList<string> Scopes);
 }

--- a/src/SqlOS/AuthServer/Services/SqlOSMachineClientAdminService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSMachineClientAdminService.cs
@@ -147,6 +147,8 @@ public sealed class SqlOSMachineClientAdminService
         {
             AddGrants(subject.Id, grants, DateTime.UtcNow, marker: null);
             await _context.SaveChangesAsync(cancellationToken);
+            await _admin.RecordAuditAsync("machine_client.grant_added", "admin", null, organizationId: subject.OrganizationId,
+                data: new { clientId, request.ResourceId, request.RoleId }, cancellationToken: cancellationToken);
         }
     }
 
@@ -158,6 +160,8 @@ public sealed class SqlOSMachineClientAdminService
             ?? throw new InvalidOperationException("Grant not found.");
         _context.Set<SqlOSFgaGrant>().Remove(grant);
         await _context.SaveChangesAsync(cancellationToken);
+        await _admin.RecordAuditAsync("machine_client.grant_removed", "admin", null, organizationId: subject.OrganizationId,
+            data: new { clientId, grantId, grant.ResourceId, grant.RoleId }, cancellationToken: cancellationToken);
     }
 
     private async Task UpsertSeededMachineClientsCoreAsync(CancellationToken cancellationToken)
@@ -168,7 +172,13 @@ public sealed class SqlOSMachineClientAdminService
         var orphans = await _context.Set<SqlOSFgaServiceAccount>()
             .Where(x => x.ConfigurationOwner == SqlOSConfigurationOwners.Code && x.ConfigurationSourceKey != null && !keys.Contains(x.ConfigurationSourceKey))
             .ToListAsync(cancellationToken);
-        foreach (var orphan in orphans) orphan.ConfigurationOrphanedAt ??= now;
+        foreach (var orphan in orphans)
+        {
+            if (orphan.ConfigurationOrphanedAt != null) continue;
+            orphan.ConfigurationOrphanedAt = now;
+            await _admin.RecordAuditAsync("configuration.orphaned", "system", "startup",
+                data: new { resourceType = "machine_client", clientId = orphan.ClientId, sourceKey = orphan.ConfigurationSourceKey }, cancellationToken: cancellationToken);
+        }
 
         foreach (var seed in seeds)
         {
@@ -193,6 +203,7 @@ public sealed class SqlOSMachineClientAdminService
             }
 
             var secretHash = ResolveSeedSecretHash(machine, account);
+            var isNew = account == null;
             if (account == null)
             {
                 var subject = new SqlOSFgaSubject
@@ -209,6 +220,17 @@ public sealed class SqlOSMachineClientAdminService
                 _context.Set<SqlOSFgaSubject>().Add(subject);
                 _context.Set<SqlOSFgaServiceAccount>().Add(account);
             }
+            var marker = $"[sqlos-machine:{sourceKey}]";
+            var old = await _context.Set<SqlOSFgaGrant>().Where(x => x.SubjectId == account.SubjectId && x.Description != null && x.Description.StartsWith(marker)).ToListAsync(cancellationToken);
+            var desiredGrants = grants.Select(x => (x.ResourceId, x.RoleId, Description: $"{marker} {x.Description}".Trim()))
+                .OrderBy(x => x.ResourceId, StringComparer.Ordinal).ThenBy(x => x.RoleId, StringComparer.Ordinal).ToArray();
+            var currentGrants = old.Select(x => (x.ResourceId, x.RoleId, x.Description!))
+                .OrderBy(x => x.ResourceId, StringComparer.Ordinal).ThenBy(x => x.RoleId, StringComparer.Ordinal).ToArray();
+            var grantDrift = !desiredGrants.SequenceEqual(currentGrants);
+            var changed = isNew || account.ConfigurationFingerprint != fingerprint || account.ConfigurationOrphanedAt != null
+                || account.ClientSecretHash != secretHash || grantDrift;
+            if (!changed) continue;
+
             account.Subject!.DisplayName = seed.Name;
             account.Description = seed.Description;
             account.ClientSecretHash = secretHash;
@@ -218,8 +240,6 @@ public sealed class SqlOSMachineClientAdminService
             account.ConfigurationOrphanedAt = null;
             account.UpdatedAt = now;
 
-            var marker = $"[sqlos-machine:{sourceKey}]";
-            var old = await _context.Set<SqlOSFgaGrant>().Where(x => x.SubjectId == account.SubjectId && x.Description != null && x.Description.StartsWith(marker)).ToListAsync(cancellationToken);
             _context.Set<SqlOSFgaGrant>().RemoveRange(old);
             AddGrants(account.SubjectId, grants, now, marker);
             await _admin.RecordAuditAsync("configuration.reconciled", "system", "startup", organizationId: organizationId,
@@ -236,6 +256,7 @@ public sealed class SqlOSMachineClientAdminService
         {
             var hash = machine.SecretHashResolver()?.Trim();
             if (string.IsNullOrWhiteSpace(hash)) throw new InvalidOperationException("Machine-client secret hash resolution returned no value.");
+            if (!IsSupportedPasswordHash(hash)) throw new InvalidOperationException("Machine-client secret hash resolution returned an unsupported PasswordHasher payload.");
             return hash;
         }
         var secret = machine.SecretResolver!()?.Trim();
@@ -315,6 +336,18 @@ public sealed class SqlOSMachineClientAdminService
             account.ConfigurationOwner, account.ConfigurationSourceKey, account.ConfigurationOrphanedAt, grantCount);
 
     private static string GenerateSecret() => WebEncoders.Base64UrlEncode(RandomNumberGenerator.GetBytes(48));
+    private static bool IsSupportedPasswordHash(string hash)
+    {
+        try
+        {
+            var payload = Convert.FromBase64String(hash);
+            return payload.Length >= 13 && payload[0] is 0x00 or 0x01;
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+    }
     private static string Require(string? value, string message, int max)
     {
         var normalized = value?.Trim();

--- a/src/SqlOS/AuthServer/Services/SqlOSMachineClientAdminService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSMachineClientAdminService.cs
@@ -1,0 +1,333 @@
+using System.Data;
+using System.Security.Cryptography;
+using System.Text.Json;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using SqlOS.AuthServer.Configuration;
+using SqlOS.AuthServer.Contracts;
+using SqlOS.AuthServer.Interfaces;
+using SqlOS.AuthServer.Models;
+using SqlOS.Fga.Models;
+
+namespace SqlOS.AuthServer.Services;
+
+public sealed class SqlOSMachineClientAdminService
+{
+    private readonly ISqlOSAuthServerDbContext _context;
+    private readonly SqlOSAdminService _admin;
+    private readonly SqlOSCryptoService _crypto;
+    private readonly SqlOSAuthServerOptions _options;
+
+    public SqlOSMachineClientAdminService(
+        ISqlOSAuthServerDbContext context,
+        SqlOSAdminService admin,
+        SqlOSCryptoService crypto,
+        IOptions<SqlOSAuthServerOptions> options)
+    {
+        _context = context;
+        _admin = admin;
+        _crypto = crypto;
+        _options = options.Value;
+    }
+
+    public async Task UpsertSeededMachineClientsAsync(CancellationToken cancellationToken = default)
+    {
+        var strategy = _context.Database.CreateExecutionStrategy();
+        await strategy.ExecuteAsync(async () =>
+        {
+            await using var transaction = await _context.Database.BeginTransactionAsync(IsolationLevel.Serializable, cancellationToken);
+            if (string.Equals(_context.Database.ProviderName, "Microsoft.EntityFrameworkCore.SqlServer", StringComparison.Ordinal))
+            {
+                await _context.Database.ExecuteSqlRawAsync("""
+                    DECLARE @result int;
+                    EXEC @result = sys.sp_getapplock @Resource=N'SqlOS:MachineClientReconciliation', @LockMode=N'Exclusive', @LockOwner=N'Transaction', @LockTimeout=30000;
+                    IF @result < 0 THROW 51000, 'Could not acquire the machine-client reconciliation lock.', 1;
+                    """, cancellationToken);
+            }
+            await UpsertSeededMachineClientsCoreAsync(cancellationToken);
+            await transaction.CommitAsync(cancellationToken);
+        });
+    }
+
+    public async Task<SqlOSMachineClientCreated> CreateAsync(SqlOSCreateMachineClientRequest request, CancellationToken cancellationToken = default)
+    {
+        var normalized = await NormalizeCreateAsync(request, cancellationToken);
+        var secret = GenerateSecret();
+        await using var transaction = await _context.Database.BeginTransactionAsync(IsolationLevel.Serializable, cancellationToken);
+        if (await _context.Set<SqlOSClientApplication>().AnyAsync(x => x.ClientId == normalized.ClientId, cancellationToken)
+            || await _context.Set<SqlOSFgaServiceAccount>().AnyAsync(x => x.ClientId == normalized.ClientId, cancellationToken))
+        {
+            throw new InvalidOperationException("A client with that client ID already exists.");
+        }
+
+        var now = DateTime.UtcNow;
+        var client = CreateClient(normalized, now);
+        var subject = new SqlOSFgaSubject
+        {
+            Id = _crypto.GenerateId("sub"), SubjectTypeId = "service_account", OrganizationId = normalized.OrganizationId,
+            DisplayName = normalized.DisplayName, ExternalRef = normalized.ClientId, CreatedAt = now, UpdatedAt = now
+        };
+        var account = new SqlOSFgaServiceAccount
+        {
+            Id = _crypto.GenerateId("sa"), SubjectId = subject.Id, ClientId = normalized.ClientId,
+            ClientSecretHash = _crypto.HashPassword(secret), Description = normalized.Description, ExpiresAt = normalized.ExpiresAt,
+            ConfigurationOwner = SqlOSConfigurationOwners.Dashboard, CreatedAt = now, UpdatedAt = now
+        };
+        _context.Set<SqlOSClientApplication>().Add(client);
+        _context.Set<SqlOSFgaSubject>().Add(subject);
+        _context.Set<SqlOSFgaServiceAccount>().Add(account);
+        AddGrants(subject.Id, normalized.Grants, now, marker: null);
+        await _context.SaveChangesAsync(cancellationToken);
+        await _admin.RecordAuditAsync("machine_client.created", "admin", null, organizationId: normalized.OrganizationId,
+            data: new { normalized.ClientId, subjectId = subject.Id, grantCount = normalized.Grants.Count }, cancellationToken: cancellationToken);
+        await transaction.CommitAsync(cancellationToken);
+        return new SqlOSMachineClientCreated(ToDto(client, account, subject, normalized.Grants.Count), secret);
+    }
+
+    public async Task<IReadOnlyList<SqlOSMachineClientDto>> ListAsync(CancellationToken cancellationToken = default)
+    {
+        var rows = await _context.Set<SqlOSFgaServiceAccount>().AsNoTracking().Include(x => x.Subject)
+            .OrderBy(x => x.Subject!.DisplayName).ToListAsync(cancellationToken);
+        var clients = await _context.Set<SqlOSClientApplication>().AsNoTracking()
+            .Where(x => rows.Select(row => row.ClientId).Contains(x.ClientId)).ToDictionaryAsync(x => x.ClientId, cancellationToken);
+        var subjects = rows.Select(x => x.SubjectId).ToArray();
+        var counts = await _context.Set<SqlOSFgaGrant>().AsNoTracking().Where(x => subjects.Contains(x.SubjectId))
+            .GroupBy(x => x.SubjectId).Select(x => new { x.Key, Count = x.Count() }).ToDictionaryAsync(x => x.Key, x => x.Count, cancellationToken);
+        return rows.Where(x => clients.ContainsKey(x.ClientId))
+            .Select(x => ToDto(clients[x.ClientId], x, x.Subject!, counts.GetValueOrDefault(x.SubjectId))).ToArray();
+    }
+
+    public async Task<SqlOSMachineClientCreated> RotateAsync(string clientId, CancellationToken cancellationToken = default)
+    {
+        var (client, account, subject) = await RequireAsync(clientId, cancellationToken);
+        EnsureDashboardOwned(account);
+        var secret = GenerateSecret();
+        account.ClientSecretHash = _crypto.HashPassword(secret);
+        account.UpdatedAt = DateTime.UtcNow;
+        await _context.SaveChangesAsync(cancellationToken);
+        await _admin.RecordAuditAsync("machine_client.secret_rotated", "admin", null, organizationId: subject.OrganizationId,
+            data: new { clientId, subjectId = subject.Id }, cancellationToken: cancellationToken);
+        var grantCount = await _context.Set<SqlOSFgaGrant>().CountAsync(x => x.SubjectId == subject.Id, cancellationToken);
+        return new SqlOSMachineClientCreated(ToDto(client, account, subject, grantCount), secret);
+    }
+
+    public async Task<SqlOSMachineClientValidation> ValidateCredentialAsync(string clientId, string secret, string resource, IReadOnlyList<string> scopes, CancellationToken cancellationToken = default)
+    {
+        var (client, account, subject) = await RequireAsync(clientId, cancellationToken);
+        var now = DateTime.UtcNow;
+        var valid = client.IsActive && client.DisabledAt == null && (account.ExpiresAt == null || account.ExpiresAt > now)
+            && secret.Length is >= 43 and <= 256 && _crypto.VerifyPassword(SqlOSClientCredentialsService.ResolveCredentialHashForVerification(account), secret)
+            && string.Equals(resource, client.Audience, StringComparison.Ordinal)
+            && scopes.All(scope => SqlOSAdminService.DeserializeJsonList(client.AllowedScopesJson).Contains(scope, StringComparer.Ordinal));
+        await _admin.RecordAuditAsync(valid ? "machine_client.credential_test_succeeded" : "machine_client.credential_test_failed",
+            "admin", null, organizationId: subject.OrganizationId, data: new { clientId, resource, scopes }, cancellationToken: cancellationToken);
+        return new SqlOSMachineClientValidation(valid, valid ? "ready" : "credential_or_binding_invalid");
+    }
+
+    public async Task RevokeAsync(string clientId, CancellationToken cancellationToken = default)
+    {
+        var (client, account, subject) = await RequireAsync(clientId, cancellationToken);
+        account.ExpiresAt = DateTime.UtcNow;
+        account.UpdatedAt = account.ExpiresAt.Value;
+        client.IsActive = false;
+        client.DisabledAt = account.ExpiresAt;
+        client.DisabledReason = "machine_client_revoked";
+        await _context.SaveChangesAsync(cancellationToken);
+        await _admin.RecordAuditAsync("machine_client.revoked", "admin", null, organizationId: subject.OrganizationId,
+            data: new { clientId, subjectId = subject.Id }, cancellationToken: cancellationToken);
+    }
+
+    public async Task AddGrantAsync(string clientId, SqlOSMachineClientGrantRequest request, CancellationToken cancellationToken = default)
+    {
+        var (_, account, subject) = await RequireAsync(clientId, cancellationToken);
+        EnsureDashboardOwned(account);
+        var grants = await NormalizeGrantsAsync([new(request.ResourceId, request.RoleId, request.Description)], cancellationToken);
+        if (!await _context.Set<SqlOSFgaGrant>().AnyAsync(x => x.SubjectId == subject.Id && x.ResourceId == request.ResourceId && x.RoleId == request.RoleId, cancellationToken))
+        {
+            AddGrants(subject.Id, grants, DateTime.UtcNow, marker: null);
+            await _context.SaveChangesAsync(cancellationToken);
+        }
+    }
+
+    public async Task RemoveGrantAsync(string clientId, string grantId, CancellationToken cancellationToken = default)
+    {
+        var (_, account, subject) = await RequireAsync(clientId, cancellationToken);
+        EnsureDashboardOwned(account);
+        var grant = await _context.Set<SqlOSFgaGrant>().SingleOrDefaultAsync(x => x.Id == grantId && x.SubjectId == subject.Id, cancellationToken)
+            ?? throw new InvalidOperationException("Grant not found.");
+        _context.Set<SqlOSFgaGrant>().Remove(grant);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+
+    private async Task UpsertSeededMachineClientsCoreAsync(CancellationToken cancellationToken)
+    {
+        var seeds = _options.ClientSeeds.Where(x => x.MachineClient != null).ToArray();
+        var keys = seeds.Select(x => x.ClientId.Trim()).ToHashSet(StringComparer.Ordinal);
+        var now = DateTime.UtcNow;
+        var orphans = await _context.Set<SqlOSFgaServiceAccount>()
+            .Where(x => x.ConfigurationOwner == SqlOSConfigurationOwners.Code && x.ConfigurationSourceKey != null && !keys.Contains(x.ConfigurationSourceKey))
+            .ToListAsync(cancellationToken);
+        foreach (var orphan in orphans) orphan.ConfigurationOrphanedAt ??= now;
+
+        foreach (var seed in seeds)
+        {
+            var machine = seed.MachineClient!;
+            var sourceKey = seed.ClientId.Trim();
+            var client = await _context.Set<SqlOSClientApplication>().SingleOrDefaultAsync(x => x.ClientId == sourceKey, cancellationToken)
+                ?? throw new InvalidOperationException($"Machine client '{sourceKey}' has no reconciled OAuth client.");
+            var organizationId = await ResolveOrganizationIdAsync(machine.OrganizationId, machine.OrganizationSlug, cancellationToken);
+            var grants = await NormalizeGrantsAsync(machine.Grants, cancellationToken);
+            var fingerprint = SqlOSConfigurationOwnershipPolicy.Fingerprint(new
+            {
+                sourceKey, organizationId, seed.Name, seed.Description, seed.Audience, seed.AllowedScopes, machine.ExpiresAt,
+                Grants = grants.Select(x => new { x.ResourceId, x.RoleId, x.Description })
+            });
+            var account = await _context.Set<SqlOSFgaServiceAccount>().Include(x => x.Subject)
+                .SingleOrDefaultAsync(x => x.ConfigurationSourceKey == sourceKey || x.ClientId == sourceKey, cancellationToken);
+            if (account != null)
+            {
+                SqlOSConfigurationOwnershipPolicy.EnsureCodeOwnership(account.ConfigurationOwner, account.ConfigurationSourceKey, sourceKey, $"Machine client '{sourceKey}'");
+                if (!string.Equals(account.Subject!.OrganizationId, organizationId, StringComparison.Ordinal))
+                    throw new InvalidOperationException($"Machine client '{sourceKey}' cannot move between organizations.");
+            }
+
+            var secretHash = ResolveSeedSecretHash(machine, account);
+            if (account == null)
+            {
+                var subject = new SqlOSFgaSubject
+                {
+                    Id = _crypto.GenerateId("sub"), SubjectTypeId = "service_account", OrganizationId = organizationId,
+                    DisplayName = seed.Name, ExternalRef = sourceKey, CreatedAt = now, UpdatedAt = now
+                };
+                account = new SqlOSFgaServiceAccount
+                {
+                    Id = _crypto.GenerateId("sa"), SubjectId = subject.Id, Subject = subject, ClientId = sourceKey,
+                    ClientSecretHash = secretHash, Description = seed.Description, ExpiresAt = machine.ExpiresAt,
+                    ConfigurationOwner = SqlOSConfigurationOwners.Code, ConfigurationSourceKey = sourceKey, CreatedAt = now
+                };
+                _context.Set<SqlOSFgaSubject>().Add(subject);
+                _context.Set<SqlOSFgaServiceAccount>().Add(account);
+            }
+            account.Subject!.DisplayName = seed.Name;
+            account.Description = seed.Description;
+            account.ClientSecretHash = secretHash;
+            account.ExpiresAt = machine.ExpiresAt;
+            account.ConfigurationFingerprint = fingerprint;
+            account.LastReconciledAt = now;
+            account.ConfigurationOrphanedAt = null;
+            account.UpdatedAt = now;
+
+            var marker = $"[sqlos-machine:{sourceKey}]";
+            var old = await _context.Set<SqlOSFgaGrant>().Where(x => x.SubjectId == account.SubjectId && x.Description != null && x.Description.StartsWith(marker)).ToListAsync(cancellationToken);
+            _context.Set<SqlOSFgaGrant>().RemoveRange(old);
+            AddGrants(account.SubjectId, grants, now, marker);
+            await _admin.RecordAuditAsync("configuration.reconciled", "system", "startup", organizationId: organizationId,
+                data: new { resourceType = "machine_client", clientId = sourceKey, subjectId = account.SubjectId, owner = SqlOSConfigurationOwners.Code, fingerprint }, cancellationToken: cancellationToken);
+        }
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+
+    private string ResolveSeedSecretHash(SqlOSMachineClientSeedOptions machine, SqlOSFgaServiceAccount? account)
+    {
+        if ((machine.SecretResolver == null) == (machine.SecretHashResolver == null))
+            throw new InvalidOperationException("Machine-client seeds require exactly one secret or secret-hash resolver.");
+        if (machine.SecretHashResolver != null)
+        {
+            var hash = machine.SecretHashResolver()?.Trim();
+            if (string.IsNullOrWhiteSpace(hash)) throw new InvalidOperationException("Machine-client secret hash resolution returned no value.");
+            return hash;
+        }
+        var secret = machine.SecretResolver!()?.Trim();
+        if (string.IsNullOrWhiteSpace(secret) || secret.Length is < 43 or > 256)
+            throw new InvalidOperationException("Machine-client secret resolution must return 43 to 256 characters.");
+        return account != null && _crypto.VerifyPassword(account.ClientSecretHash, secret) ? account.ClientSecretHash : _crypto.HashPassword(secret);
+    }
+
+    private async Task<NormalizedCreate> NormalizeCreateAsync(SqlOSCreateMachineClientRequest request, CancellationToken cancellationToken)
+    {
+        var clientId = Require(request.ClientId, "Client ID is required.", 200);
+        var displayName = Require(request.DisplayName, "Display name is required.", 200);
+        var audience = Require(request.Audience, "Audience is required.", 500);
+        var organizationId = await ResolveOrganizationIdAsync(request.OrganizationId, null, cancellationToken);
+        var scopes = request.Scopes.Where(x => !string.IsNullOrWhiteSpace(x)).Select(x => x.Trim()).Distinct(StringComparer.Ordinal).ToArray();
+        if (scopes.Length == 0) throw new InvalidOperationException("At least one scope is required.");
+        var grants = await NormalizeGrantsAsync(request.Grants, cancellationToken);
+        return new(clientId, displayName, request.Description?.Trim(), audience, scopes, organizationId, request.ExpiresAt, grants);
+    }
+
+    private async Task<string?> ResolveOrganizationIdAsync(string? organizationId, string? organizationSlug, CancellationToken cancellationToken)
+    {
+        if (!string.IsNullOrWhiteSpace(organizationId) && !string.IsNullOrWhiteSpace(organizationSlug))
+            throw new InvalidOperationException("Specify an organization ID or slug, not both.");
+        if (string.IsNullOrWhiteSpace(organizationId) && string.IsNullOrWhiteSpace(organizationSlug)) return null;
+        var organization = await _context.Set<SqlOSOrganization>().AsNoTracking().SingleOrDefaultAsync(x =>
+            !string.IsNullOrWhiteSpace(organizationId) ? x.Id == organizationId.Trim() : x.Slug == organizationSlug!.Trim(), cancellationToken);
+        return organization?.Id ?? throw new InvalidOperationException("Organization not found.");
+    }
+
+    private async Task<IReadOnlyList<SqlOSMachineClientGrantSeedOptions>> NormalizeGrantsAsync(IEnumerable<SqlOSMachineClientGrantSeedOptions> grants, CancellationToken cancellationToken)
+    {
+        var normalized = grants.Select(x => new SqlOSMachineClientGrantSeedOptions(Require(x.ResourceId, "Grant resource is required.", 450), Require(x.RoleId, "Grant role is required.", 450), x.Description?.Trim()))
+            .DistinctBy(x => (x.ResourceId, x.RoleId)).ToArray();
+        var resourceIds = normalized.Select(x => x.ResourceId).Distinct().ToArray();
+        var roleIds = normalized.Select(x => x.RoleId).Distinct().ToArray();
+        if (await _context.Set<SqlOSFgaResource>().CountAsync(x => resourceIds.Contains(x.Id), cancellationToken) != resourceIds.Length) throw new InvalidOperationException("One or more grant resources do not exist.");
+        if (await _context.Set<SqlOSFgaRole>().CountAsync(x => roleIds.Contains(x.Id), cancellationToken) != roleIds.Length) throw new InvalidOperationException("One or more grant roles do not exist.");
+        return normalized;
+    }
+
+    private void AddGrants(string subjectId, IReadOnlyList<SqlOSMachineClientGrantSeedOptions> grants, DateTime now, string? marker)
+    {
+        foreach (var grant in grants) _context.Set<SqlOSFgaGrant>().Add(new SqlOSFgaGrant
+        {
+            Id = _crypto.GenerateId("grant"), SubjectId = subjectId, ResourceId = grant.ResourceId, RoleId = grant.RoleId,
+            Description = marker == null ? grant.Description : $"{marker} {grant.Description}".Trim(), CreatedAt = now, UpdatedAt = now
+        });
+    }
+
+    private SqlOSClientApplication CreateClient(NormalizedCreate request, DateTime now) => new()
+    {
+        Id = _crypto.GenerateId("cli"), ClientId = request.ClientId, Name = request.DisplayName, Description = request.Description,
+        Audience = request.Audience, ClientType = "confidential", RegistrationSource = "admin", TokenEndpointAuthMethod = "client_secret_basic",
+        GrantTypesJson = JsonSerializer.Serialize(new[] { SqlOSOAuthGrantTypes.ClientCredentials }), ResponseTypesJson = "[]", RequirePkce = false,
+        AllowedScopesJson = JsonSerializer.Serialize(request.Scopes), RedirectUrisJson = "[]", IsActive = true,
+        AccessMode = SqlOSApplicationAccessModes.AllOrganizations, CreatedAt = now
+    };
+
+    private async Task<(SqlOSClientApplication Client, SqlOSFgaServiceAccount Account, SqlOSFgaSubject Subject)> RequireAsync(string clientId, CancellationToken cancellationToken)
+    {
+        var account = await _context.Set<SqlOSFgaServiceAccount>().Include(x => x.Subject).SingleOrDefaultAsync(x => x.ClientId == clientId, cancellationToken)
+            ?? throw new InvalidOperationException("Machine client not found.");
+        var client = await _context.Set<SqlOSClientApplication>().SingleAsync(x => x.ClientId == clientId, cancellationToken);
+        return (client, account, account.Subject!);
+    }
+
+    private static void EnsureDashboardOwned(SqlOSFgaServiceAccount account)
+    {
+        if (!string.Equals(account.ConfigurationOwner, SqlOSConfigurationOwners.Dashboard, StringComparison.Ordinal))
+            throw new InvalidOperationException("This machine client is code-owned. Change its seed and secret resolver instead.");
+    }
+
+    private static SqlOSMachineClientDto ToDto(SqlOSClientApplication client, SqlOSFgaServiceAccount account, SqlOSFgaSubject subject, int grantCount)
+        => new(client.ClientId, subject.DisplayName, account.Description, client.Audience, SqlOSAdminService.DeserializeJsonList(client.AllowedScopesJson), subject.OrganizationId,
+            account.ExpiresAt, account.LastUsedAt, client.IsActive && client.DisabledAt == null && (account.ExpiresAt == null || account.ExpiresAt > DateTime.UtcNow),
+            account.ConfigurationOwner, account.ConfigurationSourceKey, account.ConfigurationOrphanedAt, grantCount);
+
+    private static string GenerateSecret() => WebEncoders.Base64UrlEncode(RandomNumberGenerator.GetBytes(48));
+    private static string Require(string? value, string message, int max)
+    {
+        var normalized = value?.Trim();
+        if (string.IsNullOrWhiteSpace(normalized)) throw new InvalidOperationException(message);
+        if (normalized.Length > max) throw new InvalidOperationException($"{message} Maximum length is {max}.");
+        return normalized;
+    }
+
+    private sealed record NormalizedCreate(string ClientId, string DisplayName, string? Description, string Audience, IReadOnlyList<string> Scopes, string? OrganizationId, DateTime? ExpiresAt, IReadOnlyList<SqlOSMachineClientGrantSeedOptions> Grants);
+}
+
+public sealed record SqlOSCreateMachineClientRequest(string ClientId, string DisplayName, string? Description, string Audience, IReadOnlyList<string> Scopes, string? OrganizationId, DateTime? ExpiresAt, IReadOnlyList<SqlOSMachineClientGrantSeedOptions> Grants);
+public sealed record SqlOSMachineClientGrantRequest(string ResourceId, string RoleId, string? Description = null);
+public sealed record SqlOSMachineClientDto(string ClientId, string DisplayName, string? Description, string Audience, IReadOnlyList<string> Scopes, string? OrganizationId, DateTime? ExpiresAt, DateTime? LastUsedAt, bool Ready, string ConfigurationOwner, string? ConfigurationSourceKey, DateTime? ConfigurationOrphanedAt, int GrantCount);
+public sealed record SqlOSMachineClientCreated(SqlOSMachineClientDto Client, string ClientSecret);
+public sealed record SqlOSMachineClientValidation(bool Valid, string Status);

--- a/src/SqlOS/Dashboard/wwwroot/app.js
+++ b/src/SqlOS/Dashboard/wwwroot/app.js
@@ -27,6 +27,7 @@
     let latestSsoDraft = null;
     let latestSsoPortalSession = null;
     let latestScimToken = null;
+    let latestMachineClientSecret = null;
     const pagerState = new Map();
     let selectedClientId = null;
     let clientDraftState = null;
@@ -72,6 +73,7 @@
         users: { title: "Users", description: "Create users and bootstrap password credentials." },
         memberships: { title: "Memberships", description: "Assign users to organizations and manage roles." },
         clients: { title: "Applications", description: "Manage owned apps, client metadata, access assignments, and lifecycle actions." },
+        "machine-clients": { title: "Machine Clients", description: "Provision OAuth client credentials and FGA service accounts as one operational identity." },
         oidc: { title: "Social Login", description: "Configure Google, Microsoft, Apple, GitHub, and custom providers for authserver-owned social login." },
         security: { title: "Security", description: "Tune refresh, idle, and absolute session lifetimes." },
         mfa: { title: "MFA", description: "Configure authenticator app enrollment and second-factor requirements." },
@@ -1291,6 +1293,11 @@
 
         if (view === "clients") {
             await renderAuthClients(route);
+            return;
+        }
+
+        if (view === "machine-clients") {
+            await renderAuthMachineClients();
             return;
         }
 
@@ -3243,6 +3250,90 @@
             form?.scrollIntoView({ behavior: "smooth", block: "start" });
             form?.querySelector("input[name=\"clientId\"]")?.focus();
         }
+    }
+
+    async function renderAuthMachineClients() {
+        const config = authViews["machine-clients"];
+        setHeader("Auth Server", config.title, config.description);
+        renderLoading("Loading machine clients...");
+        const [machines, organizations] = await Promise.all([
+            fetchJson(`${authApiBasePath}/machine-clients`),
+            fetchJson(`${authApiBasePath}/organizations?page=1&pageSize=100`)
+        ]);
+        const organizationRows = organizations.data || [];
+
+        content.innerHTML = `
+            ${consumeFlashHtml()}
+            ${latestMachineClientSecret ? `<section class="panel callout"><h2>Copy this secret now</h2><p>SqlOS stores only a slow hash and cannot show this value again.</p><div class="inline-code">${esc(latestMachineClientSecret.secret)}</div><p><strong>Client ID:</strong> ${esc(latestMachineClientSecret.clientId)}</p><button id="machine-secret-ack" type="button">I copied it</button></section>` : ""}
+            <div class="panel-grid">
+                <section class="panel">
+                    <h2>Create machine client</h2>
+                    <p>Creates the confidential OAuth client, FGA subject, credential hash, and initial grant atomically.</p>
+                    <form id="machine-client-form">
+                        <input name="clientId" maxlength="200" placeholder="nightly-worker" required>
+                        <input name="displayName" maxlength="200" placeholder="Nightly worker" required>
+                        <input name="description" maxlength="500" placeholder="Purpose (optional)">
+                        <input name="audience" maxlength="500" placeholder="https://api.example.com" required>
+                        <input name="scopes" placeholder="jobs.run jobs.read" required>
+                        <select name="organizationId"><option value="">No organization binding</option>${organizationRows.map(org => `<option value="${esc(org.id)}">${esc(org.name)}</option>`).join("")}</select>
+                        <input name="expiresAt" type="datetime-local" placeholder="Expiry (optional)">
+                        <input name="resourceId" placeholder="Initial FGA resource ID (optional)">
+                        <input name="roleId" placeholder="Initial FGA role ID (optional)">
+                        <button type="submit">Create and reveal secret once</button>
+                    </form>
+                </section>
+                <section class="panel">
+                    <h2>Worker configuration</h2>
+                    ${renderMetadataRows([
+                        { label: "Token endpoint", value: `${window.location.origin}${authServerBasePath}/token` },
+                        { label: "Authentication", value: "HTTP Basic (client_secret_basic)" },
+                        { label: "Grant", value: "client_credentials" }
+                    ])}
+                    <p>Code-owned clients should use <code>SeedMachineClient</code> and a host secret resolver. Dashboard-owned clients reveal a generated secret only at creation and rotation.</p>
+                </section>
+            </div>
+            <section class="panel">
+                <h2>Operational identities</h2>
+                ${machines.length ? `<div class="table-wrap"><table><thead><tr><th>Name</th><th>Client / audience</th><th>Status</th><th>Ownership</th><th>Grants</th><th>Last use</th><th>Actions</th></tr></thead><tbody>${machines.map(machine => `<tr>
+                    <td>${esc(machine.displayName)}</td>
+                    <td><code>${esc(machine.clientId)}</code><br><small>${esc(machine.audience)}</small></td>
+                    <td>${machine.ready ? '<span class="status active">Ready</span>' : '<span class="status inactive">Unavailable</span>'}</td>
+                    <td>${esc(machine.configurationOwner)}${machine.configurationSourceKey ? `<br><small>${esc(machine.configurationSourceKey)}</small>` : ""}${machine.configurationOrphanedAt ? '<br><span class="status warning">Orphaned</span>' : ""}</td>
+                    <td>${esc(machine.grantCount)}</td><td>${machine.lastUsedAt ? esc(formatDate(machine.lastUsedAt)) : "Never"}</td>
+                    <td><button type="button" data-machine-test="${esc(machine.clientId)}" data-resource="${esc(machine.audience)}" data-scopes="${esc(machine.scopes.join(" "))}">Test</button> ${machine.configurationOwner === "dashboard" ? `<button type="button" data-machine-rotate="${esc(machine.clientId)}">Rotate</button>` : ""} <button type="button" data-machine-revoke="${esc(machine.clientId)}">Revoke</button></td>
+                </tr>`).join("")}</tbody></table></div>` : "<p>No machine clients yet.</p>"}
+                <p><a href="${esc(pathForRoute("fga-service-accounts"))}" data-dashboard-route="fga-service-accounts">Inspect service-account subjects and grant paths in FGA</a></p>
+            </section>`;
+
+        bindForm("machine-client-form", async form => {
+            const resourceId = String(form.get("resourceId") || "").trim();
+            const roleId = String(form.get("roleId") || "").trim();
+            if ((resourceId && !roleId) || (!resourceId && roleId)) throw new Error("Specify both initial resource and role IDs.");
+            const result = await fetchJson(`${authApiBasePath}/machine-clients`, { method: "POST", body: JSON.stringify({
+                clientId: form.get("clientId"), displayName: form.get("displayName"), description: form.get("description") || null,
+                audience: form.get("audience"), scopes: String(form.get("scopes") || "").split(/\s+/).filter(Boolean),
+                organizationId: form.get("organizationId") || null, expiresAt: form.get("expiresAt") ? new Date(form.get("expiresAt")).toISOString() : null,
+                grants: resourceId ? [{ resourceId, roleId, description: "Initial dashboard grant" }] : []
+            }) });
+            latestMachineClientSecret = { clientId: result.client.clientId, secret: result.clientSecret };
+            await renderAuthMachineClients();
+        });
+        document.getElementById("machine-secret-ack")?.addEventListener("click", async () => { latestMachineClientSecret = null; await renderAuthMachineClients(); });
+        document.querySelectorAll("[data-machine-rotate]").forEach(button => button.addEventListener("click", async () => {
+            if (!window.confirm(`Rotate ${button.dataset.machineRotate}? The old secret stops working immediately.`)) return;
+            const result = await fetchJson(`${authApiBasePath}/machine-clients/${encodeURIComponent(button.dataset.machineRotate)}/rotate`, { method: "POST" });
+            latestMachineClientSecret = { clientId: result.client.clientId, secret: result.clientSecret }; await renderAuthMachineClients();
+        }));
+        document.querySelectorAll("[data-machine-test]").forEach(button => button.addEventListener("click", async () => {
+            const secret = window.prompt(`Paste the current secret for ${button.dataset.machineTest}. It is sent only to this authenticated admin operation and is never stored or returned.`);
+            if (!secret) return;
+            const result = await fetchJson(`${authApiBasePath}/machine-clients/${encodeURIComponent(button.dataset.machineTest)}/validate`, { method: "POST", body: JSON.stringify({ clientSecret: secret, resource: button.dataset.resource, scopes: button.dataset.scopes.split(/\s+/).filter(Boolean) }) });
+            setFlash(result.valid ? "success" : "error", result.valid ? "Credential, audience, scope, expiry, and client status are valid." : "Credential or binding is invalid."); await renderAuthMachineClients();
+        }));
+        document.querySelectorAll("[data-machine-revoke]").forEach(button => button.addEventListener("click", async () => {
+            if (!window.confirm(`Immediately revoke ${button.dataset.machineRevoke}? Existing database-validated service tokens will stop working.`)) return;
+            await fetchJson(`${authApiBasePath}/machine-clients/${encodeURIComponent(button.dataset.machineRevoke)}/revoke`, { method: "POST" }); setFlash("success", "Machine client revoked."); await renderAuthMachineClients();
+        }));
     }
 
     async function renderAuthOidc() {

--- a/src/SqlOS/Dashboard/wwwroot/index.html
+++ b/src/SqlOS/Dashboard/wwwroot/index.html
@@ -34,6 +34,7 @@
                     <a href="#" data-route="auth-users">Users</a>
                     <a href="#" data-route="auth-memberships">Memberships</a>
                     <a href="#" data-route="auth-clients">Applications</a>
+                    <a href="#" data-route="auth-machine-clients">Machine Clients</a>
                     <a href="#" data-route="auth-oidc">OIDC</a>
                     <a href="#" data-route="auth-security">Security</a>
                     <a href="#" data-route="auth-mfa">MFA</a>

--- a/src/SqlOS/Extensions/ServiceCollectionExtensions.cs
+++ b/src/SqlOS/Extensions/ServiceCollectionExtensions.cs
@@ -109,6 +109,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<SqlOSInvitationService>();
         services.AddScoped<SqlOSDeviceAuthorizationService>();
         services.AddScoped<SqlOSClientCredentialsService>();
+        services.AddScoped<SqlOSMachineClientAdminService>();
         services.AddScoped<SqlOSCimdClientService>();
         services.AddScoped<SqlOSDynamicClientRegistrationService>();
         services.AddScoped<SqlOSClientResolutionService>();

--- a/src/SqlOS/Fga/Configuration/SqlOSFgaModelConfiguration.cs
+++ b/src/SqlOS/Fga/Configuration/SqlOSFgaModelConfiguration.cs
@@ -165,6 +165,12 @@ public static class SqlOSFgaModelConfiguration
         {
             entity.ToTable(tables.ServiceAccounts, schema, t => t.ExcludeFromMigrations());
             entity.HasKey(e => e.Id);
+            entity.Property(e => e.ClientId).HasMaxLength(450);
+            entity.Property(e => e.ConfigurationOwner).HasMaxLength(32);
+            entity.Property(e => e.ConfigurationSourceKey).HasMaxLength(200);
+            entity.Property(e => e.ConfigurationFingerprint).HasMaxLength(128);
+            entity.HasIndex(e => e.ClientId).IsUnique();
+            entity.HasIndex(e => new { e.ConfigurationOwner, e.ConfigurationSourceKey }).IsUnique();
             entity.HasOne(e => e.Subject)
                 .WithOne(s => s.ServiceAccount)
                 .HasForeignKey<SqlOSFgaServiceAccount>(e => e.SubjectId)

--- a/src/SqlOS/Fga/Dashboard/SqlOSFgaDashboardMiddleware.cs
+++ b/src/SqlOS/Fga/Dashboard/SqlOSFgaDashboardMiddleware.cs
@@ -807,6 +807,9 @@ public class SqlOSFgaDashboardMiddleware
                 s.Description,
                 s.LastUsedAt,
                 s.ExpiresAt,
+                s.ConfigurationOwner,
+                s.ConfigurationSourceKey,
+                s.ConfigurationOrphanedAt,
                 s.CreatedAt
             })
             .ToListAsync();

--- a/src/SqlOS/Fga/Models/SqlOSFgaServiceAccount.cs
+++ b/src/SqlOS/Fga/Models/SqlOSFgaServiceAccount.cs
@@ -14,6 +14,11 @@ public class SqlOSFgaServiceAccount
     public DateTime? ExpiresAt { get; set; }
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+    public string ConfigurationOwner { get; set; } = "dashboard";
+    public string? ConfigurationSourceKey { get; set; }
+    public string? ConfigurationFingerprint { get; set; }
+    public DateTime? LastReconciledAt { get; set; }
+    public DateTime? ConfigurationOrphanedAt { get; set; }
 
     // Navigation
     public SqlOSFgaSubject? Subject { get; set; }

--- a/src/SqlOS/Fga/Schema/007_MachineClientOwnership.sql
+++ b/src/SqlOS/Fga/Schema/007_MachineClientOwnership.sql
@@ -1,0 +1,21 @@
+IF COL_LENGTH('{Schema}.{ServiceAccounts}', 'ConfigurationOwner') IS NULL
+BEGIN
+    ALTER TABLE [{Schema}].[{ServiceAccounts}] ADD
+        [ConfigurationOwner] NVARCHAR(32) NOT NULL CONSTRAINT [DF_{ServiceAccounts}_ConfigurationOwner] DEFAULT N'dashboard',
+        [ConfigurationSourceKey] NVARCHAR(200) NULL,
+        [ConfigurationFingerprint] NVARCHAR(128) NULL,
+        [LastReconciledAt] DATETIME2 NULL,
+        [ConfigurationOrphanedAt] DATETIME2 NULL;
+END
+GO
+
+ALTER TABLE [{Schema}].[{ServiceAccounts}] ALTER COLUMN [ClientId] NVARCHAR(450) NOT NULL;
+GO
+
+IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'UX_{ServiceAccounts}_ClientId' AND object_id = OBJECT_ID('[{Schema}].[{ServiceAccounts}]'))
+    CREATE UNIQUE INDEX [UX_{ServiceAccounts}_ClientId] ON [{Schema}].[{ServiceAccounts}] ([ClientId]);
+GO
+
+IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'UX_{ServiceAccounts}_ConfigurationSource' AND object_id = OBJECT_ID('[{Schema}].[{ServiceAccounts}]'))
+    CREATE UNIQUE INDEX [UX_{ServiceAccounts}_ConfigurationSource] ON [{Schema}].[{ServiceAccounts}] ([ConfigurationOwner], [ConfigurationSourceKey]) WHERE [ConfigurationSourceKey] IS NOT NULL;
+GO

--- a/src/SqlOS/Services/SqlOSBootstrapper.cs
+++ b/src/SqlOS/Services/SqlOSBootstrapper.cs
@@ -13,6 +13,7 @@ public sealed class SqlOSBootstrapper
     private readonly SqlOSSchemaInitializer _authSchemaInitializer;
     private readonly SqlOSCryptoService _cryptoService;
     private readonly SqlOSAdminService _adminService;
+    private readonly SqlOSMachineClientAdminService _machineClients;
     private readonly SqlOSSettingsService _settingsService;
     private readonly SqlOSEmailAdminService _emailAdminService;
     private readonly SqlOSFgaSchemaInitializer _fgaSchemaInitializer;
@@ -26,6 +27,7 @@ public sealed class SqlOSBootstrapper
         SqlOSSchemaInitializer authSchemaInitializer,
         SqlOSCryptoService cryptoService,
         SqlOSAdminService adminService,
+        SqlOSMachineClientAdminService machineClients,
         SqlOSSettingsService settingsService,
         SqlOSEmailAdminService emailAdminService,
         SqlOSFgaSchemaInitializer fgaSchemaInitializer,
@@ -38,6 +40,7 @@ public sealed class SqlOSBootstrapper
         _authSchemaInitializer = authSchemaInitializer;
         _cryptoService = cryptoService;
         _adminService = adminService;
+        _machineClients = machineClients;
         _settingsService = settingsService;
         _emailAdminService = emailAdminService;
         _fgaSchemaInitializer = fgaSchemaInitializer;
@@ -78,6 +81,7 @@ public sealed class SqlOSBootstrapper
         }
 
         await _adminService.UpsertSeededClientsAsync(cancellationToken);
+        await _machineClients.UpsertSeededMachineClientsAsync(cancellationToken);
         await _adminService.UpsertSeededOidcConnectionsAsync(cancellationToken);
         await _adminService.UpsertSeededSamlConnectionsAsync(cancellationToken);
         await _adminService.UpsertSeededScimConnectionsAsync(cancellationToken);

--- a/tests/SqlOS.IntegrationTests/ClientCredentialsIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/ClientCredentialsIntegrationTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using System.Text.Json;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
@@ -14,6 +15,44 @@ namespace SqlOS.IntegrationTests;
 [TestClass]
 public sealed class ClientCredentialsIntegrationTests
 {
+    [TestMethod]
+    public async Task UnifiedMachineClient_RealSql_AtomicallyProvisionsRotatesAndRevokesProtocolIdentity()
+    {
+        var suffix = Guid.NewGuid().ToString("N");
+        var clientId = $"unified-{suffix}";
+        var audience = $"https://api.example.test/unified/{suffix}";
+        var context = AspireFixture.SharedContext;
+        var options = Options.Create(AspireFixture.Options);
+        var crypto = new SqlOSCryptoService(context, options, AspireFixture.DataProtectionProvider);
+        var admin = new SqlOSAdminService(context, options, crypto);
+        var machines = new SqlOSMachineClientAdminService(context, admin, crypto, options);
+        var protocol = new SqlOSClientCredentialsService(context, crypto, admin, options);
+        var organization = await admin.CreateOrganizationAsync(new SqlOSCreateOrganizationRequest($"Unified {suffix}", $"unified-{suffix}"));
+        var resourceTypeId = await context.Set<SqlOSFgaResourceType>().Select(x => x.Id).FirstAsync();
+        var role = new SqlOSFgaRole { Id = $"role_{suffix}", Key = $"runner-{suffix}", Name = "Runner" };
+        var resource = new SqlOSFgaResource { Id = $"res_{suffix}", ResourceTypeId = resourceTypeId, Name = "Jobs", IsActive = true };
+        context.Set<SqlOSFgaRole>().Add(role);
+        context.Set<SqlOSFgaResource>().Add(resource);
+        await context.SaveChangesAsync();
+
+        var created = await machines.CreateAsync(new SqlOSCreateMachineClientRequest(
+            clientId, "Unified worker", null, audience, ["jobs.run"], organization.Id, null, [new(resource.Id, role.Id)]));
+        var issued = await protocol.ExchangeAsync(clientId, created.ClientSecret, audience, "jobs.run", new DefaultHttpContext(), default);
+        (await crypto.ValidateAccessTokenAsync(issued.AccessToken, audience)).Should().NotBeNull();
+        var account = await context.Set<SqlOSFgaServiceAccount>().SingleAsync(x => x.ClientId == clientId);
+        (await context.Set<SqlOSFgaGrant>().AnyAsync(x => x.SubjectId == account.SubjectId && x.ResourceId == resource.Id && x.RoleId == role.Id)).Should().BeTrue();
+
+        var rotated = await machines.RotateAsync(clientId);
+        await FluentActions.Invoking(() => protocol.ExchangeAsync(clientId, created.ClientSecret, audience, "jobs.run", new DefaultHttpContext(), default))
+            .Should().ThrowAsync<SqlOSClientCredentialsException>();
+        (await protocol.ExchangeAsync(clientId, rotated.ClientSecret, audience, "jobs.run", new DefaultHttpContext(), default)).AccessToken.Should().NotBeNullOrWhiteSpace();
+
+        await machines.RevokeAsync(clientId);
+        (await crypto.ValidateAccessTokenAsync(issued.AccessToken, audience)).Should().BeNull();
+        JsonSerializer.Serialize(await context.Set<SqlOSAuditEvent>().Where(x => x.ActorId == clientId || x.DataJson!.Contains(clientId)).ToListAsync())
+            .Should().NotContain(created.ClientSecret).And.NotContain(rotated.ClientSecret);
+    }
+
     [TestMethod]
     public async Task ClientCredentials_RealSql_IssuesValidServiceTokenAndRevokesWithoutHumanSession()
     {

--- a/tests/SqlOS.Tests/SqlOSAdminAuthorizationMetadataTests.cs
+++ b/tests/SqlOS.Tests/SqlOSAdminAuthorizationMetadataTests.cs
@@ -87,6 +87,8 @@ public sealed class SqlOSAdminAuthorizationMetadataTests
             await client.PostAsJsonAsync("/sqlos/admin/auth/api/sessions/revocation", new { userId = "victim", confirm = true }),
             await client.GetAsync("/sqlos/admin/auth/api/otp/readiness"),
             await client.PostAsJsonAsync("/sqlos/admin/auth/api/otp/test-delivery", new { method = "email", destination = "operator@example.test" }),
+            await client.GetAsync("/sqlos/admin/auth/api/machine-clients"),
+            await client.PostAsJsonAsync("/sqlos/admin/auth/api/machine-clients", new { }),
             await client.PutAsJsonAsync("/sqlos/admin/email/api/templates/missing", new { }),
             await client.DeleteAsync("/sqlos/admin/email/api/templates/missing")
         };

--- a/tests/SqlOS.Tests/SqlOSAuthEndpointRouteInventoryTests.cs
+++ b/tests/SqlOS.Tests/SqlOSAuthEndpointRouteInventoryTests.cs
@@ -49,7 +49,9 @@ public class SqlOSAuthEndpointRouteInventoryTests
             "POST /sqlos/admin/auth/api/sessions/revocation",
             "GET /sqlos/admin/auth/api/settings/security",
             "GET /sqlos/admin/auth/api/otp/readiness",
-            "POST /sqlos/admin/auth/api/otp/test-delivery"
+            "POST /sqlos/admin/auth/api/otp/test-delivery",
+            "GET /sqlos/admin/auth/api/machine-clients",
+            "POST /sqlos/admin/auth/api/machine-clients"
         };
 
         actual.Should().Contain(expected);

--- a/tests/SqlOS.Tests/SqlOSMachineClientAdminServiceTests.cs
+++ b/tests/SqlOS.Tests/SqlOSMachineClientAdminServiceTests.cs
@@ -1,0 +1,128 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SqlOS.AuthServer.Configuration;
+using SqlOS.AuthServer.Contracts;
+using SqlOS.AuthServer.Models;
+using SqlOS.AuthServer.Services;
+using SqlOS.Fga.Models;
+using SqlOS.Tests.Infrastructure;
+
+namespace SqlOS.Tests;
+
+[TestClass]
+public sealed class SqlOSMachineClientAdminServiceTests
+{
+    [TestMethod]
+    public async Task DashboardCreateRotateValidateAndRevoke_RevealsSecretsOnlyOnce()
+    {
+        await using var context = CreateContext();
+        var options = Options.Create(new SqlOSAuthServerOptions());
+        var crypto = TestCryptoService.Create(context, options);
+        var admin = new SqlOSAdminService(context, options, crypto);
+        var service = new SqlOSMachineClientAdminService(context, admin, crypto, options);
+        var (organization, resource, role) = await SeedDependenciesAsync(context, admin);
+
+        var created = await service.CreateAsync(new SqlOSCreateMachineClientRequest(
+            "nightly-worker", "Nightly worker", "Runs nightly jobs", "https://api.example.test",
+            ["jobs.run"], organization.Id, DateTime.UtcNow.AddDays(30), [new(resource.Id, role.Id)]));
+
+        created.ClientSecret.Should().HaveLength(64);
+        var listJson = JsonSerializer.Serialize(await service.ListAsync());
+        listJson.Should().NotContain(created.ClientSecret);
+        listJson.Should().NotContain("ClientSecretHash");
+        (await service.ValidateCredentialAsync("nightly-worker", created.ClientSecret, "https://api.example.test", ["jobs.run"])).Valid.Should().BeTrue();
+        (await service.ValidateCredentialAsync("nightly-worker", created.ClientSecret, "https://wrong.example.test", ["jobs.run"])).Valid.Should().BeFalse();
+
+        var rotated = await service.RotateAsync("nightly-worker");
+        rotated.ClientSecret.Should().NotBe(created.ClientSecret);
+        (await service.ValidateCredentialAsync("nightly-worker", created.ClientSecret, "https://api.example.test", ["jobs.run"])).Valid.Should().BeFalse();
+        (await service.ValidateCredentialAsync("nightly-worker", rotated.ClientSecret, "https://api.example.test", ["jobs.run"])).Valid.Should().BeTrue();
+
+        await service.RevokeAsync("nightly-worker");
+        (await service.ValidateCredentialAsync("nightly-worker", rotated.ClientSecret, "https://api.example.test", ["jobs.run"])).Valid.Should().BeFalse();
+        (await context.Set<SqlOSFgaGrant>().CountAsync()).Should().Be(1, "revocation and grant removal have distinct effects");
+        JsonSerializer.Serialize(await context.Set<SqlOSAuditEvent>().ToListAsync()).Should().NotContain(created.ClientSecret).And.NotContain(rotated.ClientSecret);
+    }
+
+    [TestMethod]
+    public async Task CodeSeed_IsIdempotentOwnershipSafeAndOrphanVisible()
+    {
+        await using var context = CreateContext();
+        var optionsValue = new SqlOSAuthServerOptions();
+        var secret = new string('s', 64);
+        var options = Options.Create(optionsValue);
+        var crypto = TestCryptoService.Create(context, options);
+        var admin = new SqlOSAdminService(context, options, crypto);
+        var (organization, resource, role) = await SeedDependenciesAsync(context, admin);
+        optionsValue.SeedMachineClient("seeded-worker", (client, machine) =>
+        {
+            client.Name = "Seeded worker";
+            client.Audience = "https://api.example.test";
+            client.AllowedScopes = ["jobs.run"];
+            machine.OrganizationId = organization.Id;
+            machine.SecretResolver = () => secret;
+            machine.Grant(resource.Id, role.Id, "Run jobs");
+        });
+        var service = new SqlOSMachineClientAdminService(context, admin, crypto, options);
+
+        await admin.UpsertSeededClientsAsync();
+        await service.UpsertSeededMachineClientsAsync();
+        await service.UpsertSeededMachineClientsAsync();
+
+        var account = await context.Set<SqlOSFgaServiceAccount>().Include(x => x.Subject).SingleAsync();
+        account.ConfigurationOwner.Should().Be(SqlOSConfigurationOwners.Code);
+        account.ConfigurationSourceKey.Should().Be("seeded-worker");
+        account.Subject!.OrganizationId.Should().Be(organization.Id);
+        (await context.Set<SqlOSFgaGrant>().CountAsync(x => x.SubjectId == account.SubjectId)).Should().Be(1);
+        (await service.ValidateCredentialAsync("seeded-worker", secret, "https://api.example.test", ["jobs.run"])).Valid.Should().BeTrue();
+        await FluentActions.Invoking(() => service.RotateAsync("seeded-worker"))
+            .Should().ThrowAsync<InvalidOperationException>().WithMessage("*code-owned*");
+
+        optionsValue.ClientSeeds.Clear();
+        await service.UpsertSeededMachineClientsAsync();
+        account.ConfigurationOrphanedAt.Should().NotBeNull();
+        account.ExpiresAt.Should().BeNull("orphan visibility must not silently revoke a worker");
+    }
+
+    [TestMethod]
+    public async Task CodeSeed_FailsClosedWithoutSecretAndDoesNotAdoptDashboardAccount()
+    {
+        await using var context = CreateContext();
+        var optionsValue = new SqlOSAuthServerOptions();
+        var options = Options.Create(optionsValue);
+        var crypto = TestCryptoService.Create(context, options);
+        var admin = new SqlOSAdminService(context, options, crypto);
+        var service = new SqlOSMachineClientAdminService(context, admin, crypto, options);
+        var (_, resource, role) = await SeedDependenciesAsync(context, admin);
+        optionsValue.SeedMachineClient("missing-secret", (client, machine) =>
+        {
+            client.Name = "Missing"; client.Audience = "api"; client.AllowedScopes = ["run"];
+            machine.SecretResolver = () => null;
+            machine.Grant(resource.Id, role.Id);
+        });
+        await admin.UpsertSeededClientsAsync();
+        await FluentActions.Invoking(() => service.UpsertSeededMachineClientsAsync())
+            .Should().ThrowAsync<InvalidOperationException>().WithMessage("*43 to 256*");
+    }
+
+    private static async Task<(SqlOSOrganization Organization, SqlOSFgaResource Resource, SqlOSFgaRole Role)> SeedDependenciesAsync(TestSqlOSInMemoryDbContext context, SqlOSAdminService admin)
+    {
+        var organization = await admin.CreateOrganizationAsync(new SqlOSCreateOrganizationRequest("Machines", $"machines-{Guid.NewGuid():N}"));
+        var resource = new SqlOSFgaResource { Id = $"res_{Guid.NewGuid():N}", Name = "Jobs", ResourceTypeId = "workspace", IsActive = true };
+        var role = new SqlOSFgaRole { Id = $"role_{Guid.NewGuid():N}", Key = "runner", Name = "Runner" };
+        context.Set<SqlOSFgaResource>().Add(resource);
+        context.Set<SqlOSFgaRole>().Add(role);
+        await context.SaveChangesAsync();
+        return (organization, resource, role);
+    }
+
+    private static TestSqlOSInMemoryDbContext CreateContext()
+        => new(new DbContextOptionsBuilder<TestSqlOSInMemoryDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .ConfigureWarnings(warnings => warnings.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+            .Options);
+}

--- a/tests/SqlOS.Tests/SqlOSMachineClientAdminServiceTests.cs
+++ b/tests/SqlOS.Tests/SqlOSMachineClientAdminServiceTests.cs
@@ -71,6 +71,7 @@ public sealed class SqlOSMachineClientAdminServiceTests
 
         await admin.UpsertSeededClientsAsync();
         await service.UpsertSeededMachineClientsAsync();
+        var originalGrantId = await context.Set<SqlOSFgaGrant>().Select(x => x.Id).SingleAsync();
         await service.UpsertSeededMachineClientsAsync();
 
         var account = await context.Set<SqlOSFgaServiceAccount>().Include(x => x.Subject).SingleAsync();
@@ -78,6 +79,8 @@ public sealed class SqlOSMachineClientAdminServiceTests
         account.ConfigurationSourceKey.Should().Be("seeded-worker");
         account.Subject!.OrganizationId.Should().Be(organization.Id);
         (await context.Set<SqlOSFgaGrant>().CountAsync(x => x.SubjectId == account.SubjectId)).Should().Be(1);
+        (await context.Set<SqlOSFgaGrant>().Select(x => x.Id).SingleAsync()).Should().Be(originalGrantId);
+        (await context.Set<SqlOSAuditEvent>().CountAsync(x => x.EventType == "configuration.reconciled" && x.DataJson != null && x.DataJson.Contains("machine_client"))).Should().Be(1);
         (await service.ValidateCredentialAsync("seeded-worker", secret, "https://api.example.test", ["jobs.run"])).Valid.Should().BeTrue();
         await FluentActions.Invoking(() => service.RotateAsync("seeded-worker"))
             .Should().ThrowAsync<InvalidOperationException>().WithMessage("*code-owned*");
@@ -107,6 +110,11 @@ public sealed class SqlOSMachineClientAdminServiceTests
         await admin.UpsertSeededClientsAsync();
         await FluentActions.Invoking(() => service.UpsertSeededMachineClientsAsync())
             .Should().ThrowAsync<InvalidOperationException>().WithMessage("*43 to 256*");
+
+        optionsValue.ClientSeeds[0].MachineClient!.SecretResolver = null;
+        optionsValue.ClientSeeds[0].MachineClient!.SecretHashResolver = () => "not-a-password-hash";
+        await FluentActions.Invoking(() => service.UpsertSeededMachineClientsAsync())
+            .Should().ThrowAsync<InvalidOperationException>().WithMessage("*unsupported PasswordHasher payload*");
     }
 
     private static async Task<(SqlOSOrganization Organization, SqlOSFgaResource Resource, SqlOSFgaRole Role)> SeedDependenciesAsync(TestSqlOSInMemoryDbContext context, SqlOSAdminService admin)

--- a/web/content/docs/authserver/dashboard-overview.mdx
+++ b/web/content/docs/authserver/dashboard-overview.mdx
@@ -135,6 +135,7 @@ For setup details, see [MFA and TOTP](/docs/authserver/mfa-totp) and [Require Au
 | Roles | `/sqlos/admin/fga/roles` | Define roles and link permissions |
 | Permissions | `/sqlos/admin/fga/permissions` | View permission keys by resource type |
 | Subjects | `/sqlos/admin/fga/users` | Manage FGA users, agents, service accounts, groups |
+| Machine clients | `/sqlos/admin/auth/machine-clients` | Create, test, rotate, revoke, and inspect unified OAuth client/FGA service-account identities |
 | Access Tester | `/sqlos/admin/fga/access-tester` | Test access decisions with a detailed trace |
 
 ## Sessions

--- a/web/content/docs/guides/service-account-jobs.mdx
+++ b/web/content/docs/guides/service-account-jobs.mdx
@@ -22,24 +22,50 @@ This guide builds **LedgerOps**, a fictional finance app whose nightly worker ex
   SqlOS can authenticate an explicitly configured confidential client with `client_secret_basic`, issue an audience-bound service token, and map its `sub` to the existing FGA service-account subject. Public clients and dynamic registration cannot enable this grant.
 </Callout>
 
-## Recommended: configure the OAuth service client
+## Recommended: declare one machine client
 
-Add a confidential client seed. The grant is off unless `EnableClientCredentials` is set, and no redirect URI or PKCE configuration is needed:
+`SeedMachineClient` reconciles the confidential OAuth client, FGA service-account subject, slow credential hash, organization binding, and initial grants as one ownership-safe unit. The resolver reads the secret from the host's existing secret provider; SqlOS never writes or logs the plaintext value:
 
 ```csharp
-options.AuthServer.ClientSeeds.Add(new SqlOSClientSeedOptions
+options.AuthServer.SeedMachineClient("ledger-exporter", (client, machine) =>
 {
-    ClientId = "ledger-exporter",
-    Name = "Ledger Exporter",
-    Audience = "https://api.example.com/ledger",
-    ClientType = "confidential",
-    EnableClientCredentials = true,
-    RequirePkce = false,
-    AllowedScopes = ["ledger.export"]
+    client.Name = "Ledger Exporter";
+    client.Description = "Nightly read-only export for Northwind";
+    client.Audience = "https://api.example.com/ledger";
+    client.AllowedScopes = ["ledger.export"];
+
+    machine.OrganizationSlug = "northwind";
+    machine.ExpiresAt = DateTime.UtcNow.AddDays(90);
+    machine.SecretResolver = () =>
+        builder.Configuration["SqlOS:MachineClients:LedgerExporter:Secret"];
+    machine.Grant("ledger::northwind", "export_reader", "Nightly ledger export");
 });
 ```
 
-Provision the matching FGA service account once from an authenticated admin command. Store only the slow hash in SqlOS and deliver the raw secret directly to the worker's secret manager:
+The secret must contain 43 to 256 characters. Missing material fails startup closed; a restart does not generate a new secret. Changing the value in the deployment secret provider performs an explicit code-owned rotation on reconciliation. Removing the declaration marks the machine client orphaned for operator review instead of silently disabling a job.
+
+Alternatively, provide `SecretHashResolver` when your deployment pipeline already produces an ASP.NET Core `PasswordHasher`-compatible hash. Specify exactly one resolver.
+
+## Dashboard and admin API workflow
+
+Open **Auth Server > Machine Clients** to create the same OAuth/FGA identity interactively. Creation is atomic and displays a generated 64-character secret exactly once. Later list/detail responses contain client ID, audience, scopes, organization, expiry, last use, ownership, readiness, and grant count—but never the hash or secret.
+
+The authenticated admin API uses these routes:
+
+| Operation | Route |
+| --- | --- |
+| List/readiness | `GET /sqlos/admin/auth/api/machine-clients` |
+| Atomic create and one-time secret | `POST /sqlos/admin/auth/api/machine-clients` |
+| Explicit rotation and one-time secret | `POST /sqlos/admin/auth/api/machine-clients/{clientId}/rotate` |
+| Credential/audience/scope test without issuing a token | `POST /sqlos/admin/auth/api/machine-clients/{clientId}/validate` |
+| Immediate OAuth and issued-token revocation | `POST /sqlos/admin/auth/api/machine-clients/{clientId}/revoke` |
+| Narrow grant changes | `POST`/`DELETE /sqlos/admin/auth/api/machine-clients/{clientId}/grants...` |
+
+Code-owned identities remain visible and testable in the dashboard, but rotation and grant mutation are blocked because startup would otherwise overwrite an operator's change. Update the declaration or secret provider instead. Dashboard-owned records remain fully operable. The generic FGA Service Accounts view still exposes the subject and grant paths and links back conceptually to the same client ID.
+
+## Lower-level provisioning remains available
+
+For advanced application-owned boundaries, the original helpers remain usable. Provision the matching FGA service account from a trusted administrative command and deliver the raw secret directly to the worker's secret manager:
 
 ```csharp
 var secret = Convert.ToHexString(RandomNumberGenerator.GetBytes(32));


### PR DESCRIPTION
Closes #215.

## What changed
- adds `SeedMachineClient` for ownership-safe OAuth client + FGA subject + credential hash + grant reconciliation
- adds atomic admin creation with one-time generated secret, redacted listing, credential/binding tests, explicit rotation, revocation, and narrow grant operations
- adds a complete embedded dashboard workflow and links to generic FGA service-account inspection
- adds FGA schema ownership/uniqueness constraints and preserves orphan visibility
- updates the service-account jobs guide with compiled code-first, API, dashboard, and low-level paths

## Security and ergonomics
- no cloud key service or external secret dependency
- only slow secret hashes are persisted; plaintext appears only in creation/rotation responses
- code-owned secrets come from application-provided resolvers and missing material fails startup
- dashboard-owned and code-owned identities cannot silently overwrite each other
- client credentials remain `client_secret_basic`, exact-audience, exact-scope, and database-lifecycle validated

## Validation
- 662 unit tests
- real SQL/protocol integration: atomic provision -> real client-credentials token -> FGA grant -> rotation/old-secret rejection -> revocation/issued-token rejection
- FGA schema v7 integration
- authenticated route inventory and fail-closed admin authorization tests
- compiled machine-client documentation example
- full docs lint/build/link gate and dashboard JavaScript syntax

An adversarial review round will be recorded on this PR before merge.
