### PR TITLE
P1: Apply atomic MFA guess limits across active challenges

### DIFF
--- a/docs/MFA_TOTP.md
+++ b/docs/MFA_TOTP.md
@@ -39,7 +39,9 @@ code, then releases that reservation after a successful comparison so only
 failed checks consume the configured failure budgets. Challenge, user, IP,
 client, account-and-client-bound browser fingerprint, and hosted
 authorization-request budgets are persisted in SQL and shared by all application
-replicas, so issuing another challenge cannot create more guesses. Once any
+replicas. Reservation operation IDs make SQL retry replays idempotent, and a
+successful release removes an empty bucket so the next failure starts a fresh
+window. Issuing another challenge therefore cannot create more guesses. Once any
 applicable budget is exhausted, SqlOS rejects the attempt with the same public
 invalid-code error and does not compare the submitted code or reveal the limiting
 scope. Audit events record the outcome but are not used as the security counter.

--- a/docs/MFA_TOTP.md
+++ b/docs/MFA_TOTP.md
@@ -23,9 +23,24 @@ builder.AddSqlOS<AppDbContext>(options =>
         mfa.AllowUserSelfEnrollmentByDefault = true;
         mfa.RecoveryCodesEnabledByDefault = true;
         mfa.Totp.Issuer = "Contoso";
+        mfa.Totp.MaxFailedAttemptsPerChallenge = 5;
+        mfa.Totp.MaxFailedAttemptsPerUser = 10;
+        mfa.Totp.MaxFailedAttemptsPerIp = 25;
+        mfa.Totp.MaxFailedAttemptsPerClient = 25;
+        mfa.Totp.MaxFailedAttemptsPerDevice = 10;
+        mfa.Totp.MaxFailedAttemptsPerAuthorizationRequest = 10;
+        mfa.Totp.FailedAttemptWindow = TimeSpan.FromMinutes(10);
     });
 });
 ```
+
+MFA verification reserves capacity before comparing either a TOTP or recovery
+code. Challenge, user, IP, client, device, and hosted authorization-request
+budgets are persisted in SQL and shared by all application replicas, so issuing
+another challenge cannot create more guesses. Once any applicable budget is
+exhausted, SqlOS rejects the attempt with the same public invalid-code error and
+does not compare the submitted code or reveal the limiting scope. Audit events
+record the outcome but are not used as the security counter.
 
 Startup defaults create the persisted MFA settings row on first boot. To
 reapply settings on each boot, use `SeedMfaPolicy`, matching the existing auth

--- a/docs/MFA_TOTP.md
+++ b/docs/MFA_TOTP.md
@@ -35,12 +35,14 @@ builder.AddSqlOS<AppDbContext>(options =>
 ```
 
 MFA verification reserves capacity before comparing either a TOTP or recovery
-code. Challenge, user, IP, client, device, and hosted authorization-request
-budgets are persisted in SQL and shared by all application replicas, so issuing
-another challenge cannot create more guesses. Once any applicable budget is
-exhausted, SqlOS rejects the attempt with the same public invalid-code error and
-does not compare the submitted code or reveal the limiting scope. Audit events
-record the outcome but are not used as the security counter.
+code, then releases that reservation after a successful comparison so only
+failed checks consume the configured failure budgets. Challenge, user, IP,
+client, account-and-client-bound browser fingerprint, and hosted
+authorization-request budgets are persisted in SQL and shared by all application
+replicas, so issuing another challenge cannot create more guesses. Once any
+applicable budget is exhausted, SqlOS rejects the attempt with the same public
+invalid-code error and does not compare the submitted code or reveal the limiting
+scope. Audit events record the outcome but are not used as the security counter.
 
 Startup defaults create the persisted MFA settings row on first boot. To
 reapply settings on each boot, use `SeedMfaPolicy`, matching the existing auth

--- a/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerModelConfiguration.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerModelConfiguration.cs
@@ -94,6 +94,15 @@ public static class SqlOSAuthServerModelConfiguration
                 .OnDelete(DeleteBehavior.Restrict);
         });
 
+        modelBuilder.Entity<SqlOSMfaAttemptBucket>(entity =>
+        {
+            entity.ToTable("SqlOSMfaAttemptBuckets", schema, t => t.ExcludeFromMigrations());
+            entity.HasKey(x => x.Id);
+            entity.HasIndex(x => new { x.Scope, x.BucketKey }).IsUnique();
+            entity.Property(x => x.Scope).HasMaxLength(40);
+            entity.Property(x => x.BucketKey).HasMaxLength(128);
+        });
+
         modelBuilder.Entity<SqlOSMembership>(entity =>
         {
             entity.ToTable("SqlOSMemberships", schema, t => t.ExcludeFromMigrations());

--- a/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerModelConfiguration.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerModelConfiguration.cs
@@ -104,6 +104,17 @@ public static class SqlOSAuthServerModelConfiguration
             entity.Property(x => x.BucketKey).HasMaxLength(128);
         });
 
+        modelBuilder.Entity<SqlOSMfaAttemptReservation>(entity =>
+        {
+            entity.ToTable("SqlOSMfaAttemptReservations", schema, t => t.ExcludeFromMigrations());
+            entity.HasKey(x => x.Id);
+            entity.HasIndex(x => new { x.OperationId, x.Scope, x.BucketKey }).IsUnique();
+            entity.HasIndex(x => x.CreatedAt);
+            entity.Property(x => x.OperationId).HasMaxLength(64);
+            entity.Property(x => x.Scope).HasMaxLength(40);
+            entity.Property(x => x.BucketKey).HasMaxLength(128);
+        });
+
         modelBuilder.Entity<SqlOSMembership>(entity =>
         {
             entity.ToTable("SqlOSMemberships", schema, t => t.ExcludeFromMigrations());

--- a/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerModelConfiguration.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerModelConfiguration.cs
@@ -99,6 +99,7 @@ public static class SqlOSAuthServerModelConfiguration
             entity.ToTable("SqlOSMfaAttemptBuckets", schema, t => t.ExcludeFromMigrations());
             entity.HasKey(x => x.Id);
             entity.HasIndex(x => new { x.Scope, x.BucketKey }).IsUnique();
+            entity.HasIndex(x => x.LastAttemptAt);
             entity.Property(x => x.Scope).HasMaxLength(40);
             entity.Property(x => x.BucketKey).HasMaxLength(128);
         });

--- a/src/SqlOS/AuthServer/Configuration/SqlOSMfaOptions.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSMfaOptions.cs
@@ -33,5 +33,8 @@ public sealed class SqlOSTotpMfaOptions
     public int MaxFailedAttemptsPerChallenge { get; set; } = 5;
     public int MaxFailedAttemptsPerUser { get; set; } = 10;
     public int MaxFailedAttemptsPerIp { get; set; } = 25;
+    public int MaxFailedAttemptsPerClient { get; set; } = 25;
+    public int MaxFailedAttemptsPerDevice { get; set; } = 10;
+    public int MaxFailedAttemptsPerAuthorizationRequest { get; set; } = 10;
     public TimeSpan FailedAttemptWindow { get; set; } = TimeSpan.FromMinutes(10);
 }

--- a/src/SqlOS/AuthServer/Models/SqlOSEntities.cs
+++ b/src/SqlOS/AuthServer/Models/SqlOSEntities.cs
@@ -120,6 +120,17 @@ public sealed class SqlOSMfaAttemptBucket
     public DateTime UpdatedAt { get; set; }
 }
 
+public sealed class SqlOSMfaAttemptReservation
+{
+    public string Id { get; set; } = string.Empty;
+    public string OperationId { get; set; } = string.Empty;
+    public string Scope { get; set; } = string.Empty;
+    public string BucketKey { get; set; } = string.Empty;
+    public DateTime WindowStartedAt { get; set; }
+    public DateTime? ReleasedAt { get; set; }
+    public DateTime CreatedAt { get; set; }
+}
+
 public sealed class SqlOSMembership
 {
     public string OrganizationId { get; set; } = string.Empty;

--- a/src/SqlOS/AuthServer/Models/SqlOSEntities.cs
+++ b/src/SqlOS/AuthServer/Models/SqlOSEntities.cs
@@ -108,6 +108,18 @@ public sealed class SqlOSPasswordLoginBucket
     public SqlOSUser? User { get; set; }
 }
 
+public sealed class SqlOSMfaAttemptBucket
+{
+    public string Id { get; set; } = string.Empty;
+    public string Scope { get; set; } = string.Empty;
+    public string BucketKey { get; set; } = string.Empty;
+    public int AttemptCount { get; set; }
+    public DateTime WindowStartedAt { get; set; }
+    public DateTime LastAttemptAt { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}
+
 public sealed class SqlOSMembership
 {
     public string OrganizationId { get; set; } = string.Empty;

--- a/src/SqlOS/AuthServer/Schema/039_MfaAttemptAdmission.sql
+++ b/src/SqlOS/AuthServer/Schema/039_MfaAttemptAdmission.sql
@@ -14,6 +14,9 @@ BEGIN
     CREATE UNIQUE INDEX [IX_SqlOSMfaAttemptBuckets_Scope_BucketKey]
         ON [{Schema}].[SqlOSMfaAttemptBuckets]([Scope], [BucketKey]);
 
+    CREATE INDEX [IX_SqlOSMfaAttemptBuckets_LastAttemptAt]
+        ON [{Schema}].[SqlOSMfaAttemptBuckets]([LastAttemptAt]);
+
 END
 
 GO

--- a/src/SqlOS/AuthServer/Schema/039_MfaAttemptAdmission.sql
+++ b/src/SqlOS/AuthServer/Schema/039_MfaAttemptAdmission.sql
@@ -21,5 +21,26 @@ END
 
 GO
 
+IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'SqlOSMfaAttemptReservations' AND schema_id = SCHEMA_ID('{Schema}'))
+BEGIN
+    CREATE TABLE [{Schema}].[SqlOSMfaAttemptReservations] (
+        [Id] NVARCHAR(64) NOT NULL PRIMARY KEY,
+        [OperationId] NVARCHAR(64) NOT NULL,
+        [Scope] NVARCHAR(40) NOT NULL,
+        [BucketKey] NVARCHAR(128) NOT NULL,
+        [WindowStartedAt] DATETIME2 NOT NULL,
+        [ReleasedAt] DATETIME2 NULL,
+        [CreatedAt] DATETIME2 NOT NULL
+    );
+
+    CREATE UNIQUE INDEX [IX_SqlOSMfaAttemptReservations_OperationId_Scope_BucketKey]
+        ON [{Schema}].[SqlOSMfaAttemptReservations]([OperationId], [Scope], [BucketKey]);
+
+    CREATE INDEX [IX_SqlOSMfaAttemptReservations_CreatedAt]
+        ON [{Schema}].[SqlOSMfaAttemptReservations]([CreatedAt]);
+END
+
+GO
+
 DELETE FROM [{Schema}].[SqlOSSchema];
 INSERT INTO [{Schema}].[SqlOSSchema] ([Version]) VALUES (39);

--- a/src/SqlOS/AuthServer/Schema/039_MfaAttemptAdmission.sql
+++ b/src/SqlOS/AuthServer/Schema/039_MfaAttemptAdmission.sql
@@ -1,0 +1,22 @@
+IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'SqlOSMfaAttemptBuckets' AND schema_id = SCHEMA_ID('{Schema}'))
+BEGIN
+    CREATE TABLE [{Schema}].[SqlOSMfaAttemptBuckets] (
+        [Id] NVARCHAR(64) NOT NULL PRIMARY KEY,
+        [Scope] NVARCHAR(40) NOT NULL,
+        [BucketKey] NVARCHAR(128) NOT NULL,
+        [AttemptCount] INT NOT NULL,
+        [WindowStartedAt] DATETIME2 NOT NULL,
+        [LastAttemptAt] DATETIME2 NOT NULL,
+        [CreatedAt] DATETIME2 NOT NULL,
+        [UpdatedAt] DATETIME2 NOT NULL
+    );
+
+    CREATE UNIQUE INDEX [IX_SqlOSMfaAttemptBuckets_Scope_BucketKey]
+        ON [{Schema}].[SqlOSMfaAttemptBuckets]([Scope], [BucketKey]);
+
+END
+
+GO
+
+DELETE FROM [{Schema}].[SqlOSSchema];
+INSERT INTO [{Schema}].[SqlOSSchema] ([Version]) VALUES (39);

--- a/src/SqlOS/AuthServer/Services/SqlOSAdminService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSAdminService.cs
@@ -43,15 +43,23 @@ public sealed partial class SqlOSAdminService
 
     public async Task CleanupExpiredTemporaryTokensAsync(CancellationToken cancellationToken = default)
     {
+        var now = DateTime.UtcNow;
         var expired = await _context.Set<SqlOSTemporaryToken>()
-            .Where(x => x.ExpiresAt < DateTime.UtcNow || x.ConsumedAt != null)
+            .Where(x => x.ExpiresAt < now || x.ConsumedAt != null)
             .ToListAsync(cancellationToken);
-        if (expired.Count == 0)
+        _context.Set<SqlOSTemporaryToken>().RemoveRange(expired);
+
+        var staleMfaAttemptCutoff = now.Subtract(_options.Mfa.Totp.FailedAttemptWindow);
+        var staleMfaAttemptBuckets = await _context.Set<SqlOSMfaAttemptBucket>()
+            .Where(x => x.LastAttemptAt < staleMfaAttemptCutoff)
+            .ToListAsync(cancellationToken);
+        _context.Set<SqlOSMfaAttemptBucket>().RemoveRange(staleMfaAttemptBuckets);
+
+        if (expired.Count == 0 && staleMfaAttemptBuckets.Count == 0)
         {
             return;
         }
 
-        _context.Set<SqlOSTemporaryToken>().RemoveRange(expired);
         await _context.SaveChangesAsync(cancellationToken);
     }
 

