### PR TITLE
Release SqlOS 3.24.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![NuGet](https://img.shields.io/nuget/v/SqlOS)](https://www.nuget.org/packages/SqlOS)
 [![.NET 9](https://img.shields.io/badge/.NET-9.0-purple)](https://dotnet.microsoft.com)
 
-SqlOS 3.23.0 provides a hosted OAuth server, branded login, organizations, sessions, and optional fine-grained authorization to an ASP.NET Core application. It runs in your process and stores its data in your SQL Server database, so you do not need a separate identity or authorization service to get started.
+SqlOS 3.24.0 provides a hosted OAuth server, branded login, organizations, sessions, and optional fine-grained authorization to an ASP.NET Core application. It runs in your process and stores its data in your SQL Server database, so you do not need a separate identity or authorization service to get started.
 
 Start with one application and hosted login. Add SAML SSO, social login, Email OTP, audit logs, calendar connections, or hierarchical authorization when your product needs them.
 
@@ -53,10 +53,10 @@ Requirements:
 Install the package:
 
 ```bash
-dotnet add package SqlOS --version 3.23.0
+dotnet add package SqlOS --version 3.24.0
 ```
 
-> The `main` branch is staged for the 3.23.0 package contract. If NuGet does not list 3.23.0 yet, run the repository examples from source or wait for the package release; do not pair these source docs with an older package.
+> The `main` branch is staged for the 3.24.0 package contract. If NuGet does not list 3.24.0 yet, run the repository examples from source or wait for the package release; do not pair these source docs with an older package.
 
 Use `SqlOSDbContext<TContext>` so SqlOS can register its EF Core model, then declare one application with `UseSingleApplication`:
 

--- a/examples/SqlOS.Example.IntegrationTests/SqlOSExampleOidcAuthIntegrationTests.cs
+++ b/examples/SqlOS.Example.IntegrationTests/SqlOSExampleOidcAuthIntegrationTests.cs
@@ -652,8 +652,9 @@ public sealed class SqlOSExampleOidcAuthIntegrationTests
         var request = new CertificateRequest("CN=SqlOSEntraMetadata", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
         var certificate = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(30));
         var rawCertificate = Convert.ToBase64String(certificate.Export(X509ContentType.Cert));
+        var tenantId = Guid.NewGuid().ToString("N");
         var metadataXml = $"""
-        <EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" entityID="https://sts.windows.net/test-tenant/">
+        <EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" entityID="https://sts.windows.net/{tenantId}/">
           <IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
             <KeyDescriptor use="signing">
               <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
@@ -662,7 +663,7 @@ public sealed class SqlOSExampleOidcAuthIntegrationTests
                 </X509Data>
               </KeyInfo>
             </KeyDescriptor>
-            <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://login.microsoftonline.com/test-tenant/saml2" />
+            <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://login.microsoftonline.com/{tenantId}/saml2" />
           </IDPSSODescriptor>
         </EntityDescriptor>
         """;

--- a/examples/SqlOS.Example.IntegrationTests/SqlOSExampleWebAuthIntegrationTests.cs
+++ b/examples/SqlOS.Example.IntegrationTests/SqlOSExampleWebAuthIntegrationTests.cs
@@ -105,7 +105,11 @@ public sealed class SqlOSExampleWebAuthIntegrationTests
         using var rsa = RSA.Create(2048);
         var request = new CertificateRequest("CN=SqlOSEntraMetadata", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
         var certificate = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(30));
-        var metadataXml = BuildFederationMetadata("https://sts.windows.net/test-tenant/", "https://login.microsoftonline.com/test-tenant/saml2", certificate);
+        var tenantId = Guid.NewGuid().ToString("N");
+        var metadataXml = BuildFederationMetadata(
+            $"https://sts.windows.net/{tenantId}/",
+            $"https://login.microsoftonline.com/{tenantId}/saml2",
+            certificate);
 
         var importResponse = await ExampleApiFixture.Client.PostAsJsonAsync($"/sqlos/admin/auth/api/sso-connections/{connectionId}/metadata", new
         {

--- a/scripts/compile-doc-snippets.mjs
+++ b/scripts/compile-doc-snippets.mjs
@@ -118,6 +118,13 @@ const snippetSpecs = [
     marker: "SeedMachineClient(",
     wrap: asMachineClientSeedProgram,
   },
+  {
+    name: "3.24 machine-client release example",
+    relativePath: "web/content/blog/sqlos-3-24-three-control-planes-one-auth-system.mdx",
+    heading: "## One machine client instead of four disconnected records",
+    marker: "SeedMachineClient(",
+    wrap: asMachineClientSeedProgram,
+  },
 ];
 
 function extractCsharpBlock({ relativePath, heading, marker }) {

--- a/src/SqlOS/SqlOS.csproj
+++ b/src/SqlOS/SqlOS.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>SqlOS</PackageId>
-    <Version>3.23.0</Version>
+    <Version>3.24.0</Version>
     <Authors>Ross Slaney</Authors>
     <Description>Embedded auth server and fine-grained authorization runtime for .NET + SQL Server + EF Core.</Description>
     <PackageTags>authentication;authorization;fga;saml;jwt;sessions;efcore;sqlserver</PackageTags>

--- a/tests/SqlOS.IntegrationTests/HeadlessAuthIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/HeadlessAuthIntegrationTests.cs
@@ -1,6 +1,8 @@
 using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
 using System.Net;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
@@ -850,13 +852,27 @@ public sealed class HeadlessAuthIntegrationTests
             "Headless SSO",
             $"urn:headless:{Guid.NewGuid():N}",
             "https://idp.example.test/sso",
-            "-----BEGIN CERTIFICATE-----\nTEST\n-----END CERTIFICATE-----",
+            CreateSamlCertificatePem(),
             true,
             true,
             "email",
             "first_name",
             "last_name"));
         return organization;
+    }
+
+    private static string CreateSamlCertificatePem()
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest(
+            "CN=HeadlessAuthIntegrationIdP",
+            rsa,
+            HashAlgorithmName.SHA256,
+            RSASignaturePadding.Pkcs1);
+        using var certificate = request.CreateSelfSigned(
+            DateTimeOffset.UtcNow.AddDays(-1),
+            DateTimeOffset.UtcNow.AddDays(30));
+        return certificate.ExportCertificatePem();
     }
 
     private static string? ExtractCookieValue(string setCookieHeader, string cookieName)

--- a/web/content/blog/hierarchical-authorization-native-ef-core.mdx
+++ b/web/content/blog/hierarchical-authorization-native-ef-core.mdx
@@ -128,7 +128,7 @@ Create the host and install the same package version used to compile this articl
 ```bash
 dotnet new web --framework net9.0 --name HierarchicalEf
 cd HierarchicalEf
-dotnet add package SqlOS --version 3.23.0
+dotnet add package SqlOS --version 3.24.0
 ```
 
 Replace `Program.cs` with the program below. It assumes SQL Server is running and that callers obtain an audience-bound access token through the [Protect an API quickstart](/docs/quickstarts/protect-api). That keeps the sample focused on upgrading the EF model rather than rebuilding the OAuth client flow in the same file.

--- a/web/content/blog/sqlos-3-24-three-control-planes-one-auth-system.mdx
+++ b/web/content/blog/sqlos-3-24-three-control-planes-one-auth-system.mdx
@@ -1,0 +1,91 @@
+---
+title: "SqlOS 3.24: Three Control Planes, One Auth System"
+description: "Configure identity in code, operate it through authenticated APIs, and troubleshoot it in the dashboard without adding an external identity platform."
+date: "2026-07-17"
+author: "Ross Slaney"
+tags: ["AuthServer", "OAuth", "SAML", "OTP", "Service Accounts", "Dashboard", "SqlOS"]
+---
+
+SqlOS has always aimed for a particular kind of developer experience: add one .NET library, keep identity data in your SQL Server database, and get a real OAuth and authorization system without adopting a second platform.
+
+That simplicity becomes harder to preserve as an identity product grows. Enterprise SAML, machine clients, application policy, revocation, and delivery diagnostics all need serious operational controls. The easy failure mode is to make every developer configure those controls manually—or to move them into a cloud service that becomes another production dependency.
+
+SqlOS 3.24 takes a different approach. Important identity features now share three explicit control planes:
+
+- **Code-first configuration** for reproducible, source-controlled desired state.
+- **Programmable administration** for authenticated services and admin APIs.
+- **Dashboard workflows** for setup, testing, troubleshooting, rotation, revocation, and audit visibility.
+
+The three paths converge on the same normalization, ownership, and runtime services. A normal application still starts without dashboard setup. Production operators gain the controls they need when they need them.
+
+## Code-owned configuration no longer means invisible configuration
+
+Startup declarations now carry explicit ownership metadata and stable source keys. Reconciliation is idempotent: an unchanged restart does not churn records or audit history. Dashboard-owned data is not silently adopted or overwritten. If a declaration disappears, SqlOS surfaces an orphan instead of deleting or disabling a working production integration.
+
+The dashboard can display code-owned records and their source keys, but it does not pretend they are ordinary editable rows. Operational actions that are safe and meaningful remain available; configuration that would be overwritten at the next restart points the operator back to code.
+
+This shared foundation now covers OAuth clients, application access assignments, OIDC, SCIM, MFA policy, SAML connections, and machine clients. It is also backed by control-plane parity tests so code, service/API, and dashboard paths cannot quietly normalize the same feature differently.
+
+## SAML can be declared without adding infrastructure
+
+An upstream SAML connection can now be seeded with a stable key, an organization ID or slug, metadata XML or explicit IdP settings, domain policy, attribute mapping, JIT behavior, and MFA trust policy.
+
+SqlOS validates HTTPS endpoints and the real X.509 signing certificate before accepting the declaration. Reconciliation will not adopt a dashboard-owned connection with the same entity ID, move a stable connection across organizations, or allow two providers to collide on an entity ID.
+
+There is no metadata-fetching daemon, cloud key service, or external control plane. The certificate is public verification material; the normal SqlOS signing keys remain protected locally through the existing Data Protection custody model.
+
+Operators can still disable a code-owned SAML connection during an incident. That emergency disable survives restart instead of being immediately undone by desired-state reconciliation.
+
+## OTP readiness without exposing provider secrets
+
+Email and phone OTP already worked through hosted AuthPage, headless flows, and the SDK. The missing piece was operational: an operator could not quickly answer whether delivery was configured, what was missing, or whether the provider would accept a test.
+
+The Security dashboard and authenticated admin API now return a redacted readiness model for both methods. It includes enabled state, provider type, bounded reason codes, exact host-configuration keys, and useful non-secret limits. ACS and Twilio credentials remain deployment-owned and never enter a dashboard response or database row.
+
+Explicit test delivery uses the same runtime abstractions as authentication, but creates no SqlOS user, session, or login challenge. Tests are limited per destination and per operator source through the distributed SQL-backed limiter. Recent diagnostics contain masked destinations and bounded provider outcomes.
+
+Phone verification also received an important protocol hardening: runtime checks are now bound to the exact stored Twilio verification SID. A code created by an administrative test—or by any other verification for the same phone number—cannot satisfy a different SqlOS login challenge.
+
+## One machine client instead of four disconnected records
+
+SqlOS 3.23 introduced OAuth client credentials for service identities. Version 3.24 completes the administrative model around it.
+
+`SeedMachineClient` declares the confidential OAuth client, FGA service-account subject, organization, audience, scopes, expiry, and initial grants together. The secret comes from an application-supplied resolver, so it can use the deployment secret mechanism you already trust:
+
+```csharp
+options.AuthServer.SeedMachineClient("ledger-exporter", (client, machine) =>
+{
+    client.Name = "Ledger Exporter";
+    client.Audience = "https://api.example.com/ledger";
+    client.AllowedScopes = ["ledger.export"];
+
+    machine.OrganizationSlug = "northwind";
+    machine.SecretResolver = () =>
+        builder.Configuration["SqlOS:MachineClients:LedgerExporter:Secret"];
+    machine.Grant("ledger::northwind", "export_reader");
+});
+```
+
+SqlOS stores only the slow hash. Missing or malformed secret material fails closed, and an unchanged restart neither generates a credential nor recreates grants.
+
+The dashboard/API path creates the same runtime identity atomically and reveals a generated secret once. Operators can test the credential plus its exact audience and scopes without issuing a token, rotate it with immediate old-secret rejection, inspect its FGA relationship, or revoke it so database-validated issued tokens stop working. Code-owned clients remain visible and testable without becoming silently dashboard-owned.
+
+## Revocation and application policy are operational features
+
+Application access policy now has a complete code-first declaration for organization, user, group, service-account, agent, and role assignments. Ownership and orphan state are visible in the API and dashboard.
+
+Platform administrators also have a complete session and refresh-token revocation workflow. Preview and execute are scope-bound and audited; operation identifiers cannot be reused against another target. User, organization, application, and session views expose the appropriate action without requiring direct SQL or a custom maintenance endpoint.
+
+## Security work should preserve the reason people chose the library
+
+Every feature in this release went through an adversarial review after implementation, with the findings and fixes recorded on its pull request. The tests include real SQL concurrency, real signed SAML login, a real client-credentials token lifecycle, distributed throttling across application contexts, dashboard/API authorization, redaction, and compiled documentation examples.
+
+The important outcome is not merely more controls. It is that the controls live behind the same ergonomic boundary as the rest of SqlOS:
+
+- no required Azure, AWS, or hosted identity dependency;
+- no setup tax for applications that do not use the feature;
+- no plaintext credential recovery path;
+- no separate policy engine for the dashboard; and
+- no hidden difference between what code declares and what the runtime enforces.
+
+Start with [Add SqlOS to your app](/docs/quickstarts/add-to-app). For the new operational paths, continue with [SAML SSO](/docs/authserver/saml-sso), [Email OTP](/docs/authserver/email-otp), [Phone OTP](/docs/authserver/phone-otp), or [Background jobs with service accounts](/docs/guides/service-account-jobs).

--- a/web/content/docs/docs-index.mdx
+++ b/web/content/docs/docs-index.mdx
@@ -5,7 +5,7 @@ order: 0
 ---
 
 <Callout type="info" title="Version contract">
-  These docs target **SqlOS 3.23.0**, **.NET 9**, **EF Core 9**, and **SQL Server**. Use the same package version as the docs; older releases do not include the complete current schema and source/reference contract.
+  These docs target **SqlOS 3.24.0**, **.NET 9**, **EF Core 9**, and **SQL Server**. Use the same package version as the docs; older releases do not include the complete current schema and source/reference contract.
 </Callout>
 
 ## Get useful proof first

--- a/web/content/docs/getting-started.mdx
+++ b/web/content/docs/getting-started.mdx
@@ -14,7 +14,7 @@ order: 0
 </Banner>
 
 <Callout type="info" title="Supported stack">
-  - **SqlOS 3.23.0**
+  - **SqlOS 3.24.0**
   - **.NET 9** (`net9.0`)
   - **EF Core 9**
   - **SQL Server**

--- a/web/content/docs/quickstarts/add-to-app.mdx
+++ b/web/content/docs/quickstarts/add-to-app.mdx
@@ -11,7 +11,7 @@ section: quickstarts
   href="#complete-program"
   actionLabel="View the code"
 >
-  Install SqlOS 3.23.0, register one SQL Server `DbContext`, declare one application, and map the routes. FGA modeling and advanced client registration can wait.
+  Install SqlOS 3.24.0, register one SQL Server `DbContext`, declare one application, and map the routes. FGA modeling and advanced client registration can wait.
 </Banner>
 
 ## Goal
@@ -30,16 +30,16 @@ Start an ASP.NET Core application with:
 - EF Core 9;
 - an existing SQL Server database and a login allowed to create tables, indexes, and functions.
 
-SqlOS 3.23.0 targets `net9.0`; it is not compatible with a `net8.0` host.
+SqlOS 3.24.0 targets `net9.0`; it is not compatible with a `net8.0` host.
 
 ## Install
 
 ```bash
-dotnet add package SqlOS --version 3.23.0
+dotnet add package SqlOS --version 3.24.0
 ```
 
 <Callout type="warning" title="Use the matching package version">
-  The `3.23.0` package is the version contract for this guide. If NuGet does not list it yet, run the source examples from this repository or wait for the release; older packages may not contain the schema and APIs documented here.
+  The `3.24.0` package is the version contract for this guide. If NuGet does not list it yet, run the source examples from this repository or wait for the release; older packages may not contain the schema and APIs documented here.
 </Callout>
 
 For a new project, store local values with user secrets:

--- a/web/content/docs/quickstarts/ef-authorization.mdx
+++ b/web/content/docs/quickstarts/ef-authorization.mdx
@@ -20,7 +20,7 @@ Create projects through an audience-protected API and return only projects the s
 
 ## Prerequisites
 
-- SqlOS 3.23.0;
+- SqlOS 3.24.0;
 - .NET 9, EF Core 9, and SQL Server;
 - a completed [Protect an API](/docs/quickstarts/protect-api) flow;
 - a valid access token whose `aud` is `http://localhost:5050/api`.

--- a/web/content/docs/quickstarts/protect-api.mdx
+++ b/web/content/docs/quickstarts/protect-api.mdx
@@ -20,7 +20,7 @@ Add `/api/me` to a one-application SqlOS host. Requests without a bearer token r
 
 ## Prerequisites
 
-- SqlOS 3.23.0;
+- SqlOS 3.24.0;
 - .NET 9 and EF Core 9;
 - the [Add SqlOS to one app](/docs/quickstarts/add-to-app) setup;
 - the working [.NET hosted-login flow](/docs/quickstarts/aspnet-core-login), adapted so its registered callback matches your handler and its audience is `http://localhost:5050/api`, or another PKCE client that does the same.

--- a/web/content/docs/quickstarts/run-example-stack.mdx
+++ b/web/content/docs/quickstarts/run-example-stack.mdx
@@ -20,7 +20,7 @@ Compare hosted and headless auth, organization workflows, SSO, sessions, audit l
 
 ## Prerequisites
 
-- SqlOS repository checked out at version 3.23.0;
+- SqlOS repository checked out at version 3.24.0;
 - .NET 9 SDK;
 - Node.js and npm;
 - Docker running with enough memory for SQL Server;

--- a/web/content/docs/quickstarts/run-todo.mdx
+++ b/web/content/docs/quickstarts/run-todo.mdx
@@ -25,7 +25,7 @@ Create an account through the SqlOS hosted AuthPage, return to a secure ASP.NET 
 - Docker running with enough memory for SQL Server;
 - ports `1435`, `5080`, `5090`, `18890`, and `18891` available.
 
-This quickstart uses the source at **SqlOS 3.23.0**. Local password authentication is the default, so the first run does not require Azure Communication Services, Twilio, or an OIDC provider.
+This quickstart uses the source at **SqlOS 3.24.0**. Local password authentication is the default, so the first run does not require Azure Communication Services, Twilio, or an OIDC provider.
 
 ## Run
 

--- a/web/content/docs/reference/index.mdx
+++ b/web/content/docs/reference/index.mdx
@@ -1,13 +1,13 @@
 ---
 title: "Reference"
-description: "Source-aligned reference for SqlOS 3.23.0 hosting, authentication, authorization, and integration APIs."
+description: "Source-aligned reference for SqlOS 3.24.0 hosting, authentication, authorization, and integration APIs."
 order: 7
 section: reference
 ---
 
 <Banner
   eyebrow="Reference"
-  title="SqlOS 3.23.0 application API"
+  title="SqlOS 3.24.0 application API"
   href="/docs/getting-started"
   actionLabel="Start with a guide"
 >
@@ -19,7 +19,7 @@ section: reference
 | Item | Value |
 | --- | --- |
 | Package | `SqlOS` |
-| Current source version | `3.23.0` |
+| Current source version | `3.24.0` |
 | Assembly | `SqlOS.dll` |
 | Target framework | `net9.0` |
 | EF Core provider | SQL Server, EF Core 9 |


### PR DESCRIPTION
## Release

Publishes the combined control-plane and operational-security work from:

- #219 — shared configuration ownership/reconciliation foundation
- #220 — code/API/dashboard parity infrastructure
- #221 — code-first application access policy
- #222 — complete platform-admin session and refresh-token revocation
- #223 — ownership-safe code-first SAML connections
- #224 — safe Email/Phone OTP readiness, tests, and diagnostics
- #225 — unified OAuth machine-client and FGA administration

## Changes

- bumps the package and current documentation contract from 3.23.0 to 3.24.0
- adds the release post, **SqlOS 3.24: Three Control Planes, One Auth System**
- compiles the release post's machine-client example against the actual library

## Validation

- `dotnet build src/SqlOS/SqlOS.csproj`
- `./scripts/docs-check.sh`
- 171 markdown files have no broken local links
- release blog and all documentation snippets compile
- website lint, TypeScript, and production build pass
