### PR TITLE
Fix blocked FGA views in the unified dashboard

### DIFF
--- a/src/SqlOS/Configuration/SqlOSOptions.cs
+++ b/src/SqlOS/Configuration/SqlOSOptions.cs
@@ -88,8 +88,8 @@ public sealed class SqlOSBrowserSecurityOptions
     public const string NoncePlaceholder = "{nonce}";
 
     /// <summary>
-    /// Content Security Policy applied to hosted SqlOS HTML. SqlOS always appends
-    /// <c>frame-ancestors 'none'</c>; callers cannot relax the anti-framing boundary.
+    /// Content Security Policy applied to hosted SqlOS HTML. SqlOS owns each
+    /// surface's <c>frame-ancestors</c> policy; callers cannot relax the anti-framing boundary.
     /// </summary>
     public string ContentSecurityPolicy { get; set; } =
         "default-src 'none'; base-uri 'none'; object-src 'none'; form-action 'self'; " +

--- a/src/SqlOS/Configuration/SqlOSOptionsValidator.cs
+++ b/src/SqlOS/Configuration/SqlOSOptionsValidator.cs
@@ -171,7 +171,7 @@ internal static class SqlOSOptionsValidator
 
         if (options.ContentSecurityPolicy.Contains("frame-ancestors", StringComparison.OrdinalIgnoreCase))
         {
-            errors.Add("BrowserSecurity.ContentSecurityPolicy cannot configure frame-ancestors; SqlOS always enforces frame-ancestors 'none'.");
+            errors.Add("BrowserSecurity.ContentSecurityPolicy cannot configure frame-ancestors; SqlOS controls it for each hosted surface.");
         }
     }
 

--- a/src/SqlOS/Dashboard/SqlOSDashboardMiddleware.cs
+++ b/src/SqlOS/Dashboard/SqlOSDashboardMiddleware.cs
@@ -503,7 +503,7 @@ public sealed class SqlOSDashboardMiddleware
             JsonSerializer.Serialize(new { scimEnabled = _scimEnabled }),
             StringComparison.Ordinal);
         html = html.Replace("__SQL_OS_BASE_PATH__", _pathPrefix, StringComparison.Ordinal);
-        html = _securityHeaders.PrepareHtml(context, html);
+        html = _securityHeaders.PrepareDashboardHtml(context, html);
         await context.Response.WriteAsync(html);
     }
 

--- a/src/SqlOS/Fga/Dashboard/SqlOSFgaDashboardMiddleware.cs
+++ b/src/SqlOS/Fga/Dashboard/SqlOSFgaDashboardMiddleware.cs
@@ -95,7 +95,7 @@ public class SqlOSFgaDashboardMiddleware
         }
 
         // Serve static files
-        await ServeStaticFile(context, relativePath);
+        await ServeStaticFile(context, relativePath, embedMode);
     }
 
     private async Task<bool> IsAuthorizedAsync(HttpContext context)
@@ -1015,7 +1015,7 @@ public class SqlOSFgaDashboardMiddleware
         return int.TryParse(value, out var parsed) ? parsed : defaultValue;
     }
 
-    private async Task ServeStaticFile(HttpContext context, string relativePath)
+    private async Task ServeStaticFile(HttpContext context, string relativePath, bool embedMode)
     {
         var serveShell = false;
         if (string.IsNullOrEmpty(relativePath) || relativePath == "/")
@@ -1039,7 +1039,7 @@ public class SqlOSFgaDashboardMiddleware
             return;
         }
 
-        var contentType = GetContentType(relativePath);
+        var contentType = serveShell ? "text/html" : GetContentType(relativePath);
         context.Response.ContentType = contentType;
 
         await using var stream = fileInfo.CreateReadStream();
@@ -1049,7 +1049,9 @@ public class SqlOSFgaDashboardMiddleware
             var html = await reader.ReadToEndAsync();
             html = html.Replace("__SQL_OS_FGA_DASHBOARD_BASE_PATH_JSON__", JsonSerializer.Serialize(GetDashboardShellPrefix().TrimEnd('/')), StringComparison.Ordinal);
             html = html.Replace("__SQL_OS_BASE_PATH__", GetDashboardShellPrefix().TrimEnd('/'), StringComparison.Ordinal);