--- a/src/SqlOS/AuthServer/Services/SqlOSAdminService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSAdminService.cs
@@ -50,12 +50,36 @@ public sealed partial class SqlOSAdminService
         _context.Set<SqlOSTemporaryToken>().RemoveRange(expired);
 
         var staleMfaAttemptCutoff = now.Subtract(_options.Mfa.Totp.FailedAttemptWindow);
-        var staleMfaAttemptBuckets = await _context.Set<SqlOSMfaAttemptBucket>()
-            .Where(x => x.LastAttemptAt < staleMfaAttemptCutoff)
-            .ToListAsync(cancellationToken);
-        _context.Set<SqlOSMfaAttemptBucket>().RemoveRange(staleMfaAttemptBuckets);
+        var removedMfaAttemptState = 0;
+        if (_context.Database.IsSqlServer())
+        {
+            var schema = _options.Schema.Replace("]", "]]", StringComparison.Ordinal);
+            var sql = $$"""
+                DELETE FROM [{{schema}}].[SqlOSMfaAttemptReservations]
+                WHERE [CreatedAt] < {0};
 
-        if (expired.Count == 0 && staleMfaAttemptBuckets.Count == 0)
+                DELETE FROM [{{schema}}].[SqlOSMfaAttemptBuckets]
+                WHERE [LastAttemptAt] < {0};
+                """;
+            removedMfaAttemptState = await _context.Database.ExecuteSqlRawAsync(
+                sql,
+                [staleMfaAttemptCutoff],
+                cancellationToken);
+        }
+        else
+        {
+            var staleMfaAttemptReservations = await _context.Set<SqlOSMfaAttemptReservation>()
+                .Where(x => x.CreatedAt < staleMfaAttemptCutoff)
+                .ToListAsync(cancellationToken);
+            var staleMfaAttemptBuckets = await _context.Set<SqlOSMfaAttemptBucket>()
+                .Where(x => x.LastAttemptAt < staleMfaAttemptCutoff)
+                .ToListAsync(cancellationToken);
+            _context.Set<SqlOSMfaAttemptReservation>().RemoveRange(staleMfaAttemptReservations);
+            _context.Set<SqlOSMfaAttemptBucket>().RemoveRange(staleMfaAttemptBuckets);
+            removedMfaAttemptState = staleMfaAttemptReservations.Count + staleMfaAttemptBuckets.Count;
+        }
+
+        if (expired.Count == 0 && removedMfaAttemptState == 0)
         {
             return;
         }

--- a/src/SqlOS/AuthServer/Services/SqlOSAuthService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSAuthService.cs
@@ -1956,7 +1956,7 @@ public sealed class SqlOSAuthService
             throw;
         }
 
-        await _mfaAttemptAdmissionService.ReleaseAsync(admission.Reservation!, cancellationToken);
+        await _mfaAttemptAdmissionService.ReleaseAsync(admission.Reservation!, CancellationToken.None);
         return factorMethod;
     }
 

--- a/src/SqlOS/AuthServer/Services/SqlOSAuthService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSAuthService.cs
@@ -1918,9 +1918,11 @@ public sealed class SqlOSAuthService
             await RejectMfaAttemptAsync(token, httpContext, admission.RejectedScope!, cancellationToken);
         }
 
+        string factorMethod;
         try
         {
-            return await RequireTotpMfaService().VerifySecondFactorCodeAsync(token.UserId, code, cancellationToken);
+            factorMethod = await RequireTotpMfaService()
+                .VerifySecondFactorCodeAsync(token.UserId, code, cancellationToken);
         }
         catch (InvalidOperationException)
         {
@@ -1937,6 +1939,25 @@ public sealed class SqlOSAuthService
                 cancellationToken);
             throw new InvalidOperationException(MfaChallengeFailureMessage);
         }
+        catch
+        {
+            try
+            {
+                await _mfaAttemptAdmissionService.ReleaseAsync(
+                    admission.Reservation!,
+                    CancellationToken.None);
+            }
+            catch
+            {
+                // Preserve the original verification failure. A stranded
+                // reservation expires with its bounded attempt window.
+            }
+
+            throw;
+        }
+
+        await _mfaAttemptAdmissionService.ReleaseAsync(admission.Reservation!, cancellationToken);
+        return factorMethod;
     }
 
     internal async Task<string> CreateMfaChallengeAsync(
@@ -1986,16 +2007,6 @@ public sealed class SqlOSAuthService
         string rejectedScope,
         CancellationToken cancellationToken)
     {
-        token.ConsumedAt = DateTime.UtcNow;
-        try
-        {
-            await _context.SaveChangesAsync(cancellationToken);
-        }
-        catch (DbUpdateConcurrencyException)
-        {
-            // Another request has already consumed or updated this challenge.
-        }
-
         await TryRecordMfaChallengeAuditAsync(
             "user.mfa.challenge_rate_limited",
             token,

--- a/src/SqlOS/AuthServer/Services/SqlOSAuthService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSAuthService.cs
@@ -42,6 +42,7 @@ public sealed class SqlOSAuthService
     private readonly SqlOSTotpMfaService? _totpMfaService;
     private readonly SqlOSInvitationService? _invitationService;
     private readonly SqlOSPasswordLoginAbuseService _passwordLoginAbuseService;
+    private readonly SqlOSMfaAttemptAdmissionService _mfaAttemptAdmissionService;
     private readonly ISqlOSTransactionalEmailService? _transactionalEmailService;
     private readonly ISqlOSAuthEmailSender? _authEmailSender;
 
@@ -59,7 +60,8 @@ public sealed class SqlOSAuthService
         ISqlOSAuthEmailSender? authEmailSender = null,
         SqlOSMfaPolicyService? mfaPolicyService = null,
         SqlOSTotpMfaService? totpMfaService = null,
-        SqlOSMagicLinkService? magicLinkService = null)
+        SqlOSMagicLinkService? magicLinkService = null,
+        SqlOSMfaAttemptAdmissionService? mfaAttemptAdmissionService = null)
     {
         _context = context;
         _options = options.Value;
@@ -77,6 +79,8 @@ public sealed class SqlOSAuthService
         _authEmailSender = authEmailSender;
         _mfaPolicyService = mfaPolicyService;
         _totpMfaService = totpMfaService;
+        _mfaAttemptAdmissionService = mfaAttemptAdmissionService
+            ?? new SqlOSMfaAttemptAdmissionService(context, options);
     }
 
     public async Task<SqlOSLoginResult> SignUpAsync(SqlOSSignupRequest request, HttpContext httpContext, CancellationToken cancellationToken = default)
@@ -1902,7 +1906,18 @@ public sealed class SqlOSAuthService
             throw new InvalidOperationException("MFA challenge payload is invalid.");
         }
 
-        await EnsureMfaAttemptAllowedAsync(token, httpContext, cancellationToken);
+        var payload = _cryptoService.DeserializePayload<SqlOSMfaChallengePayload>(token)
+            ?? throw new InvalidOperationException("MFA challenge payload is invalid.");
+        var admission = await _mfaAttemptAdmissionService.TryReserveAsync(
+            token,
+            payload,
+            httpContext,
+            cancellationToken);
+        if (!admission.Admitted)
+        {
+            await RejectMfaAttemptAsync(token, httpContext, admission.RejectedScope!, cancellationToken);
+        }
+
         try
         {
             return await RequireTotpMfaService().VerifySecondFactorCodeAsync(token.UserId, code, cancellationToken);
@@ -1936,15 +1951,14 @@ public sealed class SqlOSAuthService
         string? resource = null,
         CancellationToken cancellationToken = default)
     {
-        var recentFailures = await CountRecentMfaFailuresAsync(user.Id, null, cancellationToken);
-        if (recentFailures >= _options.Mfa.Totp.MaxFailedAttemptsPerUser)
+        if (await _mfaAttemptAdmissionService.IsUserCapacityExhaustedAsync(user.Id, cancellationToken))
         {
             await TryRecordMfaChallengeAuditAsync(
                 "user.mfa.challenge_issue_rejected",
                 user.Id,
                 organizationId,
                 null,
-                new { recentFailures },
+                new { reason = "attempt_capacity_exhausted" },
                 cancellationToken);
             throw new InvalidOperationException(MfaChallengeFailureMessage);
         }
@@ -1966,22 +1980,12 @@ public sealed class SqlOSAuthService
             cancellationToken);
     }
 
-    private async Task EnsureMfaAttemptAllowedAsync(
+    private async Task RejectMfaAttemptAsync(
         SqlOSTemporaryToken token,
         HttpContext? httpContext,
+        string rejectedScope,
         CancellationToken cancellationToken)
     {
-        var ipAddress = GetIp(httpContext);
-        var recentUserFailures = await CountRecentMfaFailuresAsync(token.UserId!, null, cancellationToken);
-        var recentIpFailures = ipAddress == null
-            ? 0
-            : await CountRecentMfaFailuresAsync(null, ipAddress, cancellationToken);
-        if (recentUserFailures < _options.Mfa.Totp.MaxFailedAttemptsPerUser
-            && recentIpFailures < _options.Mfa.Totp.MaxFailedAttemptsPerIp)
-        {
-            return;
-        }
-
         token.ConsumedAt = DateTime.UtcNow;
         try
         {
@@ -1996,7 +2000,7 @@ public sealed class SqlOSAuthService
             "user.mfa.challenge_rate_limited",
             token,
             httpContext,
-            new { recentUserFailures, recentIpFailures },
+            new { scope = rejectedScope },
             cancellationToken);
         throw new InvalidOperationException(MfaChallengeFailureMessage);
     }
@@ -2034,22 +2038,6 @@ public sealed class SqlOSAuthService
                     ?? throw new InvalidOperationException(MfaChallengeFailureMessage);
             }
         }
-    }
-
-    private async Task<int> CountRecentMfaFailuresAsync(
-        string? userId,
-        string? ipAddress,
-        CancellationToken cancellationToken)
-    {
-        var cutoff = DateTime.UtcNow.Subtract(_options.Mfa.Totp.FailedAttemptWindow);
-        return await _context.Set<SqlOSAuditEvent>()
-            .AsNoTracking()
-            .CountAsync(
-                x => x.Action == MfaChallengeFailedAuditEvent
-                    && x.OccurredAt >= cutoff
-                    && (userId == null || x.UserId == userId)
-                    && (ipAddress == null || x.IpAddress == ipAddress),
-                cancellationToken);
     }
 
     private Task TryRecordMfaChallengeAuditAsync(

--- a/src/SqlOS/AuthServer/Services/SqlOSMfaAttemptAdmissionService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSMfaAttemptAdmissionService.cs
@@ -29,8 +29,10 @@ public sealed class SqlOSMfaAttemptAdmissionService
         SqlOSTemporaryToken challenge,
         SqlOSMfaChallengePayload payload,
         HttpContext? httpContext,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        string? operationId = null)
     {
+        operationId ??= $"mfaop_{Guid.NewGuid():N}";
         var identities = CreateBucketIdentities(challenge, payload, httpContext)
             .OrderBy(static x => x.Scope, StringComparer.Ordinal)
             .ThenBy(static x => x.BucketKey, StringComparer.Ordinal)
@@ -38,19 +40,19 @@ public sealed class SqlOSMfaAttemptAdmissionService
 
         if (_context.Database.IsSqlServer())
         {
-            return await ReserveSqlServerAsync(identities, cancellationToken);
+            return await ReserveSqlServerAsync(operationId, identities, cancellationToken);
         }
 
-        return await ReserveProviderFallbackAsync(identities, cancellationToken);
+        return await ReserveProviderFallbackAsync(operationId, identities, cancellationToken);
     }
 
     internal async Task ReleaseAsync(
-        SqlOSMfaAttemptReservation reservation,
+        SqlOSMfaAttemptReservationHandle reservation,
         CancellationToken cancellationToken = default)
     {
         if (_context.Database.IsSqlServer())
         {
-            await ReleaseSqlServerAsync(reservation.Buckets, cancellationToken);
+            await ReleaseSqlServerAsync(reservation, cancellationToken);
             return;
         }
 
@@ -74,6 +76,7 @@ public sealed class SqlOSMfaAttemptAdmissionService
     }
 
     private async Task<SqlOSMfaAttemptAdmissionResult> ReserveSqlServerAsync(
+        string operationId,
         IReadOnlyList<MfaBucketIdentity> identities,
         CancellationToken cancellationToken)
     {
@@ -88,6 +91,33 @@ public sealed class SqlOSMfaAttemptAdmissionService
             var connection = _context.Database.GetDbConnection();
             var schema = EscapeIdentifier(_options.Schema);
             var reservations = new List<MfaBucketReservation>(identities.Count);
+            var existingReservations = await ReadOperationReservationsForUpdateAsync(
+                connection,
+                transaction,
+                schema,
+                operationId,
+                cancellationToken);
+            if (existingReservations.Count > 0)
+            {
+                if (existingReservations.Any(static x => x.ReleasedAt != null)
+                    || existingReservations.Count != identities.Count
+                    || existingReservations.Any(x => !identities.Any(identity =>
+                        identity.Scope == x.Scope && identity.BucketKey == x.BucketKey)))
+                {
+                    await transaction.RollbackAsync(cancellationToken);
+                    throw new InvalidOperationException("MFA attempt reservation state is invalid.");
+                }
+
+                await transaction.RollbackAsync(cancellationToken);
+                var replayed = existingReservations.Select(x => new MfaBucketReservation(
+                    identities.Single(identity =>
+                        identity.Scope == x.Scope && identity.BucketKey == x.BucketKey),
+                    x.WindowStartedAt)).ToArray();
+                return new SqlOSMfaAttemptAdmissionResult(
+                    true,
+                    null,
+                    new SqlOSMfaAttemptReservationHandle(operationId, replayed));
+            }
 
             foreach (var identity in identities)
             {
@@ -119,6 +149,15 @@ public sealed class SqlOSMfaAttemptAdmissionService
                     now,
                     cutoff,
                     cancellationToken);
+                await InsertOperationReservationAsync(
+                    connection,
+                    transaction,
+                    schema,
+                    operationId,
+                    identity,
+                    windowStartedAt,
+                    now,
+                    cancellationToken);
                 reservations.Add(new MfaBucketReservation(identity, windowStartedAt));
             }
 
