### PR TITLE
Revoke SSO portal sessions when organizations are deactivated

### DIFF
--- a/src/SqlOS/AuthServer/Endpoints/SsoPortalEndpoints.cs
+++ b/src/SqlOS/AuthServer/Endpoints/SsoPortalEndpoints.cs
@@ -30,6 +30,8 @@ public static partial class EndpointRouteBuilderExtensions
         RouteGroupBuilder portal,
         RouteGroupBuilder setupApi)
     {
+        setupApi.AddEndpointFilter<SqlOSSsoPortalSessionAvailabilityFilter>();
+
         adminApi.MapGet("/organizations/{organizationId}/sso-portal/sessions", async (HttpContext context, string organizationId, int? page, int? pageSize, SqlOSSsoPortalService portalService, IOptions<SqlOSAuthServerOptions> options, IHostEnvironment environment, CancellationToken cancellationToken) =>
         {
             if (!await IsAdminAuthorizedAsync(context, options.Value, environment))
@@ -130,6 +132,7 @@ public static partial class EndpointRouteBuilderExtensions
             : Results.NotFound());
 
         var api = portal.MapGroup("/api");
+        api.AddEndpointFilter<SqlOSSsoPortalSessionAvailabilityFilter>();
 
         api.MapGet("/state", async (HttpContext context, SqlOSSsoPortalService portalService, CancellationToken cancellationToken) =>
         {
@@ -575,5 +578,24 @@ public static partial class EndpointRouteBuilderExtensions
             await portalService.SignOutAsync(context, cancellationToken);
             return Results.Ok(new SqlOSSsoSetupActionResult("redirect", null, null));
         });
+    }
+}
+
+internal sealed class SqlOSSsoPortalSessionAvailabilityFilter : IEndpointFilter
+{
+    public async ValueTask<object?> InvokeAsync(
+        EndpointFilterInvocationContext context,
+        EndpointFilterDelegate next)
+    {
+        try
+        {
+            return await next(context);
+        }
+        catch (SqlOSSsoPortalSessionUnavailableException)
+        {
+            return Results.Json(
+                new { message = SqlOSSsoPortalSessionUnavailableException.PublicMessage },
+                statusCode: StatusCodes.Status401Unauthorized);
+        }
     }
 }

--- a/src/SqlOS/AuthServer/Services/SqlOSAdminService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSAdminService.cs
@@ -668,6 +668,7 @@ public sealed partial class SqlOSAdminService
             .FirstOrDefaultAsync(x => x.Id == organizationId, cancellationToken)
             ?? throw new InvalidOperationException("Organization not found.");
         var isDeactivating = organization.IsActive && !request.IsActive;
+        var isReactivating = !organization.IsActive && request.IsActive;
 
         var slug = string.IsNullOrWhiteSpace(request.Slug) ? Slugify(request.Name) : Slugify(request.Slug);
         var slugExists = await _context.Set<SqlOSOrganization>()
@@ -692,14 +693,21 @@ public sealed partial class SqlOSAdminService
                 reason: "organization_deactivated",
                 now: now,
                 cancellationToken: cancellationToken);
+        }
 
+        if (isDeactivating || isReactivating)
+        {
+            var now = DateTime.UtcNow;
+            var revocationReason = isDeactivating
+                ? "organization_deactivated"
+                : "organization_reactivated";
             var portalSessions = await _context.Set<SqlOSSsoPortalSession>()
                 .Where(x => x.OrganizationId == organization.Id && x.RevokedAt == null)
                 .ToListAsync(cancellationToken);
             foreach (var portalSession in portalSessions)
             {
                 portalSession.RevokedAt = now;
-                portalSession.RevokedReason = "organization_deactivated";
+                portalSession.RevokedReason = revocationReason;
             }
 
             await RecordAuditAsync(
@@ -709,7 +717,7 @@ public sealed partial class SqlOSAdminService
                 organizationId: organization.Id,
                 data: new
                 {
-                    reason = "organization_deactivated",
+                    reason = revocationReason,
                     revokedSessions = portalSessions.Count
                 },
                 cancellationToken: cancellationToken);

--- a/src/SqlOS/AuthServer/Services/SqlOSAdminService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSAdminService.cs
@@ -618,8 +618,52 @@ public sealed partial class SqlOSAdminService
         return organization;
     }
 
-    public async Task<SqlOSOrganization> UpdateOrganizationAsync(string organizationId, SqlOSUpdateOrganizationRequest request, CancellationToken cancellationToken = default)
+    public async Task<SqlOSOrganization> UpdateOrganizationAsync(
+        string organizationId,
+        SqlOSUpdateOrganizationRequest request,
+        CancellationToken cancellationToken = default)
     {
+        if (!_context.Database.IsRelational() || _context.Database.CurrentTransaction != null)
+        {
+            await SqlOSSsoPortalOrganizationLock.AcquireAsync(_context, organizationId, cancellationToken);
+            return await UpdateOrganizationCoreAsync(organizationId, request, cancellationToken);
+        }
+
+        var strategy = _context.Database.CreateExecutionStrategy();
+        var attempt = 0;
+        return await strategy.ExecuteAsync(async () =>
+        {
+            if (attempt++ > 0 && _context is DbContext retryContext)
+            {
+                retryContext.ChangeTracker.Clear();
+            }
+
+            await using var transaction = await _context.Database.BeginTransactionAsync(
+                System.Data.IsolationLevel.Serializable,
+                cancellationToken);
+            await SqlOSSsoPortalOrganizationLock.AcquireAsync(_context, organizationId, cancellationToken);
+            var updated = await UpdateOrganizationCoreAsync(organizationId, request, cancellationToken);
+            await transaction.CommitAsync(cancellationToken);
+            return updated;
+        });
+    }
+
+    private async Task<SqlOSOrganization> UpdateOrganizationCoreAsync(
+        string organizationId,
+        SqlOSUpdateOrganizationRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (_context is DbContext dbContext)
+        {
+            var trackedOrganization = dbContext.ChangeTracker
+                .Entries<SqlOSOrganization>()
+                .FirstOrDefault(x => x.Entity.Id == organizationId);
+            if (trackedOrganization != null)
+            {
+                await trackedOrganization.ReloadAsync(cancellationToken);
+            }
+        }
+
         var organization = await _context.Set<SqlOSOrganization>()
             .FirstOrDefaultAsync(x => x.Id == organizationId, cancellationToken)
             ?? throw new InvalidOperationException("Organization not found.");
@@ -640,16 +684,41 @@ public sealed partial class SqlOSAdminService
 
         if (isDeactivating)
         {
+            var now = DateTime.UtcNow;
             await SqlOSAuthLifecyclePolicy.RevokeAsync(
                 _context,
                 userId: null,
                 organizationId: organization.Id,
                 reason: "organization_deactivated",
-                now: DateTime.UtcNow,
+                now: now,
+                cancellationToken: cancellationToken);
+
+            var portalSessions = await _context.Set<SqlOSSsoPortalSession>()
+                .Where(x => x.OrganizationId == organization.Id && x.RevokedAt == null)
+                .ToListAsync(cancellationToken);
+            foreach (var portalSession in portalSessions)
+            {
+                portalSession.RevokedAt = now;
+                portalSession.RevokedReason = "organization_deactivated";
+            }
+
+            await RecordAuditAsync(
+                "sso.portal.sessions.revoked",
+                "admin",
+                actorId: null,
+                organizationId: organization.Id,
+                data: new
+                {
+                    reason = "organization_deactivated",
+                    revokedSessions = portalSessions.Count
+                },
                 cancellationToken: cancellationToken);
         }
+        else
+        {
+            await _context.SaveChangesAsync(cancellationToken);
+        }
 
-        await _context.SaveChangesAsync(cancellationToken);
         return organization;
     }
 

--- a/src/SqlOS/AuthServer/Services/SqlOSOrganizationDomainService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSOrganizationDomainService.cs
@@ -122,9 +122,90 @@ public sealed class SqlOSOrganizationDomainService
         HttpContext? httpContext = null,
         CancellationToken cancellationToken = default)
     {
+        var ownershipCheck = await CheckOwnershipAsync(
+            organizationId,
+            domainId,
+            cancellationToken);
+        return await ApplyOwnershipCheckAsync(
+            ownershipCheck,
+            httpContext,
+            cancellationToken);
+    }
+
+    internal async Task<SqlOSOrganizationDomainOwnershipCheck> CheckOwnershipAsync(
+        string organizationId,
+        string domainId,
+        CancellationToken cancellationToken = default)
+    {
+        var claim = await _context.Set<SqlOSOrganizationDomain>()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(
+                x => x.Id == domainId
+                    && x.OrganizationId == organizationId
+                    && x.RevokedAt == null,
+                cancellationToken)
+            ?? throw new InvalidOperationException("Domain verification request was not found.");
+
+        if (claim.Status == SqlOSOrganizationDomainStatuses.Active)
+        {
+            return new SqlOSOrganizationDomainOwnershipCheck(
+                claim.OrganizationId,
+                claim.Id,
+                claim.Domain,
+                claim.VerificationToken,
+                Verified: true);
+        }
+
+        if (string.IsNullOrWhiteSpace(claim.VerificationToken))
+        {
+            throw new InvalidOperationException("Domain verification token is missing.");
+        }
+
+        var ownership = SqlOSDomainOwnershipVerification.BuildOwnershipRecord(
+            claim.Domain,
+            claim.VerificationToken,
+            _options.SsoPortal);
+        var verified = SqlOSDomainOwnershipVerification.IsLocalhostDomain(claim.Domain)
+            && _options.SsoPortal.AllowLocalhostDomainVerification;
+        if (!verified)
+        {
+            verified = await _dnsVerifier.HasTxtRecordValueAsync(
+                ownership.Name,
+                ownership.Value,
+                cancellationToken);
+        }
+
+        return new SqlOSOrganizationDomainOwnershipCheck(
+            claim.OrganizationId,
+            claim.Id,
+            claim.Domain,
+            claim.VerificationToken,
+            verified);
+    }
+
+    internal async Task<SqlOSOrganizationDomainResult> ApplyOwnershipCheckAsync(
+        SqlOSOrganizationDomainOwnershipCheck ownershipCheck,
+        HttpContext? httpContext = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (_context is DbContext dbContext)
+        {
+            var trackedClaim = dbContext.ChangeTracker
+                .Entries<SqlOSOrganizationDomain>()
+                .FirstOrDefault(x => x.Entity.Id == ownershipCheck.DomainId);
+            if (trackedClaim != null)
+            {
+                await trackedClaim.ReloadAsync(cancellationToken);
+            }
+        }
+
         var claim = await _context.Set<SqlOSOrganizationDomain>()
             .Include(x => x.Organization)
-            .FirstOrDefaultAsync(x => x.Id == domainId && x.OrganizationId == organizationId && x.RevokedAt == null, cancellationToken)
+            .FirstOrDefaultAsync(
+                x => x.Id == ownershipCheck.DomainId
+                    && x.OrganizationId == ownershipCheck.OrganizationId
+                    && x.RevokedAt == null,
+                cancellationToken)
             ?? throw new InvalidOperationException("Domain verification request was not found.");
 
         if (claim.Status == SqlOSOrganizationDomainStatuses.Active)
@@ -137,21 +218,23 @@ public sealed class SqlOSOrganizationDomainService
             throw new InvalidOperationException("Domain verification token is missing.");
         }
 
