### PR TITLE
Scope audit idempotency keys to event tenancy

### DIFF
--- a/docs/AUDIT_LOGS.md
+++ b/docs/AUDIT_LOGS.md
@@ -21,9 +21,10 @@ await auditLogs.RecordAsync(new SqlOSAuditLogRecordRequest(
     {
         ["result"] = "success",
         ["role"] = "viewer"
-    },
-    IdempotencyKey: $"document:{documentId}:shared:{userId}"));
+    }));
 ```
+
+SqlOS generates a unique `EventId` for every recorded event. Ordinary audit writes do not need an idempotency key.
 
 Use dot-delimited, past-tense or outcome-specific action names such as `user.login.succeeded`, `client.disabled`, `retail.inventory_item.updated`, or `document.shared`. Keep names stable because operators will filter and export by action.
 
@@ -47,7 +48,9 @@ Prefer short outcome fields such as:
 
 ## Idempotency
 
-`IdempotencyKey` is hashed before storage as part of a versioned namespace containing the normalized organization id (including an explicit global/null value), resolved application id and key, source, and exact action. If a caller retries the same event with the same key inside that namespace, `RecordAsync` returns the original event and does not insert a duplicate. The same key in another organization, application, source, or action namespace creates an independent event.
+`IdempotencyKey` is optional. Omit it for a normal audit write; SqlOS assigns the event id and records every call as a new event. Supply a key only when the caller may retry the same business operation and needs those delivery attempts to produce one audit event—for example, when publishing from an outbox.
+
+SqlOS cannot generate that retry key because it cannot know whether two calls describe a retry or two legitimate operations. When supplied, the key is hashed before storage as part of a versioned namespace containing the normalized organization id (including an explicit global/null value), resolved application id and key, source, and exact action. A retry with the same key inside that namespace returns the original event and does not insert a duplicate. The same key in another organization, application, source, or action namespace creates an independent event.
 
 Use a stable business-operation identifier such as `share:{shareOperationId}` or an outbox message id. Do not use a fresh request or trace id for each retry. The namespace already supplies the organization, application, source, and action dimensions, so callers do not need to repeat those values in the key. A retry must supply the same scope fields as the original call; this is also what prevents a caller from receiving an event created in another scope.
 

--- a/docs/AUDIT_LOGS.md
+++ b/docs/AUDIT_LOGS.md
@@ -47,7 +47,11 @@ Prefer short outcome fields such as:
 
 ## Idempotency
 
-`IdempotencyKey` is hashed before storage. If a caller retries the same event with the same key, `RecordAsync` returns the original event and does not insert a duplicate. Include the application key, action, target id, actor id, and request id when building keys for retry-safe writes.
+`IdempotencyKey` is hashed before storage as part of a versioned namespace containing the normalized organization id (including an explicit global/null value), resolved application id and key, source, and exact action. If a caller retries the same event with the same key inside that namespace, `RecordAsync` returns the original event and does not insert a duplicate. The same key in another organization, application, source, or action namespace creates an independent event.
+
+Use a stable business-operation identifier such as `share:{shareOperationId}` or an outbox message id. Do not use a fresh request or trace id for each retry. The namespace already supplies the organization, application, source, and action dimensions, so callers do not need to repeat those values in the key. A retry must supply the same scope fields as the original call; this is also what prevents a caller from receiving an event created in another scope.
+
+Existing audit rows keep their legacy key hash during schema upgrade. SqlOS does not recover or rewrite raw keys. A retry can return a legacy row only when its organization, resolved application id/key, source, and action all match the current request. New rows use only the scoped hash and remain concurrency-safe through a unique filtered index. A detected hash/index conflict that cannot be resolved to an event in the caller's exact scope throws `SqlOSAuditLogIdempotencyConflictException` with error code `idempotency_conflict`; it never returns the conflicting row.
 
 ## Dashboard And Export
 

--- a/src/SqlOS/AuditLogs/SqlOSAuditLogContracts.cs
+++ b/src/SqlOS/AuditLogs/SqlOSAuditLogContracts.cs
@@ -61,6 +61,18 @@ public sealed record SqlOSAuditLogRecordResult(
     bool Created,
     SqlOSAuditLogEvent Event);
 
+public sealed class SqlOSAuditLogIdempotencyConflictException : InvalidOperationException
+{
+    public const string ErrorCode = "idempotency_conflict";
+
+    internal SqlOSAuditLogIdempotencyConflictException(Exception innerException)
+        : base("The audit event idempotency namespace conflicts with an existing event.", innerException)
+    {
+    }
+
+    public string Error => ErrorCode;
+}
+
 public sealed record SqlOSAuditLogListRequest(
     int? Page = null,
     int? PageSize = null,

--- a/src/SqlOS/AuditLogs/SqlOSAuditLogService.cs
+++ b/src/SqlOS/AuditLogs/SqlOSAuditLogService.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using SqlOS.AuthServer.Interfaces;
 using SqlOS.AuthServer.Models;
@@ -51,6 +52,7 @@ public sealed class SqlOSAuditLogService : ISqlOSAuditLogService
     {
         var action = NormalizeRequired(request.Action, nameof(request.Action), 160);
         var source = NormalizeNullable(request.Source, 80) ?? "application";
+        var organizationId = NormalizeNullable(request.OrganizationId, 64);
         var actor = NormalizeActor(request.Actor);
         var targets = NormalizeTargets(request.Targets);
         var now = DateTime.UtcNow;
@@ -59,13 +61,27 @@ public sealed class SqlOSAuditLogService : ISqlOSAuditLogService
             request.ApplicationId,
             request.ApplicationKey,
             cancellationToken);
-        var idempotencyKeyHash = HashIdempotencyKey(request.IdempotencyKey);
+        var normalizedIdempotencyKey = NormalizeNullable(request.IdempotencyKey, 512);
+        var legacyIdempotencyKeyHash = HashValue(normalizedIdempotencyKey);
+        var idempotencyScopeHash = HashIdempotencyScope(
+            organizationId,
+            applicationId,
+            applicationKey,
+            source,
+            action,
+            normalizedIdempotencyKey);
 
-        if (idempotencyKeyHash != null)
+        if (idempotencyScopeHash != null)
         {
-            var existing = await _context.Set<SqlOSAuditEvent>()
-                .AsNoTracking()
-                .FirstOrDefaultAsync(x => x.IdempotencyKeyHash == idempotencyKeyHash, cancellationToken);
+            var existing = await FindIdempotentEventAsync(
+                idempotencyScopeHash,
+                legacyIdempotencyKeyHash!,
+                organizationId,
+                applicationId,
+                applicationKey,
+                source,
+                action,
+                cancellationToken);
             if (existing != null)
             {
                 return new SqlOSAuditLogRecordResult(existing.Id, Created: false, MapEvent(existing));
@@ -83,7 +99,7 @@ public sealed class SqlOSAuditLogService : ISqlOSAuditLogService
         var entity = new SqlOSAuditEvent
         {
             Id = _cryptoService.GenerateId("evt"),
-            OrganizationId = NormalizeNullable(request.OrganizationId, 64),
+            OrganizationId = organizationId,
             ApplicationId = applicationId,
             ApplicationKey = applicationKey,
             UserId = NormalizeNullable(request.UserId, 64)
@@ -105,7 +121,7 @@ public sealed class SqlOSAuditLogService : ISqlOSAuditLogService
             UserAgent = NormalizeNullable(request.Context?.UserAgent, 512),
             RequestId = NormalizeNullable(request.Context?.RequestId, 128),
             CorrelationId = NormalizeNullable(request.Context?.CorrelationId, 128),
-            IdempotencyKeyHash = idempotencyKeyHash
+            IdempotencyScopeHash = idempotencyScopeHash
         };
 
         _context.Set<SqlOSAuditEvent>().Add(entity);
@@ -114,21 +130,49 @@ public sealed class SqlOSAuditLogService : ISqlOSAuditLogService
         {
             await _context.SaveChangesAsync(cancellationToken);
         }
-        catch (DbUpdateException) when (idempotencyKeyHash != null)
+        catch (DbUpdateException exception) when (
+            idempotencyScopeHash != null && IsUniqueConstraintViolation(exception))
         {
-            var existing = await _context.Set<SqlOSAuditEvent>()
-                .AsNoTracking()
-                .FirstOrDefaultAsync(x => x.IdempotencyKeyHash == idempotencyKeyHash, cancellationToken);
+            var existing = await FindIdempotentEventAsync(
+                idempotencyScopeHash,
+                legacyIdempotencyKeyHash!,
+                organizationId,
+                applicationId,
+                applicationKey,
+                source,
+                action,
+                cancellationToken);
             if (existing != null)
             {
                 return new SqlOSAuditLogRecordResult(existing.Id, Created: false, MapEvent(existing));
             }
 
-            throw;
+            throw new SqlOSAuditLogIdempotencyConflictException(exception);
         }
 
         return new SqlOSAuditLogRecordResult(entity.Id, Created: true, MapEvent(entity));
     }
+
+    private async Task<SqlOSAuditEvent?> FindIdempotentEventAsync(
+        string idempotencyScopeHash,
+        string legacyIdempotencyKeyHash,
+        string? organizationId,
+        string? applicationId,
+        string? applicationKey,
+        string source,
+        string action,
+        CancellationToken cancellationToken)
+        => await _context.Set<SqlOSAuditEvent>()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(x =>
+                (x.IdempotencyScopeHash == idempotencyScopeHash
+                    || (x.IdempotencyScopeHash == null && x.IdempotencyKeyHash == legacyIdempotencyKeyHash))
+                && x.OrganizationId == organizationId
+                && x.ApplicationId == applicationId
+                && x.ApplicationKey == applicationKey
+                && x.Source == source
+                && x.Action == action,
+                cancellationToken);
 
     public async Task<SqlOSAuditLogListResult> ListAsync(
         SqlOSAuditLogListRequest request,
@@ -569,7 +613,13 @@ public sealed class SqlOSAuditLogService : ISqlOSAuditLogService
         return value[..maxLength];
     }
 
-    private static string? HashIdempotencyKey(string? idempotencyKey)
+    internal static string? HashIdempotencyScope(
+        string? organizationId,
+        string? applicationId,
+        string? applicationKey,
+        string source,
+        string action,
+        string? idempotencyKey)
     {
         var normalized = NormalizeNullable(idempotencyKey, 512);
         if (normalized == null)
@@ -577,9 +627,46 @@ public sealed class SqlOSAuditLogService : ISqlOSAuditLogService
             return null;
         }
 
-        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(normalized));
+        var canonical = new StringBuilder("sqlos-audit-idempotency-v2");
+        AppendNamespacePart(canonical, NormalizeNullable(organizationId, 64));
+        AppendNamespacePart(canonical, NormalizeNullable(applicationId, 64));
+        AppendNamespacePart(canonical, NormalizeNullable(applicationKey, 200));
+        AppendNamespacePart(canonical, NormalizeNullable(source, 80) ?? "application");
+        AppendNamespacePart(canonical, NormalizeRequired(action, nameof(action), 160));
+        AppendNamespacePart(canonical, normalized);
+        return HashValue(canonical.ToString());
+    }
+
+    internal static string? HashLegacyIdempotencyKey(string? idempotencyKey)
+        => HashValue(NormalizeNullable(idempotencyKey, 512));
+
+    private static string? HashValue(string? value)
+    {
+        if (value == null)
+        {
+            return null;
+        }
+
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(value));
         return Convert.ToHexString(bytes).ToLowerInvariant();
     }
+
+    private static void AppendNamespacePart(StringBuilder builder, string? value)
+    {
+        builder.Append('|');
+        if (value == null)
+        {
+            builder.Append("-1:");
+            return;
+        }
+
+        builder.Append(value.Length.ToString(CultureInfo.InvariantCulture));
+        builder.Append(':');
+        builder.Append(value);
+    }
+
+    private static bool IsUniqueConstraintViolation(DbUpdateException exception)
+        => exception.GetBaseException() is SqlException { Number: 2601 or 2627 };
 
     private static string EscapeForJsonContains(string value)
         => value.Replace("\\", "\\\\", StringComparison.Ordinal)

--- a/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerModelConfiguration.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerModelConfiguration.cs
@@ -629,6 +629,9 @@ public static class SqlOSAuthServerModelConfiguration
             entity.HasIndex(x => x.IdempotencyKeyHash)
                 .IsUnique()
                 .HasFilter("[IdempotencyKeyHash] IS NOT NULL");
+            entity.HasIndex(x => x.IdempotencyScopeHash)
+                .IsUnique()
+                .HasFilter("[IdempotencyScopeHash] IS NOT NULL");
             entity.Property(x => x.EventType).HasMaxLength(160);
             entity.Property(x => x.ApplicationId).HasMaxLength(64);
             entity.Property(x => x.ApplicationKey).HasMaxLength(200);
@@ -644,6 +647,7 @@ public static class SqlOSAuthServerModelConfiguration
             entity.Property(x => x.RequestId).HasMaxLength(128);
             entity.Property(x => x.CorrelationId).HasMaxLength(128);
             entity.Property(x => x.IdempotencyKeyHash).HasMaxLength(128);
+            entity.Property(x => x.IdempotencyScopeHash).HasMaxLength(128);
         });
 
         modelBuilder.Entity<SqlOSSettings>(entity =>

--- a/src/SqlOS/AuthServer/Models/SqlOSEntities.cs
+++ b/src/SqlOS/AuthServer/Models/SqlOSEntities.cs
@@ -653,6 +653,7 @@ public sealed class SqlOSAuditEvent
     public string? RequestId { get; set; }
     public string? CorrelationId { get; set; }
     public string? IdempotencyKeyHash { get; set; }
+    public string? IdempotencyScopeHash { get; set; }
     public string? DataJson { get; set; }
 }
 

--- a/src/SqlOS/AuthServer/Schema/038_ScopedAuditIdempotency.sql
+++ b/src/SqlOS/AuthServer/Schema/038_ScopedAuditIdempotency.sql
@@ -1,0 +1,23 @@
+IF OBJECT_ID('[{Schema}].[SqlOSAuditEvents]', 'U') IS NOT NULL
+AND COL_LENGTH('[{Schema}].[SqlOSAuditEvents]', 'IdempotencyScopeHash') IS NULL
+    ALTER TABLE [{Schema}].[SqlOSAuditEvents] ADD [IdempotencyScopeHash] NVARCHAR(128) NULL;
+
+GO
+
+IF OBJECT_ID('[{Schema}].[SqlOSAuditEvents]', 'U') IS NOT NULL
+AND NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE [name] = 'UX_SqlOSAuditEvents_IdempotencyScopeHash'
+      AND [object_id] = OBJECT_ID('[{Schema}].[SqlOSAuditEvents]')
+)
+BEGIN
+    CREATE UNIQUE INDEX [UX_SqlOSAuditEvents_IdempotencyScopeHash]
+        ON [{Schema}].[SqlOSAuditEvents] ([IdempotencyScopeHash])
+        WHERE [IdempotencyScopeHash] IS NOT NULL;
+END
+
+GO
+
+DELETE FROM [{Schema}].[SqlOSSchema];
+INSERT INTO [{Schema}].[SqlOSSchema] ([Version]) VALUES (38);

--- a/tests/SqlOS.IntegrationTests/AuditLogIdempotencyIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/AuditLogIdempotencyIntegrationTests.cs
@@ -1,0 +1,138 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SqlOS.AuditLogs;
+using SqlOS.AuthServer.Configuration;
+using SqlOS.AuthServer.Models;
+using SqlOS.AuthServer.Services;
+using SqlOS.IntegrationTests.Infrastructure;
+
+namespace SqlOS.IntegrationTests;
+
+[TestClass]
+public sealed class AuditLogIdempotencyIntegrationTests
+{
+    [TestMethod]
+    public async Task ConcurrentRealSqlAuditWrites_InsertExactlyOncePerCanonicalNamespace()
+    {
+        await using var setup = await AspireFixture.CreateIsolatedAuthContextAsync("AuditIdempotency");
+        try
+        {
+            var connectionString = setup.Database.GetConnectionString()!;
+            var ready = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            async Task<SqlOSAuditLogRecordResult> RecordAsync()
+            {
+                await using var context = CreateContext(connectionString);
+                var service = CreateService(context);
+                await ready.Task;
+                return await service.RecordAsync(CreateRequest("org_1", "workspace-web", "application"));
+            }
+
+            var attempts = Enumerable.Range(0, 8).Select(_ => RecordAsync()).ToArray();
+            ready.SetResult();
+            var results = await Task.WhenAll(attempts).WaitAsync(TimeSpan.FromSeconds(45));
+
+            results.Should().ContainSingle(x => x.Created);
+            results.Select(x => x.EventId).Distinct().Should().ContainSingle();
+            setup.ChangeTracker.Clear();
+            (await setup.Set<SqlOSAuditEvent>().AsNoTracking().CountAsync()).Should().Be(1);
+        }
+        finally
+        {
+            await setup.Database.EnsureDeletedAsync();
+        }
+    }
+
+    [TestMethod]
+    public async Task RealSqlAuditIdempotency_AllowsSameKeyAcrossTenantApplicationSourceAndGlobalScopes()
+    {
+        await using var context = await AspireFixture.CreateIsolatedAuthContextAsync("AuditScopes");
+        try
+        {
+            var service = CreateService(context);
+
+            var results = new[]
+            {
+                await service.RecordAsync(CreateRequest("org_1", "workspace-web", "application")),
+                await service.RecordAsync(CreateRequest("org_2", "workspace-web", "application")),
+                await service.RecordAsync(CreateRequest(null, "workspace-web", "application")),
+                await service.RecordAsync(CreateRequest("org_1", "admin-web", "application")),
+                await service.RecordAsync(CreateRequest("org_1", "workspace-web", "authserver"))
+            };
+
+            results.Should().OnlyContain(x => x.Created);
+            results.Select(x => x.EventId).Should().OnlyHaveUniqueItems();
+            (await context.Set<SqlOSAuditEvent>().AsNoTracking().CountAsync()).Should().Be(5);
+        }
+        finally
+        {
+            await context.Database.EnsureDeletedAsync();
+        }
+    }
+
+    [TestMethod]
+    public async Task RealSqlAuditIdempotency_HashCollisionReturnsTypedConflictWithoutOtherScopeEvent()
+    {
+        await using var context = await AspireFixture.CreateIsolatedAuthContextAsync("AuditConflict");
+        try
+        {
+            const string key = "business-operation-42";
+            context.Set<SqlOSAuditEvent>().Add(new SqlOSAuditEvent
+            {
+                Id = "evt_other_scope",
+                OrganizationId = "org_other",
+                ApplicationKey = "workspace-web",
+                Source = "application",
+                Action = "document.shared",
+                EventType = "document.shared",
+                ActorType = "system",
+                TargetsJson = "[]",
+                OccurredAt = DateTime.UtcNow,
+                IngestedAt = DateTime.UtcNow,
+                IdempotencyScopeHash = SqlOSAuditLogService.HashIdempotencyScope(
+                    "org_requested", null, "workspace-web", "application", "document.shared", key)
+            });
+            await context.SaveChangesAsync();
+            var service = CreateService(context);
+
+            var act = async () => await service.RecordAsync(CreateRequest(
+                "org_requested", "workspace-web", "application", key));
+
+            var exception = await act.Should().ThrowAsync<SqlOSAuditLogIdempotencyConflictException>();
+            exception.Which.Error.Should().Be(SqlOSAuditLogIdempotencyConflictException.ErrorCode);
+            exception.Which.Message.Should().NotContain("evt_other_scope").And.NotContain(key);
+            (await context.Set<SqlOSAuditEvent>().AsNoTracking().CountAsync()).Should().Be(1);
+        }
+        finally
+        {
+            await context.Database.EnsureDeletedAsync();
+        }
+    }
+
+    private static SqlOSAuditLogRecordRequest CreateRequest(
+        string? organizationId,
+        string applicationKey,
+        string source,
+        string idempotencyKey = "business-operation-42")
+        => new(
+            Action: "document.shared",
+            OrganizationId: organizationId,
+            ApplicationKey: applicationKey,
+            Source: source,
+            Actor: new SqlOSAuditActor("user", "usr_1"),
+            Targets: [new SqlOSAuditTarget("document", "doc_1")],
+            IdempotencyKey: idempotencyKey);
+
+    private static TestSqlOSDbContext CreateContext(string connectionString)
+        => new(new DbContextOptionsBuilder<TestSqlOSDbContext>()
+            .UseSqlServer(connectionString)
+            .Options);
+
+    private static SqlOSAuditLogService CreateService(TestSqlOSDbContext context)
+    {
+        var options = Options.Create(new SqlOSAuthServerOptions());
+        return new SqlOSAuditLogService(context, new SqlOSCryptoService(context, options));
+    }
+}

--- a/tests/SqlOS.IntegrationTests/SchemaInitializerIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/SchemaInitializerIntegrationTests.cs
@@ -14,7 +14,7 @@ namespace SqlOS.IntegrationTests;
 [TestClass]
 public sealed class SchemaInitializerIntegrationTests
 {
-    private const int CurrentSchemaVersion = 37;
+    private const int CurrentSchemaVersion = 38;
 
     [TestMethod]
     public async Task EnsureSchema_CreatesCoreTables()
@@ -265,8 +265,10 @@ public sealed class SchemaInitializerIntegrationTests
 
             Assert.IsTrue(await ColumnExistsAsync(context, "SqlOSAuditEvents", "Action"));
             Assert.IsTrue(await ColumnExistsAsync(context, "SqlOSAuditEvents", "IdempotencyKeyHash"));
+            Assert.IsTrue(await ColumnExistsAsync(context, "SqlOSAuditEvents", "IdempotencyScopeHash"));
             Assert.IsTrue(await IndexExistsAsync(context, "SqlOSAuditEvents", "IX_SqlOSAuditEvents_Action_OccurredAt"));
             Assert.IsTrue(await IndexExistsAsync(context, "SqlOSAuditEvents", "UX_SqlOSAuditEvents_IdempotencyKeyHash"));
+            Assert.IsTrue(await IndexExistsAsync(context, "SqlOSAuditEvents", "UX_SqlOSAuditEvents_IdempotencyScopeHash"));
             Assert.AreEqual("user.login", await ScalarStringAsync(context, "SELECT TOP 1 [Action] FROM [dbo].[SqlOSAuditEvents]"));
             Assert.AreEqual(CurrentSchemaVersion, await ScalarIntAsync(context, "SELECT TOP 1 [Version] FROM [dbo].[SqlOSSchema]"));
         }

--- a/tests/SqlOS.Tests/SqlOSAuditLogsTests.cs
+++ b/tests/SqlOS.Tests/SqlOSAuditLogsTests.cs
@@ -112,6 +112,108 @@ public sealed class SqlOSAuditLogsTests
     }
 
     [TestMethod]
+    public async Task AuditLogs_RecordAsync_IdempotencyNamespaceSeparatesSecurityAndOperationScopes()
+    {
+        using var context = CreateContext();
+        var service = CreateService(context);
+        const string key = "business-operation-42";
+
+        var baseline = await service.RecordAsync(CreateRecord(
+            "document.shared",
+            organizationId: "org_1",
+            applicationKey: "workspace-web",
+            source: "application",
+            idempotencyKey: key));
+        var sameScope = await service.RecordAsync(CreateRecord(
+            "document.shared",
+            organizationId: "org_1",
+            applicationKey: "workspace-web",
+            source: "application",
+            idempotencyKey: key));
+        var otherOrganization = await service.RecordAsync(CreateRecord(
+            "document.shared",
+            organizationId: "org_2",
+            applicationKey: "workspace-web",
+            source: "application",
+            idempotencyKey: key));
+        var globalOrganization = await service.RecordAsync(CreateRecord(
+            "document.shared",
+            organizationId: null,
+            applicationKey: "workspace-web",
+            source: "application",
+            idempotencyKey: key));
+        var otherApplication = await service.RecordAsync(CreateRecord(
+            "document.shared",
+            organizationId: "org_1",
+            applicationKey: "admin-web",
+            source: "application",
+            idempotencyKey: key));
+        var otherSource = await service.RecordAsync(CreateRecord(
+            "document.shared",
+            organizationId: "org_1",
+            applicationKey: "workspace-web",
+            source: "authserver",
+            idempotencyKey: key));
+        var otherAction = await service.RecordAsync(CreateRecord(
+            "document.unshared",
+            organizationId: "org_1",
+            applicationKey: "workspace-web",
+            source: "application",
+            idempotencyKey: key));
+
+        baseline.Created.Should().BeTrue();
+        sameScope.Created.Should().BeFalse();
+        sameScope.EventId.Should().Be(baseline.EventId);
+        new[] { otherOrganization, globalOrganization, otherApplication, otherSource, otherAction }
+            .Should().OnlyContain(x => x.Created);
+        (await context.Set<SqlOSAuditEvent>().CountAsync()).Should().Be(6);
+        (await context.Set<SqlOSAuditEvent>().ToListAsync())
+            .Should().OnlyContain(x => x.IdempotencyKeyHash == null && x.IdempotencyScopeHash != null);
+    }
+
+    [TestMethod]
+    public async Task AuditLogs_RecordAsync_LegacyHashReturnsOnlyMatchingScope()
+    {
+        using var context = CreateContext();
+        const string key = "legacy-operation-42";
+        context.Set<SqlOSAuditEvent>().Add(new SqlOSAuditEvent
+        {
+            Id = "evt_legacy",
+            OrganizationId = "org_1",
+            ApplicationKey = "workspace-web",
+            Source = "application",
+            Action = "document.shared",
+            EventType = "document.shared",
+            ActorType = "user",
+            ActorId = "usr_1",
+            TargetsJson = "[]",
+            OccurredAt = DateTime.UtcNow,
+            IngestedAt = DateTime.UtcNow,
+            IdempotencyKeyHash = SqlOSAuditLogService.HashLegacyIdempotencyKey(key)
+        });
+        await context.SaveChangesAsync();
+        var service = CreateService(context);
+
+        var retry = await service.RecordAsync(CreateRecord(
+            "document.shared",
+            organizationId: "org_1",
+            applicationKey: "workspace-web",
+            idempotencyKey: key));
+        var otherTenant = await service.RecordAsync(CreateRecord(
+            "document.shared",
+            organizationId: "org_2",
+            applicationKey: "workspace-web",
+            idempotencyKey: key));
+
+        retry.Created.Should().BeFalse();
+        retry.EventId.Should().Be("evt_legacy");
+        retry.Event.OrganizationId.Should().Be("org_1");
+        otherTenant.Created.Should().BeTrue();
+        otherTenant.Event.OrganizationId.Should().Be("org_2");
+        (await context.Set<SqlOSAuditEvent>().CountAsync()).Should().Be(2);
+    }
+
+    [TestMethod]
     public async Task AuditLogs_RecordAsync_RedactsDisallowedMetadataFields()
     {
         using var context = CreateContext();
@@ -327,7 +429,7 @@ public sealed class SqlOSAuditLogsTests
 
     private static SqlOSAuditLogRecordRequest CreateRecord(
         string action,
-        string organizationId = "org_1",
+        string? organizationId = "org_1",
         string? applicationKey = null,
         string source = "application",
         string actorType = "user",

--- a/web/content/blog/audit-logs-for-multi-tenant-products.mdx
+++ b/web/content/blog/audit-logs-for-multi-tenant-products.mdx
@@ -107,13 +107,15 @@ new Dictionary<string, object?>
 
 That is enough for an operator to answer what happened without exposing access tokens, cookies, passwords, raw exceptions, or request bodies.
 
-## Idempotency belongs in the audit layer
+## Retry idempotency is opt-in
 
-Audit writes often happen near mutations. Mutations are retried. Workers can restart. Clients can resubmit.
+SqlOS generates a unique event id for every audit write. Most callers should stop there: omit `IdempotencyKey`, and each call records a new event without requiring the application to design another identifier.
+
+Some audit writes happen in retrying workflows. Outbox workers can restart and clients can resubmit the same business operation.
 
 Duplicate audit events make investigations worse because operators have to decide whether two rows represent two actions or one retried write.
 
-SqlOS accepts an `IdempotencyKey` on audit writes. The key is hashed before storage. If the same key appears again, `RecordAsync` returns the original event instead of inserting a duplicate.
+For those workflows, SqlOS accepts an optional consumer-provided `IdempotencyKey`. SqlOS cannot generate it because only the application knows whether two deliveries represent the same operation or two legitimate operations. The key is hashed with the event's organization, application, source, and action. If the same operation is delivered again in that scope, `RecordAsync` returns the original event instead of inserting a duplicate.
 
 That lets application code build retry-safe audit writes from domain facts:
 

--- a/web/content/docs/guides/audit-logs.mdx
+++ b/web/content/docs/guides/audit-logs.mdx
@@ -149,13 +149,13 @@ inventoryApi.MapPut("/locations/{locationId}/inventory/{itemId}", async (
             ["newQuantity"] = item.QuantityOnHand,
             ["delta"] = item.QuantityOnHand - previousQuantity
         },
-        IdempotencyKey: $"retail:inventory:{item.Id}:updated:{userId}:{httpContext.TraceIdentifier}"),
+        IdempotencyKey: $"inventory-update:{request.OperationId}"),
         ct);
 
     return Results.Ok(item);
 });
 
-public sealed record UpdateInventoryRequest(int QuantityOnHand);
+public sealed record UpdateInventoryRequest(int QuantityOnHand, string OperationId);
 ```
 
 This example uses a representative host-owned `InventoryItem` model with an explicit `OrganizationId`. The query binds the resource to the token's organization, then the FGA check proves the same actor may edit that resource. If your schema derives tenancy from a parent or FGA root instead, resolve and verify that trusted ownership mapping before mutation and use the resolved organization in the audit row. A valid token alone is not authorization.