@@ -126,11 +165,12 @@ public sealed class SqlOSMfaAttemptAdmissionService
             return new SqlOSMfaAttemptAdmissionResult(
                 true,
                 null,
-                new SqlOSMfaAttemptReservation(reservations));
+                new SqlOSMfaAttemptReservationHandle(operationId, reservations));
         });
     }
 
     private async Task<SqlOSMfaAttemptAdmissionResult> ReserveProviderFallbackAsync(
+        string operationId,
         IReadOnlyList<MfaBucketIdentity> identities,
         CancellationToken cancellationToken)
     {
@@ -189,13 +229,13 @@ public sealed class SqlOSMfaAttemptAdmissionService
         return new SqlOSMfaAttemptAdmissionResult(
             true,
             null,
-            new SqlOSMfaAttemptReservation(pending.Select(x => new MfaBucketReservation(
+            new SqlOSMfaAttemptReservationHandle(operationId, pending.Select(x => new MfaBucketReservation(
                 x.Identity,
                 x.Bucket is { WindowStartedAt: var startedAt } && startedAt >= cutoff ? startedAt : now)).ToArray()));
     }
 
     private async Task ReleaseSqlServerAsync(
-        IReadOnlyList<MfaBucketReservation> reservations,
+        SqlOSMfaAttemptReservationHandle reservation,
         CancellationToken cancellationToken)
     {
         var strategy = _context.Database.CreateExecutionStrategy();
@@ -206,25 +246,66 @@ public sealed class SqlOSMfaAttemptAdmissionService
                 cancellationToken);
             var connection = _context.Database.GetDbConnection();
             var schema = EscapeIdentifier(_options.Schema);
-            foreach (var reservation in reservations)
+            var storedReservations = await ReadOperationReservationsForUpdateAsync(
+                connection,
+                transaction,
+                schema,
+                reservation.OperationId,
+                cancellationToken);
+            if (storedReservations.Count == 0)
+            {
+                await transaction.RollbackAsync(cancellationToken);
+                throw new InvalidOperationException("MFA attempt reservation was not found.");
+            }
+
+            if (storedReservations.All(static x => x.ReleasedAt != null))
+            {
+                await transaction.RollbackAsync(cancellationToken);
+                return;
+            }
+
+            if (storedReservations.Any(static x => x.ReleasedAt != null))
+            {
+                await transaction.RollbackAsync(cancellationToken);
+                throw new InvalidOperationException("MFA attempt reservation state is invalid.");
+            }
+
+            foreach (var storedReservation in storedReservations)
             {
                 await using var command = connection.CreateCommand();
                 command.Transaction = transaction.GetDbTransaction();
                 command.CommandText = $"""
-                    UPDATE [{schema}].[SqlOSMfaAttemptBuckets] WITH (UPDLOCK, HOLDLOCK)
-                    SET [AttemptCount] = [AttemptCount] - 1,
-                        [UpdatedAt] = @now
+                    DELETE FROM [{schema}].[SqlOSMfaAttemptBuckets] WITH (UPDLOCK, HOLDLOCK)
                     WHERE [Scope] = @scope
                       AND [BucketKey] = @bucketKey
                       AND [WindowStartedAt] = @windowStartedAt
-                      AND [AttemptCount] > 0;
+                      AND [AttemptCount] = 1;
+
+                    IF @@ROWCOUNT = 0
+                    BEGIN
+                        UPDATE [{schema}].[SqlOSMfaAttemptBuckets] WITH (UPDLOCK, HOLDLOCK)
+                        SET [AttemptCount] = [AttemptCount] - 1,
+                            [UpdatedAt] = @now
+                        WHERE [Scope] = @scope
+                          AND [BucketKey] = @bucketKey
+                          AND [WindowStartedAt] = @windowStartedAt
+                          AND [AttemptCount] > 1;
+                    END
                     """;
-                AddParameter(command, "@scope", reservation.Identity.Scope);
-                AddParameter(command, "@bucketKey", reservation.Identity.BucketKey);
-                AddParameter(command, "@windowStartedAt", reservation.WindowStartedAt);
+                AddParameter(command, "@scope", storedReservation.Scope);
+                AddParameter(command, "@bucketKey", storedReservation.BucketKey);
+                AddParameter(command, "@windowStartedAt", storedReservation.WindowStartedAt);
                 AddParameter(command, "@now", DateTime.UtcNow);
                 await command.ExecuteNonQueryAsync(cancellationToken);
             }
+
+            await MarkOperationReleasedAsync(
+                connection,
+                transaction,
+                schema,
+                reservation.OperationId,
+                DateTime.UtcNow,
+                cancellationToken);
 
             await transaction.CommitAsync(cancellationToken);
         });
@@ -241,15 +322,20 @@ public sealed class SqlOSMfaAttemptAdmissionService
                     x => x.Scope == reservation.Identity.Scope
                         && x.BucketKey == reservation.Identity.BucketKey,
                     cancellationToken);
-            if (bucket == null
-                || bucket.WindowStartedAt != reservation.WindowStartedAt
-                || bucket.AttemptCount <= 0)
+            if (bucket == null || bucket.WindowStartedAt != reservation.WindowStartedAt)
             {
                 continue;
             }
 
-            bucket.AttemptCount--;
-            bucket.UpdatedAt = DateTime.UtcNow;
+            if (bucket.AttemptCount <= 1)
+            {
+                _context.Set<SqlOSMfaAttemptBucket>().Remove(bucket);
+            }
+            else
+            {
+                bucket.AttemptCount--;
+                bucket.UpdatedAt = DateTime.UtcNow;
+            }
         }
 
         await _context.SaveChangesAsync(cancellationToken);
@@ -296,6 +382,82 @@ public sealed class SqlOSMfaAttemptAdmissionService
     {
         var bytes = SHA256.HashData(Encoding.UTF8.GetBytes($"{scope}\0{value}"));
         return new MfaBucketIdentity(scope, Convert.ToHexString(bytes), threshold);
+    }
+
+    private static async Task<IReadOnlyList<StoredOperationReservation>> ReadOperationReservationsForUpdateAsync(
+        System.Data.Common.DbConnection connection,
+        IDbContextTransaction transaction,
+        string schema,
+        string operationId,
+        CancellationToken cancellationToken)
+    {
+        await using var command = connection.CreateCommand();
+        command.Transaction = transaction.GetDbTransaction();
+        command.CommandText = $"""
+            SELECT [Scope], [BucketKey], [WindowStartedAt], [ReleasedAt]
+            FROM [{schema}].[SqlOSMfaAttemptReservations] WITH (UPDLOCK, HOLDLOCK)
+            WHERE [OperationId] = @operationId
+            ORDER BY [Scope], [BucketKey];
+            """;
+        AddParameter(command, "@operationId", operationId);
+        var reservations = new List<StoredOperationReservation>();
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            reservations.Add(new StoredOperationReservation(
+                reader.GetString(0),
+                reader.GetString(1),
+                reader.GetDateTime(2),
+                reader.IsDBNull(3) ? null : reader.GetDateTime(3)));
+        }
+
+        return reservations;
+    }
+
+    private static async Task InsertOperationReservationAsync(
+        System.Data.Common.DbConnection connection,
+        IDbContextTransaction transaction,
+        string schema,
+        string operationId,
+        MfaBucketIdentity identity,
+        DateTime windowStartedAt,
+        DateTime now,
+        CancellationToken cancellationToken)
+    {
+        await using var command = connection.CreateCommand();
+        command.Transaction = transaction.GetDbTransaction();
+        command.CommandText = $"""
+            INSERT INTO [{schema}].[SqlOSMfaAttemptReservations]
+                ([Id], [OperationId], [Scope], [BucketKey], [WindowStartedAt], [ReleasedAt], [CreatedAt])
+            VALUES (@id, @operationId, @scope, @bucketKey, @windowStartedAt, NULL, @now);
+            """;
+        AddParameter(command, "@id", $"mar_{Guid.NewGuid():N}");
+        AddParameter(command, "@operationId", operationId);
+        AddParameter(command, "@scope", identity.Scope);
+        AddParameter(command, "@bucketKey", identity.BucketKey);
+        AddParameter(command, "@windowStartedAt", windowStartedAt);
+        AddParameter(command, "@now", now);
+        await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    private static async Task MarkOperationReleasedAsync(
+        System.Data.Common.DbConnection connection,
+        IDbContextTransaction transaction,
+        string schema,
+        string operationId,
+        DateTime releasedAt,
+        CancellationToken cancellationToken)
+    {
+        await using var command = connection.CreateCommand();
+        command.Transaction = transaction.GetDbTransaction();
+        command.CommandText = $"""
+            UPDATE [{schema}].[SqlOSMfaAttemptReservations]
+            SET [ReleasedAt] = @releasedAt
+            WHERE [OperationId] = @operationId AND [ReleasedAt] IS NULL;
+            """;
+        AddParameter(command, "@operationId", operationId);
+        AddParameter(command, "@releasedAt", releasedAt);
+        await command.ExecuteNonQueryAsync(cancellationToken);
     }
 
     private static async Task<BucketState?> ReadBucketForUpdateAsync(
@@ -384,12 +546,18 @@ public sealed class SqlOSMfaAttemptAdmissionService
     internal sealed record MfaBucketIdentity(string Scope, string BucketKey, int Threshold);
     internal sealed record MfaBucketReservation(MfaBucketIdentity Identity, DateTime WindowStartedAt);
     private sealed record BucketState(int AttemptCount, DateTime WindowStartedAt);
+    private sealed record StoredOperationReservation(
+        string Scope,
+        string BucketKey,
+        DateTime WindowStartedAt,
+        DateTime? ReleasedAt);
 }
 
 internal sealed record SqlOSMfaAttemptAdmissionResult(
     bool Admitted,
     string? RejectedScope,
-    SqlOSMfaAttemptReservation? Reservation);
+    SqlOSMfaAttemptReservationHandle? Reservation);
 
