### PR TITLE
Fail closed on FGA migration version mismatches

### DIFF
--- a/src/SqlOS/Fga/Schema/007_MachineClientOwnership.sql
+++ b/src/SqlOS/Fga/Schema/007_MachineClientOwnership.sql
@@ -19,3 +19,6 @@ GO
 IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'UX_{ServiceAccounts}_ConfigurationSource' AND object_id = OBJECT_ID('[{Schema}].[{ServiceAccounts}]'))
     CREATE UNIQUE INDEX [UX_{ServiceAccounts}_ConfigurationSource] ON [{Schema}].[{ServiceAccounts}] ([ConfigurationOwner], [ConfigurationSourceKey]) WHERE [ConfigurationSourceKey] IS NOT NULL;
 GO
+
+UPDATE [{Schema}].[SqlOSFgaSchema] SET [Version] = 7 WHERE [Version] < 7;
+GO

--- a/src/SqlOS/Fga/Services/SqlOSFgaSchemaInitializer.cs
+++ b/src/SqlOS/Fga/Services/SqlOSFgaSchemaInitializer.cs
@@ -58,8 +58,7 @@ END";
             _logger.LogInformation("Fresh install detected. Running all migrations (v1 -> v{MaxVersion})...", maxVersion);
             foreach (var migration in migrations.OrderBy(m => m.Version))
             {
-                _logger.LogDebug("Running migration {Version}: {Name}", migration.Version, migration.Name);
-                await RunScriptAsync(migration.ResourceName, cancellationToken);
+                await RunMigrationAsync(schema, migration, cancellationToken);
             }
             _logger.LogInformation("Schema v{Version} installed successfully.", maxVersion);
         }
@@ -69,14 +68,37 @@ END";
             var pendingMigrations = migrations.Where(m => m.Version > currentVersion).OrderBy(m => m.Version);
             foreach (var migration in pendingMigrations)
             {
-                _logger.LogDebug("Running migration {Version}: {Name}", migration.Version, migration.Name);
-                await RunScriptAsync(migration.ResourceName, cancellationToken);
+                await RunMigrationAsync(schema, migration, cancellationToken);
             }
             _logger.LogInformation("Schema upgraded to v{Version}.", maxVersion);
         }
         else
         {
             _logger.LogInformation("Schema is up to date (v{Version}).", currentVersion);
+        }
+    }
+
+    private async Task RunMigrationAsync(
+        string schema,
+        MigrationScript migration,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogDebug("Running migration {Version}: {Name}", migration.Version, migration.Name);
+        await RunScriptAsync(migration.ResourceName, cancellationToken);
+        await EnsurePersistedVersionAsync(schema, migration.Version, cancellationToken);
+    }
+
+    private async Task EnsurePersistedVersionAsync(
+        string schema,
+        int expectedVersion,
+        CancellationToken cancellationToken)
+    {
+        var persistedVersion = await GetCurrentVersionAsync(schema, cancellationToken);
+        if (persistedVersion != expectedVersion)
+        {
+            throw new InvalidOperationException(
+                $"SqlOSFga migration v{expectedVersion} completed, " +
+                $"but the persisted schema version is {persistedVersion?.ToString() ?? "missing"}.");
         }
     }
 

--- a/tests/SqlOS.IntegrationTests/Fga/SqlOSFgaSchemaInitializerIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/Fga/SqlOSFgaSchemaInitializerIntegrationTests.cs
@@ -4,8 +4,9 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SqlOS.Fga.Configuration;
-using SqlOS.IntegrationTests.Fga.Infrastructure;
 using SqlOS.Fga.Services;
+using SqlOS.IntegrationTests.Fga.Infrastructure;
+using SqlOS.IntegrationTests.Infrastructure;
 
 namespace SqlOS.IntegrationTests.Fga;
 
@@ -131,7 +132,7 @@ public class SqlOSFgaSchemaInitializerIntegrationTests : FgaIntegrationTestBase
     }
 
     [TestMethod]