@@ -168,15 +168,15 @@ Use `ApplicationKey` for the product surface that produced the event. If the key
 
 ## 4. Make retries safe
 
-Set `IdempotencyKey` when a request may be retried. SqlOS hashes the key before storage. A duplicate key returns the original event instead of inserting another row.
+Set `IdempotencyKey` when an operation may be retried. SqlOS hashes the key together with the normalized organization, resolved application, source, and exact action. A duplicate inside that exact namespace returns the original event instead of inserting another row; the same key in another scope creates an independent event.
 
 Good idempotency keys usually include:
 
-- application key
-- action
-- target resource id
-- actor id
-- request id or domain operation id
+- a stable domain operation id, such as `share:{shareOperationId}`
+- an outbox message id that stays unchanged across delivery attempts
+- a business command id persisted with the mutation
+
+Do not generate a fresh request or trace id for each retry. The scope fields are already part of the namespace, so they do not need to be repeated in the key. Always derive organization and application scope from trusted server-side state; a retry returns an existing event only when all scope fields match.
 
 ## 5. Keep metadata safe
 

--- a/web/content/docs/guides/audit-logs.mdx
+++ b/web/content/docs/guides/audit-logs.mdx
@@ -148,17 +148,16 @@ inventoryApi.MapPut("/locations/{locationId}/inventory/{itemId}", async (
             ["previousQuantity"] = previousQuantity,
             ["newQuantity"] = item.QuantityOnHand,
             ["delta"] = item.QuantityOnHand - previousQuantity
-        },
-        IdempotencyKey: $"inventory-update:{request.OperationId}"),
+        }),
         ct);
 
     return Results.Ok(item);
 });
 