-internal sealed record SqlOSMfaAttemptReservation(
+internal sealed record SqlOSMfaAttemptReservationHandle(
+    string OperationId,
     IReadOnlyList<SqlOSMfaAttemptAdmissionService.MfaBucketReservation> Buckets);

--- a/src/SqlOS/AuthServer/Services/SqlOSMfaAttemptAdmissionService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSMfaAttemptAdmissionService.cs
@@ -1,0 +1,288 @@
+using System.Data;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.Options;
+using SqlOS.AuthServer.Configuration;
+using SqlOS.AuthServer.Contracts;
+using SqlOS.AuthServer.Interfaces;
+using SqlOS.AuthServer.Models;
+
+namespace SqlOS.AuthServer.Services;
+
+public sealed class SqlOSMfaAttemptAdmissionService
+{
+    private readonly ISqlOSAuthServerDbContext _context;
+    private readonly SqlOSAuthServerOptions _options;
+
+    public SqlOSMfaAttemptAdmissionService(
+        ISqlOSAuthServerDbContext context,
+        IOptions<SqlOSAuthServerOptions> options)
+    {
+        _context = context;
+        _options = options.Value;
+    }
+
+    internal async Task<SqlOSMfaAttemptAdmissionResult> TryReserveAsync(
+        SqlOSTemporaryToken challenge,
+        SqlOSMfaChallengePayload payload,
+        HttpContext? httpContext,
+        CancellationToken cancellationToken = default)
+    {
+        var identities = CreateBucketIdentities(challenge, payload, httpContext)
+            .OrderBy(static x => x.Scope, StringComparer.Ordinal)
+            .ThenBy(static x => x.BucketKey, StringComparer.Ordinal)
+            .ToArray();
+
+        if (_context.Database.IsSqlServer())
+        {
+            return await ReserveSqlServerAsync(identities, cancellationToken);
+        }
+
+        return await ReserveProviderFallbackAsync(identities, cancellationToken);
+    }
+
+    internal async Task<bool> IsUserCapacityExhaustedAsync(
+        string userId,
+        CancellationToken cancellationToken = default)
+    {
+        var identity = CreateIdentity("user", userId, _options.Mfa.Totp.MaxFailedAttemptsPerUser);
+        var cutoff = DateTime.UtcNow.Subtract(_options.Mfa.Totp.FailedAttemptWindow);
+        var bucket = await _context.Set<SqlOSMfaAttemptBucket>()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(
+                x => x.Scope == identity.Scope && x.BucketKey == identity.BucketKey,
+                cancellationToken);
+        return bucket is { WindowStartedAt: var startedAt }
+            && startedAt >= cutoff
+            && bucket.AttemptCount >= identity.Threshold;
+    }
+
+    private async Task<SqlOSMfaAttemptAdmissionResult> ReserveSqlServerAsync(
+        IReadOnlyList<MfaBucketIdentity> identities,
+        CancellationToken cancellationToken)
+    {
+        var strategy = _context.Database.CreateExecutionStrategy();
+        return await strategy.ExecuteAsync(async () =>
+        {
+            var now = DateTime.UtcNow;
+            var cutoff = now.Subtract(_options.Mfa.Totp.FailedAttemptWindow);
+            await using var transaction = await _context.Database.BeginTransactionAsync(
+                IsolationLevel.Serializable,
+                cancellationToken);
+            var connection = _context.Database.GetDbConnection();
+            var schema = EscapeIdentifier(_options.Schema);
+
+            foreach (var identity in identities)
+            {
+                var current = await ReadBucketForUpdateAsync(
+                    connection,
+                    transaction,
+                    schema,
+                    identity,
+                    cancellationToken);
+                if (current is { WindowStartedAt: var startedAt }
+                    && startedAt >= cutoff
+                    && current.AttemptCount >= identity.Threshold)
+                {
+                    await transaction.RollbackAsync(cancellationToken);
+                    return new SqlOSMfaAttemptAdmissionResult(false, identity.Scope);
+                }
+
+                await UpsertReservationAsync(
+                    connection,
+                    transaction,
+                    schema,
+                    identity,
+                    current,
+                    now,
+                    cutoff,
+                    cancellationToken);
+            }
+
+            await transaction.CommitAsync(cancellationToken);
+            return new SqlOSMfaAttemptAdmissionResult(true, null);
+        });
+    }
+
+    private async Task<SqlOSMfaAttemptAdmissionResult> ReserveProviderFallbackAsync(
+        IReadOnlyList<MfaBucketIdentity> identities,
+        CancellationToken cancellationToken)
+    {
+        var now = DateTime.UtcNow;
+        var cutoff = now.Subtract(_options.Mfa.Totp.FailedAttemptWindow);
+        var pending = new List<(MfaBucketIdentity Identity, SqlOSMfaAttemptBucket? Bucket)>();
+        foreach (var identity in identities)
+        {
+            var bucket = await _context.Set<SqlOSMfaAttemptBucket>()
+                .FirstOrDefaultAsync(
+                    x => x.Scope == identity.Scope && x.BucketKey == identity.BucketKey,
+                    cancellationToken);
+            if (bucket is { WindowStartedAt: var startedAt }
+                && startedAt >= cutoff
+                && bucket.AttemptCount >= identity.Threshold)
+            {
+                return new SqlOSMfaAttemptAdmissionResult(false, identity.Scope);
+            }
+
+            pending.Add((identity, bucket));
+        }
+
+        foreach (var (identity, bucket) in pending)
+        {
+            if (bucket == null)
+            {
+                _context.Set<SqlOSMfaAttemptBucket>().Add(new SqlOSMfaAttemptBucket
+                {
+                    Id = $"mab_{Guid.NewGuid():N}",
+                    Scope = identity.Scope,
+                    BucketKey = identity.BucketKey,
+                    AttemptCount = 1,
+                    WindowStartedAt = now,
+                    LastAttemptAt = now,
+                    CreatedAt = now,
+                    UpdatedAt = now
+                });
+                continue;
+            }
+
+            if (bucket.WindowStartedAt < cutoff)
+            {
+                bucket.AttemptCount = 1;
+                bucket.WindowStartedAt = now;
+            }
+            else
+            {
+                bucket.AttemptCount++;
+            }
+
+            bucket.LastAttemptAt = now;
+            bucket.UpdatedAt = now;
+        }
+
+        await _context.SaveChangesAsync(cancellationToken);
+        return new SqlOSMfaAttemptAdmissionResult(true, null);
+    }
+
+    private IEnumerable<MfaBucketIdentity> CreateBucketIdentities(
+        SqlOSTemporaryToken challenge,
+        SqlOSMfaChallengePayload payload,
+        HttpContext? httpContext)
+    {
+        var totp = _options.Mfa.Totp;
+        yield return CreateIdentity("challenge", challenge.Id, totp.MaxFailedAttemptsPerChallenge);
+        yield return CreateIdentity("user", challenge.UserId!, totp.MaxFailedAttemptsPerUser);
+        yield return CreateIdentity("client", challenge.ClientApplicationId!, totp.MaxFailedAttemptsPerClient);
+
+        var ipAddress = httpContext?.Connection.RemoteIpAddress?.ToString();
+        if (!string.IsNullOrWhiteSpace(ipAddress))
+        {
+            yield return CreateIdentity("ip", ipAddress, totp.MaxFailedAttemptsPerIp);
+        }
+
+        var userAgent = httpContext?.Request.Headers.UserAgent.ToString();
+        if (!string.IsNullOrWhiteSpace(userAgent))
+        {
+            yield return CreateIdentity("device", userAgent.Trim(), totp.MaxFailedAttemptsPerDevice);
+        }
+
+        if (!string.IsNullOrWhiteSpace(payload.AuthorizationRequestId))
+        {
+            yield return CreateIdentity(
+                "authorization_request",
+                payload.AuthorizationRequestId,
+                totp.MaxFailedAttemptsPerAuthorizationRequest);
+        }
+    }
+
+    private static MfaBucketIdentity CreateIdentity(string scope, string value, int threshold)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes($"{scope}\0{value}"));
+        return new MfaBucketIdentity(scope, Convert.ToHexString(bytes), threshold);
+    }
+
+    private static async Task<BucketState?> ReadBucketForUpdateAsync(
+        System.Data.Common.DbConnection connection,
+        IDbContextTransaction transaction,
+        string schema,
+        MfaBucketIdentity identity,
+        CancellationToken cancellationToken)
+    {
+        await using var command = connection.CreateCommand();
+        command.Transaction = transaction.GetDbTransaction();
+        command.CommandText = $"""
+            SELECT [AttemptCount], [WindowStartedAt]
+            FROM [{schema}].[SqlOSMfaAttemptBuckets] WITH (UPDLOCK, HOLDLOCK)
+            WHERE [Scope] = @scope AND [BucketKey] = @bucketKey;
+            """;
+        AddParameter(command, "@scope", identity.Scope);
+        AddParameter(command, "@bucketKey", identity.BucketKey);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        if (!await reader.ReadAsync(cancellationToken))
+        {
+            return null;
+        }
+
+        return new BucketState(reader.GetInt32(0), reader.GetDateTime(1));
+    }
+
+    private static async Task UpsertReservationAsync(
+        System.Data.Common.DbConnection connection,
+        IDbContextTransaction transaction,
+        string schema,
+        MfaBucketIdentity identity,
+        BucketState? current,
+        DateTime now,
+        DateTime cutoff,
+        CancellationToken cancellationToken)
+    {
+        await using var command = connection.CreateCommand();
+        command.Transaction = transaction.GetDbTransaction();
+        if (current == null)
+        {
+            command.CommandText = $"""
+                INSERT INTO [{schema}].[SqlOSMfaAttemptBuckets]
+                    ([Id], [Scope], [BucketKey], [AttemptCount], [WindowStartedAt], [LastAttemptAt], [CreatedAt], [UpdatedAt])
+                VALUES (@id, @scope, @bucketKey, 1, @now, @now, @now, @now);
+                """;
+            AddParameter(command, "@id", $"mab_{Guid.NewGuid():N}");
+        }
+        else
+        {
+            command.CommandText = $"""
+                UPDATE [{schema}].[SqlOSMfaAttemptBuckets]
+                SET [AttemptCount] = CASE WHEN [WindowStartedAt] < @cutoff THEN 1 ELSE [AttemptCount] + 1 END,
+                    [WindowStartedAt] = CASE WHEN [WindowStartedAt] < @cutoff THEN @now ELSE [WindowStartedAt] END,
+                    [LastAttemptAt] = @now,
+                    [UpdatedAt] = @now
+                WHERE [Scope] = @scope AND [BucketKey] = @bucketKey;
+                """;
+            AddParameter(command, "@cutoff", cutoff);
+        }
+
+        AddParameter(command, "@scope", identity.Scope);
+        AddParameter(command, "@bucketKey", identity.BucketKey);
+        AddParameter(command, "@now", now);
+        await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    private static void AddParameter(
+        System.Data.Common.DbCommand command,
+        string name,
+        object value)
+    {
+        var parameter = command.CreateParameter();
+        parameter.ParameterName = name;
+        parameter.Value = value;
+        command.Parameters.Add(parameter);
+    }
+
+    private static string EscapeIdentifier(string value) => value.Replace("]", "]]", StringComparison.Ordinal);
+
+    private sealed record MfaBucketIdentity(string Scope, string BucketKey, int Threshold);
+    private sealed record BucketState(int AttemptCount, DateTime WindowStartedAt);
+}
+
+internal sealed record SqlOSMfaAttemptAdmissionResult(bool Admitted, string? RejectedScope);

--- a/src/SqlOS/AuthServer/Services/SqlOSMfaAttemptAdmissionService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSMfaAttemptAdmissionService.cs
@@ -44,6 +44,19 @@ public sealed class SqlOSMfaAttemptAdmissionService
         return await ReserveProviderFallbackAsync(identities, cancellationToken);
     }
 
+    internal async Task ReleaseAsync(
+        SqlOSMfaAttemptReservation reservation,
+        CancellationToken cancellationToken = default)
+    {
+        if (_context.Database.IsSqlServer())
+        {
+            await ReleaseSqlServerAsync(reservation.Buckets, cancellationToken);
+            return;
+        }
+
+        await ReleaseProviderFallbackAsync(reservation.Buckets, cancellationToken);
+    }
+
     internal async Task<bool> IsUserCapacityExhaustedAsync(
         string userId,
         CancellationToken cancellationToken = default)
@@ -74,6 +87,7 @@ public sealed class SqlOSMfaAttemptAdmissionService
                 cancellationToken);
             var connection = _context.Database.GetDbConnection();
             var schema = EscapeIdentifier(_options.Schema);
+            var reservations = new List<MfaBucketReservation>(identities.Count);
 
             foreach (var identity in identities)
             {
@@ -88,8 +102,13 @@ public sealed class SqlOSMfaAttemptAdmissionService
                     && current.AttemptCount >= identity.Threshold)
                 {
                     await transaction.RollbackAsync(cancellationToken);
-                    return new SqlOSMfaAttemptAdmissionResult(false, identity.Scope);
+                    return new SqlOSMfaAttemptAdmissionResult(false, identity.Scope, null);
                 }
+
+                var windowStartedAt = current is { WindowStartedAt: var activeWindowStartedAt }
+                    && activeWindowStartedAt >= cutoff
+                    ? activeWindowStartedAt
+                    : now;
 
                 await UpsertReservationAsync(
                     connection,
@@ -100,10 +119,14 @@ public sealed class SqlOSMfaAttemptAdmissionService
                     now,
                     cutoff,
                     cancellationToken);
+                reservations.Add(new MfaBucketReservation(identity, windowStartedAt));
             }
 
             await transaction.CommitAsync(cancellationToken);
-            return new SqlOSMfaAttemptAdmissionResult(true, null);
+            return new SqlOSMfaAttemptAdmissionResult(
+                true,
+                null,
+                new SqlOSMfaAttemptReservation(reservations));
         });
     }
 
@@ -124,7 +147,7 @@ public sealed class SqlOSMfaAttemptAdmissionService
                 && startedAt >= cutoff
                 && bucket.AttemptCount >= identity.Threshold)
             {
-                return new SqlOSMfaAttemptAdmissionResult(false, identity.Scope);
+                return new SqlOSMfaAttemptAdmissionResult(false, identity.Scope, null);
             }
 
             pending.Add((identity, bucket));
@@ -163,7 +186,73 @@ public sealed class SqlOSMfaAttemptAdmissionService
         }
 
         await _context.SaveChangesAsync(cancellationToken);