+        if (!string.Equals(claim.Domain, ownershipCheck.Domain, StringComparison.Ordinal)
+            || !string.Equals(
+                claim.VerificationToken,
+                ownershipCheck.VerificationToken,
+                StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("Domain verification request changed. Retry ownership verification.");
+        }
+
         var ownership = SqlOSDomainOwnershipVerification.BuildOwnershipRecord(
             claim.Domain,
             claim.VerificationToken,
             _options.SsoPortal);
         var now = DateTime.UtcNow;
-        var verified = SqlOSDomainOwnershipVerification.IsLocalhostDomain(claim.Domain)
-            && _options.SsoPortal.AllowLocalhostDomainVerification;
-        if (!verified)
-        {
-            verified = await _dnsVerifier.HasTxtRecordValueAsync(ownership.Name, ownership.Value, cancellationToken);
-        }
-
         claim.LastCheckedAt = now;
         claim.UpdatedAt = now;
-        if (!verified)
+        if (!ownershipCheck.Verified)
         {
             claim.LastError = $"TXT record not found. Create {ownership.Type} {ownership.Name} with value {ownership.Value}.";
             await _context.SaveChangesAsync(cancellationToken);
@@ -165,14 +248,20 @@ public sealed class SqlOSOrganizationDomainService
             return ToResult(claim);
         }
 
-        await EnsureNoActiveClaimElsewhereAsync(organizationId, claim.Domain, cancellationToken);
+        await EnsureNoActiveClaimElsewhereAsync(
+            ownershipCheck.OrganizationId,
+            claim.Domain,
+            cancellationToken);
         claim.Status = SqlOSOrganizationDomainStatuses.Active;
         claim.VerifiedAt = now;
         claim.LastError = null;
 
         if (claim.Organization != null
             && string.IsNullOrWhiteSpace(claim.Organization.PrimaryDomain)
-            && !await IsPrimaryDomainInUseElsewhereAsync(organizationId, claim.Domain, cancellationToken))
+            && !await IsPrimaryDomainInUseElsewhereAsync(
+                ownershipCheck.OrganizationId,
+                claim.Domain,
+                cancellationToken))
         {
             claim.Organization.PrimaryDomain = claim.Domain;
         }
@@ -304,3 +393,10 @@ public sealed class SqlOSOrganizationDomainService
             cancellationToken: cancellationToken);
     }
 }
+
+internal sealed record SqlOSOrganizationDomainOwnershipCheck(
+    string OrganizationId,
+    string DomainId,
+    string Domain,
+    string? VerificationToken,
+    bool Verified);

--- a/src/SqlOS/AuthServer/Services/SqlOSSsoPortalOrganizationLock.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSSsoPortalOrganizationLock.cs
@@ -1,0 +1,40 @@
+using Microsoft.EntityFrameworkCore;
+using SqlOS.AuthServer.Interfaces;
+
+namespace SqlOS.AuthServer.Services;
+
+internal static class SqlOSSsoPortalOrganizationLock
+{
+    internal static string GetResource(string organizationId)
+        => $"SqlOS:SsoPortalOrganization:{organizationId}";
+
+    internal static async Task AcquireAsync(
+        ISqlOSAuthServerDbContext context,
+        string organizationId,
+        CancellationToken cancellationToken)
+    {
+        if (!string.Equals(
+                context.Database.ProviderName,
+                "Microsoft.EntityFrameworkCore.SqlServer",
+                StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        if (context.Database.CurrentTransaction == null)
+        {
+            throw new InvalidOperationException("The SSO portal organization lock requires an active transaction.");
+        }
+
+        var resource = GetResource(organizationId);
+        await context.Database.ExecuteSqlInterpolatedAsync($"""
+            DECLARE @result int;
+            EXEC @result = sys.sp_getapplock
+                @Resource = {resource},
+                @LockMode = 'Exclusive',
+                @LockOwner = 'Transaction',
+                @LockTimeout = 30000;
+            IF @result < 0 THROW 51000, 'Could not acquire the SSO portal organization lock.', 1;
+            """, cancellationToken);
+    }
+}

--- a/src/SqlOS/AuthServer/Services/SqlOSSsoPortalService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSSsoPortalService.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
@@ -206,33 +207,53 @@ public sealed class SqlOSSsoPortalService
             throw new InvalidOperationException("Portal setup token is required.");
         }
 
-        var now = DateTime.UtcNow;
         var tokenHash = _cryptoService.HashToken(rawLinkToken.Trim());
-        var session = await _context.Set<SqlOSSsoPortalSession>()
-            .Include(x => x.Organization)
-            .Include(x => x.Connection)
-            .FirstOrDefaultAsync(x => x.LinkTokenHash == tokenHash, cancellationToken)
-            ?? throw new InvalidOperationException("Portal setup token is invalid or expired.");
-
-        EnsureSessionCanOpen(session, now);
+        var organizationId = await _context.Set<SqlOSSsoPortalSession>()
+            .AsNoTracking()
+            .Where(x => x.LinkTokenHash == tokenHash)
+            .Select(x => x.OrganizationId)
+            .FirstOrDefaultAsync(cancellationToken);
+        if (string.IsNullOrWhiteSpace(organizationId))
+        {
+            throw new InvalidOperationException("Portal setup token is invalid or expired.");
+        }
 
         var rawSessionToken = _cryptoService.GenerateOpaqueToken();
-        session.SessionTokenHash = _cryptoService.HashToken(rawSessionToken);
-        session.OpenedAt = now;
-        session.LastSeenAt = now;
-        session.IpAddress = httpContext.Connection.RemoteIpAddress?.ToString();
-        session.UserAgent = httpContext.Request.Headers.UserAgent.ToString();
-        await _context.SaveChangesAsync(cancellationToken);
+        var sessionTokenHash = _cryptoService.HashToken(rawSessionToken);
 
-        SetPortalCookie(httpContext, rawSessionToken, session.ExpiresAt);
-        await RecordPortalAuditAsync(
-            "sso.portal.session.opened",
-            session,
-            httpContext,
-            new { session.Id, session.ConnectionId },
-            cancellationToken);
+        if (!_context.Database.IsRelational() || _context.Database.CurrentTransaction != null)
+        {
+            return await OpenSessionCoreAsync(
+                tokenHash,
+                organizationId,
+                rawSessionToken,
+                sessionTokenHash,
+                httpContext,
+                cancellationToken);
+        }
 
-        return ToSessionResult(session, setupUrl: null);
+        var strategy = _context.Database.CreateExecutionStrategy();
+        var attempt = 0;
+        return await strategy.ExecuteAsync(async () =>
+        {
+            if (attempt++ > 0 && _context is DbContext retryContext)
+            {
+                retryContext.ChangeTracker.Clear();
+            }
+
+            await using var transaction = await _context.Database.BeginTransactionAsync(
+                IsolationLevel.Serializable,
+                cancellationToken);
+            var opened = await OpenSessionCoreAsync(
+                tokenHash,
+                organizationId,
+                rawSessionToken,
+                sessionTokenHash,
+                httpContext,
+                cancellationToken);
+            await transaction.CommitAsync(cancellationToken);
+            return opened;
+        });
     }
 
     public async Task<SqlOSSsoPortalSession?> TryGetSessionAsync(HttpContext httpContext, CancellationToken cancellationToken = default)
@@ -248,7 +269,13 @@ public sealed class SqlOSSsoPortalService
         var session = await _context.Set<SqlOSSsoPortalSession>()
             .Include(x => x.Organization)
             .Include(x => x.Connection)
-            .FirstOrDefaultAsync(x => x.SessionTokenHash == tokenHash, cancellationToken);
+            .FirstOrDefaultAsync(
+                x => x.SessionTokenHash == tokenHash
+                    && x.Organization != null
+                    && x.Organization.IsActive
+                    && x.RevokedAt == null
+                    && x.ExpiresAt > now,
+                cancellationToken);
         if (session == null || !IsSessionUsable(session, now))
         {
             ClearPortalCookie(httpContext);
@@ -284,13 +311,20 @@ public sealed class SqlOSSsoPortalService
         ClearPortalCookie(httpContext);
     }
 
-    public async Task<SqlOSSsoPortalStateResult> GetStateAsync(
+    public Task<SqlOSSsoPortalStateResult> GetStateAsync(
         SqlOSSsoPortalSession session,
         CancellationToken cancellationToken = default)
+        => ExecutePortalOperationAsync(
+            session.Id,
+            session.OrganizationId,
+            lockedSession => GetStateCoreAsync(lockedSession, cancellationToken),
+            cancellationToken);
+
+    private async Task<SqlOSSsoPortalStateResult> GetStateCoreAsync(
+        SqlOSSsoPortalSession session,
+        CancellationToken cancellationToken)
     {
-        var organization = await _context.Set<SqlOSOrganization>()
-            .AsNoTracking()
-            .FirstAsync(x => x.Id == session.OrganizationId, cancellationToken);
+        var organization = session.Organization!;
         var connection = await EnsurePortalConnectionAsync(organization, cancellationToken, session);
         var domain = await _domainService.GetPreferredDomainAsync(organization.Id, cancellationToken);
 
@@ -316,11 +350,22 @@ public sealed class SqlOSSsoPortalService
             BuildAllowedActions(organization, connection, domain));
     }
 