-public sealed record UpdateInventoryRequest(int QuantityOnHand, string OperationId);
+public sealed record UpdateInventoryRequest(int QuantityOnHand);
 ```
 
-This example uses a representative host-owned `InventoryItem` model with an explicit `OrganizationId`. The query binds the resource to the token's organization, then the FGA check proves the same actor may edit that resource. If your schema derives tenancy from a parent or FGA root instead, resolve and verify that trusted ownership mapping before mutation and use the resolved organization in the audit row. A valid token alone is not authorization.
+This example uses a representative host-owned `InventoryItem` model with an explicit `OrganizationId`. The query binds the resource to the token's organization, then the FGA check proves the same actor may edit that resource. If your schema derives tenancy from a parent or FGA root instead, resolve and verify that trusted ownership mapping before mutation and use the resolved organization in the audit row. A valid token alone is not authorization. SqlOS generates the audit event id; this ordinary write does not need an idempotency key.
 
 <Callout type="warning" title="Decide how durable the audit must be">
   `SaveChangesAsync` followed by `RecordAsync` is two writes, not one atomic operation. A process failure between them can commit the business change without its audit event. If that event cannot be lost, commit the mutation and audit row in one application transaction when both use the same database context, or write an outbox record in the mutation transaction and publish it to `RecordAsync` with a stable idempotency key.
@@ -168,7 +167,9 @@ Use `ApplicationKey` for the product surface that produced the event. If the key
 
 ## 4. Make retries safe
 
-Set `IdempotencyKey` when an operation may be retried. SqlOS hashes the key together with the normalized organization, resolved application, source, and exact action. A duplicate inside that exact namespace returns the original event instead of inserting another row; the same key in another scope creates an independent event.
+`IdempotencyKey` is optional. Omit it for ordinary audit writes; SqlOS generates a unique event id and records every call. Set it only when the caller may deliver the same business operation more than once and needs those retries to converge on one event, such as an outbox worker. SqlOS cannot infer whether two calls are retries or two legitimate operations, so this stable operation identifier must come from the retrying workflow.
+
+When supplied, SqlOS hashes the key together with the normalized organization, resolved application, source, and exact action. A duplicate inside that exact namespace returns the original event instead of inserting another row; the same key in another scope creates an independent event.
 
 Good idempotency keys usually include:
 

--- a/web/content/docs/reference/audit-logs.mdx
+++ b/web/content/docs/reference/audit-logs.mdx
@@ -107,13 +107,13 @@ documentsApi.MapPost("/documents/{id}/share", async (
             ["result"] = "success",
             ["role"] = request.Role
         },
-        IdempotencyKey: $"document:{id}:shared:{userId}:{httpContext.TraceIdentifier}"),
+        IdempotencyKey: $"share:{request.OperationId}"),
         ct);
 
     return Results.NoContent();
 });
 
-public sealed record ShareDocumentRequest(string Role);
+public sealed record ShareDocumentRequest(string Role, string OperationId);
 ```
 
 This example assumes the application defines the `document.share` authorization policy. The request DTO contains only the requested business value; document, actor, and tenant details come from trusted server-side state.