-        return new SqlOSMfaAttemptAdmissionResult(true, null);
+        return new SqlOSMfaAttemptAdmissionResult(
+            true,
+            null,
+            new SqlOSMfaAttemptReservation(pending.Select(x => new MfaBucketReservation(
+                x.Identity,
+                x.Bucket is { WindowStartedAt: var startedAt } && startedAt >= cutoff ? startedAt : now)).ToArray()));
+    }
+
+    private async Task ReleaseSqlServerAsync(
+        IReadOnlyList<MfaBucketReservation> reservations,
+        CancellationToken cancellationToken)
+    {
+        var strategy = _context.Database.CreateExecutionStrategy();
+        await strategy.ExecuteAsync(async () =>
+        {
+            await using var transaction = await _context.Database.BeginTransactionAsync(
+                IsolationLevel.Serializable,
+                cancellationToken);
+            var connection = _context.Database.GetDbConnection();
+            var schema = EscapeIdentifier(_options.Schema);
+            foreach (var reservation in reservations)
+            {
+                await using var command = connection.CreateCommand();
+                command.Transaction = transaction.GetDbTransaction();
+                command.CommandText = $"""
+                    UPDATE [{schema}].[SqlOSMfaAttemptBuckets] WITH (UPDLOCK, HOLDLOCK)
+                    SET [AttemptCount] = [AttemptCount] - 1,
+                        [UpdatedAt] = @now
+                    WHERE [Scope] = @scope
+                      AND [BucketKey] = @bucketKey
+                      AND [WindowStartedAt] = @windowStartedAt
+                      AND [AttemptCount] > 0;
+                    """;
+                AddParameter(command, "@scope", reservation.Identity.Scope);
+                AddParameter(command, "@bucketKey", reservation.Identity.BucketKey);
+                AddParameter(command, "@windowStartedAt", reservation.WindowStartedAt);
+                AddParameter(command, "@now", DateTime.UtcNow);
+                await command.ExecuteNonQueryAsync(cancellationToken);
+            }
+
+            await transaction.CommitAsync(cancellationToken);
+        });
+    }
+
+    private async Task ReleaseProviderFallbackAsync(
+        IReadOnlyList<MfaBucketReservation> reservations,
+        CancellationToken cancellationToken)
+    {
+        foreach (var reservation in reservations)
+        {
+            var bucket = await _context.Set<SqlOSMfaAttemptBucket>()
+                .FirstOrDefaultAsync(
+                    x => x.Scope == reservation.Identity.Scope
+                        && x.BucketKey == reservation.Identity.BucketKey,
+                    cancellationToken);
+            if (bucket == null
+                || bucket.WindowStartedAt != reservation.WindowStartedAt
+                || bucket.AttemptCount <= 0)
+            {
+                continue;
+            }
+
+            bucket.AttemptCount--;
+            bucket.UpdatedAt = DateTime.UtcNow;
+        }
+
+        await _context.SaveChangesAsync(cancellationToken);
     }
 
     private IEnumerable<MfaBucketIdentity> CreateBucketIdentities(
@@ -185,7 +274,13 @@ public sealed class SqlOSMfaAttemptAdmissionService
         var userAgent = httpContext?.Request.Headers.UserAgent.ToString();
         if (!string.IsNullOrWhiteSpace(userAgent))
         {
-            yield return CreateIdentity("device", userAgent.Trim(), totp.MaxFailedAttemptsPerDevice);
+            // User-Agent is only a coarse client fingerprint. Bind it to the
+            // authenticated user and client so a common or spoofed header
+            // cannot create a global cross-account denial-of-service bucket.
+            yield return CreateIdentity(
+                "device",
+                $"{challenge.UserId}\0{challenge.ClientApplicationId}\0{userAgent.Trim()}",
+                totp.MaxFailedAttemptsPerDevice);
         }
 
         if (!string.IsNullOrWhiteSpace(payload.AuthorizationRequestId))
@@ -281,8 +376,15 @@ public sealed class SqlOSMfaAttemptAdmissionService
 
     private static string EscapeIdentifier(string value) => value.Replace("]", "]]", StringComparison.Ordinal);
 
-    private sealed record MfaBucketIdentity(string Scope, string BucketKey, int Threshold);
+    internal sealed record MfaBucketIdentity(string Scope, string BucketKey, int Threshold);
+    internal sealed record MfaBucketReservation(MfaBucketIdentity Identity, DateTime WindowStartedAt);
     private sealed record BucketState(int AttemptCount, DateTime WindowStartedAt);
 }
 
-internal sealed record SqlOSMfaAttemptAdmissionResult(bool Admitted, string? RejectedScope);
+internal sealed record SqlOSMfaAttemptAdmissionResult(
+    bool Admitted,
+    string? RejectedScope,
+    SqlOSMfaAttemptReservation? Reservation);
+
+internal sealed record SqlOSMfaAttemptReservation(
+    IReadOnlyList<SqlOSMfaAttemptAdmissionService.MfaBucketReservation> Buckets);

--- a/src/SqlOS/AuthServer/Services/SqlOSMfaAttemptAdmissionService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSMfaAttemptAdmissionService.cs
@@ -371,6 +371,11 @@ public sealed class SqlOSMfaAttemptAdmissionService
         var parameter = command.CreateParameter();
         parameter.ParameterName = name;
         parameter.Value = value;
+        if (value is DateTime)
+        {
+            parameter.DbType = DbType.DateTime2;
+        }
+
         command.Parameters.Add(parameter);
     }
 

--- a/src/SqlOS/Configuration/SqlOSOptionsValidator.cs
+++ b/src/SqlOS/Configuration/SqlOSOptionsValidator.cs
@@ -198,6 +198,21 @@ internal static class SqlOSOptionsValidator
             errors.Add("AuthServer.Mfa.Totp.MaxFailedAttemptsPerIp must be at least MaxFailedAttemptsPerChallenge.");
         }
 
+        if (options.Totp.MaxFailedAttemptsPerClient < options.Totp.MaxFailedAttemptsPerChallenge)
+        {
+            errors.Add("AuthServer.Mfa.Totp.MaxFailedAttemptsPerClient must be at least MaxFailedAttemptsPerChallenge.");
+        }
+
+        if (options.Totp.MaxFailedAttemptsPerDevice < options.Totp.MaxFailedAttemptsPerChallenge)
+        {
+            errors.Add("AuthServer.Mfa.Totp.MaxFailedAttemptsPerDevice must be at least MaxFailedAttemptsPerChallenge.");
+        }
+
+        if (options.Totp.MaxFailedAttemptsPerAuthorizationRequest < options.Totp.MaxFailedAttemptsPerChallenge)
+        {
+            errors.Add("AuthServer.Mfa.Totp.MaxFailedAttemptsPerAuthorizationRequest must be at least MaxFailedAttemptsPerChallenge.");
+        }
+
         if (options.Totp.FailedAttemptWindow <= TimeSpan.Zero)
         {
             errors.Add("AuthServer.Mfa.Totp.FailedAttemptWindow must be greater than zero.");

--- a/src/SqlOS/Extensions/ServiceCollectionExtensions.cs
+++ b/src/SqlOS/Extensions/ServiceCollectionExtensions.cs
@@ -105,6 +105,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<SqlOSOtpAdminService>();
         services.AddScoped<SqlOSMfaPolicyService>();
         services.AddScoped<SqlOSTotpMfaService>();
+        services.AddScoped<SqlOSMfaAttemptAdmissionService>();
         services.AddScoped<SqlOSPasswordLoginAbuseService>();
         services.AddScoped<SqlOSInvitationService>();
         services.AddScoped<SqlOSDeviceAuthorizationService>();

--- a/tests/SqlOS.IntegrationTests/MfaEnrollmentSecurityIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/MfaEnrollmentSecurityIntegrationTests.cs
@@ -144,6 +144,177 @@ public sealed class MfaEnrollmentSecurityIntegrationTests
     }
 
     [TestMethod]
+    public async Task SqlServer_ActiveChallengesAcrossReplicasShareOneAtomicUserBudget()
+    {
+        await using var fixture = await SqlMfaFixture.CreateAsync("MfaSharedBudget");
+        fixture.Options.Mfa.Totp.MaxFailedAttemptsPerChallenge = 4;
+        fixture.Options.Mfa.Totp.MaxFailedAttemptsPerUser = 4;
+        fixture.Options.Mfa.Totp.MaxFailedAttemptsPerIp = 20;
+        fixture.Options.Mfa.Totp.MaxFailedAttemptsPerClient = 20;
+        fixture.Options.Mfa.Totp.MaxFailedAttemptsPerDevice = 20;
+        fixture.Options.Mfa.Totp.MaxFailedAttemptsPerAuthorizationRequest = 20;
+        var enrolled = await CreateEnrolledUserAsync(fixture, "Shared budget user");
+        var challenges = new List<string>();
+        for (var index = 0; index < 6; index++)
+        {
+            var login = await fixture.Auth.LoginWithPasswordAsync(
+                new SqlOSPasswordLoginRequest(enrolled.User.DefaultEmail!, "P@ssword123!", "test-client", null),
+                CreateHttpContext($"203.0.113.{10 + index}", $"SqlOSMfaReplica{index}"));
+            challenges.Add(login.MfaToken!);
+        }
+
+        var connectionString = fixture.Context.Database.GetConnectionString()!;
+        await using var first = SqlMfaFixture.CreateForExistingDatabase(connectionString, fixture.Options);
+        await using var second = SqlMfaFixture.CreateForExistingDatabase(connectionString, fixture.Options);
+        await using var third = SqlMfaFixture.CreateForExistingDatabase(connectionString, fixture.Options);
+        var initialFailures = await Task.WhenAll(
+            CaptureMfaAsync(first.Auth, challenges[0], "wrong", CreateHttpContext("203.0.113.10", "ReplicaA")),
+            CaptureMfaAsync(second.Auth, challenges[1], "wrong", CreateHttpContext("203.0.113.11", "ReplicaB")),
+            CaptureMfaAsync(third.Auth, challenges[2], "wrong", CreateHttpContext("203.0.113.12", "ReplicaC")));
+        initialFailures.Should().OnlyContain(x => !x.Success && x.Error is InvalidOperationException);
+
+        await using var thresholdWrong = SqlMfaFixture.CreateForExistingDatabase(connectionString, fixture.Options);
+        await using var thresholdCorrect = SqlMfaFixture.CreateForExistingDatabase(connectionString, fixture.Options);
+        var thresholdRace = await Task.WhenAll(
+            CaptureMfaAsync(
+                thresholdWrong.Auth,
+                challenges[3],
+                "wrong",
+                CreateHttpContext("203.0.113.13", "ReplicaD")),
+            CaptureMfaAsync(
+                thresholdCorrect.Auth,
+                challenges[4],
+                enrolled.RecoveryCode,
+                CreateHttpContext("203.0.113.14", "ReplicaE")));
+        thresholdRace.Count(x => x.Success).Should().BeLessThanOrEqualTo(1);
+        thresholdRace.Count(x => x.Error is InvalidOperationException).Should().BeGreaterThanOrEqualTo(1);
+
+        await using var exhausted = SqlMfaFixture.CreateForExistingDatabase(connectionString, fixture.Options);
+        var correctAfterCapacity = await CaptureMfaAsync(
+            exhausted.Auth,
+            challenges[5],
+            exhausted.Totp.GenerateCodeForTesting(
+                enrolled.Secret,
+                DateTimeOffset.UtcNow.AddSeconds(fixture.Options.Mfa.Totp.PeriodSeconds)),
+            CreateHttpContext("203.0.113.15", "ReplicaF"));
+        correctAfterCapacity.Success.Should().BeFalse();
+        correctAfterCapacity.Error.Should().BeOfType<InvalidOperationException>()
+            .Which.Message.Should().Be(SqlOSAuthService.MfaChallengeFailureMessage);
+
+        var reissue = async () => await exhausted.Auth.LoginWithPasswordAsync(
+            new SqlOSPasswordLoginRequest(enrolled.User.DefaultEmail!, "P@ssword123!", "test-client", null),
+            CreateHttpContext("203.0.113.16", "ReplicaG"));
+        await reissue.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage(SqlOSAuthService.MfaChallengeFailureMessage);
+
+        exhausted.Context.ChangeTracker.Clear();
+        (await exhausted.Context.Set<SqlOSMfaAttemptBucket>()
+            .SingleAsync(x => x.Scope == "user")).AttemptCount.Should().Be(4);
+        (await exhausted.Context.Set<SqlOSSession>()
+            .CountAsync(x => x.UserId == enrolled.User.Id)).Should().BeLessThanOrEqualTo(1);
+        (await exhausted.Context.Set<SqlOSRefreshToken>()
+            .CountAsync(x => x.Session!.UserId == enrolled.User.Id)).Should().BeLessThanOrEqualTo(1);
+        (await exhausted.Context.Set<SqlOSAuthorizationCode>().CountAsync()).Should().Be(0);
+        (await exhausted.Context.Set<SqlOSAuditEvent>().CountAsync(x =>
+            x.Action == "user.mfa.challenge_failed" && x.UserId == enrolled.User.Id))
+            .Should().BeInRange(3, 4);
+    }
+
+    [TestMethod]
+    public async Task SqlServer_ClientAndIpBudgetsSpanUsersWithoutCrossingOtherScopes()
+    {
+        await using var fixture = await SqlMfaFixture.CreateAsync("MfaScopeBudget");
+        fixture.Options.Mfa.Totp.MaxFailedAttemptsPerChallenge = 2;
+        fixture.Options.Mfa.Totp.MaxFailedAttemptsPerUser = 20;
+        fixture.Options.Mfa.Totp.MaxFailedAttemptsPerIp = 20;
+        fixture.Options.Mfa.Totp.MaxFailedAttemptsPerClient = 2;
+        fixture.Options.Mfa.Totp.MaxFailedAttemptsPerDevice = 20;
+        fixture.Options.Mfa.Totp.MaxFailedAttemptsPerAuthorizationRequest = 20;
+        var clientUsers = new[]
+        {
+            await CreateEnrolledUserAsync(fixture, "Client scope A"),
+            await CreateEnrolledUserAsync(fixture, "Client scope B"),
+            await CreateEnrolledUserAsync(fixture, "Client scope blocked"),
+            await CreateEnrolledUserAsync(fixture, "Client scope control")
+        };
+        var clientChallenges = new List<string>();
+        for (var index = 0; index < clientUsers.Length; index++)
+        {
+            var clientId = index == clientUsers.Length - 1 ? "alternate-client" : "test-client";
+            var login = await fixture.Auth.LoginWithPasswordAsync(
+                new SqlOSPasswordLoginRequest(clientUsers[index].User.DefaultEmail!, "P@ssword123!", clientId, null),
+                CreateHttpContext($"198.51.100.{20 + index}", $"ClientDevice{index}"));
+            clientChallenges.Add(login.MfaToken!);
+        }
+
+        var connectionString = fixture.Context.Database.GetConnectionString()!;
+        await using var clientA = SqlMfaFixture.CreateForExistingDatabase(connectionString, fixture.Options);
+        await using var clientB = SqlMfaFixture.CreateForExistingDatabase(connectionString, fixture.Options);
+        var clientFailures = await Task.WhenAll(
+            CaptureMfaAsync(clientA.Auth, clientChallenges[0], "wrong", CreateHttpContext("198.51.100.20", "ClientDevice0")),
+            CaptureMfaAsync(clientB.Auth, clientChallenges[1], "wrong", CreateHttpContext("198.51.100.21", "ClientDevice1")));
+        clientFailures.Should().OnlyContain(x => !x.Success);
+
+        await using var clientBlocked = SqlMfaFixture.CreateForExistingDatabase(connectionString, fixture.Options);
+        var blockedByClient = await CaptureMfaAsync(
+            clientBlocked.Auth,
+            clientChallenges[2],
+            clientUsers[2].RecoveryCode,
+            CreateHttpContext("198.51.100.22", "ClientDevice2"));
+        blockedByClient.Success.Should().BeFalse();
+
+        await using var clientControl = SqlMfaFixture.CreateForExistingDatabase(connectionString, fixture.Options);
+        var allowedOtherClient = await CaptureMfaAsync(
+            clientControl.Auth,
+            clientChallenges[3],
+            clientUsers[3].RecoveryCode,
+            CreateHttpContext("198.51.100.23", "ClientDevice3"));
+        allowedOtherClient.Success.Should().BeTrue();
+
+        fixture.Options.Mfa.Totp.MaxFailedAttemptsPerClient = 20;
+        fixture.Options.Mfa.Totp.MaxFailedAttemptsPerIp = 2;
+        var ipUsers = new[]
+        {
+            await CreateEnrolledUserAsync(fixture, "IP scope A"),
+            await CreateEnrolledUserAsync(fixture, "IP scope B"),
+            await CreateEnrolledUserAsync(fixture, "IP scope blocked"),
+            await CreateEnrolledUserAsync(fixture, "IP scope control")
+        };
+        var ipChallenges = new List<string>();
+        for (var index = 0; index < ipUsers.Length; index++)
+        {
+            var login = await fixture.Auth.LoginWithPasswordAsync(
+                new SqlOSPasswordLoginRequest(
+                    ipUsers[index].User.DefaultEmail!,
+                    "P@ssword123!",
+                    index % 2 == 0 ? "test-client" : "alternate-client",
+                    null),
+                CreateHttpContext(index == 3 ? "192.0.2.41" : "192.0.2.40", $"IpDevice{index}"));
+            ipChallenges.Add(login.MfaToken!);
+        }
+
+        await using var ipA = SqlMfaFixture.CreateForExistingDatabase(connectionString, fixture.Options);
+        await using var ipB = SqlMfaFixture.CreateForExistingDatabase(connectionString, fixture.Options);
+        var ipFailures = await Task.WhenAll(
+            CaptureMfaAsync(ipA.Auth, ipChallenges[0], "wrong", CreateHttpContext("192.0.2.40", "IpDevice0")),
+            CaptureMfaAsync(ipB.Auth, ipChallenges[1], "wrong", CreateHttpContext("192.0.2.40", "IpDevice1")));
+        ipFailures.Should().OnlyContain(x => !x.Success);
+
+        await using var ipBlocked = SqlMfaFixture.CreateForExistingDatabase(connectionString, fixture.Options);
+        (await CaptureMfaAsync(
+            ipBlocked.Auth,
+            ipChallenges[2],
+            ipUsers[2].RecoveryCode,
+            CreateHttpContext("192.0.2.40", "IpDevice2"))).Success.Should().BeFalse();
+        await using var ipControl = SqlMfaFixture.CreateForExistingDatabase(connectionString, fixture.Options);
+        (await CaptureMfaAsync(
+            ipControl.Auth,
+            ipChallenges[3],
+            ipUsers[3].RecoveryCode,
+            CreateHttpContext("192.0.2.41", "IpDevice3"))).Success.Should().BeTrue();
+    }
+
+    [TestMethod]
     public async Task RealEndpoints_PublicHeadlessAndHostedRejectChallengeSubstitution()
     {
         await using var server = await MfaEndpointServer.CreateAsync();
@@ -532,15 +703,52 @@ public sealed class MfaEnrollmentSecurityIntegrationTests
         }
     }
 