-            html = _securityHeaders.PrepareHtml(context, html);
+            html = embedMode
+                ? _securityHeaders.PrepareSameOriginEmbeddedHtml(context, html)
+                : _securityHeaders.PrepareHtml(context, html);
             await context.Response.WriteAsync(html);
             return;
         }

--- a/src/SqlOS/Security/SqlOSBrowserSecurityHeaders.cs
+++ b/src/SqlOS/Security/SqlOSBrowserSecurityHeaders.cs
@@ -30,19 +30,67 @@ internal sealed class SqlOSBrowserSecurityHeaders
     }
 
     public string PrepareHtml(HttpContext context, string html)
+        => PrepareHtml(context, html, "DENY", "'none'", allowSameOriginChildFrames: false);
+
+    public string PrepareDashboardHtml(HttpContext context, string html)
+        => PrepareHtml(context, html, "DENY", "'none'", allowSameOriginChildFrames: true);
+
+    public string PrepareSameOriginEmbeddedHtml(HttpContext context, string html)
+        => PrepareHtml(context, html, "SAMEORIGIN", "'self'", allowSameOriginChildFrames: false);
+
+    private string PrepareHtml(
+        HttpContext context,
+        string html,
+        string xFrameOptions,
+        string frameAncestors,
+        bool allowSameOriginChildFrames)
     {
         ApplyBaseline(context.Response);
+        context.Response.Headers["X-Frame-Options"] = xFrameOptions;
         var nonce = WebEncoders.Base64UrlEncode(RandomNumberGenerator.GetBytes(18));
         var policy = _options.ContentSecurityPolicy.Replace(
             SqlOSBrowserSecurityOptions.NoncePlaceholder,
             nonce,
             StringComparison.Ordinal);
+        var normalizedPolicy = policy.Trim().TrimEnd(';');
+        if (allowSameOriginChildFrames)
+        {
+            normalizedPolicy = EnsureDirectiveIncludesSource(normalizedPolicy, "frame-src", "'self'");
+        }
         context.Response.Headers["Content-Security-Policy"] =
-            $"{policy.Trim().TrimEnd(';')}; frame-ancestors 'none'";
+            $"{normalizedPolicy}; frame-ancestors {frameAncestors}";
 
         var encodedNonce = WebUtility.HtmlEncode(nonce);
         return InlineElementPattern.Replace(
             html,
             match => $"<{match.Groups[1].Value} nonce=\"{encodedNonce}\"");
+    }
+
+    private static string EnsureDirectiveIncludesSource(string policy, string directiveName, string source)
+    {
+        var directives = policy.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToList();
+        var directiveIndex = directives.FindIndex(directive =>
+        {
+            var separator = directive.IndexOfAny([' ', '\t']);
+            var name = separator < 0 ? directive : directive[..separator];
+            return name.Equals(directiveName, StringComparison.OrdinalIgnoreCase);
+        });
+
+        if (directiveIndex < 0)
+        {
+            directives.Add($"{directiveName} {source}");
+            return string.Join("; ", directives);
+        }
+
+        var tokens = directives[directiveIndex]
+            .Split([' ', '\t'], StringSplitOptions.RemoveEmptyEntries)
+            .ToList();
+        tokens.RemoveAll(token => token.Equals("'none'", StringComparison.OrdinalIgnoreCase));
+        if (!tokens.Contains(source, StringComparer.OrdinalIgnoreCase))
+        {
+            tokens.Add(source);
+        }
+        directives[directiveIndex] = string.Join(' ', tokens);
+        return string.Join("; ", directives);
     }
 }

--- a/tests/SqlOS.Tests/SqlOSDashboardAuthMiddlewareTests.cs
+++ b/tests/SqlOS.Tests/SqlOSDashboardAuthMiddlewareTests.cs
@@ -182,9 +182,26 @@ public sealed class SqlOSDashboardAuthMiddlewareTests
         response.ContentTypeOptions.Should().Be("nosniff");
         response.ReferrerPolicy.Should().Be("no-referrer");
         response.ContentSecurityPolicy.Should().Contain("frame-ancestors 'none'");