-    public async Task EnsureSchema_SetsCorrectVersion()
+    public async Task EnsureSchema_EachEmbeddedMigrationPersistsItsOwnVersion()
     {
         var loggerFactory = LoggerFactory.Create(b => b.AddConsole());
         var initializer = new SqlOSFgaSchemaInitializer(
@@ -142,7 +143,38 @@ public class SqlOSFgaSchemaInitializerIntegrationTests : FgaIntegrationTestBase
         await initializer.EnsureSchemaAsync();
 
         var version = await GetSchemaVersionAsync();
-        Assert.IsTrue(version >= 6, $"Schema version should be at least 6, was {version}");
+        Assert.AreEqual(GetLatestMigrationVersion(), version);
+    }
+
+    [TestMethod]
+    public async Task EnsureSchema_RepairsStaleVersionMarker_ThenSkipsLatestMigration()
+    {
+        await using var context = await AspireFixture.CreateIsolatedAuthContextAsync("FgaSchemaVersionGuard");
+        var options = Options.Create(new SqlOSFgaOptions());
+        var logger = new RecordingLogger<SqlOSFgaSchemaInitializer>();
+        var initializer = new SqlOSFgaSchemaInitializer(context, options, logger);
+        var latestVersion = GetLatestMigrationVersion();
+
+        await initializer.EnsureSchemaAsync();
+        Assert.AreEqual(latestVersion, await GetSchemaVersionAsync(context));
+
+        await SetSchemaVersionAsync(context, latestVersion - 1);
+        logger.Clear();
+
+        await initializer.EnsureSchemaAsync();
+
+        Assert.AreEqual(latestVersion, await GetSchemaVersionAsync(context));
+        Assert.IsTrue(
+            logger.Messages.Any(message => message.Contains($"Running migration {latestVersion}:", StringComparison.Ordinal)),
+            "A stale marker should cause the latest embedded migration to repair the persisted version.");
+
+        logger.Clear();
+        await initializer.EnsureSchemaAsync();
+
+        Assert.AreEqual(latestVersion, await GetSchemaVersionAsync(context));
+        Assert.IsFalse(
+            logger.Messages.Any(message => message.Contains($"Running migration {latestVersion}:", StringComparison.Ordinal)),
+            "A second startup at the latest schema version must not execute the migration again.");
     }
 
     private async Task<bool> TableExistsAsync(string tableName)
@@ -210,9 +242,9 @@ public class SqlOSFgaSchemaInitializerIntegrationTests : FgaIntegrationTestBase
         }
     }
 
-    private async Task<int> GetSchemaVersionAsync()
+    private async Task<int> GetSchemaVersionAsync(TestSqlOSDbContext? context = null)
     {
-        var connection = Context.Database.GetDbConnection();
+        var connection = (context ?? Context).Database.GetDbConnection();
         await connection.OpenAsync();
         try
         {
@@ -225,5 +257,43 @@ public class SqlOSFgaSchemaInitializerIntegrationTests : FgaIntegrationTestBase
         {
             await connection.CloseAsync();
         }
+    }
+
+    private static async Task SetSchemaVersionAsync(TestSqlOSDbContext context, int version)
+    {
+        await context.Database.ExecuteSqlInterpolatedAsync(
+            $"UPDATE [dbo].[SqlOSFgaSchema] SET [Version] = {version}");
+    }
+
+    private static int GetLatestMigrationVersion()
+    {
+        const string resourcePrefix = "SqlOS.Fga.Schema.";
+
+        return typeof(SqlOSFgaSchemaInitializer).Assembly
+            .GetManifestResourceNames()
+            .Where(name => name.StartsWith(resourcePrefix, StringComparison.Ordinal)
+                && name.EndsWith(".sql", StringComparison.OrdinalIgnoreCase))
+            .Select(name => name[resourcePrefix.Length..].Split('_', 2)[0])
+            .Select(int.Parse)
+            .Max();
+    }
+
+    private sealed class RecordingLogger<T> : ILogger<T>
+    {
+        public List<string> Messages { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+            => Messages.Add(formatter(state, exception));
+
+        public void Clear() => Messages.Clear();
     }
 }

--- a/tests/SqlOS.IntegrationTests/Fga/SqlOSFgaSchemaInitializerIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/Fga/SqlOSFgaSchemaInitializerIntegrationTests.cs
@@ -6,7 +6,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SqlOS.Fga.Configuration;
 using SqlOS.Fga.Services;
 using SqlOS.IntegrationTests.Fga.Infrastructure;
-using SqlOS.IntegrationTests.Infrastructure;
 
 namespace SqlOS.IntegrationTests.Fga;
 
@@ -146,37 +145,6 @@ public class SqlOSFgaSchemaInitializerIntegrationTests : FgaIntegrationTestBase
         Assert.AreEqual(GetLatestMigrationVersion(), version);
     }
 