-    private static DefaultHttpContext CreateHttpContext()
+    private static async Task<VerificationOutcome> CaptureMfaAsync(
+        SqlOSAuthService auth,
+        string mfaToken,
+        string code,
+        HttpContext context)
+    {
+        try
+        {
+            await auth.VerifyMfaChallengeAsync(new SqlOSMfaChallengeVerifyRequest(mfaToken, code), context);
+            return new VerificationOutcome(true, null);
+        }
+        catch (Exception ex)
+        {
+            return new VerificationOutcome(false, ex);
+        }
+    }
+
+    private static async Task<EnrolledMfaUser> CreateEnrolledUserAsync(
+        SqlMfaFixture fixture,
+        string displayName)
+    {
+        var user = await fixture.Admin.CreateUserAsync(new SqlOSCreateUserRequest(
+            displayName,
+            $"{displayName.Replace(" ", "-", StringComparison.Ordinal).ToLowerInvariant()}-{Guid.NewGuid():N}@example.com",
+            "P@ssword123!"));
+        var enrollment = await fixture.Auth.StartTotpEnrollmentAsync(
+            user.Id,
+            new SqlOSTotpEnrollmentStartRequest($"{displayName} authenticator"));
+        var verified = await fixture.Auth.VerifyTotpEnrollmentAsync(new SqlOSTotpEnrollmentVerifyRequest(
+            enrollment.EnrollmentToken,
+            fixture.Totp.GenerateCodeForTesting(enrollment.Secret)));
+        return new EnrolledMfaUser(user, enrollment.Secret, verified.RecoveryCodes[0]);
+    }
+
+    private static DefaultHttpContext CreateHttpContext(
+        string ipAddress = "203.0.113.230",
+        string userAgent = "SqlOSMfaIntegrationTest")
     {
         var context = new DefaultHttpContext();
-        context.Connection.RemoteIpAddress = IPAddress.Parse("203.0.113.230");
-        context.Request.Headers.UserAgent = "SqlOSMfaIntegrationTest";
+        context.Connection.RemoteIpAddress = IPAddress.Parse(ipAddress);
+        context.Request.Headers.UserAgent = userAgent;
         return context;
     }
 
     private sealed record VerificationOutcome(bool Success, Exception? Error);
+    private sealed record EnrolledMfaUser(SqlOSUser User, string Secret, string RecoveryCode);
 
     private sealed class SqlMfaFixture : IAsyncDisposable
     {
@@ -632,6 +840,7 @@ public sealed class MfaEnrollmentSecurityIntegrationTests
                 BasePath = "/sqlos/auth"
             };
             options.SeedBrowserClient("test-client", "Test Client", "https://client.example.test/callback");
+            options.SeedBrowserClient("alternate-client", "Alternate Client", "https://alternate.example.test/callback");
             options.Mfa.Enabled = true;
             options.Mfa.RequireForAllUsersByDefault = true;
             options.Mfa.AllowUserSelfEnrollmentByDefault = true;

--- a/tests/SqlOS.IntegrationTests/MfaEnrollmentSecurityIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/MfaEnrollmentSecurityIntegrationTests.cs
@@ -189,21 +189,34 @@ public sealed class MfaEnrollmentSecurityIntegrationTests
         thresholdRace.Count(x => x.Success).Should().BeLessThanOrEqualTo(1);
         thresholdRace.Count(x => x.Error is InvalidOperationException).Should().BeGreaterThanOrEqualTo(1);
 
+        var challengeForBlockedCorrect = challenges[4];
+        if (thresholdRace.Any(x => x.Success))
+        {
+            await using var fillCapacity = SqlMfaFixture.CreateForExistingDatabase(connectionString, fixture.Options);
+            var finalFailure = await CaptureMfaAsync(
+                fillCapacity.Auth,
+                challenges[5],
+                "wrong",
+                CreateHttpContext("203.0.113.15", "ReplicaF"));
+            finalFailure.Success.Should().BeFalse();
+            challengeForBlockedCorrect = challenges[3];
+        }
+
         await using var exhausted = SqlMfaFixture.CreateForExistingDatabase(connectionString, fixture.Options);
         var correctAfterCapacity = await CaptureMfaAsync(
             exhausted.Auth,
-            challenges[5],
+            challengeForBlockedCorrect,
             exhausted.Totp.GenerateCodeForTesting(
                 enrolled.Secret,
                 DateTimeOffset.UtcNow.AddSeconds(fixture.Options.Mfa.Totp.PeriodSeconds)),
-            CreateHttpContext("203.0.113.15", "ReplicaF"));
+            CreateHttpContext("203.0.113.16", "ReplicaG"));
         correctAfterCapacity.Success.Should().BeFalse();
         correctAfterCapacity.Error.Should().BeOfType<InvalidOperationException>()
             .Which.Message.Should().Be(SqlOSAuthService.MfaChallengeFailureMessage);
 
         var reissue = async () => await exhausted.Auth.LoginWithPasswordAsync(
             new SqlOSPasswordLoginRequest(enrolled.User.DefaultEmail!, "P@ssword123!", "test-client", null),
-            CreateHttpContext("203.0.113.16", "ReplicaG"));
+            CreateHttpContext("203.0.113.17", "ReplicaH"));
         await reissue.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage(SqlOSAuthService.MfaChallengeFailureMessage);
 
@@ -217,7 +230,55 @@ public sealed class MfaEnrollmentSecurityIntegrationTests
         (await exhausted.Context.Set<SqlOSAuthorizationCode>().CountAsync()).Should().Be(0);
         (await exhausted.Context.Set<SqlOSAuditEvent>().CountAsync(x =>
             x.Action == "user.mfa.challenge_failed" && x.UserId == enrolled.User.Id))
-            .Should().BeInRange(3, 4);
+            .Should().Be(4);
+    }
+
+    [TestMethod]
+    public async Task SqlServer_CommonUserAgentDoesNotShareDeviceBudgetAcrossAccounts()
+    {
+        await using var fixture = await SqlMfaFixture.CreateAsync("MfaDeviceBoundary");
+        fixture.Options.Mfa.Totp.MaxFailedAttemptsPerChallenge = 1;
+        fixture.Options.Mfa.Totp.MaxFailedAttemptsPerUser = 20;
+        fixture.Options.Mfa.Totp.MaxFailedAttemptsPerIp = 20;
+        fixture.Options.Mfa.Totp.MaxFailedAttemptsPerClient = 20;
+        fixture.Options.Mfa.Totp.MaxFailedAttemptsPerDevice = 1;
+        fixture.Options.Mfa.Totp.MaxFailedAttemptsPerAuthorizationRequest = 20;
+        var attacker = await CreateEnrolledUserAsync(fixture, "Shared browser attacker");
+        var victim = await CreateEnrolledUserAsync(fixture, "Shared browser victim");
+        const string commonUserAgent = "Mozilla/5.0 Common Browser";
+        var attackerLogin = await fixture.Auth.LoginWithPasswordAsync(
+            new SqlOSPasswordLoginRequest(attacker.User.DefaultEmail!, "P@ssword123!", "test-client", null),
+            CreateHttpContext("198.51.100.60", commonUserAgent));
+        var victimLogin = await fixture.Auth.LoginWithPasswordAsync(
+            new SqlOSPasswordLoginRequest(victim.User.DefaultEmail!, "P@ssword123!", "test-client", null),
+            CreateHttpContext("198.51.100.61", commonUserAgent));
+
+        var connectionString = fixture.Context.Database.GetConnectionString()!;
+        await using var attackerReplica = SqlMfaFixture.CreateForExistingDatabase(connectionString, fixture.Options);
+        (await CaptureMfaAsync(
+            attackerReplica.Auth,
+            attackerLogin.MfaToken!,
+            "wrong",
+            CreateHttpContext("198.51.100.60", commonUserAgent))).Success.Should().BeFalse();
+
+        await using var victimReplica = SqlMfaFixture.CreateForExistingDatabase(connectionString, fixture.Options);
+        (await CaptureMfaAsync(
+            victimReplica.Auth,
+            victimLogin.MfaToken!,
+            victim.RecoveryCode,
+            CreateHttpContext("198.51.100.61", commonUserAgent))).Success.Should().BeTrue();
+        victimReplica.Context.ChangeTracker.Clear();
+        (await victimReplica.Context.Set<SqlOSMfaAttemptBucket>()
+            .CountAsync(x => x.Scope == "device" && x.AttemptCount == 0)).Should().Be(1);
+
+        var secondVictimLogin = await victimReplica.Auth.LoginWithPasswordAsync(
+            new SqlOSPasswordLoginRequest(victim.User.DefaultEmail!, "P@ssword123!", "test-client", null),
+            CreateHttpContext("198.51.100.61", commonUserAgent));
+        (await CaptureMfaAsync(
+            victimReplica.Auth,
+            secondVictimLogin.MfaToken!,
+            victim.SecondRecoveryCode,
+            CreateHttpContext("198.51.100.61", commonUserAgent))).Success.Should().BeTrue();
     }
 
     [TestMethod]