@@ -138,7 +138,7 @@ This example assumes the application defines the `document.share` authorization 
 | `Targets` | `IReadOnlyList<SqlOSAuditTarget>?` | Resources affected by the action. |
 | `Context` | `SqlOSAuditContext?` | IP, user agent, session, request, and correlation identifiers. |
 | `Metadata` | `IReadOnlyDictionary<string, object?>?` | Non-sensitive structured details. |
-| `IdempotencyKey` | `string?` | Retry-safe key, hashed before storage. Duplicate keys return the original event. |
+| `IdempotencyKey` | `string?` | Stable business-operation key, hashed with organization, resolved application, source, and exact action. A retry in that exact namespace returns the original event. |
 | `OccurredAt` | `DateTime?` | Event time. Defaults to current UTC time. |
 
 ## Actor
@@ -174,6 +174,14 @@ Use multiple targets when one operation affects a hierarchy. For example, an inv
 - `X-Correlation-ID` / `X-Correlation-Id`
 
 Create `SqlOSAuditContext` manually for background jobs, service accounts, queues, and scheduled maintenance.
+
+## Idempotency namespace
+
+SqlOS hashes a versioned canonical representation of the normalized organization id (with global/null as a distinct value), resolved application id and key, source, exact action, and supplied `IdempotencyKey`. The same key is independent across any of those scope dimensions. A retry can return only an event whose stored scope exactly matches the request.
+
+Use a stable domain operation or outbox message id, for example `share:{shareOperationId}`. Do not generate a new request or trace id for each retry. Organization, application, source, and action are already in the namespace and do not need to be duplicated in the caller key.
+
+Schema upgrades preserve existing rows and their legacy hashes without recovering raw keys. Legacy retries deduplicate only when every stored scope field matches. New writes use the scoped hash and a unique filtered SQL index. If an index/hash conflict cannot be resolved inside the exact caller scope, `RecordAsync` throws `SqlOSAuditLogIdempotencyConflictException` with `Error == "idempotency_conflict"` instead of returning another scope's event.
 
 ## Metadata safety
 

