### PR TITLE
Release SqlOS 3.24.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![NuGet](https://img.shields.io/nuget/v/SqlOS)](https://www.nuget.org/packages/SqlOS)
 [![.NET 9](https://img.shields.io/badge/.NET-9.0-purple)](https://dotnet.microsoft.com)
 
-SqlOS 3.24.0 provides a hosted OAuth server, branded login, organizations, sessions, and optional fine-grained authorization to an ASP.NET Core application. It runs in your process and stores its data in your SQL Server database, so you do not need a separate identity or authorization service to get started.
+SqlOS 3.24.1 provides a hosted OAuth server, branded login, organizations, sessions, and optional fine-grained authorization to an ASP.NET Core application. It runs in your process and stores its data in your SQL Server database, so you do not need a separate identity or authorization service to get started.
 
 Start with one application and hosted login. Add SAML SSO, social login, Email OTP, audit logs, calendar connections, or hierarchical authorization when your product needs them.
 
@@ -53,10 +53,10 @@ Requirements:
 Install the package:
 
 ```bash
-dotnet add package SqlOS --version 3.24.0
+dotnet add package SqlOS --version 3.24.1
 ```
 
-> The `main` branch is staged for the 3.24.0 package contract. If NuGet does not list 3.24.0 yet, run the repository examples from source or wait for the package release; do not pair these source docs with an older package.
+> The `main` branch is staged for the 3.24.1 package contract. If NuGet does not list 3.24.1 yet, run the repository examples from source or wait for the package release; do not pair these source docs with an older package.
 
 Use `SqlOSDbContext<TContext>` so SqlOS can register its EF Core model, then declare one application with `UseSingleApplication`:
 

--- a/src/SqlOS/SqlOS.csproj
+++ b/src/SqlOS/SqlOS.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>SqlOS</PackageId>
-    <Version>3.24.0</Version>
+    <Version>3.24.1</Version>
     <Authors>Ross Slaney</Authors>
     <Description>Embedded auth server and fine-grained authorization runtime for .NET + SQL Server + EF Core.</Description>
     <PackageTags>authentication;authorization;fga;saml;jwt;sessions;efcore;sqlserver</PackageTags>

--- a/web/content/blog/hierarchical-authorization-native-ef-core.mdx
+++ b/web/content/blog/hierarchical-authorization-native-ef-core.mdx
@@ -128,7 +128,7 @@ Create the host and install the same package version used to compile this articl
 ```bash
 dotnet new web --framework net9.0 --name HierarchicalEf
 cd HierarchicalEf
-dotnet add package SqlOS --version 3.24.0
+dotnet add package SqlOS --version 3.24.1
 ```
 
 Replace `Program.cs` with the program below. It assumes SQL Server is running and that callers obtain an audience-bound access token through the [Protect an API quickstart](/docs/quickstarts/protect-api). That keeps the sample focused on upgrading the EF model rather than rebuilding the OAuth client flow in the same file.

--- a/web/content/blog/sqlos-3-24-1-fail-closed-at-the-boundaries.mdx
+++ b/web/content/blog/sqlos-3-24-1-fail-closed-at-the-boundaries.mdx
@@ -1,0 +1,69 @@
+---
+title: "SqlOS 3.24.1: Fail Closed at the Boundaries"
+description: "A patch release that tightens schema upgrades, confidential OAuth client authentication, and delegated SSO setup lifecycles."
+date: "2026-07-27"
+author: "Ross Slaney"
+tags: ["AuthServer", "OAuth", "SAML", "FGA", "Security", "SqlOS"]
+---
+
+SqlOS 3.24.1 is a focused security and correctness release. It does not introduce a new identity model. It makes three existing boundaries behave the way operators and developers reasonably expect when the surrounding state changes:
+
+- a schema upgrade is complete only when the database records the matching schema version;
+- a confidential OAuth client must authenticate as that client when it exchanges a code or refresh token; and
+- a delegated SSO setup capability stops working when its organization is deactivated.
+
+The common principle is simple: cached, partial, or adjacent state must not be enough to cross an identity boundary.
+
+## Schema upgrades now prove their own version
+
+SqlOS applies its FGA schema from embedded, numbered migrations. One migration added the machine-client ownership fields but did not advance the persisted FGA schema marker. The SQL change could succeed while the database continued to identify itself as the previous version, causing the migration to run again on later startups.
+
+Version 3.24.1 fixes that migration and adds a version-independent guard. After every FGA migration, startup reloads the persisted schema version and requires it to match the migration that just ran. If a future script forgets its version update—or writes the wrong one—initialization fails at that script.
+
+This is deliberately broader than a one-off correction. The integration test derives the expected version from the embedded migration set, so adding migration 8, 9, or 20 without advancing the database marker breaks CI before it becomes an upgrade problem.
+
+For production, keep using a canary upgrade against a restored database before rolling the package to every replica. See [Production Readiness](/docs/guides/production-readiness#6-roll-schema-changes-forward-through-one-instance) for the rollout boundary.
+
+## Confidential OAuth clients authenticate on every token exchange
+
+A confidential client is a server-side application that can keep a credential. Its secret authenticates the OAuth application; it is not a user password and it does not grant FGA permissions.
+
+SqlOS now applies `client_secret_basic` at the shared token endpoint for all confidential-client exchanges:
+
+- authorization code;
+- refresh token; and
+- client credentials.
+
+The authorization code and refresh token remain bound to their original client. A credential for client A cannot exchange an artifact issued to client B. Missing, malformed, disabled, revoked, expired, or ambiguous credentials return generic OAuth errors without consuming the code or refresh token, so an invalid attempt cannot burn a legitimate exchange.
+
+Public browser, native, device, CIMD, and DCR clients remain public. They continue to use PKCE or their existing public-client flow and are not forced to invent a secret they cannot protect.
+
+Dashboard-managed confidential clients can overlap two hashed credentials during a rotation: create the replacement, move the server-side application, and revoke the old credential. Code-owned clients resolve their secret from the host configuration or secret provider and fail startup closed when the material is unavailable.
+
+The [Clients reference](/docs/authserver/clients#confidential-server-side-clients) covers server-side web clients. For service-to-service tokens and optional SqlOS FGA grants, use [Background jobs with service accounts](/docs/guides/service-account-jobs).
+
+## Organization deactivation closes delegated SSO setup
+
+Customer-managed SSO uses a narrow capability: a one-time setup link becomes a short-lived continuation cookie that can configure one organization's SAML connection. That capability must be subordinate to the organization lifecycle.
+
+In 3.24.1, deactivating an organization revokes all of its pending and opened SSO setup sessions in the same transaction. Portal operations serialize against organization lifecycle changes and reload current database state before reading or mutating configuration. An operation either completes before deactivation and is then revoked, or observes the inactive organization and fails closed.
+
+The public response stays generic, so callers cannot use the portal to distinguish an inactive organization from an expired or revoked capability. Reactivating the organization does not restore old links or cookies; an operator must issue a new setup link.
+
+This is separate from end-user OAuth session revocation. Organization deactivation already enforces the broader authentication lifecycle. The 3.24.1 change closes the delegated administration path that was not previously included in that lifecycle.
+
+See [Let customer admins set up enterprise SSO](/docs/guides/customer-managed-sso#10-operate-and-revoke-safely) for the complete capability and revocation model.
+
+## Upgrade notes
+
+Upgrade the package normally:
+
+```bash
+dotnet add package SqlOS --version 3.24.1
+```
+
+Then run one new revision against a restored production database, wait for `SqlOS initialization complete.`, and smoke-test the identity paths your application uses.
+
+If you use confidential clients, ensure every server-side code and refresh-token exchange supplies its configured client secret. Public clients require no change. If an organization was deactivated and later reactivated, issue a fresh SSO setup link instead of expecting an older capability to work.
+
+This patch is backed by real SQL upgrade and concurrency tests, full confidential-client exchange coverage, public-client regression coverage, and the repository's complete build, documentation, unit, integration, example-application, and coverage gates.

--- a/web/content/docs/docs-index.mdx
+++ b/web/content/docs/docs-index.mdx
@@ -5,7 +5,7 @@ order: 0
 ---
 
 <Callout type="info" title="Version contract">
-  These docs target **SqlOS 3.24.0**, **.NET 9**, **EF Core 9**, and **SQL Server**. Use the same package version as the docs; older releases do not include the complete current schema and source/reference contract.
+  These docs target **SqlOS 3.24.1**, **.NET 9**, **EF Core 9**, and **SQL Server**. Use the same package version as the docs; older releases do not include the complete current schema and source/reference contract.
 </Callout>
 
 ## Get useful proof first

--- a/web/content/docs/getting-started.mdx
+++ b/web/content/docs/getting-started.mdx
@@ -14,7 +14,7 @@ order: 0
 </Banner>
 
 <Callout type="info" title="Supported stack">
-  - **SqlOS 3.24.0**
+  - **SqlOS 3.24.1**
   - **.NET 9** (`net9.0`)
   - **EF Core 9**
   - **SQL Server**

--- a/web/content/docs/guides/customer-managed-sso.mdx
+++ b/web/content/docs/guides/customer-managed-sso.mdx
@@ -249,6 +249,8 @@ Check that the resulting session uses SAML authentication and that the user and 
 
 Creating a new setup link does not invalidate earlier links. Revoke obsolete setup sessions from the organization SSO tab, especially after a support handoff or accidental disclosure. Link/session revocation affects only the delegated setup credential; it does not revoke end-user OAuth sessions.
 
+Organization deactivation is the enclosing security boundary. When an organization transitions to inactive, SqlOS revokes every pending or opened setup session in the same transaction. In-flight portal operations are serialized against that lifecycle change and reload the current organization and session state before making a change. Old links and continuation cookies therefore fail with the same generic invalid-or-expired response after deactivation. Reactivating the organization does not revive them; issue a new setup link for a new administrative handoff.
+
 Activation also does not revoke active end-user sessions. If existing matching-domain members must immediately sign in again through SSO, use the separate **Revoke organization sessions** action and confirm it explicitly. It requires an active connection and active verified domain, then revokes matching-domain OAuth/refresh sessions and hosted AuthPage sessions for that organization. It does not revoke users from other domains or organizations.
 
 Portal creation, open, close, revoke, provider selection, enrollment-policy changes, domain verification, metadata import, activation, disable, tests, and organization-session revocation write organization-scoped audit events. Review them in **Governance → Audit Logs**.
@@ -273,6 +275,7 @@ For a local portal-only test, create the organization with a primary domain befo
 
 - Customer IT admins configure only their organization without global dashboard access.
 - The setup URL is single-use and replaceable through a new, independently revocable session.
+- Deactivating the organization invalidates all of its delegated setup links and cookies; reactivation requires a new link.
 - DNS ownership, metadata readiness, enrollment policy, and PKCE test status are visible before activation.
 - Eligible matching-domain users route through SSO; other users follow the configured fallback policy.
 - Session revocation happens only through the separate confirm-gated action.

--- a/web/content/docs/guides/production-readiness.mdx
+++ b/web/content/docs/guides/production-readiness.mdx
@@ -233,6 +233,8 @@ The SQL authorization function is installed with `CREATE OR ALTER FUNCTION`, whi
 
 Each AuthServer script and its ledger entry commit in one transaction, so an interrupted startup safely retries the unrecorded script. The initializer does **not** acquire a distributed migration lock, wrap the entire release upgrade in one cross-script transaction, or provide down migrations.
 
+FGA migration scripts carry a matching persisted schema version. After every FGA migration, SqlOS reloads `SqlOSFgaSchema.Version` and requires it to match the embedded migration number before startup can continue. A missing, stale, or incorrectly advanced marker fails initialization at the offending migration instead of reporting a schema level the database has not actually reached. Do not edit shipped scripts or their version updates; add a new numbered migration and validate the upgrade against a restored database.
+
 Use this rollout sequence:
 
 1. Back up the database and Data Protection key ring; record the application and SqlOS package versions.

--- a/web/content/docs/quickstarts/add-to-app.mdx
+++ b/web/content/docs/quickstarts/add-to-app.mdx
@@ -11,7 +11,7 @@ section: quickstarts
   href="#complete-program"
   actionLabel="View the code"
 >
-  Install SqlOS 3.24.0, register one SQL Server `DbContext`, declare one application, and map the routes. FGA modeling and advanced client registration can wait.
+  Install SqlOS 3.24.1, register one SQL Server `DbContext`, declare one application, and map the routes. FGA modeling and advanced client registration can wait.
 </Banner>
 
 ## Goal
@@ -30,16 +30,16 @@ Start an ASP.NET Core application with:
 - EF Core 9;
 - an existing SQL Server database and a login allowed to create tables, indexes, and functions.
 
-SqlOS 3.24.0 targets `net9.0`; it is not compatible with a `net8.0` host.
+SqlOS 3.24.1 targets `net9.0`; it is not compatible with a `net8.0` host.
 
 ## Install
 
 ```bash
-dotnet add package SqlOS --version 3.24.0
+dotnet add package SqlOS --version 3.24.1
 ```
 
 <Callout type="warning" title="Use the matching package version">
-  The `3.24.0` package is the version contract for this guide. If NuGet does not list it yet, run the source examples from this repository or wait for the release; older packages may not contain the schema and APIs documented here.
+  The `3.24.1` package is the version contract for this guide. If NuGet does not list it yet, run the source examples from this repository or wait for the release; older packages may not contain the schema and APIs documented here.
 </Callout>
 
 For a new project, store local values with user secrets:

--- a/web/content/docs/quickstarts/ef-authorization.mdx
+++ b/web/content/docs/quickstarts/ef-authorization.mdx
@@ -20,7 +20,7 @@ Create projects through an audience-protected API and return only projects the s
 
 ## Prerequisites
 
-- SqlOS 3.24.0;
+- SqlOS 3.24.1;
 - .NET 9, EF Core 9, and SQL Server;
 - a completed [Protect an API](/docs/quickstarts/protect-api) flow;
 - a valid access token whose `aud` is `http://localhost:5050/api`.

--- a/web/content/docs/quickstarts/protect-api.mdx
+++ b/web/content/docs/quickstarts/protect-api.mdx
@@ -20,7 +20,7 @@ Add `/api/me` to a one-application SqlOS host. Requests without a bearer token r
 
 ## Prerequisites
 
-- SqlOS 3.24.0;
+- SqlOS 3.24.1;
 - .NET 9 and EF Core 9;
 - the [Add SqlOS to one app](/docs/quickstarts/add-to-app) setup;
 - the working [.NET hosted-login flow](/docs/quickstarts/aspnet-core-login), adapted so its registered callback matches your handler and its audience is `http://localhost:5050/api`, or another PKCE client that does the same.

--- a/web/content/docs/quickstarts/run-example-stack.mdx
+++ b/web/content/docs/quickstarts/run-example-stack.mdx
@@ -20,7 +20,7 @@ Compare hosted and headless auth, organization workflows, SSO, sessions, audit l
 
 ## Prerequisites
 
-- SqlOS repository checked out at version 3.24.0;
+- SqlOS repository checked out at version 3.24.1;
 - .NET 9 SDK;
 - Node.js and npm;
 - Docker running with enough memory for SQL Server;

--- a/web/content/docs/quickstarts/run-todo.mdx
+++ b/web/content/docs/quickstarts/run-todo.mdx
@@ -25,7 +25,7 @@ Create an account through the SqlOS hosted AuthPage, return to a secure ASP.NET 
 - Docker running with enough memory for SQL Server;
 - ports `1435`, `5080`, `5090`, `18890`, and `18891` available.
 
-This quickstart uses the source at **SqlOS 3.24.0**. Local password authentication is the default, so the first run does not require Azure Communication Services, Twilio, or an OIDC provider.
+This quickstart uses the source at **SqlOS 3.24.1**. Local password authentication is the default, so the first run does not require Azure Communication Services, Twilio, or an OIDC provider.
 
 ## Run
 

--- a/web/content/docs/reference/index.mdx
+++ b/web/content/docs/reference/index.mdx
@@ -1,13 +1,13 @@
 ---
 title: "Reference"
-description: "Source-aligned reference for SqlOS 3.24.0 hosting, authentication, authorization, and integration APIs."
+description: "Source-aligned reference for SqlOS 3.24.1 hosting, authentication, authorization, and integration APIs."
 order: 7
 section: reference
 ---
 
 <Banner
   eyebrow="Reference"
-  title="SqlOS 3.24.0 application API"
+  title="SqlOS 3.24.1 application API"
   href="/docs/getting-started"
   actionLabel="Start with a guide"
 >
@@ -19,7 +19,7 @@ section: reference
 | Item | Value |
 | --- | --- |
 | Package | `SqlOS` |
-| Current source version | `3.24.0` |
+| Current source version | `3.24.1` |
 | Assembly | `SqlOS.dll` |
 | Target framework | `net9.0` |
 | EF Core provider | SQL Server, EF Core 9 |


### PR DESCRIPTION
## Release

Publishes the focused security and correctness fixes merged after 3.24.0:

- #254 — fail startup when an FGA migration does not persist its matching schema version
- #255 — authenticate confidential OAuth clients consistently across authorization-code, refresh-token, and client-credentials exchanges
- #256 — revoke delegated SSO setup capabilities when an organization is deactivated

## Changes

- bumps the package and current documentation contract from 3.24.0 to 3.24.1
- adds **SqlOS 3.24.1: Fail Closed at the Boundaries**
- documents fail-closed FGA migration-version verification
- documents organization deactivation and reactivation semantics for SSO setup links and portal cookies
- updates installation and source-aligned reference pages to the 3.24.1 package contract

## Validation

- `dotnet build SqlOS.sln --configuration Release --no-restore --disable-build-servers --maxcpucount:1`
  - 15 projects built
  - 0 warnings, 0 errors
- `./scripts/docs-check.sh`
  - source contracts and 41 documentation images validated
  - all documentation snippets compiled
  - website lint and TypeScript passed
  - production build generated 138 pages, including the new release post
  - 172 Markdown files have no broken local links
- `dotnet pack src/SqlOS/SqlOS.csproj --configuration Release --no-build --no-restore`
  - produced `SqlOS.3.24.1.nupkg`
  - package metadata and embedded README report version 3.24.1
- `./scripts/check-release-checklist.sh`
  - release compatibility checklist accepted
- `git diff --check`