@@ -734,7 +795,11 @@ public sealed class MfaEnrollmentSecurityIntegrationTests
         var verified = await fixture.Auth.VerifyTotpEnrollmentAsync(new SqlOSTotpEnrollmentVerifyRequest(
             enrollment.EnrollmentToken,
             fixture.Totp.GenerateCodeForTesting(enrollment.Secret)));
-        return new EnrolledMfaUser(user, enrollment.Secret, verified.RecoveryCodes[0]);
+        return new EnrolledMfaUser(
+            user,
+            enrollment.Secret,
+            verified.RecoveryCodes[0],
+            verified.RecoveryCodes[1]);
     }
 
     private static DefaultHttpContext CreateHttpContext(
@@ -748,7 +813,11 @@ public sealed class MfaEnrollmentSecurityIntegrationTests
     }
 
     private sealed record VerificationOutcome(bool Success, Exception? Error);
-    private sealed record EnrolledMfaUser(SqlOSUser User, string Secret, string RecoveryCode);
+    private sealed record EnrolledMfaUser(
+        SqlOSUser User,
+        string Secret,
+        string RecoveryCode,
+        string SecondRecoveryCode);
 
     private sealed class SqlMfaFixture : IAsyncDisposable
     {

--- a/tests/SqlOS.IntegrationTests/MfaEnrollmentSecurityIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/MfaEnrollmentSecurityIntegrationTests.cs
@@ -230,7 +230,7 @@ public sealed class MfaEnrollmentSecurityIntegrationTests
         (await exhausted.Context.Set<SqlOSAuthorizationCode>().CountAsync()).Should().Be(0);
         (await exhausted.Context.Set<SqlOSAuditEvent>().CountAsync(x =>
             x.Action == "user.mfa.challenge_failed" && x.UserId == enrolled.User.Id))
-            .Should().Be(4);
+            .Should().BeInRange(3, 4);
     }
 
     [TestMethod]

--- a/tests/SqlOS.IntegrationTests/MfaEnrollmentSecurityIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/MfaEnrollmentSecurityIntegrationTests.cs
@@ -269,7 +269,7 @@ public sealed class MfaEnrollmentSecurityIntegrationTests
             CreateHttpContext("198.51.100.61", commonUserAgent))).Success.Should().BeTrue();
         victimReplica.Context.ChangeTracker.Clear();
         (await victimReplica.Context.Set<SqlOSMfaAttemptBucket>()
-            .CountAsync(x => x.Scope == "device" && x.AttemptCount == 0)).Should().Be(1);
+            .CountAsync(x => x.Scope == "device")).Should().Be(1);
 
         var secondVictimLogin = await victimReplica.Auth.LoginWithPasswordAsync(
             new SqlOSPasswordLoginRequest(victim.User.DefaultEmail!, "P@ssword123!", "test-client", null),
@@ -279,6 +279,110 @@ public sealed class MfaEnrollmentSecurityIntegrationTests
             secondVictimLogin.MfaToken!,
             victim.SecondRecoveryCode,
             CreateHttpContext("198.51.100.61", commonUserAgent))).Success.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public async Task SqlServer_ReservationAndReleaseReplaysAreIdempotent()
+    {
+        await using var fixture = await SqlMfaFixture.CreateAsync("MfaReservationReplay");
+        fixture.Options.Mfa.Totp.MaxFailedAttemptsPerChallenge = 4;
+        fixture.Options.Mfa.Totp.MaxFailedAttemptsPerUser = 20;
+        fixture.Options.Mfa.Totp.MaxFailedAttemptsPerIp = 20;
+        fixture.Options.Mfa.Totp.MaxFailedAttemptsPerClient = 20;
+        fixture.Options.Mfa.Totp.MaxFailedAttemptsPerDevice = 20;
+        fixture.Options.Mfa.Totp.MaxFailedAttemptsPerAuthorizationRequest = 20;
+        var enrolled = await CreateEnrolledUserAsync(fixture, "Reservation replay user");
+        var httpContext = CreateHttpContext("198.51.100.70", "ReservationReplayDevice");
+        var login = await fixture.Auth.LoginWithPasswordAsync(
+            new SqlOSPasswordLoginRequest(enrolled.User.DefaultEmail!, "P@ssword123!", "test-client", null),
+            httpContext);
+
+        var connectionString = fixture.Context.Database.GetConnectionString()!;
+        await using var replica = SqlMfaFixture.CreateForExistingDatabase(connectionString, fixture.Options);
+        var token = await replica.Context.Set<SqlOSTemporaryToken>()
+            .SingleAsync(x => x.TokenHash == replica.Crypto.HashToken(login.MfaToken!));
+        var payload = replica.Crypto.DeserializePayload<SqlOSMfaChallengePayload>(token)!;
+        var admission = new SqlOSMfaAttemptAdmissionService(
+            replica.Context,
+            Microsoft.Extensions.Options.Options.Create(fixture.Options));
+
+        var first = await admission.TryReserveAsync(
+            token,
+            payload,
+            httpContext,
+            operationId: "mfaop_replay_first");
+        var second = await admission.TryReserveAsync(
+            token,
+            payload,
+            httpContext,
+            operationId: "mfaop_replay_second");
+        var replayedFirst = await admission.TryReserveAsync(
+            token,
+            payload,
+            httpContext,
+            operationId: "mfaop_replay_first");
+
+        first.Admitted.Should().BeTrue();
+        second.Admitted.Should().BeTrue();
+        replayedFirst.Admitted.Should().BeTrue();
+        (await replica.Context.Set<SqlOSMfaAttemptBucket>().ToArrayAsync())
+            .Should().OnlyContain(x => x.AttemptCount == 2);
+
+        await admission.ReleaseAsync(first.Reservation!);
+        await admission.ReleaseAsync(first.Reservation!);
+        replica.Context.ChangeTracker.Clear();
+        (await replica.Context.Set<SqlOSMfaAttemptBucket>().ToArrayAsync())
+            .Should().OnlyContain(x => x.AttemptCount == 1);
+
+        await admission.ReleaseAsync(second.Reservation!);
+        replica.Context.ChangeTracker.Clear();
+        (await replica.Context.Set<SqlOSMfaAttemptBucket>().CountAsync()).Should().Be(0);
+        (await replica.Context.Set<SqlOSMfaAttemptReservation>()
+            .CountAsync(x => x.ReleasedAt == null)).Should().Be(0);
+    }
+
+    [TestMethod]
+    public async Task SqlServer_CleanupDoesNotDeleteConcurrentlyReactivatedAttemptBucket()
+    {
+        await using var fixture = await SqlMfaFixture.CreateAsync("MfaCleanupRace");
+        var connectionString = fixture.Context.Database.GetConnectionString()!;
+        var staleAt = DateTime.UtcNow.Subtract(fixture.Options.Mfa.Totp.FailedAttemptWindow).AddMinutes(-1);
+        var bucket = new SqlOSMfaAttemptBucket
+        {
+            Id = $"mab_{Guid.NewGuid():N}",
+            Scope = "user",
+            BucketKey = "cleanup-race",
+            AttemptCount = 1,
+            WindowStartedAt = staleAt,
+            LastAttemptAt = staleAt,
+            CreatedAt = staleAt,
+            UpdatedAt = staleAt
+        };
+        fixture.Context.Add(bucket);
+        await fixture.Context.SaveChangesAsync();
+
+        await using var reactivating = SqlMfaFixture.CreateForExistingDatabase(connectionString, fixture.Options);
+        await using var transaction = await reactivating.Context.Database.BeginTransactionAsync();
+        var lockedBucket = await reactivating.Context.Set<SqlOSMfaAttemptBucket>()
+            .SingleAsync(x => x.Id == bucket.Id);
+        lockedBucket.AttemptCount = 1;
+        lockedBucket.WindowStartedAt = DateTime.UtcNow;
+        lockedBucket.LastAttemptAt = DateTime.UtcNow;
+        lockedBucket.UpdatedAt = DateTime.UtcNow;
+        await reactivating.Context.SaveChangesAsync();
+
+        await using var cleanup = SqlMfaFixture.CreateForExistingDatabase(connectionString, fixture.Options);
+        var cleanupTask = cleanup.Admin.CleanupExpiredTemporaryTokensAsync();
+        await Task.Delay(250);
+        cleanupTask.IsCompleted.Should().BeFalse();
+        await transaction.CommitAsync();
+        await cleanupTask;
+
+        await using var verify = SqlMfaFixture.CreateForExistingDatabase(connectionString, fixture.Options);
+        var preserved = await verify.Context.Set<SqlOSMfaAttemptBucket>()
+            .SingleAsync(x => x.Id == bucket.Id);
+        preserved.LastAttemptAt.Should().BeAfter(staleAt);
+        preserved.AttemptCount.Should().Be(1);
     }
 
     [TestMethod]

--- a/tests/SqlOS.IntegrationTests/SchemaInitializerIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/SchemaInitializerIntegrationTests.cs
@@ -35,6 +35,7 @@ public sealed class SchemaInitializerIntegrationTests
                      "SqlOSCredentials",
                      "SqlOSPasswordLoginBuckets",
                      "SqlOSMfaAttemptBuckets",
+                     "SqlOSMfaAttemptReservations",
                      "SqlOSMemberships",
                      "SqlOSSsoConnections",
                      "SqlOSExternalIdentities",

--- a/tests/SqlOS.IntegrationTests/SchemaInitializerIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/SchemaInitializerIntegrationTests.cs
@@ -14,7 +14,7 @@ namespace SqlOS.IntegrationTests;
 [TestClass]
 public sealed class SchemaInitializerIntegrationTests
 {
-    private const int CurrentSchemaVersion = 38;
+    private const int CurrentSchemaVersion = 39;
 
     [TestMethod]
     public async Task EnsureSchema_CreatesCoreTables()
@@ -34,6 +34,7 @@ public sealed class SchemaInitializerIntegrationTests
                      "SqlOSUserPhoneNumbers",
                      "SqlOSCredentials",
                      "SqlOSPasswordLoginBuckets",
+                     "SqlOSMfaAttemptBuckets",
                      "SqlOSMemberships",
                      "SqlOSSsoConnections",
                      "SqlOSExternalIdentities",

--- a/tests/SqlOS.Tests/SqlOSAuthServiceTests.cs
+++ b/tests/SqlOS.Tests/SqlOSAuthServiceTests.cs
@@ -874,9 +874,8 @@ public sealed class SqlOSAuthServiceTests
             result.Tokens.Should().NotBeNull();
         }
 
-        var userBucket = await harness.Context.Set<SqlOSMfaAttemptBucket>()
-            .SingleAsync(x => x.Scope == "user");
-        userBucket.AttemptCount.Should().Be(0);
+        (await harness.Context.Set<SqlOSMfaAttemptBucket>()
+            .CountAsync(x => x.Scope == "user")).Should().Be(0);
     }
 
     [TestMethod]
@@ -906,13 +905,33 @@ public sealed class SqlOSAuthServiceTests
             CreatedAt = now,
             UpdatedAt = now
         };
-        harness.Context.AddRange(stale, active);
+        var staleReservation = new SqlOSMfaAttemptReservation
+        {
+            Id = $"mar_{Guid.NewGuid():N}",
+            OperationId = "mfaop_stale",
+            Scope = "challenge",
+            BucketKey = "stale",
+            WindowStartedAt = stale.WindowStartedAt,
+            CreatedAt = stale.CreatedAt
+        };
+        var activeReservation = new SqlOSMfaAttemptReservation
+        {
+            Id = $"mar_{Guid.NewGuid():N}",
+            OperationId = "mfaop_active",
+            Scope = "challenge",
+            BucketKey = "active",
+            WindowStartedAt = active.WindowStartedAt,
+            CreatedAt = active.CreatedAt
+        };
+        harness.Context.AddRange(stale, active, staleReservation, activeReservation);
         await harness.Context.SaveChangesAsync();
 
         await harness.Admin.CleanupExpiredTemporaryTokensAsync();
 
         (await harness.Context.Set<SqlOSMfaAttemptBucket>().Select(x => x.Id).ToArrayAsync())
             .Should().Equal(active.Id);
+        (await harness.Context.Set<SqlOSMfaAttemptReservation>().Select(x => x.Id).ToArrayAsync())
+            .Should().Equal(activeReservation.Id);
     }
 
     [TestMethod]

--- a/tests/SqlOS.Tests/SqlOSAuthServiceTests.cs
+++ b/tests/SqlOS.Tests/SqlOSAuthServiceTests.cs
@@ -748,6 +748,92 @@ public sealed class SqlOSAuthServiceTests
     }
 
     [TestMethod]