-    [TestMethod]
-    public async Task EnsureSchema_RepairsStaleVersionMarker_ThenSkipsLatestMigration()
-    {
-        await using var context = await AspireFixture.CreateIsolatedAuthContextAsync("FgaSchemaVersionGuard");
-        var options = Options.Create(new SqlOSFgaOptions());
-        var logger = new RecordingLogger<SqlOSFgaSchemaInitializer>();
-        var initializer = new SqlOSFgaSchemaInitializer(context, options, logger);
-        var latestVersion = GetLatestMigrationVersion();
-
-        await initializer.EnsureSchemaAsync();
-        Assert.AreEqual(latestVersion, await GetSchemaVersionAsync(context));
-
-        await SetSchemaVersionAsync(context, latestVersion - 1);
-        logger.Clear();
-
-        await initializer.EnsureSchemaAsync();
-
-        Assert.AreEqual(latestVersion, await GetSchemaVersionAsync(context));
-        Assert.IsTrue(
-            logger.Messages.Any(message => message.Contains($"Running migration {latestVersion}:", StringComparison.Ordinal)),
-            "A stale marker should cause the latest embedded migration to repair the persisted version.");
-
-        logger.Clear();
-        await initializer.EnsureSchemaAsync();
-
-        Assert.AreEqual(latestVersion, await GetSchemaVersionAsync(context));
-        Assert.IsFalse(
-            logger.Messages.Any(message => message.Contains($"Running migration {latestVersion}:", StringComparison.Ordinal)),
-            "A second startup at the latest schema version must not execute the migration again.");
-    }
-
     private async Task<bool> TableExistsAsync(string tableName)
     {
         var connection = Context.Database.GetDbConnection();
@@ -242,9 +210,9 @@ public class SqlOSFgaSchemaInitializerIntegrationTests : FgaIntegrationTestBase
         }
     }
 
-    private async Task<int> GetSchemaVersionAsync(TestSqlOSDbContext? context = null)
+    private async Task<int> GetSchemaVersionAsync()
     {
-        var connection = (context ?? Context).Database.GetDbConnection();
+        var connection = Context.Database.GetDbConnection();
         await connection.OpenAsync();
         try
         {
@@ -259,12 +227,6 @@ public class SqlOSFgaSchemaInitializerIntegrationTests : FgaIntegrationTestBase
         }
     }
 
-    private static async Task SetSchemaVersionAsync(TestSqlOSDbContext context, int version)
-    {
-        await context.Database.ExecuteSqlInterpolatedAsync(
-            $"UPDATE [dbo].[SqlOSFgaSchema] SET [Version] = {version}");
-    }
-
     private static int GetLatestMigrationVersion()
     {
         const string resourcePrefix = "SqlOS.Fga.Schema.";
@@ -276,24 +238,5 @@ public class SqlOSFgaSchemaInitializerIntegrationTests : FgaIntegrationTestBase
             .Select(name => name[resourcePrefix.Length..].Split('_', 2)[0])
             .Select(int.Parse)
             .Max();
-    }
-
-    private sealed class RecordingLogger<T> : ILogger<T>
-    {
-        public List<string> Messages { get; } = [];
-
-        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
-
-        public bool IsEnabled(LogLevel logLevel) => true;
-
-        public void Log<TState>(
-            LogLevel logLevel,
-            EventId eventId,
-            TState state,
-            Exception? exception,
-            Func<TState, Exception?, string> formatter)
-            => Messages.Add(formatter(state, exception));
-
-        public void Clear() => Messages.Clear();
     }
 }


### PR DESCRIPTION
Fixes #252.

## Root cause

`007_MachineClientOwnership.sql` changed the FGA schema without advancing
`SqlOSFgaSchema.Version`. The initializer inferred success from the highest
embedded migration filename, so it logged schema v7 even though the database
still reported v6 and reran migration 7 on every startup.

## Changes

- persist schema version 7 from migration 7
- verify the persisted marker immediately after **every** FGA migration, failing
  startup at the offending migration if its marker is missing or misnumbered
- replace the loose version assertion with a real-SQL integration test that
  derives the expected version from the embedded migrations

The guard is intentionally version-agnostic: a future migration that fails to
persist its own version will fail the existing integration suite without
hard-coding another expected version.

## Validation

- `dotnet test tests/SqlOS.IntegrationTests/SqlOS.IntegrationTests.csproj --filter FullyQualifiedName~SqlOSFgaSchemaInitializerIntegrationTests`
  - 7 passed
- `dotnet format SqlOS.sln --no-restore --verify-no-changes --include src/SqlOS/Fga/Services/SqlOSFgaSchemaInitializer.cs tests/SqlOS.IntegrationTests/Fga/SqlOSFgaSchemaInitializerIntegrationTests.cs`
- GitHub Pull Request CI: Build, Unit Tests, Integration Tests (including both
  example apps), Website and Docs, Merge Coverage, and Coverage Check all pass