-    public async Task<SqlOSSsoPortalStateResult> SetProviderAsync(
+    public Task<SqlOSSsoPortalStateResult> SetProviderAsync(
         SqlOSSsoPortalSession session,
         SqlOSUpdateSsoPortalProviderRequest request,
         HttpContext? httpContext = null,
         CancellationToken cancellationToken = default)
+        => ExecutePortalOperationAsync(
+            session.Id,
+            session.OrganizationId,
+            lockedSession => SetProviderCoreAsync(lockedSession, request, httpContext, cancellationToken),
+            cancellationToken);
+
+    private async Task<SqlOSSsoPortalStateResult> SetProviderCoreAsync(
+        SqlOSSsoPortalSession session,
+        SqlOSUpdateSsoPortalProviderRequest request,
+        HttpContext? httpContext,
+        CancellationToken cancellationToken)
     {
         session.Provider = NormalizeProvider(request.Provider)
             ?? throw new InvalidOperationException("Provider is required.");
@@ -335,11 +380,22 @@ public sealed class SqlOSSsoPortalService
         return await GetStateAsync(session, cancellationToken);
     }
 
-    public async Task<SqlOSSsoPortalStateResult> UpdateEnrollmentPolicyAsync(
+    public Task<SqlOSSsoPortalStateResult> UpdateEnrollmentPolicyAsync(
         SqlOSSsoPortalSession session,
         SqlOSSsoPortalEnrollmentPolicyRequest request,
         HttpContext? httpContext = null,
         CancellationToken cancellationToken = default)
+        => ExecutePortalOperationAsync(
+            session.Id,
+            session.OrganizationId,
+            lockedSession => UpdateEnrollmentPolicyCoreAsync(lockedSession, request, httpContext, cancellationToken),
+            cancellationToken);
+
+    private async Task<SqlOSSsoPortalStateResult> UpdateEnrollmentPolicyCoreAsync(
+        SqlOSSsoPortalSession session,
+        SqlOSSsoPortalEnrollmentPolicyRequest request,
+        HttpContext? httpContext,
+        CancellationToken cancellationToken)
     {
         var connection = await RequirePortalConnectionAsync(session, cancellationToken);
         connection.AutoLinkByEmail = request.RequireSsoForExistingMembers;
@@ -365,11 +421,22 @@ public sealed class SqlOSSsoPortalService
     public SqlOSSsoMetadataValidationResult ValidateMetadata(SqlOSSsoPortalMetadataRequest request)
         => _adminService.ValidateSsoMetadata(new SqlOSImportSsoMetadataRequest(request.MetadataXml));
 
-    public async Task<SqlOSSsoPortalStateResult> StartDomainVerificationAsync(
+    public Task<SqlOSSsoPortalStateResult> StartDomainVerificationAsync(
         SqlOSSsoPortalSession session,
         SqlOSSsoPortalDomainRequest request,
         HttpContext? httpContext = null,
         CancellationToken cancellationToken = default)
+        => ExecutePortalOperationAsync(
+            session.Id,
+            session.OrganizationId,
+            lockedSession => StartDomainVerificationCoreAsync(lockedSession, request, httpContext, cancellationToken),
+            cancellationToken);
+
+    private async Task<SqlOSSsoPortalStateResult> StartDomainVerificationCoreAsync(
+        SqlOSSsoPortalSession session,
+        SqlOSSsoPortalDomainRequest request,
+        HttpContext? httpContext,
+        CancellationToken cancellationToken)
     {
         await _domainService.StartVerificationAsync(
             session.OrganizationId,
@@ -380,21 +447,43 @@ public sealed class SqlOSSsoPortalService
         return await GetStateAsync(session, cancellationToken);
     }
 
-    public async Task<SqlOSSsoPortalStateResult> ConfirmDomainOwnershipAsync(
+    public Task<SqlOSSsoPortalStateResult> ConfirmDomainOwnershipAsync(
         SqlOSSsoPortalSession session,
         string domainId,
         HttpContext? httpContext = null,
         CancellationToken cancellationToken = default)
+        => ExecutePortalOperationAsync(
+            session.Id,
+            session.OrganizationId,
+            lockedSession => ConfirmDomainOwnershipCoreAsync(lockedSession, domainId, httpContext, cancellationToken),
+            cancellationToken);
+
+    private async Task<SqlOSSsoPortalStateResult> ConfirmDomainOwnershipCoreAsync(
+        SqlOSSsoPortalSession session,
+        string domainId,
+        HttpContext? httpContext,
+        CancellationToken cancellationToken)
     {
         await _domainService.ConfirmOwnershipAsync(session.OrganizationId, domainId, httpContext, cancellationToken);
         return await GetStateAsync(session, cancellationToken);
     }
 
-    public async Task<SqlOSSsoPortalStateResult> ImportMetadataAsync(
+    public Task<SqlOSSsoPortalStateResult> ImportMetadataAsync(
         SqlOSSsoPortalSession session,
         SqlOSSsoPortalMetadataRequest request,
         HttpContext? httpContext = null,
         CancellationToken cancellationToken = default)
+        => ExecutePortalOperationAsync(
+            session.Id,
+            session.OrganizationId,
+            lockedSession => ImportMetadataCoreAsync(lockedSession, request, httpContext, cancellationToken),
+            cancellationToken);
+
+    private async Task<SqlOSSsoPortalStateResult> ImportMetadataCoreAsync(
+        SqlOSSsoPortalSession session,
+        SqlOSSsoPortalMetadataRequest request,
+        HttpContext? httpContext,
+        CancellationToken cancellationToken)
     {
         var connection = await RequirePortalConnectionAsync(session, cancellationToken);
         var updated = await _adminService.ImportSsoMetadataAsync(
@@ -418,10 +507,20 @@ public sealed class SqlOSSsoPortalService
         return await GetStateAsync(session, cancellationToken);
     }
 
-    public async Task<SqlOSSsoPortalStateResult> ActivateAsync(
+    public Task<SqlOSSsoPortalStateResult> ActivateAsync(
         SqlOSSsoPortalSession session,
         HttpContext? httpContext = null,
         CancellationToken cancellationToken = default)
+        => ExecutePortalOperationAsync(
+            session.Id,
+            session.OrganizationId,
+            lockedSession => ActivateCoreAsync(lockedSession, httpContext, cancellationToken),
+            cancellationToken);
+
+    private async Task<SqlOSSsoPortalStateResult> ActivateCoreAsync(
+        SqlOSSsoPortalSession session,
+        HttpContext? httpContext,
+        CancellationToken cancellationToken)
     {
         var connection = await RequirePortalConnectionAsync(session, cancellationToken);
         EnsureConnectionHasMetadata(connection);
@@ -440,10 +539,20 @@ public sealed class SqlOSSsoPortalService
         return await GetStateAsync(session, cancellationToken);
     }
 
-    public async Task<SqlOSSsoPortalStateResult> DisableAsync(
+    public Task<SqlOSSsoPortalStateResult> DisableAsync(
         SqlOSSsoPortalSession session,
         HttpContext? httpContext = null,
         CancellationToken cancellationToken = default)
+        => ExecutePortalOperationAsync(
+            session.Id,
+            session.OrganizationId,
+            lockedSession => DisableCoreAsync(lockedSession, httpContext, cancellationToken),
+            cancellationToken);
+
+    private async Task<SqlOSSsoPortalStateResult> DisableCoreAsync(
+        SqlOSSsoPortalSession session,
+        HttpContext? httpContext,
+        CancellationToken cancellationToken)
     {
         var connection = await RequirePortalConnectionAsync(session, cancellationToken);
         connection.IsEnabled = false;
@@ -460,11 +569,22 @@ public sealed class SqlOSSsoPortalService
         return await GetStateAsync(session, cancellationToken);
     }
 
-    public async Task<SqlOSSsoPortalRevokeOrganizationSessionsResult> RevokeOrganizationSessionsAsync(
+    public Task<SqlOSSsoPortalRevokeOrganizationSessionsResult> RevokeOrganizationSessionsAsync(
         SqlOSSsoPortalSession session,
         SqlOSSsoPortalRevokeOrganizationSessionsRequest request,
         HttpContext? httpContext = null,
         CancellationToken cancellationToken = default)
+        => ExecutePortalOperationAsync(
+            session.Id,
+            session.OrganizationId,
+            lockedSession => RevokeOrganizationSessionsCoreAsync(lockedSession, request, httpContext, cancellationToken),
+            cancellationToken);
+
+    private async Task<SqlOSSsoPortalRevokeOrganizationSessionsResult> RevokeOrganizationSessionsCoreAsync(
+        SqlOSSsoPortalSession session,
+        SqlOSSsoPortalRevokeOrganizationSessionsRequest request,
+        HttpContext? httpContext,
+        CancellationToken cancellationToken)
     {
         if (!request.Confirm)
         {
@@ -560,13 +680,32 @@ public sealed class SqlOSSsoPortalService
             now);
     }
 
-    public async Task<SqlOSSsoPortalTestResult> RecordTestAsync(
+    public Task<SqlOSSsoPortalTestResult> RecordTestAsync(
         SqlOSSsoPortalSession session,
         string status,
         string message,
         string? authorizationUrl,
         HttpContext? httpContext = null,
         CancellationToken cancellationToken = default)
+        => ExecutePortalOperationAsync(
+            session.Id,
+            session.OrganizationId,
+            lockedSession => RecordTestCoreAsync(
+                lockedSession,
+                status,
+                message,
+                authorizationUrl,
+                httpContext,
+                cancellationToken),
+            cancellationToken);
+
+    private async Task<SqlOSSsoPortalTestResult> RecordTestCoreAsync(
+        SqlOSSsoPortalSession session,
+        string status,
+        string message,
+        string? authorizationUrl,
+        HttpContext? httpContext,
+        CancellationToken cancellationToken)
     {
         var now = DateTime.UtcNow;
         session.LastTestedAt = now;
@@ -656,7 +795,7 @@ public sealed class SqlOSSsoPortalService
             await SetProviderAsync(session, request, httpContext, cancellationToken);
             return await ViewActionAsync(session, "domain", null, null, cancellationToken);
         }
-        catch (InvalidOperationException ex)
+        catch (InvalidOperationException ex) when (ex is not SqlOSSsoPortalSessionUnavailableException)
         {
             return await ViewActionAsync(
                 session,
@@ -678,7 +817,7 @@ public sealed class SqlOSSsoPortalService
             await UpdateEnrollmentPolicyAsync(session, request, httpContext, cancellationToken);
             return await ViewActionAsync(session, "policy", null, null, cancellationToken);
         }
-        catch (InvalidOperationException ex)
+        catch (InvalidOperationException ex) when (ex is not SqlOSSsoPortalSessionUnavailableException)
         {
             return await ViewActionAsync(session, "policy", ex.Message, null, cancellationToken);
         }
@@ -692,15 +831,10 @@ public sealed class SqlOSSsoPortalService
     {
         try
         {
-            await _domainService.StartVerificationAsync(
-                session.OrganizationId,
-                request,
-                httpContext,
-                session.CreatedByUserId,
-                cancellationToken);
+            await StartDomainVerificationAsync(session, request, httpContext, cancellationToken);
             return await ViewActionAsync(session, "domain", null, null, cancellationToken);
         }
-        catch (InvalidOperationException ex)
+        catch (InvalidOperationException ex) when (ex is not SqlOSSsoPortalSessionUnavailableException)
         {
             return await ViewActionAsync(
                 session,
@@ -719,15 +853,16 @@ public sealed class SqlOSSsoPortalService
     {
         try
         {
-            var domain = await _domainService.ConfirmOwnershipAsync(session.OrganizationId, domainId, httpContext, cancellationToken);
+            var state = await ConfirmDomainOwnershipAsync(session, domainId, httpContext, cancellationToken);
+            var domain = state.Domain;
             return await ViewActionAsync(
                 session,
-                domain.Status == SqlOSOrganizationDomainStatuses.Active ? "metadata" : "domain",
-                domain.Status == SqlOSOrganizationDomainStatuses.Active ? null : domain.LastError,
+                domain?.Status == SqlOSOrganizationDomainStatuses.Active ? "metadata" : "domain",
+                domain?.Status == SqlOSOrganizationDomainStatuses.Active ? null : domain?.LastError,
                 null,
                 cancellationToken);
         }
-        catch (InvalidOperationException ex)
+        catch (InvalidOperationException ex) when (ex is not SqlOSSsoPortalSessionUnavailableException)
         {
             return await ViewActionAsync(session, "domain", ex.Message, null, cancellationToken);
         }
@@ -744,7 +879,7 @@ public sealed class SqlOSSsoPortalService
             await ImportMetadataAsync(session, request, httpContext, cancellationToken);
             return await ViewActionAsync(session, "activate", null, null, cancellationToken);
         }
-        catch (InvalidOperationException ex)
+        catch (InvalidOperationException ex) when (ex is not SqlOSSsoPortalSessionUnavailableException)
         {
             return await ViewActionAsync(
                 session,
@@ -765,7 +900,7 @@ public sealed class SqlOSSsoPortalService
             await ActivateAsync(session, httpContext, cancellationToken);
             return await ViewActionAsync(session, "test", null, null, cancellationToken);
         }
-        catch (InvalidOperationException ex)
+        catch (InvalidOperationException ex) when (ex is not SqlOSSsoPortalSessionUnavailableException)
         {
             return await ViewActionAsync(session, "activate", ex.Message, null, cancellationToken);
         }
@@ -781,7 +916,7 @@ public sealed class SqlOSSsoPortalService
             await DisableAsync(session, httpContext, cancellationToken);
             return await ViewActionAsync(session, "activate", null, null, cancellationToken);
         }
-        catch (InvalidOperationException ex)
+        catch (InvalidOperationException ex) when (ex is not SqlOSSsoPortalSessionUnavailableException)
         {
             return await ViewActionAsync(session, "activate", ex.Message, null, cancellationToken);
         }
@@ -834,7 +969,7 @@ public sealed class SqlOSSsoPortalService
                 cancellationToken);
             return await ViewActionAsync(session, "test", null, null, cancellationToken);
         }
-        catch (InvalidOperationException ex)
+        catch (InvalidOperationException ex) when (ex is not SqlOSSsoPortalSessionUnavailableException)
         {
             return await ViewActionAsync(session, "test", ex.Message, null, cancellationToken);
         }
@@ -847,6 +982,138 @@ public sealed class SqlOSSsoPortalService
         IReadOnlyDictionary<string, string>? fieldErrors,
         CancellationToken cancellationToken)
         => new("view", null, await GetSetupViewAsync(session, view, error, fieldErrors, cancellationToken));
+
+    private async Task<SqlOSSsoPortalSessionResult> OpenSessionCoreAsync(
+        string linkTokenHash,
+        string organizationId,
+        string rawSessionToken,
+        string sessionTokenHash,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        await SqlOSSsoPortalOrganizationLock.AcquireAsync(_context, organizationId, cancellationToken);
+
+        var now = DateTime.UtcNow;
+        var session = await _context.Set<SqlOSSsoPortalSession>()
+            .Include(x => x.Organization)
+            .Include(x => x.Connection)
+            .FirstOrDefaultAsync(
+                x => x.LinkTokenHash == linkTokenHash
+                    && x.OrganizationId == organizationId
+                    && x.Organization != null
+                    && x.Organization.IsActive
+                    && x.RevokedAt == null
+                    && x.ExpiresAt > now,
+                cancellationToken)
+            ?? throw new InvalidOperationException("Portal setup token is invalid or expired.");
+
+        if (session.OpenedAt != null
+            && string.Equals(session.SessionTokenHash, sessionTokenHash, StringComparison.Ordinal))
+        {
+            SetPortalCookie(httpContext, rawSessionToken, session.ExpiresAt);
+            return ToSessionResult(session, setupUrl: null);
+        }
+
+        EnsureSessionCanOpen(session, now);
+
+        session.SessionTokenHash = sessionTokenHash;
+        session.OpenedAt = now;
+        session.LastSeenAt = now;
+        session.IpAddress = httpContext.Connection.RemoteIpAddress?.ToString();
+        session.UserAgent = httpContext.Request.Headers.UserAgent.ToString();
+        await _context.SaveChangesAsync(cancellationToken);
+
+        SetPortalCookie(httpContext, rawSessionToken, session.ExpiresAt);
+        await RecordPortalAuditAsync(
+            "sso.portal.session.opened",
+            session,
+            httpContext,
+            new { session.Id, session.ConnectionId },
+            cancellationToken);
+
+        return ToSessionResult(session, setupUrl: null);
+    }
+
+    private async Task<TResult> ExecutePortalOperationAsync<TResult>(
+        string sessionId,
+        string organizationId,
+        Func<SqlOSSsoPortalSession, Task<TResult>> mutation,
+        CancellationToken cancellationToken)
+    {
+        if (!_context.Database.IsRelational() || _context.Database.CurrentTransaction != null)
+        {
+            return await ExecutePortalOperationCoreAsync(
+                sessionId,
+                organizationId,
+                mutation,
+                cancellationToken);
+        }
+
+        var strategy = _context.Database.CreateExecutionStrategy();
+        var attempt = 0;
+        return await strategy.ExecuteAsync(async () =>
+        {
+            if (attempt++ > 0 && _context is DbContext retryContext)
+            {
+                retryContext.ChangeTracker.Clear();
+            }
+
+            await using var transaction = await _context.Database.BeginTransactionAsync(
+                IsolationLevel.Serializable,
+                cancellationToken);
+            var result = await ExecutePortalOperationCoreAsync(
+                sessionId,
+                organizationId,
+                mutation,
+                cancellationToken);
+            await transaction.CommitAsync(cancellationToken);
+            return result;
+        });
+    }
+
+    private async Task<TResult> ExecutePortalOperationCoreAsync<TResult>(
+        string sessionId,
+        string organizationId,
+        Func<SqlOSSsoPortalSession, Task<TResult>> mutation,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(organizationId))
+        {
+            throw new SqlOSSsoPortalSessionUnavailableException();
+        }
+
+        await SqlOSSsoPortalOrganizationLock.AcquireAsync(_context, organizationId, cancellationToken);
+        var session = await RequireAvailableSessionAsync(
+            sessionId,
+            organizationId,
+            cancellationToken);
+        return await mutation(session);
+    }
+
+    private async Task<SqlOSSsoPortalSession> RequireAvailableSessionAsync(
+        string sessionId,
+        string organizationId,
+        CancellationToken cancellationToken)
+    {
+        var now = DateTime.UtcNow;
+        var session = await _context.Set<SqlOSSsoPortalSession>()
+            .Include(x => x.Organization)
+            .Include(x => x.Connection)
+            .FirstOrDefaultAsync(
+                x => x.Id == sessionId
+                    && x.OrganizationId == organizationId
+                    && x.Organization != null
+                    && x.Organization.IsActive
+                    && x.RevokedAt == null
+                    && x.ExpiresAt > now,
+                cancellationToken);
+        if (session == null || !IsSessionAvailableForOperation(session, now))
+        {
+            throw new SqlOSSsoPortalSessionUnavailableException();
+        }
+
+        return session;
+    }
 
     private async Task<SqlOSSsoConnection> EnsurePortalConnectionAsync(
         SqlOSOrganization organization,
@@ -1060,7 +1327,9 @@ public sealed class SqlOSSsoPortalService
 
     private static void EnsureSessionCanOpen(SqlOSSsoPortalSession session, DateTime now)
     {
-        if (session.RevokedAt != null || session.ExpiresAt <= now)
+        if (session.Organization?.IsActive != true
+            || session.RevokedAt != null
+            || session.ExpiresAt <= now)
         {
             throw new InvalidOperationException("Portal setup token is invalid or expired.");
         }
@@ -1072,10 +1341,19 @@ public sealed class SqlOSSsoPortalService
     }
 
     private bool IsSessionUsable(SqlOSSsoPortalSession session, DateTime now)
-        => session.RevokedAt == null
+        => session.Organization?.IsActive == true
+           && session.RevokedAt == null
            && session.ExpiresAt > now
            && !string.IsNullOrWhiteSpace(session.SessionTokenHash)
            && (session.LastSeenAt == null || session.LastSeenAt.Value.Add(_portalOptions.SessionIdleTimeout) > now);
+
+    private bool IsSessionAvailableForOperation(SqlOSSsoPortalSession session, DateTime now)
+        => session.Organization?.IsActive == true
+           && session.RevokedAt == null
+           && session.ExpiresAt > now
+           && (string.IsNullOrWhiteSpace(session.SessionTokenHash)
+               || session.LastSeenAt == null
+               || session.LastSeenAt.Value.Add(_portalOptions.SessionIdleTimeout) > now);
 
     private static void EnsureConnectionHasMetadata(SqlOSSsoConnection connection)
     {

--- a/src/SqlOS/AuthServer/Services/SqlOSSsoPortalService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSSsoPortalService.cs
@@ -90,10 +90,6 @@ public sealed class SqlOSSsoPortalService
         HttpContext? httpContext = null,
         CancellationToken cancellationToken = default)
     {
-        var organization = await _context.Set<SqlOSOrganization>()
-            .FirstOrDefaultAsync(x => x.Id == request.OrganizationId && x.IsActive, cancellationToken)
-            ?? throw new InvalidOperationException("Organization not found.");
-
         var now = DateTime.UtcNow;
         var expiresAt = request.ExpiresAt ?? now.Add(_portalOptions.DefaultLinkLifetime);
         if (expiresAt <= now)
@@ -102,37 +98,49 @@ public sealed class SqlOSSsoPortalService
         }
 
         var provider = NormalizeProvider(request.Provider);
-        var connection = await EnsurePortalConnectionAsync(organization, cancellationToken);
         var rawLinkToken = _cryptoService.GenerateOpaqueToken();
-        var session = new SqlOSSsoPortalSession
+        var linkTokenHash = _cryptoService.HashToken(rawLinkToken);
+        var sessionId = _cryptoService.GenerateId("ssp");
+
+        if (!_context.Database.IsRelational() || _context.Database.CurrentTransaction != null)
         {
-            Id = _cryptoService.GenerateId("ssp"),
-            OrganizationId = organization.Id,
-            ConnectionId = connection.Id,
-            LinkTokenHash = _cryptoService.HashToken(rawLinkToken),
-            Provider = provider,
-            ReturnUrl = NormalizeOptional(request.ReturnUrl),
-            ActorType = "platform_admin",
-            CreatedByUserId = NormalizeOptional(request.CreatedByUserId),
-            CreatedAt = now,
-            ExpiresAt = expiresAt,
-            IpAddress = httpContext?.Connection.RemoteIpAddress?.ToString(),
-            UserAgent = httpContext?.Request.Headers.UserAgent.ToString()
-        };
+            return await CreateSessionCoreAsync(
+                request,
+                sessionId,
+                rawLinkToken,
+                linkTokenHash,
+                provider,
+                now,
+                expiresAt,
+                httpContext,
+                cancellationToken);
+        }
 
-        _context.Set<SqlOSSsoPortalSession>().Add(session);
-        await _context.SaveChangesAsync(cancellationToken);
+        var strategy = _context.Database.CreateExecutionStrategy();
+        var attempt = 0;
+        return await strategy.ExecuteAsync(async () =>
+        {
+            if (attempt++ > 0 && _context is DbContext retryContext)
+            {
+                retryContext.ChangeTracker.Clear();
+            }
 
-        await RecordPortalAuditAsync(
-            "sso.portal.session.created",
-            session,
-            httpContext,
-            new { session.Id, connectionId = connection.Id, provider, expiresAt },
-            cancellationToken);
-
-        session.Organization = organization;
-        session.Connection = connection;
-        return ToSessionResult(session, BuildSetupUrl(rawLinkToken, httpContext));
+            await using var transaction = await _context.Database.BeginTransactionAsync(
+                IsolationLevel.Serializable,
+                cancellationToken);
+            var created = await CreateSessionCoreAsync(
+                request,
+                sessionId,
+                rawLinkToken,
+                linkTokenHash,
+                provider,
+                now,
+                expiresAt,
+                httpContext,
+                cancellationToken);
+            await transaction.CommitAsync(cancellationToken);
+            return created;
+        });
     }
 
     public async Task<object> ListOrganizationSessionsAsync(
@@ -447,24 +455,44 @@ public sealed class SqlOSSsoPortalService
         return await GetStateAsync(session, cancellationToken);
     }
 
-    public Task<SqlOSSsoPortalStateResult> ConfirmDomainOwnershipAsync(
+    public async Task<SqlOSSsoPortalStateResult> ConfirmDomainOwnershipAsync(
         SqlOSSsoPortalSession session,
         string domainId,
         HttpContext? httpContext = null,
         CancellationToken cancellationToken = default)
-        => ExecutePortalOperationAsync(
+    {
+        _ = await ExecutePortalOperationAsync(
             session.Id,
             session.OrganizationId,
-            lockedSession => ConfirmDomainOwnershipCoreAsync(lockedSession, domainId, httpContext, cancellationToken),
+            _ => Task.FromResult(true),
             cancellationToken);
+
+        var ownershipCheck = await _domainService.CheckOwnershipAsync(
+            session.OrganizationId,
+            domainId,
+            cancellationToken);
+
+        return await ExecutePortalOperationAsync(
+            session.Id,
+            session.OrganizationId,
+            lockedSession => ConfirmDomainOwnershipCoreAsync(
+                lockedSession,
+                ownershipCheck,
+                httpContext,
+                cancellationToken),
+            cancellationToken);
+    }
 
     private async Task<SqlOSSsoPortalStateResult> ConfirmDomainOwnershipCoreAsync(
         SqlOSSsoPortalSession session,
-        string domainId,
+        SqlOSOrganizationDomainOwnershipCheck ownershipCheck,
         HttpContext? httpContext,
         CancellationToken cancellationToken)
     {
-        await _domainService.ConfirmOwnershipAsync(session.OrganizationId, domainId, httpContext, cancellationToken);
+        await _domainService.ApplyOwnershipCheckAsync(
+            ownershipCheck,
+            httpContext,
+            cancellationToken);
         return await GetStateAsync(session, cancellationToken);
     }
 
@@ -1032,6 +1060,74 @@ public sealed class SqlOSSsoPortalService
             cancellationToken);
 
         return ToSessionResult(session, setupUrl: null);
+    }
+
+    private async Task<SqlOSSsoPortalSessionResult> CreateSessionCoreAsync(
+        SqlOSCreateSsoPortalSessionRequest request,
+        string sessionId,
+        string rawLinkToken,
+        string linkTokenHash,
+        string? provider,
+        DateTime now,
+        DateTime expiresAt,
+        HttpContext? httpContext,
+        CancellationToken cancellationToken)
+    {
+        await SqlOSSsoPortalOrganizationLock.AcquireAsync(
+            _context,
+            request.OrganizationId,
+            cancellationToken);
+
+        var organization = await _context.Set<SqlOSOrganization>()
+            .FirstOrDefaultAsync(
+                x => x.Id == request.OrganizationId && x.IsActive,
+                cancellationToken)
+            ?? throw new InvalidOperationException("Organization not found.");
+
+        var existing = await _context.Set<SqlOSSsoPortalSession>()
+            .Include(x => x.Connection)
+            .FirstOrDefaultAsync(x => x.Id == sessionId, cancellationToken);
+        if (existing != null)
+        {
+            if (!string.Equals(existing.LinkTokenHash, linkTokenHash, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException("Portal session identifier collision.");
+            }
+
+            existing.Organization = organization;
+            return ToSessionResult(existing, BuildSetupUrl(rawLinkToken, httpContext));
+        }
+
+        var connection = await EnsurePortalConnectionAsync(organization, cancellationToken);
+        var session = new SqlOSSsoPortalSession
+        {
+            Id = sessionId,
+            OrganizationId = organization.Id,
+            ConnectionId = connection.Id,
+            LinkTokenHash = linkTokenHash,
+            Provider = provider,
+            ReturnUrl = NormalizeOptional(request.ReturnUrl),
+            ActorType = "platform_admin",
+            CreatedByUserId = NormalizeOptional(request.CreatedByUserId),
+            CreatedAt = now,
+            ExpiresAt = expiresAt,
+            IpAddress = httpContext?.Connection.RemoteIpAddress?.ToString(),
+            UserAgent = httpContext?.Request.Headers.UserAgent.ToString()
+        };
+
+        _context.Set<SqlOSSsoPortalSession>().Add(session);
+        await _context.SaveChangesAsync(cancellationToken);
+
+        await RecordPortalAuditAsync(
+            "sso.portal.session.created",
+            session,
+            httpContext,
+            new { session.Id, connectionId = connection.Id, provider, expiresAt },
+            cancellationToken);
+
+        session.Organization = organization;
+        session.Connection = connection;
+        return ToSessionResult(session, BuildSetupUrl(rawLinkToken, httpContext));
     }
 
     private async Task<TResult> ExecutePortalOperationAsync<TResult>(

--- a/src/SqlOS/AuthServer/Services/SqlOSSsoPortalSessionUnavailableException.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSSsoPortalSessionUnavailableException.cs
@@ -1,0 +1,12 @@
+namespace SqlOS.AuthServer.Services;
+
+internal sealed class SqlOSSsoPortalSessionUnavailableException
+    : InvalidOperationException
+{
+    internal const string PublicMessage = "Portal session is invalid or expired.";
+
+    internal SqlOSSsoPortalSessionUnavailableException()
+        : base(PublicMessage)
+    {
+    }
+}

--- a/tests/SqlOS.IntegrationTests/AuthServiceIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/AuthServiceIntegrationTests.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using System.Text;
 using FluentAssertions;
 using Microsoft.AspNetCore.DataProtection;
@@ -423,6 +424,103 @@ public sealed class AuthServiceIntegrationTests
         var unrelatedRefresh = await verification.Auth.RefreshAsync(
             new SqlOSRefreshRequest(unrelatedSourceTokens.RefreshToken, sourceOrganizationId));
         unrelatedRefresh.OrganizationId.Should().Be(sourceOrganizationId);
+    }
+
+    [TestMethod]
+    public async Task OrganizationDeactivation_SerializesAgainstStalePortalMutationAcrossDbContexts()
+    {
+        var suffix = Guid.NewGuid().ToString("N");
+        string organizationId;
+        string portalSessionId;
+        string pendingSetupToken;
+        string openedPortalCookie;
+        SqlOSUpdateOrganizationRequest deactivationRequest;
+
+        await using (var issuance = BuildIsolatedLifecycleStack())
+        {
+            var organization = await issuance.Admin.CreateOrganizationAsync(
+                new SqlOSCreateOrganizationRequest(
+                    $"Portal Deactivation Race {suffix}",
+                    null,
+                    $"{suffix}.portal-race.test"));
+            organizationId = organization.Id;
+            deactivationRequest = new SqlOSUpdateOrganizationRequest(
+                organization.Name,
+                organization.Slug,
+                organization.PrimaryDomain,
+                IsActive: false);
+            var created = await issuance.Portal.CreateSessionAsync(
+                new SqlOSCreateSsoPortalSessionRequest(organization.Id, Provider: "okta"),
+                new DefaultHttpContext());
+            portalSessionId = created.Id;
+            var pending = await issuance.Portal.CreateSessionAsync(
+                new SqlOSCreateSsoPortalSessionRequest(organization.Id),
+                new DefaultHttpContext());
+            pendingSetupToken = QueryHelpers.ParseQuery(new Uri(pending.SetupUrl!).Query)["token"].ToString();
+            var opened = await issuance.Portal.CreateSessionAsync(
+                new SqlOSCreateSsoPortalSessionRequest(organization.Id),
+                new DefaultHttpContext());
+            var openContext = new DefaultHttpContext();
+            await issuance.Portal.OpenSessionAsync(
+                QueryHelpers.ParseQuery(new Uri(opened.SetupUrl!).Query)["token"].ToString(),
+                openContext);
+            openedPortalCookie = openContext.Response.Headers.SetCookie.ToString().Split(';', 2)[0];
+        }
+
+        await using var mutation = BuildIsolatedLifecycleStack();
+        var stalePortalSession = await mutation.Context.Set<SqlOSSsoPortalSession>()
+            .SingleAsync(x => x.Id == portalSessionId);
+        stalePortalSession.Provider.Should().Be("okta");
+
+        await using var deactivation = BuildIsolatedLifecycleStack();
+        await using var deactivationTransaction = await deactivation.Context.Database.BeginTransactionAsync(
+            IsolationLevel.Serializable);
+        await deactivation.Admin.UpdateOrganizationAsync(
+            organizationId,
+            deactivationRequest);
+
+        var mutationTask = mutation.Portal.SetProviderAsync(
+            stalePortalSession,
+            new SqlOSUpdateSsoPortalProviderRequest("google-workspace"),
+            new DefaultHttpContext());
+        await Task.Delay(250);
+        mutationTask.IsCompleted.Should().BeFalse(
+            "the portal mutation must serialize behind the organization lifecycle transaction");
+
+        await deactivationTransaction.CommitAsync();
+
+        var mutationAction = async () => await mutationTask;
+        await mutationAction.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Portal session is invalid or expired.");
+
+        await using var verification = BuildIsolatedLifecycleStack();
+        (await verification.Context.Set<SqlOSOrganization>()
+            .SingleAsync(x => x.Id == organizationId)).IsActive.Should().BeFalse();
+        var revokedSession = await verification.Context.Set<SqlOSSsoPortalSession>()
+            .SingleAsync(x => x.Id == portalSessionId);
+        revokedSession.Provider.Should().Be("okta");
+        revokedSession.RevokedAt.Should().NotBeNull();
+        revokedSession.RevokedReason.Should().Be("organization_deactivated");
+        (await verification.Context.Set<SqlOSSsoPortalSession>()
+            .Where(x => x.OrganizationId == organizationId)
+            .ToListAsync()).Should().OnlyContain(x =>
+                x.RevokedAt != null && x.RevokedReason == "organization_deactivated");
+
+        var pendingOpen = async () => await verification.Portal.OpenSessionAsync(
+            pendingSetupToken,
+            new DefaultHttpContext());
+        await pendingOpen.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Portal setup token is invalid or expired.");
+        var openedRequest = new DefaultHttpContext();
+        openedRequest.Request.Headers.Cookie = openedPortalCookie;
+        (await verification.Portal.TryGetSessionAsync(openedRequest)).Should().BeNull();
+
+        (await verification.Context.Set<SqlOSAuditEvent>().AnyAsync(x =>
+            x.EventType == "sso.portal.sessions.revoked"
+            && x.OrganizationId == organizationId
+            && x.MetadataJson != null
+            && x.MetadataJson.Contains("\"revokedSessions\":3")))
+            .Should().BeTrue();
     }
 
     [TestMethod]

--- a/tests/SqlOS.IntegrationTests/AuthServiceIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/AuthServiceIntegrationTests.cs
@@ -524,6 +524,105 @@ public sealed class AuthServiceIntegrationTests
     }
 
     [TestMethod]
+    public async Task OrganizationDeactivation_SerializesAgainstPortalCapabilityIssuance()
+    {
+        var suffix = Guid.NewGuid().ToString("N");
+        var pause = new PausePortalSessionInsertInterceptor();
+        await using var issuance = BuildIsolatedLifecycleStack(interceptor: pause);
+        var organization = await issuance.Admin.CreateOrganizationAsync(
+            new SqlOSCreateOrganizationRequest(
+                $"Portal Issuance Race {suffix}",
+                null,
+                $"{suffix}.portal-issuance-race.test"));
+
+        var createTask = issuance.Portal.CreateSessionAsync(
+            new SqlOSCreateSsoPortalSessionRequest(organization.Id),
+            new DefaultHttpContext());
+        await pause.InsertReached.Task.WaitAsync(TimeSpan.FromSeconds(30));
+
+        await using var deactivation = BuildIsolatedLifecycleStack();
+        var deactivationTask = deactivation.Admin.UpdateOrganizationAsync(
+            organization.Id,
+            new SqlOSUpdateOrganizationRequest(
+                organization.Name,
+                organization.Slug,
+                organization.PrimaryDomain,
+                IsActive: false));
+
+        var firstCompleted = await Task.WhenAny(
+            deactivationTask,
+            Task.Delay(TimeSpan.FromSeconds(2)));
+        pause.ReleaseInsert.TrySetResult(true);
+
+        firstCompleted.Should().NotBe(
+            deactivationTask,
+            "capability issuance must hold the organization lock until its insert commits");
+        var created = await createTask;
+        await deactivationTask;
+
+        await using var verification = BuildIsolatedLifecycleStack();
+        var stored = await verification.Context.Set<SqlOSSsoPortalSession>()
+            .SingleAsync(x => x.Id == created.Id);
+        stored.RevokedAt.Should().NotBeNull();
+        stored.RevokedReason.Should().Be("organization_deactivated");
+    }
+
+    [TestMethod]
+    public async Task OrganizationDeactivation_DoesNotWaitForPortalDnsVerification()
+    {
+        var suffix = Guid.NewGuid().ToString("N");
+        var dns = new PauseDomainDnsVerifier();
+        await using var confirmation = BuildIsolatedLifecycleStack(dnsVerifier: dns);
+        var organization = await confirmation.Admin.CreateOrganizationAsync(
+            new SqlOSCreateOrganizationRequest(
+                $"Portal DNS Race {suffix}",
+                null,
+                $"{suffix}.portal-dns-race.test"));
+        var created = await confirmation.Portal.CreateSessionAsync(
+            new SqlOSCreateSsoPortalSessionRequest(organization.Id),
+            new DefaultHttpContext());
+        var session = await confirmation.Context.Set<SqlOSSsoPortalSession>()
+            .SingleAsync(x => x.Id == created.Id);
+        var state = await confirmation.Portal.StartDomainVerificationAsync(
+            session,
+            new SqlOSSsoPortalDomainRequest($"{suffix}.verification.test"),
+            new DefaultHttpContext());
+
+        var confirmationTask = confirmation.Portal.ConfirmDomainOwnershipAsync(
+            session,
+            state.Domain!.Id,
+            new DefaultHttpContext());
+        await dns.LookupReached.Task.WaitAsync(TimeSpan.FromSeconds(30));
+
+        await using var deactivation = BuildIsolatedLifecycleStack();
+        var deactivationTask = deactivation.Admin.UpdateOrganizationAsync(
+            organization.Id,
+            new SqlOSUpdateOrganizationRequest(
+                organization.Name,
+                organization.Slug,
+                organization.PrimaryDomain,
+                IsActive: false));
+        var firstCompleted = await Task.WhenAny(
+            deactivationTask,
+            Task.Delay(TimeSpan.FromSeconds(5)));
+        dns.ReleaseLookup.TrySetResult(true);
+
+        firstCompleted.Should().Be(
+            deactivationTask,
+            "outbound DNS work must not hold the organization transaction lock");
+        await deactivationTask;
+        var confirmationAction = async () => await confirmationTask;
+        await confirmationAction.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Portal session is invalid or expired.");
+
+        await using var verification = BuildIsolatedLifecycleStack();
+        var storedDomain = await verification.Context.Set<SqlOSOrganizationDomain>()
+            .SingleAsync(x => x.Id == state.Domain.Id);
+        storedDomain.Status.Should().Be(SqlOSOrganizationDomainStatuses.PendingOwnership);
+        storedDomain.VerifiedAt.Should().BeNull();
+    }
+
+    [TestMethod]
     public async Task Signup_Refresh_Logout_RoundTrips()
     {
         var auth = BuildAuthService();
@@ -751,9 +850,11 @@ public sealed class AuthServiceIntegrationTests
         return new TestSqlOSDbContext(dbOptions);
     }
 
-    private static IsolatedLifecycleStack BuildIsolatedLifecycleStack()
+    private static IsolatedLifecycleStack BuildIsolatedLifecycleStack(
+        IInterceptor? interceptor = null,
+        ISqlOSDomainDnsVerifier? dnsVerifier = null)
     {
-        var context = BuildIsolatedContext();
+        var context = BuildIsolatedContext(interceptor);
         var options = Options.Create(AspireFixture.Options);
         var crypto = new SqlOSCryptoService(context, options, AspireFixture.DataProtectionProvider);
         var admin = new SqlOSAdminService(context, options, crypto);
@@ -775,7 +876,7 @@ public sealed class AuthServiceIntegrationTests
             options,
             crypto,
             admin,
-            new RejectingDomainDnsVerifier());
+            dnsVerifier ?? new RejectingDomainDnsVerifier());
         var portal = new SqlOSSsoPortalService(context, options, crypto, admin, domains);
         return new IsolatedLifecycleStack(context, crypto, admin, auth, authPage, authorization, portal);
     }
@@ -807,6 +908,53 @@ public sealed class AuthServiceIntegrationTests
             string expectedValue,
             CancellationToken cancellationToken = default)
             => Task.FromResult(false);
+    }
+
+    private sealed class PauseDomainDnsVerifier : ISqlOSDomainDnsVerifier
+    {
+        public TaskCompletionSource<bool> LookupReached { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource<bool> ReleaseLookup { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public async Task<bool> HasTxtRecordValueAsync(
+            string recordName,
+            string expectedValue,
+            CancellationToken cancellationToken = default)
+        {
+            LookupReached.TrySetResult(true);
+            return await ReleaseLookup.Task.WaitAsync(cancellationToken);
+        }
+    }
+
+    private sealed class PausePortalSessionInsertInterceptor : SaveChangesInterceptor
+    {
+        private int _hasPaused;
+
+        public TaskCompletionSource<bool> InsertReached { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource<bool> ReleaseInsert { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public override async ValueTask<InterceptionResult<int>> SavingChangesAsync(
+            DbContextEventData eventData,
+            InterceptionResult<int> result,
+            CancellationToken cancellationToken = default)
+        {
+            var context = eventData.Context;
+            var isPortalSessionInsert = context != null
+                && context.ChangeTracker.Entries<SqlOSSsoPortalSession>()
+                    .Any(entry => entry.State == EntityState.Added);
+            if (isPortalSessionInsert && Interlocked.Exchange(ref _hasPaused, 1) == 0)
+            {
+                InsertReached.TrySetResult(true);
+                await ReleaseInsert.Task.WaitAsync(cancellationToken);
+            }
+
+            return result;
+        }
     }
 
     [TestMethod]

--- a/tests/SqlOS.Tests/SqlOSAdminAuthorizationMetadataTests.cs
+++ b/tests/SqlOS.Tests/SqlOSAdminAuthorizationMetadataTests.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SqlOS.AuthServer.Contracts;
+using SqlOS.AuthServer.Extensions;
 using SqlOS.AuthServer.Services;
 using SqlOS.Dashboard;
 using SqlOS.Extensions;
@@ -165,6 +166,21 @@ public sealed class SqlOSAdminAuthorizationMetadataTests
             .And.NotContain("organization");
     }
 
+    [TestMethod]
+    public async Task PortalSessionAvailabilityFilter_MapsRevalidationRaceToGenericUnauthorized()
+    {
+        var filter = new SqlOSSsoPortalSessionAvailabilityFilter();
+        var result = await filter.InvokeAsync(
+            new TestEndpointFilterInvocationContext(new DefaultHttpContext()),
+            _ => ValueTask.FromException<object?>(
+                new SqlOSSsoPortalSessionUnavailableException()));
+
+        result.Should().BeAssignableTo<IStatusCodeHttpResult>()
+            .Which.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+        ((IValueHttpResult)result!).Value.Should().BeEquivalentTo(
+            new { message = "Portal session is invalid or expired." });
+    }
+
     private static string ExtractSetupToken(string setupUrl)
     {
         var query = new Uri(setupUrl).Query;
@@ -193,5 +209,16 @@ public sealed class SqlOSAdminAuthorizationMetadataTests
         app.MapSqlOS();
         await app.StartAsync();
         return app;
+    }
+
+    private sealed class TestEndpointFilterInvocationContext(HttpContext httpContext)
+        : EndpointFilterInvocationContext
+    {
+        public override HttpContext HttpContext { get; } = httpContext;
+
+        public override IList<object?> Arguments { get; } = [];
+
+        public override T GetArgument<T>(int index)
+            => (T)Arguments[index]!;
     }
 }

--- a/tests/SqlOS.Tests/SqlOSAdminAuthorizationMetadataTests.cs
+++ b/tests/SqlOS.Tests/SqlOSAdminAuthorizationMetadataTests.cs
@@ -12,6 +12,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SqlOS.AuthServer.Contracts;
+using SqlOS.AuthServer.Services;
 using SqlOS.Dashboard;
 using SqlOS.Extensions;
 using SqlOS.Tests.Infrastructure;
@@ -110,6 +112,63 @@ public sealed class SqlOSAdminAuthorizationMetadataTests
         portalEndpoints.Should().OnlyContain(endpoint =>
             endpoint.Metadata.GetMetadata<SqlOSAdminPublicExceptionMetadata>() != null
             && endpoint.Metadata.GetMetadata<SqlOSAdminRequiredMetadata>() == null);
+    }
+
+    [TestMethod]
+    public async Task DeactivatedOrganization_PortalRoutesReturnOnlyGenericCapabilityErrors()
+    {
+        await using var app = await CreateAppAsync(Environments.Production);
+        string setupToken;
+        string portalCookie;
+
+        await using (var scope = app.Services.CreateAsyncScope())
+        {
+            var admin = scope.ServiceProvider.GetRequiredService<SqlOSAdminService>();
+            var portal = scope.ServiceProvider.GetRequiredService<SqlOSSsoPortalService>();
+            var organization = await admin.CreateOrganizationAsync(
+                new SqlOSCreateOrganizationRequest(
+                    "Generic Portal Error Org",
+                    null,
+                    "generic-portal-error.test"));
+            var pending = await portal.CreateSessionAsync(
+                new SqlOSCreateSsoPortalSessionRequest(organization.Id));
+            setupToken = ExtractSetupToken(pending.SetupUrl!);
+            var opened = await portal.CreateSessionAsync(
+                new SqlOSCreateSsoPortalSessionRequest(organization.Id));
+            var openContext = new DefaultHttpContext();
+            await portal.OpenSessionAsync(ExtractSetupToken(opened.SetupUrl!), openContext);
+            portalCookie = openContext.Response.Headers.SetCookie.ToString().Split(';', 2)[0];
+
+            await admin.UpdateOrganizationAsync(
+                organization.Id,
+                new SqlOSUpdateOrganizationRequest(
+                    organization.Name,
+                    organization.Slug,
+                    organization.PrimaryDomain,
+                    IsActive: false));
+        }
+
+        var client = app.GetTestClient();
+        var startResponse = await client.GetAsync(
+            $"{PortalPrefix}/start?token={Uri.EscapeDataString(setupToken)}");
+        startResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var startBody = await startResponse.Content.ReadAsStringAsync();
+        startBody.Should().Contain("Portal setup token is invalid or expired.");
+        startBody.ToLowerInvariant().Should().NotContain("organization");
+
+        using var stateRequest = new HttpRequestMessage(HttpMethod.Get, $"{PortalApiPrefix}/state");
+        stateRequest.Headers.Add("Cookie", portalCookie);
+        var stateResponse = await client.SendAsync(stateRequest);
+        stateResponse.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        (await stateResponse.Content.ReadAsStringAsync())
+            .Should().Contain("Portal session is invalid or expired.")
+            .And.NotContain("organization");
+    }
+
+    private static string ExtractSetupToken(string setupUrl)
+    {
+        var query = new Uri(setupUrl).Query;
+        return Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery(query)["token"].ToString();
     }
 
     private static async Task<WebApplication> CreateAppAsync(string environment)

--- a/tests/SqlOS.Tests/SqlOSSsoPortalServiceTests.cs
+++ b/tests/SqlOS.Tests/SqlOSSsoPortalServiceTests.cs
@@ -130,6 +130,157 @@ public sealed class SqlOSSsoPortalServiceTests
     }
 
     [TestMethod]
+    public async Task OrganizationDeactivation_RevokesPortalCapabilitiesAndReactivationDoesNotReviveThem()
+    {
+        using var harness = await PortalHarness.CreateAsync();
+        var org = await harness.Admin.CreateOrganizationAsync(
+            new SqlOSCreateOrganizationRequest("Deactivated Portal Org", null, "deactivated-portal.test"));
+        var pending = await harness.Portal.CreateSessionAsync(
+            new SqlOSCreateSsoPortalSessionRequest(org.Id, Provider: "okta"),
+            harness.Http);
+        var opened = await harness.Portal.CreateSessionAsync(
+            new SqlOSCreateSsoPortalSessionRequest(org.Id, Provider: "microsoft-entra"),
+            harness.Http);
+        var openHttp = PortalHarness.CreateHttpContext();
+        await harness.Portal.OpenSessionAsync(ExtractToken(opened.SetupUrl!), openHttp);
+        var openedCookie = openHttp.Response.Headers.SetCookie.ToString().Split(';', 2)[0];
+
+        await harness.Admin.UpdateOrganizationAsync(
+            org.Id,
+            new SqlOSUpdateOrganizationRequest(
+                org.Name,
+                org.Slug,
+                org.PrimaryDomain,
+                IsActive: false));
+
+        var revoked = await harness.Context.Set<SqlOSSsoPortalSession>()
+            .Where(x => x.OrganizationId == org.Id)
+            .ToListAsync();
+        revoked.Should().HaveCount(2);
+        revoked.Should().OnlyContain(x =>
+            x.RevokedAt != null && x.RevokedReason == "organization_deactivated");
+        (await harness.Context.Set<SqlOSAuditEvent>().AnyAsync(x =>
+            x.EventType == "sso.portal.sessions.revoked"
+            && x.OrganizationId == org.Id
+            && x.MetadataJson != null
+            && x.MetadataJson.Contains("\"reason\":\"organization_deactivated\"", StringComparison.Ordinal)
+            && x.MetadataJson.Contains("\"revokedSessions\":2", StringComparison.Ordinal)))
+            .Should().BeTrue();
+
+        var pendingOpen = async () => await harness.Portal.OpenSessionAsync(
+            ExtractToken(pending.SetupUrl!),
+            PortalHarness.CreateHttpContext());
+        await pendingOpen.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Portal setup token is invalid or expired.");
+
+        var openedRequest = PortalHarness.CreateHttpContext();
+        openedRequest.Request.Headers.Cookie = openedCookie;
+        (await harness.Portal.TryGetSessionAsync(openedRequest)).Should().BeNull();
+
+        await harness.Admin.UpdateOrganizationAsync(
+            org.Id,
+            new SqlOSUpdateOrganizationRequest(
+                org.Name,
+                org.Slug,
+                org.PrimaryDomain,
+                IsActive: true));
+
+        await pendingOpen.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Portal setup token is invalid or expired.");
+        var reactivatedRequest = PortalHarness.CreateHttpContext();
+        reactivatedRequest.Request.Headers.Cookie = openedCookie;
+        (await harness.Portal.TryGetSessionAsync(reactivatedRequest)).Should().BeNull();
+
+        var replacement = await harness.Portal.CreateSessionAsync(
+            new SqlOSCreateSsoPortalSessionRequest(org.Id),
+            harness.Http);
+        replacement.SetupUrl.Should().NotBeNullOrWhiteSpace();
+        replacement.Id.Should().NotBe(pending.Id).And.NotBe(opened.Id);
+    }
+
+    [TestMethod]
+    public async Task InactiveOrganization_FailsClosedEvenWhenPortalSessionsWereNotRevoked()
+    {
+        using var harness = await PortalHarness.CreateAsync();
+        var org = await harness.Admin.CreateOrganizationAsync(
+            new SqlOSCreateOrganizationRequest("Defense In Depth Org", null, "defense-in-depth.test"));
+        var pending = await harness.Portal.CreateSessionAsync(
+            new SqlOSCreateSsoPortalSessionRequest(org.Id, Provider: "okta"),
+            harness.Http);
+        var opened = await harness.Portal.CreateSessionAsync(
+            new SqlOSCreateSsoPortalSessionRequest(org.Id, Provider: "microsoft-entra"),
+            harness.Http);
+        var openHttp = PortalHarness.CreateHttpContext();
+        await harness.Portal.OpenSessionAsync(ExtractToken(opened.SetupUrl!), openHttp);
+        var openedCookie = openHttp.Response.Headers.SetCookie.ToString().Split(';', 2)[0];
+        var openedSession = await harness.Context.Set<SqlOSSsoPortalSession>()
+            .SingleAsync(x => x.Id == opened.Id);
+
+        org.IsActive = false;
+        await harness.Context.SaveChangesAsync();
+        (await harness.Context.Set<SqlOSSsoPortalSession>()
+            .Where(x => x.OrganizationId == org.Id)
+            .AllAsync(x => x.RevokedAt == null)).Should().BeTrue();
+
+        var pendingOpen = async () => await harness.Portal.OpenSessionAsync(
+            ExtractToken(pending.SetupUrl!),
+            PortalHarness.CreateHttpContext());
+        await pendingOpen.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Portal setup token is invalid or expired.");
+
+        var openedRequest = PortalHarness.CreateHttpContext();
+        openedRequest.Request.Headers.Cookie = openedCookie;
+        (await harness.Portal.TryGetSessionAsync(openedRequest)).Should().BeNull();
+
+        var read = async () => await harness.Portal.GetStateAsync(openedSession);
+        await read.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Portal session is invalid or expired.");
+        var mutation = async () => await harness.Portal.SetProviderAsync(
+            openedSession,
+            new SqlOSUpdateSsoPortalProviderRequest("google-workspace"),
+            harness.Http);
+        await mutation.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Portal session is invalid or expired.");
+        openedSession.Provider.Should().Be("microsoft-entra");
+    }
+
+    [TestMethod]
+    public async Task TryGetSessionAsync_RejectsIdleAndAbsoluteExpiry()
+    {
+        using var harness = await PortalHarness.CreateAsync(options =>
+            options.SsoPortal.SessionIdleTimeout = TimeSpan.FromMinutes(1));
+        var org = await harness.Admin.CreateOrganizationAsync(
+            new SqlOSCreateOrganizationRequest("Expired Portal Org", null, "expired-portal.test"));
+        var idle = await harness.Portal.CreateSessionAsync(
+            new SqlOSCreateSsoPortalSessionRequest(org.Id),
+            harness.Http);
+        var idleOpenHttp = PortalHarness.CreateHttpContext();
+        await harness.Portal.OpenSessionAsync(ExtractToken(idle.SetupUrl!), idleOpenHttp);
+        var idleCookie = idleOpenHttp.Response.Headers.SetCookie.ToString().Split(';', 2)[0];
+        var idleSession = await harness.Context.Set<SqlOSSsoPortalSession>()
+            .SingleAsync(x => x.Id == idle.Id);
+        idleSession.LastSeenAt = DateTime.UtcNow.AddMinutes(-2);
+
+        var absolute = await harness.Portal.CreateSessionAsync(
+            new SqlOSCreateSsoPortalSessionRequest(org.Id),
+            harness.Http);
+        var absoluteOpenHttp = PortalHarness.CreateHttpContext();
+        await harness.Portal.OpenSessionAsync(ExtractToken(absolute.SetupUrl!), absoluteOpenHttp);
+        var absoluteCookie = absoluteOpenHttp.Response.Headers.SetCookie.ToString().Split(';', 2)[0];
+        var absoluteSession = await harness.Context.Set<SqlOSSsoPortalSession>()
+            .SingleAsync(x => x.Id == absolute.Id);
+        absoluteSession.ExpiresAt = DateTime.UtcNow.AddSeconds(-1);
+        await harness.Context.SaveChangesAsync();
+
+        var idleRequest = PortalHarness.CreateHttpContext();
+        idleRequest.Request.Headers.Cookie = idleCookie;
+        (await harness.Portal.TryGetSessionAsync(idleRequest)).Should().BeNull();
+        var absoluteRequest = PortalHarness.CreateHttpContext();
+        absoluteRequest.Request.Headers.Cookie = absoluteCookie;
+        (await harness.Portal.TryGetSessionAsync(absoluteRequest)).Should().BeNull();
+    }
+
+    [TestMethod]
     public async Task ImportMetadataAndActivateAsync_EnableHomeRealmDiscoveryForOnlyPortalOrganization()
     {
         using var harness = await PortalHarness.CreateAsync();

--- a/tests/SqlOS.Tests/SqlOSSsoPortalServiceTests.cs
+++ b/tests/SqlOS.Tests/SqlOSSsoPortalServiceTests.cs
@@ -177,6 +177,11 @@ public sealed class SqlOSSsoPortalServiceTests
         openedRequest.Request.Headers.Cookie = openedCookie;
         (await harness.Portal.TryGetSessionAsync(openedRequest)).Should().BeNull();
 
+        var legacyPending = revoked.Single(x => x.Id == pending.Id);
+        legacyPending.RevokedAt = null;
+        legacyPending.RevokedReason = null;
+        await harness.Context.SaveChangesAsync();
+
         await harness.Admin.UpdateOrganizationAsync(
             org.Id,
             new SqlOSUpdateOrganizationRequest(
@@ -190,6 +195,15 @@ public sealed class SqlOSSsoPortalServiceTests
         var reactivatedRequest = PortalHarness.CreateHttpContext();
         reactivatedRequest.Request.Headers.Cookie = openedCookie;
         (await harness.Portal.TryGetSessionAsync(reactivatedRequest)).Should().BeNull();
+        legacyPending.RevokedAt.Should().NotBeNull();
+        legacyPending.RevokedReason.Should().Be("organization_reactivated");
+        (await harness.Context.Set<SqlOSAuditEvent>().AnyAsync(x =>
+            x.EventType == "sso.portal.sessions.revoked"
+            && x.OrganizationId == org.Id
+            && x.MetadataJson != null
+            && x.MetadataJson.Contains("\"reason\":\"organization_reactivated\"", StringComparison.Ordinal)
+            && x.MetadataJson.Contains("\"revokedSessions\":1", StringComparison.Ordinal)))
+            .Should().BeTrue();
 
         var replacement = await harness.Portal.CreateSessionAsync(
             new SqlOSCreateSsoPortalSessionRequest(org.Id),


### PR DESCRIPTION
Fixes #242

## Summary

- Revoke every unrevoked SSO setup link and portal cookie when an organization transitions to inactive.
- Record the revocation count and reason in the audit log inside the same organization-deactivation transaction.
- Serialize organization lifecycle changes and portal reads/mutations with one per-organization SQL lock.
- Re-check current organization activity, revocation, absolute expiry, and idle expiry at each portal operation boundary.
- Return the existing generic public capability errors without disclosing organization state.

## Root cause

Organization deactivation invoked the general authentication lifecycle policy, but that policy did not cover `SqlOSSsoPortalSession`. Portal cookie validation also checked expiry, revocation, and token presence without checking `SqlOSOrganization.IsActive`. Finally, a request that loaded a valid session immediately before deactivation could retain stale tracked state and mutate the SSO connection after deactivation committed.

## Implementation notes

`SqlOSAdminService.UpdateOrganizationAsync` now runs organization updates in a serializable transaction. On deactivation it revokes portal sessions and records `sso.portal.sessions.revoked` before committing. Portal setup-link opening, state reads, and state-changing operations use the same organization-scoped transaction lock and reload current database state after acquiring it. This gives deterministic ordering: a portal operation either finishes before deactivation and is then revoked, or observes the inactive/revoked state and fails closed.

Reactivation leaves the revoked rows unchanged, so operators must issue a new setup capability.

## Regression coverage

- Deactivation revokes pending and opened portal capabilities and audits the count.
- Reactivation does not revive old links or cookies.
- Inactive organizations fail closed even if session revocation is bypassed.
- Idle timeout, absolute expiry, and explicit revocation remain enforced.
- Public start/API routes expose only generic invalid-or-expired errors.
- A real SQL test holds deactivation open in one context while a stale mutation races from another; the mutation waits, reloads current state, and is rejected.
- The real SQL test also verifies an inactive pending link and an existing cookie across separate contexts.

## Validation

- `SqlOS.Tests`: 673 passed.
- Focused SQL integration regression: 1 passed.
- `dotnet build src/SqlOS/SqlOS.csproj --no-restore`: passed.
- `dotnet format ... --verify-no-changes`: passed.
- `git diff --check`: passed.