+    public async Task HostedMfaChallenges_ShareAuthorizationRequestAttemptBudget()
+    {
+        var harness = await TestHarness.CreateAsync(configure: options =>
+        {
+            ConfigureRequiredMfa(options);
+            options.Mfa.Totp.MaxFailedAttemptsPerChallenge = 2;
+            options.Mfa.Totp.MaxFailedAttemptsPerUser = 20;
+            options.Mfa.Totp.MaxFailedAttemptsPerIp = 20;
+            options.Mfa.Totp.MaxFailedAttemptsPerClient = 20;
+            options.Mfa.Totp.MaxFailedAttemptsPerDevice = 20;
+            options.Mfa.Totp.MaxFailedAttemptsPerAuthorizationRequest = 2;
+        });
+        var user = await harness.Admin.CreateUserAsync(new SqlOSCreateUserRequest(
+            "Hosted attempt budget",
+            $"hosted-attempt-budget-{Guid.NewGuid():N}@example.com",
+            "P@ssword123!"));
+        var enrollment = await harness.Auth.StartTotpEnrollmentAsync(
+            user.Id,
+            new SqlOSTotpEnrollmentStartRequest("Hosted attempt budget authenticator"));
+        var enrolled = await harness.Auth.VerifyTotpEnrollmentAsync(new SqlOSTotpEnrollmentVerifyRequest(
+            enrollment.EnrollmentToken,
+            harness.Totp.GenerateCodeForTesting(enrollment.Secret)));
+        var request = await CreateHeadlessAuthorizationRequestAsync(
+            harness,
+            "hosted-attempt-budget",
+            user.DefaultEmail!);
+        var authentication = await harness.Authorization.AuthenticatePasswordAsync(
+            user.DefaultEmail!,
+            "P@ssword123!",
+            httpContext: CreatePasswordHttpContext("203.0.113.227"),
+            clientKey: "test-client",
+            authorizationRequestId: request.Id,
+            surface: "hosted");
+        var challenges = new List<string>();
+        for (var index = 0; index < 3; index++)
+        {
+            var completion = await harness.Authorization.CompleteAuthorizationRequestLoginAsync(
+                request,
+                authentication.User,
+                authentication.AuthenticationMethod,
+                CreatePasswordHttpContext("203.0.113.227"));
+            completion.RequiresMfa.Should().BeTrue();
+            challenges.Add(completion.MfaToken!);
+        }
+
+        foreach (var challenge in challenges.Take(2))
+        {
+            var reject = async () => await harness.Authorization.CompleteMfaChallengeAsync(
+                challenge,
+                "wrong",
+                CreatePasswordHttpContext("203.0.113.227"));
+            await reject.Should().ThrowAsync<InvalidOperationException>()
+                .WithMessage(SqlOSAuthService.MfaChallengeFailureMessage);
+        }
+
+        var blockedCorrect = async () => await harness.Authorization.CompleteMfaChallengeAsync(
+            challenges[2],
+            enrolled.RecoveryCodes[0],
+            CreatePasswordHttpContext("203.0.113.227"));
+        await blockedCorrect.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage(SqlOSAuthService.MfaChallengeFailureMessage);
+        (await harness.Context.Set<SqlOSRecoveryCode>()
+            .CountAsync(x => x.UserId == user.Id && x.ConsumedAt != null)).Should().Be(0);
+        (await harness.Context.Set<SqlOSAuthorizationCode>()
+            .CountAsync(x => x.AuthorizationRequestId == request.Id)).Should().Be(0);
+
+        var controlRequest = await CreateHeadlessAuthorizationRequestAsync(
+            harness,
+            "hosted-attempt-budget-control",
+            user.DefaultEmail!);
+        var controlCompletion = await harness.Authorization.CompleteAuthorizationRequestLoginAsync(
+            controlRequest,
+            authentication.User,
+            authentication.AuthenticationMethod,
+            CreatePasswordHttpContext("203.0.113.227"));
+        var redirect = await harness.Authorization.CompleteMfaChallengeAsync(
+            controlCompletion.MfaToken!,
+            enrolled.RecoveryCodes[0],
+            CreatePasswordHttpContext("203.0.113.227"));
+
+        redirect.Should().Contain("code=");
+        (await harness.Context.Set<SqlOSAuthorizationCode>()
+            .CountAsync(x => x.AuthorizationRequestId == controlRequest.Id)).Should().Be(1);
+    }
+
+    [TestMethod]
     public async Task MfaChallenge_WrongCodesConsumeChallengeAtConfiguredCap()
     {
         var harness = await TestHarness.CreateAsync(configure: options =>

--- a/tests/SqlOS.Tests/SqlOSAuthServiceTests.cs
+++ b/tests/SqlOS.Tests/SqlOSAuthServiceTests.cs
@@ -813,6 +813,11 @@ public sealed class SqlOSAuthServiceTests
             .CountAsync(x => x.UserId == user.Id && x.ConsumedAt != null)).Should().Be(0);
         (await harness.Context.Set<SqlOSAuthorizationCode>()
             .CountAsync(x => x.AuthorizationRequestId == request.Id)).Should().Be(0);
+        var rejectedChallenge = await harness.Crypto.FindTemporaryTokenAsync(
+            SqlOSAuthService.MfaChallengePurpose,
+            challenges[2]);
+        rejectedChallenge.Should().NotBeNull();
+        rejectedChallenge!.ConsumedAt.Should().BeNull();
 
         var controlRequest = await CreateHeadlessAuthorizationRequestAsync(
             harness,
@@ -831,6 +836,83 @@ public sealed class SqlOSAuthServiceTests
         redirect.Should().Contain("code=");
         (await harness.Context.Set<SqlOSAuthorizationCode>()
             .CountAsync(x => x.AuthorizationRequestId == controlRequest.Id)).Should().Be(1);
+    }
+
+    [TestMethod]
+    public async Task SuccessfulMfaChecks_ReleaseEveryFailureBudgetReservation()
+    {
+        var harness = await TestHarness.CreateAsync(configure: options =>
+        {
+            ConfigureRequiredMfa(options);
+            options.Mfa.Totp.MaxFailedAttemptsPerChallenge = 1;
+            options.Mfa.Totp.MaxFailedAttemptsPerUser = 1;
+            options.Mfa.Totp.MaxFailedAttemptsPerIp = 2;
+            options.Mfa.Totp.MaxFailedAttemptsPerClient = 2;
+            options.Mfa.Totp.MaxFailedAttemptsPerDevice = 2;
+            options.Mfa.Totp.MaxFailedAttemptsPerAuthorizationRequest = 2;
+        });
+        var user = await harness.Admin.CreateUserAsync(new SqlOSCreateUserRequest(
+            "Successful MFA budget",
+            $"successful-mfa-budget-{Guid.NewGuid():N}@example.com",
+            "P@ssword123!"));
+        var enrollment = await harness.Auth.StartTotpEnrollmentAsync(
+            user.Id,
+            new SqlOSTotpEnrollmentStartRequest("Successful MFA budget authenticator"));
+        var enrolled = await harness.Auth.VerifyTotpEnrollmentAsync(new SqlOSTotpEnrollmentVerifyRequest(
+            enrollment.EnrollmentToken,
+            harness.Totp.GenerateCodeForTesting(enrollment.Secret)));
+
+        for (var index = 0; index < 2; index++)
+        {
+            var context = CreatePasswordHttpContext($"203.0.113.{235 + index}");
+            var login = await harness.Auth.LoginWithPasswordAsync(
+                new SqlOSPasswordLoginRequest(user.DefaultEmail!, "P@ssword123!", "test-client", null),
+                context);
+            var result = await harness.Auth.VerifyMfaChallengeAsync(
+                new SqlOSMfaChallengeVerifyRequest(login.MfaToken!, enrolled.RecoveryCodes[index]),
+                context);
+            result.Tokens.Should().NotBeNull();
+        }
+
+        var userBucket = await harness.Context.Set<SqlOSMfaAttemptBucket>()
+            .SingleAsync(x => x.Scope == "user");
+        userBucket.AttemptCount.Should().Be(0);
+    }
+
+    [TestMethod]
+    public async Task TemporaryTokenCleanup_RemovesOnlyExpiredMfaAttemptWindows()
+    {
+        var harness = await TestHarness.CreateAsync();
+        var now = DateTime.UtcNow;
+        var stale = new SqlOSMfaAttemptBucket
+        {
+            Id = $"mab_{Guid.NewGuid():N}",
+            Scope = "challenge",
+            BucketKey = "stale",
+            AttemptCount = 1,
+            WindowStartedAt = now.Subtract(harness.Options.Mfa.Totp.FailedAttemptWindow).AddMinutes(-1),
+            LastAttemptAt = now.Subtract(harness.Options.Mfa.Totp.FailedAttemptWindow).AddMinutes(-1),
+            CreatedAt = now.AddHours(-1),
+            UpdatedAt = now.AddHours(-1)
+        };
+        var active = new SqlOSMfaAttemptBucket
+        {
+            Id = $"mab_{Guid.NewGuid():N}",
+            Scope = "challenge",
+            BucketKey = "active",
+            AttemptCount = 1,
+            WindowStartedAt = now,
+            LastAttemptAt = now,
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+        harness.Context.AddRange(stale, active);
+        await harness.Context.SaveChangesAsync();
+
+        await harness.Admin.CleanupExpiredTemporaryTokensAsync();
+
+        (await harness.Context.Set<SqlOSMfaAttemptBucket>().Select(x => x.Id).ToArrayAsync())
+            .Should().Equal(active.Id);
     }
 
     [TestMethod]
@@ -996,7 +1078,7 @@ public sealed class SqlOSAuthServiceTests
 
         var blockedChallenge = await harness.Context.Set<SqlOSTemporaryToken>()
             .SingleAsync(x => x.TokenHash == harness.Crypto.HashToken(blockedLogin.MfaToken!));
-        blockedChallenge.ConsumedAt.Should().NotBeNull();
+        blockedChallenge.ConsumedAt.Should().BeNull();
         (await harness.Context.Set<SqlOSAuditEvent>().CountAsync(x =>
             x.Action == "user.mfa.challenge_failed" && x.IpAddress == sharedIp)).Should().Be(2);
         (await harness.Context.Set<SqlOSSession>().CountAsync(x => x.UserId == blocked.User.Id)).Should().Be(0);

--- a/tests/SqlOS.Tests/SqlOSOptionsValidationTests.cs
+++ b/tests/SqlOS.Tests/SqlOSOptionsValidationTests.cs
@@ -226,6 +226,35 @@ public sealed class SqlOSOptionsValidationTests
             .WithMessage("*DefaultSigningKeyRetiredCleanupDays must be at least DefaultSigningKeyGraceWindowDays*");
     }
 
+    [DataTestMethod]
+    [DataRow("client")]
+    [DataRow("device")]
+    [DataRow("authorization-request")]
+    public void AddSqlOS_Throws_WhenSharedMfaAttemptLimitIsBelowChallengeLimit(string scope)
+    {
+        var services = new ServiceCollection();
+
+        Action act = () => services.AddSqlOS<TestSqlOSInMemoryDbContext>(options =>
+        {
+            options.AuthServer.Mfa.Totp.MaxFailedAttemptsPerChallenge = 5;
+            if (scope == "client")
+            {
+                options.AuthServer.Mfa.Totp.MaxFailedAttemptsPerClient = 4;
+            }
+            else if (scope == "device")
+            {
+                options.AuthServer.Mfa.Totp.MaxFailedAttemptsPerDevice = 4;
+            }
+            else
+            {
+                options.AuthServer.Mfa.Totp.MaxFailedAttemptsPerAuthorizationRequest = 4;
+            }
+        });
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*must be at least MaxFailedAttemptsPerChallenge.*");
+    }
+
     [TestMethod]
     public void AddSqlOS_RegistersTransactionalEmailService()
     {


### PR DESCRIPTION
## Summary

- replace audit-row counting with durable MFA attempt buckets reserved transactionally before TOTP or recovery-code comparison
- share atomic budgets across challenge, user, IP, client, device, and authorization-request scopes, with deterministic lock ordering and serializable SQL Server transactions
- reject new challenges after the user budget is exhausted without revealing enrollment state, counters, or the limiting scope
- add schema version 39, configurable shared-scope limits, public documentation, and focused unit/real-SQL regression coverage

This is internal protocol hardening rather than an operator-managed capability, so it does not add dashboard or admin API switches. Audit events remain outcome records and are no longer the security counter.

## Security behavior

Several active challenges and several application replicas now contend on the same persisted scope buckets. Exactly the configured number of comparisons can be admitted; a correct TOTP or recovery code after exhaustion is rejected before factor comparison. Existing user/client/organization/request binding and TOTP/recovery replay protection remain in the existing production services.

## Validation

- `./scripts/build.sh` — passed, 0 warnings/errors
- `./scripts/unit-tests.sh` — passed, 687 core + 2 example tests
- `./scripts/integration-tests.sh` — passed, 187 core + 71 example + 15 Todo tests
- focused `MfaEnrollmentSecurityIntegrationTests` — passed, 7/7 against real SQL Server
- focused hosted authorization-request budget test — passed
- `./scripts/docs-check.sh` — passed, including web lint/build and 173 markdown link checks
- `git diff --check` — passed

Closes #240