--- a/web/content/docs/reference/audit-logs.mdx
+++ b/web/content/docs/reference/audit-logs.mdx
@@ -106,17 +106,16 @@ documentsApi.MapPost("/documents/{id}/share", async (
         {
             ["result"] = "success",
             ["role"] = request.Role
-        },
-        IdempotencyKey: $"share:{request.OperationId}"),
+        }),
         ct);
 
     return Results.NoContent();
 });
 
-public sealed record ShareDocumentRequest(string Role, string OperationId);
+public sealed record ShareDocumentRequest(string Role);
 ```
 
-This example assumes the application defines the `document.share` authorization policy. The request DTO contains only the requested business value; document, actor, and tenant details come from trusted server-side state.
+This example assumes the application defines the `document.share` authorization policy. The request DTO contains only the requested business value; document, actor, and tenant details come from trusted server-side state. SqlOS generates the audit event id, so an ordinary write like this does not need an idempotency key.
 
 <Callout type="warning" title="Recording after save is not atomic">
   The straightforward `SaveChangesAsync` then `RecordAsync` sequence can lose the audit event if the process fails between those calls. When an audit event must be guaranteed, either enlist the mutation and audit insert in one application transaction when they share a database context, or write an outbox message in the mutation transaction and have a worker call `RecordAsync` with a stable idempotency key.
@@ -138,7 +137,7 @@ This example assumes the application defines the `document.share` authorization 
 | `Targets` | `IReadOnlyList<SqlOSAuditTarget>?` | Resources affected by the action. |
 | `Context` | `SqlOSAuditContext?` | IP, user agent, session, request, and correlation identifiers. |
 | `Metadata` | `IReadOnlyDictionary<string, object?>?` | Non-sensitive structured details. |
-| `IdempotencyKey` | `string?` | Stable business-operation key, hashed with organization, resolved application, source, and exact action. A retry in that exact namespace returns the original event. |
+| `IdempotencyKey` | `string?` | Optional stable operation or outbox key for deduplicating retries. Omit it for ordinary writes; SqlOS always generates the event id. |
 | `OccurredAt` | `DateTime?` | Event time. Defaults to current UTC time. |
 
 ## Actor
@@ -177,7 +176,9 @@ Create `SqlOSAuditContext` manually for background jobs, service accounts, queue
 
 ## Idempotency namespace
 
-SqlOS hashes a versioned canonical representation of the normalized organization id (with global/null as a distinct value), resolved application id and key, source, exact action, and supplied `IdempotencyKey`. The same key is independent across any of those scope dimensions. A retry can return only an event whose stored scope exactly matches the request.
+Every successful write receives a SqlOS-generated `EventId`. `IdempotencyKey` is a separate, optional retry token: omit it for ordinary writes, and every call records a new event. Supply it only when a retrying workflow, such as an outbox worker, needs repeated delivery of one business operation to converge on one audit event. SqlOS cannot generate this token because it cannot distinguish a retry from a second legitimate operation.
+
+When a key is supplied, SqlOS hashes a versioned canonical representation of the normalized organization id (with global/null as a distinct value), resolved application id and key, source, exact action, and supplied key. The same key is independent across any of those scope dimensions. A retry can return only an event whose stored scope exactly matches the request.
 
 Use a stable domain operation or outbox message id, for example `share:{shareOperationId}`. Do not generate a new request or trace id for each retry. Organization, application, source, and action are already in the namespace and do not need to be duplicated in the caller key.
 
@@ -241,7 +242,7 @@ public interface ISqlOSAuditLogService
 }
 ```
 
