### PR TITLE
Fix signing-key operations with EF retry strategies

### DIFF
--- a/src/SqlOS/AuthServer/Services/SqlOSCryptoService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSCryptoService.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
@@ -330,41 +331,41 @@ public sealed class SqlOSCryptoService
         bool validateExistingCustody,
         CancellationToken cancellationToken)
     {
-        await using var transaction = await BeginSigningKeyTransactionAsync(cancellationToken);
-        SqlOSSigningKey? createdKey = null;
+        var createdKeys = new List<SqlOSSigningKey>();
         try
         {
-            var keys = await LoadAndValidateSigningKeysAsync(cancellationToken);
-            var activeKeys = keys.Where(static key => key.IsActive).ToList();
-            if (activeKeys.Count > 1)
+            var result = await ExecuteSigningKeyTransactionAsync(async attemptCancellationToken =>
             {
-                throw new InvalidOperationException("SqlOS found multiple active signing keys. Refusing to issue tokens until signing-key state is repaired.");
-            }
-
-            if (activeKeys.Count == 1)
-            {
-                if (validateExistingCustody)
+                var keys = await LoadAndValidateSigningKeysAsync(attemptCancellationToken);
+                var activeKeys = keys.Where(static key => key.IsActive).ToList();
+                if (activeKeys.Count > 1)
                 {
-                    await ValidateCustodyCanSignAsync(activeKeys[0], cancellationToken);
+                    throw new InvalidOperationException("SqlOS found multiple active signing keys. Refusing to issue tokens until signing-key state is repaired.");
                 }
-                await CommitAsync(transaction, cancellationToken);
-                return activeKeys[0];
-            }
 
-            createdKey = await CreateSigningKeyAsync(keys, cancellationToken);
-            _context.Set<SqlOSSigningKey>().Add(createdKey);
-            await _context.SaveChangesAsync(cancellationToken);
-            await CommitAsync(transaction, cancellationToken);
+                if (activeKeys.Count == 1)
+                {
+                    if (validateExistingCustody)
+                    {
+                        await ValidateCustodyCanSignAsync(activeKeys[0], attemptCancellationToken);
+                    }
+                    return activeKeys[0];
+                }
+
+                var createdKey = await CreateSigningKeyAsync(keys, attemptCancellationToken);
+                createdKeys.Add(createdKey);
+                _context.Set<SqlOSSigningKey>().Add(createdKey);
+                await _context.SaveChangesAsync(attemptCancellationToken);
+                return createdKey;
+            }, cancellationToken);
+
+            await CleanupUncommittedCreatedKeysAsync(createdKeys, cancellationToken);
             _validationSigningKeyCache.InvalidateAll();
-            return createdKey;
+            return result;
         }
         catch
         {
-            if (createdKey != null)
-            {
-                await TryDeleteCreatedKeyAsync(createdKey);
-            }
-
+            await CleanupUncommittedCreatedKeysAsync(createdKeys, CancellationToken.None);
             throw;
         }
     }
@@ -396,44 +397,44 @@ public sealed class SqlOSCryptoService
 
     public async Task<SqlOSSigningKey> RotateSigningKeyAsync(CancellationToken cancellationToken = default)
     {
-        await using var transaction = await BeginSigningKeyTransactionAsync(cancellationToken);
-        var now = DateTime.UtcNow;
-        SqlOSSigningKey? newKey = null;
+        var createdKeys = new List<SqlOSSigningKey>();
 
         try
         {
-            var keys = await LoadAndValidateSigningKeysAsync(cancellationToken);
-            var activeKeys = keys.Where(static key => key.IsActive).ToList();
-            if (activeKeys.Count > 1)
+            var result = await ExecuteSigningKeyTransactionAsync(async attemptCancellationToken =>
             {
-                throw new InvalidOperationException("SqlOS found multiple active signing keys. Refusing rotation until signing-key state is repaired.");
-            }
+                var keys = await LoadAndValidateSigningKeysAsync(attemptCancellationToken);
+                var activeKeys = keys.Where(static key => key.IsActive).ToList();
+                if (activeKeys.Count > 1)
+                {
+                    throw new InvalidOperationException("SqlOS found multiple active signing keys. Refusing rotation until signing-key state is repaired.");
+                }
 
-            if (activeKeys.Count == 1)
-            {
-                await ValidateCustodyCanSignAsync(activeKeys[0], cancellationToken);
-            }
+                if (activeKeys.Count == 1)
+                {
+                    await ValidateCustodyCanSignAsync(activeKeys[0], attemptCancellationToken);
+                }
 
-            newKey = await CreateSigningKeyAsync(keys, cancellationToken);
-            if (activeKeys.Count == 1)
-            {
-                activeKeys[0].IsActive = false;
-                activeKeys[0].RetiredAt = now;
-            }
+                var newKey = await CreateSigningKeyAsync(keys, attemptCancellationToken);
+                createdKeys.Add(newKey);
+                if (activeKeys.Count == 1)
+                {
+                    activeKeys[0].IsActive = false;
+                    activeKeys[0].RetiredAt = DateTime.UtcNow;
+                }
 
-            _context.Set<SqlOSSigningKey>().Add(newKey);
-            await _context.SaveChangesAsync(cancellationToken);
-            await CommitAsync(transaction, cancellationToken);
+                _context.Set<SqlOSSigningKey>().Add(newKey);
+                await _context.SaveChangesAsync(attemptCancellationToken);
+                return newKey;
+            }, cancellationToken);
+
+            await CleanupUncommittedCreatedKeysAsync(createdKeys, cancellationToken);
             _validationSigningKeyCache.InvalidateAll();
-            return newKey;
+            return result;
         }
         catch
         {
-            if (newKey != null)
-            {
-                await TryDeleteCreatedKeyAsync(newKey);
-            }
-
+            await CleanupUncommittedCreatedKeysAsync(createdKeys, CancellationToken.None);
             throw;
         }
     }