+        response.ContentSecurityPolicy.Should().Contain("frame-src 'self'");
         response.ContentSecurityPolicy.Should().NotContain("unsafe-inline");
         response.Body.Should().MatchRegex("<script nonce=\"[A-Za-z0-9_-]+\">");
         response.Body.Should().MatchRegex("<script nonce=\"[A-Za-z0-9_-]+\" src=");
+    }
+
+    [TestMethod]
+    public void DashboardShell_CustomFrameSource_CannotExcludeIntentionalSameOriginChild()
+    {
+        var options = new SqlOSOptions();
+        options.BrowserSecurity.ContentSecurityPolicy += "; frame-src 'none'";
+        var headers = new SqlOSBrowserSecurityHeaders(Options.Create(options));
+        var context = new DefaultHttpContext();
+
+        headers.PrepareDashboardHtml(context, "<html></html>");
+
+        var policy = context.Response.Headers.ContentSecurityPolicy.ToString();
+        policy.Should().Contain("frame-src 'self'");
+        policy.Should().NotContain("frame-src 'none'");
+        policy.Split("frame-src", StringSplitOptions.None).Should().HaveCount(2);
     }
 
     [TestMethod]
@@ -246,6 +263,69 @@ public sealed class SqlOSDashboardAuthMiddlewareTests
     }
 
     [TestMethod]
+    public async Task FgaDashboardShell_NormalNavigation_RemainsNonFrameable()
+    {
+        var response = await GetFgaDashboardAsync("/sqlos/admin/fga/resources");
+
+        response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        response.XFrameOptions.Should().Be("DENY");
+        response.ContentSecurityPolicy.Should().Contain("frame-ancestors 'none'");
+        response.ContentType.Should().Be("text/html");
+        response.Body.Should().Contain("SqlOSFga Dashboard");
+    }
+
+    [TestMethod]
+    public async Task FgaDashboardShell_IntentionalEmbed_AllowsOnlySameOriginFraming()
+    {
+        var resources = await GetFgaDashboardAsync("/sqlos/admin/fga/resources", "?embed=1");
+        var roles = await GetFgaDashboardAsync("/sqlos/admin/fga/roles", "?embed=1");
+
+        foreach (var response in new[] { resources, roles })
+        {
+            response.StatusCode.Should().Be(StatusCodes.Status200OK);
+            response.XFrameOptions.Should().Be("SAMEORIGIN");
+            response.ContentSecurityPolicy.Should().Contain("frame-ancestors 'self'");
+            response.ContentSecurityPolicy.Should().NotContain("frame-ancestors 'none'");
+            response.ContentType.Should().Be("text/html");
+            response.Body.Should().Contain("SqlOSFga Dashboard");
+        }
+    }
+
+    [TestMethod]
+    public async Task DashboardShell_EmbedQuery_CannotRelaxNonFgaFramingPolicy()
+    {
+        using var harness = CreateHarness(options =>
+        {
+            options.AuthMode = SqlOSDashboardAuthMode.DevelopmentOnly;
+            options.AuthorizationCallback = _ => Task.FromResult(true);
+        });
+
+        var response = await harness.GetAsync("/sqlos/", "?embed=1");
+
+        response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        response.XFrameOptions.Should().Be("DENY");
+        response.ContentSecurityPolicy.Should().Contain("frame-ancestors 'none'");
+        response.ContentSecurityPolicy.Should().Contain("frame-src 'self'");
+    }
+
+    [TestMethod]
+    public async Task FgaDashboardShell_EmbedQuery_StillRequiresDashboardAuthorization()
+    {
+        var response = await GetFgaDashboardAsync(
+            "/sqlos/admin/fga/resources",
+            "?embed=1",
+            options =>
+            {
+                options.AuthMode = SqlOSDashboardAuthMode.Password;
+                options.Password = "correct-password";
+            });
+
+        response.StatusCode.Should().Be(StatusCodes.Status302Found);
+        response.Location.Should().StartWith("/sqlos/login?next=");
+        response.XFrameOptions.Should().Be("DENY");
+    }
+
+    [TestMethod]
     public async Task DashboardClientReturnPath_UsesExactOrChildSegmentBoundary()
     {
         var files = new ManifestEmbeddedFileProvider(
@@ -301,6 +381,58 @@ public sealed class SqlOSDashboardAuthMiddlewareTests
             provider.GetRequiredService<IOptions<SqlOSOptions>>());
 
         return new DashboardMiddlewareHarness(provider, middleware);
+    }
+
+    private static async Task<DashboardResponse> GetFgaDashboardAsync(
+        string path,
+        string? queryString = null,
+        Action<SqlOSDashboardOptions>? configure = null)
+    {
+        var dashboardOptions = new SqlOSDashboardOptions
+        {
+            AuthMode = SqlOSDashboardAuthMode.DevelopmentOnly,
+            AuthorizationCallback = _ => Task.FromResult(true)
+        };
+        configure?.Invoke(dashboardOptions);
+
+        var services = new ServiceCollection();
+        services.AddDataProtection();
+        services.AddSingleton<SqlOSDashboardSessionService>();
+        await using var provider = services.BuildServiceProvider();
+        var middleware = new SqlOSFgaDashboardMiddleware(
+            context =>
+            {
+                context.Response.StatusCode = StatusCodes.Status418ImATeapot;
+                return Task.CompletedTask;
+            },
+            "/sqlos/admin/fga",
+            new TestHostEnvironment(),
+            dashboardOptions,
+            provider.GetRequiredService<SqlOSDashboardSessionService>(),
+            Options.Create(new SqlOSOptions()));
+        var context = new DefaultHttpContext { RequestServices = provider };
+        context.Request.Path = path;
+        if (queryString != null)
+        {
+            context.Request.QueryString = new QueryString(queryString);
+        }
+        context.Response.Body = new MemoryStream();
+
+        await middleware.InvokeAsync(context);
+
+        context.Response.Body.Position = 0;
+        using var reader = new StreamReader(context.Response.Body, Encoding.UTF8);
+        return new DashboardResponse(
+            context.Response.StatusCode,
+            await reader.ReadToEndAsync(),
+            Array.Empty<string>(),
+            null,
+            context.Response.Headers["X-Frame-Options"].ToString(),
+            context.Response.Headers["X-Content-Type-Options"].ToString(),
+            context.Response.Headers["Referrer-Policy"].ToString(),
+            context.Response.Headers["Content-Security-Policy"].ToString(),
+            context.Response.Headers.Location.ToString(),
+            context.Response.ContentType);
     }
 
     private sealed class DashboardMiddlewareHarness : IDisposable