-`RecordAsync` returns `Created = false` when the idempotency key already exists and the original event is returned.
+`RecordAsync` always returns the SqlOS-generated event id. When an optional idempotency key matches an event in the same namespace, it returns `Created = false` and the original event; without a key, each call creates a new event.
 
 ## Dashboard
 


### PR DESCRIPTION
## Summary

- hash audit idempotency keys inside a versioned namespace containing normalized organization, resolved application identity, source, and exact action
- preserve legacy audit hashes and allow legacy retries only when every stored scope field matches
- add schema v38 with a unique scoped-hash index and a typed `idempotency_conflict` failure that never returns an event from another scope
- document stable business-operation keys and the migration/compatibility contract

This is shared audit runtime behavior rather than an operator-managed setting, so code/API/dashboard configuration parity is not applicable. Existing ingestion paths continue to use the same `ISqlOSAuditLogService`.

## Validation

- `./scripts/build.sh` — passed, 0 warnings / 0 errors
- `./scripts/unit-tests.sh` — passed, 676 SqlOS tests + 2 example tests
- `./scripts/integration-tests.sh` — passed, 184 core + 71 example + 15 Todo integration tests
- targeted real-SQL audit tests — passed: 8-writer exactly-once race, tenant/application/source/global isolation, typed non-disclosing conflict, and v22 schema upgrade
- `./scripts/docs-check.sh` — passed, snippets compiled, web lint/build passed, 173 Markdown files had no broken local links
- `git diff --check` — passed

Closes #230