@@ -1081,16 +1082,25 @@ public sealed class SqlOSCryptoService
         }
     }
 
-    private async Task<IDbContextTransaction?> BeginSigningKeyTransactionAsync(CancellationToken cancellationToken)
+    private async Task<SqlOSSigningKey> ExecuteSigningKeyTransactionAsync(
+        Func<CancellationToken, Task<SqlOSSigningKey>> operation,
+        CancellationToken cancellationToken)
     {
         if (!_context.Database.IsRelational())
         {
-            return null;
+            return await operation(cancellationToken);
         }
 
-        var transaction = await _context.Database.BeginTransactionAsync(IsolationLevel.Serializable, cancellationToken);
-        try
+        SqlOSSigningKey? attemptedResult = null;
+        var attemptStarted = false;
+        var strategy = _context.Database.CreateExecutionStrategy();
+        async Task<SqlOSSigningKey> ExecuteAttemptAsync(CancellationToken attemptCancellationToken)
         {
+            if (attemptStarted)
+            {
+                DetachTrackedSigningKeys();
+            }
+            attemptStarted = true;
             if (string.Equals(
                 _context.Database.ProviderName,
                 "Microsoft.EntityFrameworkCore.SqlServer",
@@ -1107,23 +1117,75 @@ public sealed class SqlOSCryptoService
                     IF @result < 0
                         THROW 51000, 'SqlOS could not acquire the signing-key custody lock.', 1;
                     """,
-                    cancellationToken);
+                    attemptCancellationToken);
             }
 
-            return transaction;
+            attemptedResult = await operation(attemptCancellationToken);
+            return attemptedResult;
+        }
+
+        async Task<bool> VerifySucceededAsync(CancellationToken verifyCancellationToken)
+            => attemptedResult != null
+                && await HasSingleActiveSigningKeyAsync(attemptedResult.Id, verifyCancellationToken);
+
+        return await RelationalExecutionStrategyExtensions.ExecuteInTransactionAsync<SqlOSSigningKey>(
+            strategy,
+            ExecuteAttemptAsync,
+            VerifySucceededAsync,
+            IsolationLevel.Serializable,
+            cancellationToken);
+    }
+
+    private async Task<bool> HasSingleActiveSigningKeyAsync(string keyId, CancellationToken cancellationToken)
+    {
+        var activeIds = await _context.Set<SqlOSSigningKey>()
+            .AsNoTracking()
+            .Where(static key => key.IsActive)
+            .Select(static key => key.Id)
+            .ToListAsync(cancellationToken);
+        return activeIds.Count == 1 && string.Equals(activeIds[0], keyId, StringComparison.Ordinal);
+    }
+
+    private async Task CleanupUncommittedCreatedKeysAsync(
+        IReadOnlyCollection<SqlOSSigningKey> createdKeys,
+        CancellationToken cancellationToken)
+    {
+        if (createdKeys.Count == 0)
+        {
+            return;
+        }
+
+        HashSet<string> persistedIds;
+        try
+        {
+            var createdIds = createdKeys.Select(static key => key.Id).ToList();
+            persistedIds = (await _context.Set<SqlOSSigningKey>()
+                    .AsNoTracking()
+                    .Where(key => createdIds.Contains(key.Id))
+                    .Select(static key => key.Id)
+                    .ToListAsync(cancellationToken))
+                .ToHashSet(StringComparer.Ordinal);
         }
         catch
         {
-            await transaction.DisposeAsync();
-            throw;
+            // A failed verification cannot safely distinguish an orphan from a key whose
+            // commit response was lost. Preserve custody material rather than deleting a
+            // key that may now be active in the database.
+            return;
+        }
+
+        foreach (var createdKey in createdKeys.Where(key => !persistedIds.Contains(key.Id)))
+        {
+            await TryDeleteCreatedKeyAsync(createdKey);
         }
     }
 
-    private static async Task CommitAsync(IDbContextTransaction? transaction, CancellationToken cancellationToken)
+    private void DetachTrackedSigningKeys()
     {
-        if (transaction != null)
+        var dbContext = _context.Database.GetService<ICurrentDbContext>().Context;
+        foreach (var entry in dbContext.ChangeTracker.Entries<SqlOSSigningKey>().ToList())
         {
-            await transaction.CommitAsync(cancellationToken);
+            entry.State = EntityState.Detached;
         }
     }
 

--- a/tests/SqlOS.IntegrationTests/AuthServerSigningKeyResilienceIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/AuthServerSigningKeyResilienceIntegrationTests.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
@@ -208,6 +209,93 @@ public sealed class AuthServerSigningKeyResilienceIntegrationTests
             }
             await DeleteDatabaseAsync(connectionString);
             DeleteKeyRingDirectory(keyRingPath);
+        }
+    }
+
+    [TestMethod]
+    public async Task EnsureAndRotateSigningKey_RetryEnabledContext_SucceedsAndRemainsIdempotent()
+    {
+        TestSqlOSDbContext? setupContext = null;
+        string? connectionString = null;
+        var keyRingPath = CreateKeyRingDirectory("retry-enabled");
+
+        try
+        {
+            setupContext = await AspireFixture.CreateIsolatedAuthContextAsync("SqlOSRetryEnabledKey");
+            connectionString = setupContext.Database.GetConnectionString();
+            await setupContext.DisposeAsync();
+            setupContext = null;
+
+            await using var retryContext = CreateRetryEnabledContext(connectionString!);
+            var stack = BuildStack(
+                retryContext,
+                CreateOptions("retry-enabled", "https://client.example.test/retry-enabled/callback"),
+                CreateFileSystemProvider(keyRingPath));
+
+            var first = await stack.Crypto.EnsureActiveSigningKeyAsync();
+            var repeated = await stack.Crypto.EnsureActiveSigningKeyAsync();
+            repeated.Id.Should().Be(first.Id);
+
+            var rotated = await stack.Crypto.RotateSigningKeyAsync();
+            rotated.Id.Should().NotBe(first.Id);
+
+            var keys = await retryContext.Set<SqlOSSigningKey>()
+                .AsNoTracking()
+                .OrderBy(key => key.ActivatedAt)
+                .ToListAsync();
+            keys.Should().HaveCount(2);
+            keys.Should().ContainSingle(key => key.IsActive).Which.Id.Should().Be(rotated.Id);
+            keys.Should().ContainSingle(key => !key.IsActive).Which.RetiredAt.Should().NotBeNull();
+        }
+        finally
+        {
+            if (setupContext != null)
+            {
+                await setupContext.DisposeAsync();
+            }
+            await DeleteDatabaseAsync(connectionString);
+            DeleteKeyRingDirectory(keyRingPath);
+        }
+    }
+
+    [TestMethod]
+    public async Task EnsureActiveSigningKey_TransientCustodyFailure_RetriesWithoutOrphaningKey()
+    {
+        TestSqlOSDbContext? setupContext = null;
+        string? connectionString = null;
+
+        try
+        {
+            setupContext = await AspireFixture.CreateIsolatedAuthContextAsync("SqlOSRetryCleanup");
+            connectionString = setupContext.Database.GetConnectionString();
+            await setupContext.DisposeAsync();
+            setupContext = null;
+
+            await using var retryContext = CreateTestRetryContext(connectionString!);
+            using var custody = new TrackingTestSigningKeyCustody
+            {
+                NextSignFailure = new TestTransientException()
+            };
+            var stack = BuildStack(
+                retryContext,
+                CreateOptions("retry-cleanup", "https://client.example.test/retry-cleanup/callback"),
+                custody);
+
+            var key = await stack.Crypto.EnsureActiveSigningKeyAsync();
+
+            custody.DeleteCount.Should().Be(1);
+            custody.KeyCount.Should().Be(1);
+            var persisted = await retryContext.Set<SqlOSSigningKey>().AsNoTracking().ToListAsync();
+            persisted.Should().ContainSingle().Which.Id.Should().Be(key.Id);
+            persisted.Should().OnlyContain(candidate => candidate.IsActive);
+        }
+        finally
+        {
+            if (setupContext != null)
+            {
+                await setupContext.DisposeAsync();
+            }
+            await DeleteDatabaseAsync(connectionString);
         }
     }
 
@@ -795,6 +883,17 @@ public sealed class AuthServerSigningKeyResilienceIntegrationTests
     private static TestSqlOSDbContext CreateContext(string connectionString)
         => new(new DbContextOptionsBuilder<TestSqlOSDbContext>().UseSqlServer(connectionString).Options);
 
+    private static TestSqlOSDbContext CreateRetryEnabledContext(string connectionString)
+        => new(new DbContextOptionsBuilder<TestSqlOSDbContext>()
+            .UseSqlServer(connectionString, sqlServer => sqlServer.EnableRetryOnFailure())
+            .Options);
+
+    private static TestSqlOSDbContext CreateTestRetryContext(string connectionString)
+        => new(new DbContextOptionsBuilder<TestSqlOSDbContext>()
+            .UseSqlServer(connectionString)
+            .ReplaceService<IExecutionStrategyFactory, TestRetryExecutionStrategyFactory>()
+            .Options);
+
     private static string CreateKeyRingDirectory(string suffix)
     {
         var path = Path.Combine(
@@ -932,6 +1031,8 @@ public sealed class AuthServerSigningKeyResilienceIntegrationTests
 
         public string ProviderId => "mock-kms:integration:v1";
         public int DeleteCount { get; private set; }
+        public int KeyCount => _keys.Count;
+        public Exception? NextSignFailure { get; init; }
 
         public Task<SqlOSSigningKeyCreationResult> CreateKeyAsync(
             string kid,
@@ -955,11 +1056,17 @@ public sealed class AuthServerSigningKeyResilienceIntegrationTests
         {
             cancellationToken.ThrowIfCancellationRequested();
             key.CustodyProvider.Should().Be(ProviderId);
+            if (NextSignFailure != null && Interlocked.Exchange(ref _signFailureRaised, 1) == 0)
+            {
+                throw NextSignFailure;
+            }
             return Task.FromResult(_keys[key.KeyReference].SignData(
                 signingInput.Span,
                 HashAlgorithmName.SHA256,
                 RSASignaturePadding.Pkcs1));
         }
+
+        private int _signFailureRaised;
 
         public Task DeleteKeyAsync(
             SqlOSSigningKeyDescriptor key,
@@ -983,4 +1090,18 @@ public sealed class AuthServerSigningKeyResilienceIntegrationTests
             _keys.Clear();
         }
     }
+
+    private sealed class TestRetryExecutionStrategyFactory(ExecutionStrategyDependencies dependencies)
+        : IExecutionStrategyFactory
+    {
+        public IExecutionStrategy Create() => new TestRetryExecutionStrategy(dependencies);
+    }
+
+    private sealed class TestRetryExecutionStrategy(ExecutionStrategyDependencies dependencies)
+        : ExecutionStrategy(dependencies, 2, TimeSpan.Zero)
+    {
+        protected override bool ShouldRetryOn(Exception exception) => exception is TestTransientException;
+    }
+
+    private sealed class TestTransientException : Exception;
 }


### PR DESCRIPTION
## Summary
- execute signing-key creation and rotation through the configured EF execution strategy
- keep the serializable transaction and SQL application lock inside each retriable unit
- verify ambiguous commits and clean abandoned custody keys without risking deletion of a committed active key
- add real SQL coverage for EnableRetryOnFailure, idempotent bootstrap, rotation, and transient custody cleanup

## Validation
- ./scripts/build.sh
- ./scripts/unit-tests.sh (683 + 2 passed)
- ./scripts/integration-tests.sh (187 + 71 + 15 passed)
- ./scripts/docs-check.sh
- git diff --check
- focused AuthServerSigningKeyResilienceIntegrationTests and retry regression tests

No dashboard or operator-managed configuration is introduced; this is internal protocol hardening and all existing signing-key runtime surfaces use the shared crypto service.

Closes #253