@@ -391,7 +523,9 @@ public sealed class SqlOSDashboardAuthMiddlewareTests
                 context.Response.Headers["X-Frame-Options"].ToString(),
                 context.Response.Headers["X-Content-Type-Options"].ToString(),
                 context.Response.Headers["Referrer-Policy"].ToString(),
-                context.Response.Headers["Content-Security-Policy"].ToString());
+                context.Response.Headers["Content-Security-Policy"].ToString(),
+                context.Response.Headers.Location.ToString(),
+                context.Response.ContentType);
         }
 
         public void Dispose()
@@ -406,7 +540,9 @@ public sealed class SqlOSDashboardAuthMiddlewareTests
         string XFrameOptions,
         string ContentTypeOptions,
         string ReferrerPolicy,
-        string ContentSecurityPolicy);
+        string ContentSecurityPolicy,
+        string Location,
+        string? ContentType);
 
     private sealed class TestHostEnvironment : IHostEnvironment
     {

--- a/web/content/docs/guides/configuration.mdx
+++ b/web/content/docs/guides/configuration.mdx
@@ -215,7 +215,7 @@ Treat `/sqlos` and `/sqlos/admin` as administrative endpoints — restrict netwo
 
 ## Hosted UI security headers
 
-Hosted auth and dashboard HTML use a restrictive nonce-based Content Security Policy and deny framing automatically. No setting is required for the built-in UI. If a reviewed customization loads scripts, styles, images, or fonts from another origin, set `options.BrowserSecurity.ContentSecurityPolicy` and keep the required `{nonce}` placeholder. `frame-ancestors 'none'` is always enforced and cannot be overridden. See [Production Readiness](/docs/guides/production-readiness#keep-the-hosted-ui-browser-boundary-intact) for the default headers and a customization example.
+Hosted auth and top-level dashboard HTML use a restrictive nonce-based Content Security Policy and deny framing automatically. No setting is required for the built-in UI. The intentional embedded FGA shell is limited to a same-origin unified dashboard parent; this narrow exception is controlled by SqlOS and is not configurable. If a reviewed customization loads scripts, styles, images, or fonts from another origin, set `options.BrowserSecurity.ContentSecurityPolicy` and keep the required `{nonce}` placeholder. `frame-ancestors` cannot be configured or overridden. See [Production Readiness](/docs/guides/production-readiness#keep-the-hosted-ui-browser-boundary-intact) for the default headers and a customization example.
 
 ## Schema ownership
 

--- a/web/content/docs/guides/production-readiness.mdx
+++ b/web/content/docs/guides/production-readiness.mdx
@@ -131,8 +131,8 @@ SqlOS still enforces its own dashboard policy inside the process. Edge protectio
 
 SqlOS applies browser security headers automatically to every hosted AuthPage, verification page, SSO setup page, and dashboard HTML response:
 
-- `X-Frame-Options: DENY`;
-- `Content-Security-Policy` with `frame-ancestors 'none'`;
+- `X-Frame-Options: DENY` on hosted auth and top-level dashboard pages;
+- `Content-Security-Policy` with `frame-ancestors 'none'` on hosted auth and top-level dashboard pages;
 - nonce-bound first-party scripts and styles, with no `unsafe-inline` script permission;
 - `X-Content-Type-Options: nosniff`;
 - `Referrer-Policy: no-referrer`.
@@ -146,7 +146,7 @@ options.BrowserSecurity.ContentSecurityPolicy =
     "script-src 'self' 'nonce-{nonce}'; style-src 'self' 'nonce-{nonce}' https://cdn.example.com";
 ```
 
-SqlOS validates this value at startup. It must be one header-safe line, must contain `{nonce}`, and cannot declare `frame-ancestors`; SqlOS always appends `frame-ancestors 'none'` so a customization cannot accidentally make credential or consent UI frameable.
+SqlOS validates this value at startup. It must be one header-safe line, must contain `{nonce}`, and cannot declare `frame-ancestors`; SqlOS owns that directive so a customization cannot make credential or consent UI frameable. The intentional embedded FGA shell alone uses `frame-ancestors 'self'`, and its unified dashboard parent remains non-frameable while allowing that same-origin child through `frame-src 'self'`.
 
 Set `Strict-Transport-Security` at the TLS-terminating reverse proxy or host for the whole application domain, not only SqlOS routes. Verify the header on `/sqlos`, `/sqlos/auth/login`, and normal application responses after deployment. Do not enable long-lived HSTS on a domain until every route is reliably HTTPS.
 


### PR DESCRIPTION
## Summary

- allow only the intentional authenticated FGA embed shell to use `SAMEORIGIN` and `frame-ancestors 'self'`
- allow the non-frameable unified dashboard parent to load that same-origin child with `frame-src 'self'`
- keep hosted auth, top-level dashboard, and normal FGA pages on `DENY` and `frame-ancestors 'none'`
- serve direct FGA SPA fallback routes as HTML so navigation and refresh do not become downloads
- document the narrow, non-configurable framing exception

This is an internal browser-security default, not an operator-managed capability, so no code/API/dashboard configuration plane is added. Host CSP customization still cannot control `frame-ancestors` or exclude the required same-origin FGA child.

## Validation

- `./scripts/build.sh` — passed, 0 warnings / 0 errors
- `./scripts/unit-tests.sh` — passed, 679 SqlOS tests and 2 example tests
- `./scripts/integration-tests.sh` — passed, 181 SqlOS integration tests, 71 example integration tests, and 15 Todo integration tests
- `./scripts/docs-check.sh` — passed, including lint, production build, snippets, images, and 173 Markdown files with no broken local links
- `node --check src/SqlOS/Dashboard/wwwroot/app.js` — passed
- `git diff --check` — passed
- headless Chromium against a local host using the production SqlOS middleware — Resources and Roles rendered inside the unified dashboard iframe; parent responses remained `DENY` / `frame-ancestors 'none'`; frame responses used `SAMEORIGIN` / `frame-ancestors 'self'`; no CSP or X-Frame-Options framing violations were logged

Closes #251
