### PR TITLE
Simplify atomic password-login admission across replicas

### DIFF
--- a/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerModelConfiguration.cs
+++ b/src/SqlOS/AuthServer/Configuration/SqlOSAuthServerModelConfiguration.cs
@@ -78,7 +78,6 @@ public static class SqlOSAuthServerModelConfiguration
             entity.HasIndex(x => new { x.NormalizedEmail, x.UpdatedAt });
             entity.HasIndex(x => new { x.UserId, x.UpdatedAt });
             entity.HasIndex(x => new { x.IpAddress, x.UpdatedAt });
-            entity.HasIndex(x => new { x.ClientKey, x.UpdatedAt });
             entity.HasIndex(x => x.LockedUntil);
             entity.Property(x => x.Scope).HasMaxLength(40);
             entity.Property(x => x.BucketKey).HasMaxLength(512);
@@ -92,6 +91,27 @@ public static class SqlOSAuthServerModelConfiguration
                 .WithMany()
                 .HasForeignKey(x => x.UserId)
                 .OnDelete(DeleteBehavior.Restrict);
+        });
+
+        modelBuilder.Entity<SqlOSPasswordLoginReservation>(entity =>
+        {
+            entity.ToTable("SqlOSPasswordLoginReservations", schema, t => t.ExcludeFromMigrations());
+            entity.HasKey(x => x.Id);
+            entity.HasIndex(x => x.ExpiresAt);
+        });
+
+        modelBuilder.Entity<SqlOSPasswordLoginReservationBucket>(entity =>
+        {
+            entity.ToTable("SqlOSPasswordLoginReservationBuckets", schema, t => t.ExcludeFromMigrations());
+            entity.HasKey(x => new { x.ReservationId, x.BucketId });
+            entity.HasOne(x => x.Reservation)
+                .WithMany(x => x.Buckets)
+                .HasForeignKey(x => x.ReservationId)
+                .OnDelete(DeleteBehavior.Cascade);
+            entity.HasOne(x => x.Bucket)
+                .WithMany(x => x.Reservations)
+                .HasForeignKey(x => x.BucketId)
+                .OnDelete(DeleteBehavior.Cascade);
         });
 
         modelBuilder.Entity<SqlOSMembership>(entity =>

--- a/src/SqlOS/AuthServer/Models/SqlOSEntities.cs
+++ b/src/SqlOS/AuthServer/Models/SqlOSEntities.cs
@@ -106,6 +106,25 @@ public sealed class SqlOSPasswordLoginBucket
     public DateTime UpdatedAt { get; set; }
 
     public SqlOSUser? User { get; set; }
+    public ICollection<SqlOSPasswordLoginReservationBucket> Reservations { get; set; } = [];
+}
+
+public sealed class SqlOSPasswordLoginReservation
+{
+    public string Id { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; }
+    public DateTime ExpiresAt { get; set; }
+
+    public ICollection<SqlOSPasswordLoginReservationBucket> Buckets { get; set; } = [];
+}
+
+public sealed class SqlOSPasswordLoginReservationBucket
+{
+    public string ReservationId { get; set; } = string.Empty;
+    public string BucketId { get; set; } = string.Empty;
+
+    public SqlOSPasswordLoginReservation? Reservation { get; set; }
+    public SqlOSPasswordLoginBucket? Bucket { get; set; }
 }
 
 public sealed class SqlOSMembership

--- a/src/SqlOS/AuthServer/Schema/039_AtomicPasswordLoginAdmission.sql
+++ b/src/SqlOS/AuthServer/Schema/039_AtomicPasswordLoginAdmission.sql
@@ -1,0 +1,86 @@
+-- Older test/repair installations can carry a schema version without the historical
+-- password bucket table. Repair it when the user prerequisite exists; otherwise keep
+-- this migration compatible with intentionally partial schemas used for upgrade checks.
+IF OBJECT_ID('[{Schema}].[SqlOSPasswordLoginBuckets]', 'U') IS NULL
+   AND OBJECT_ID('[{Schema}].[SqlOSUsers]', 'U') IS NOT NULL
+BEGIN
+    CREATE TABLE [{Schema}].[SqlOSPasswordLoginBuckets] (
+        [Id] NVARCHAR(64) NOT NULL PRIMARY KEY,
+        [Scope] NVARCHAR(40) NOT NULL,
+        [BucketKey] NVARCHAR(512) NOT NULL,
+        [NormalizedEmail] NVARCHAR(320) NULL,
+        [UserId] NVARCHAR(64) NULL,
+        [ClientKey] NVARCHAR(850) NULL,
+        [IpAddress] NVARCHAR(128) NULL,
+        [UserAgentHash] NVARCHAR(128) NULL,
+        [FailureCount] INT NOT NULL CONSTRAINT [DF_SqlOSPasswordLoginBuckets_FailureCount] DEFAULT 0,
+        [WindowStartedAt] DATETIME2 NULL,
+        [LastFailureAt] DATETIME2 NULL,
+        [LastSuccessAt] DATETIME2 NULL,
+        [LockedUntil] DATETIME2 NULL,
+        [LockoutReason] NVARCHAR(120) NULL,
+        [CreatedAt] DATETIME2 NOT NULL,
+        [UpdatedAt] DATETIME2 NOT NULL
+    );
+
+    CREATE UNIQUE INDEX [IX_SqlOSPasswordLoginBuckets_Scope_BucketKey]
+        ON [{Schema}].[SqlOSPasswordLoginBuckets]([Scope], [BucketKey]);
+    CREATE INDEX [IX_SqlOSPasswordLoginBuckets_NormalizedEmail_UpdatedAt]
+        ON [{Schema}].[SqlOSPasswordLoginBuckets]([NormalizedEmail], [UpdatedAt]);
+    CREATE INDEX [IX_SqlOSPasswordLoginBuckets_UserId_UpdatedAt]
+        ON [{Schema}].[SqlOSPasswordLoginBuckets]([UserId], [UpdatedAt]);
+    CREATE INDEX [IX_SqlOSPasswordLoginBuckets_IpAddress_UpdatedAt]
+        ON [{Schema}].[SqlOSPasswordLoginBuckets]([IpAddress], [UpdatedAt]);
+    CREATE INDEX [IX_SqlOSPasswordLoginBuckets_LockedUntil]
+        ON [{Schema}].[SqlOSPasswordLoginBuckets]([LockedUntil]);
+
+    ALTER TABLE [{Schema}].[SqlOSPasswordLoginBuckets]
+        ADD CONSTRAINT [FK_SqlOSPasswordLoginBuckets_Users_UserId]
+            FOREIGN KEY ([UserId]) REFERENCES [{Schema}].[SqlOSUsers]([Id]);
+END
+
+IF OBJECT_ID('[{Schema}].[SqlOSPasswordLoginBuckets]', 'U') IS NOT NULL
+   AND NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'SqlOSPasswordLoginReservations' AND schema_id = SCHEMA_ID('{Schema}'))
+BEGIN
+    CREATE TABLE [{Schema}].[SqlOSPasswordLoginReservations] (
+        [Id] NVARCHAR(64) NOT NULL PRIMARY KEY,
+        [CreatedAt] DATETIME2 NOT NULL,
+        [ExpiresAt] DATETIME2 NOT NULL
+    );
+
+    CREATE INDEX [IX_SqlOSPasswordLoginReservations_ExpiresAt]
+        ON [{Schema}].[SqlOSPasswordLoginReservations]([ExpiresAt]);
+END
+
+IF OBJECT_ID('[{Schema}].[SqlOSPasswordLoginBuckets]', 'U') IS NOT NULL
+   AND NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'SqlOSPasswordLoginReservationBuckets' AND schema_id = SCHEMA_ID('{Schema}'))
+BEGIN
+    CREATE TABLE [{Schema}].[SqlOSPasswordLoginReservationBuckets] (
+        [ReservationId] NVARCHAR(64) NOT NULL,
+        [BucketId] NVARCHAR(64) NOT NULL,
+        CONSTRAINT [PK_SqlOSPasswordLoginReservationBuckets] PRIMARY KEY ([ReservationId], [BucketId]),
+        CONSTRAINT [FK_SqlOSPasswordLoginReservationBuckets_Reservations_ReservationId]
+            FOREIGN KEY ([ReservationId]) REFERENCES [{Schema}].[SqlOSPasswordLoginReservations]([Id]) ON DELETE CASCADE,
+        CONSTRAINT [FK_SqlOSPasswordLoginReservationBuckets_Buckets_BucketId]
+            FOREIGN KEY ([BucketId]) REFERENCES [{Schema}].[SqlOSPasswordLoginBuckets]([Id]) ON DELETE CASCADE
+    );
+
+    CREATE INDEX [IX_SqlOSPasswordLoginReservationBuckets_BucketId]
+        ON [{Schema}].[SqlOSPasswordLoginReservationBuckets]([BucketId]);
+END
+
+-- Client identifiers may use the full 850-character registration limit. Keeping that
+-- diagnostic value in a composite SQL Server index can exceed the 1,700-byte key limit.
+IF EXISTS (
+    SELECT * FROM sys.indexes
+    WHERE [name] = 'IX_SqlOSPasswordLoginBuckets_ClientKey_UpdatedAt'
+      AND [object_id] = OBJECT_ID('[{Schema}].[SqlOSPasswordLoginBuckets]'))
+BEGIN
+    DROP INDEX [IX_SqlOSPasswordLoginBuckets_ClientKey_UpdatedAt]
+        ON [{Schema}].[SqlOSPasswordLoginBuckets];
+END
+
+GO
+
+DELETE FROM [{Schema}].[SqlOSSchema];
+INSERT INTO [{Schema}].[SqlOSSchema] ([Version]) VALUES (39);

--- a/src/SqlOS/AuthServer/Services/SqlOSAuthService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSAuthService.cs
@@ -113,49 +113,48 @@ public sealed class SqlOSAuthService
             throw new InvalidOperationException("Local password authentication is disabled.");
         }
 
+        var client = await _adminService.RequireClientAsync(request.ClientId, null, cancellationToken);
         var normalizedEmail = SqlOSAdminService.NormalizeEmail(request.Email);
         var attempt = _passwordLoginAbuseService.CreateAttempt(
             normalizedEmail,
             httpContext,
             clientKey: request.ClientId,
             surface: "api");
-        await _passwordLoginAbuseService.EnsureAllowedAsync(attempt, cancellationToken);
 
         var email = await _context.Set<SqlOSUserEmail>()
+            .AsNoTracking()
             .FirstOrDefaultAsync(x => x.NormalizedEmail == normalizedEmail, cancellationToken);
-        if (email == null)
-        {
-            await _passwordLoginAbuseService.RecordFailureAsync(attempt, "unknown_email", cancellationToken);
-            throw new InvalidOperationException(SqlOSPasswordLoginAbuseService.PublicFailureMessage);
-        }
+        attempt = attempt with { UserId = email?.UserId };
 
-        attempt = attempt with { UserId = email.UserId };
-        await _passwordLoginAbuseService.EnsureAllowedAsync(attempt, cancellationToken);
-
-        if (_options.RequireVerifiedEmailForPasswordLogin && !email.IsVerified)
+        if (email != null && _options.RequireVerifiedEmailForPasswordLogin && !email.IsVerified)
         {
             throw new InvalidOperationException("Email must be verified before password login.");
         }
 
-        var credential = await _context.Set<SqlOSCredential>()
-            .FirstOrDefaultAsync(x => x.UserId == email.UserId && x.Type == "password" && x.RevokedAt == null, cancellationToken);
-        if (credential == null)
+        var credential = email == null
+            ? null
+            : await _context.Set<SqlOSCredential>()
+                .AsNoTracking()
+                .FirstOrDefaultAsync(x => x.UserId == email.UserId && x.Type == "password" && x.RevokedAt == null, cancellationToken);
+        await _passwordLoginAbuseService.ReserveAsync(attempt, cancellationToken);
+        var passwordMatches = _cryptoService.VerifyPassword(
+            credential?.SecretHash ?? SqlOSClientAuthenticationService.DummyCredentialHash,
+            request.Password);
+        if (credential == null || !passwordMatches)
         {
-            await _passwordLoginAbuseService.RecordFailureAsync(attempt, "missing_password_credential", cancellationToken);
+            var failureReason = email == null
+                ? "unknown_email"
+                : credential == null
+                    ? "missing_password_credential"
+                    : "invalid_password";
+            await _passwordLoginAbuseService.RecordFailureAsync(attempt, failureReason, cancellationToken);
             throw new InvalidOperationException(SqlOSPasswordLoginAbuseService.PublicFailureMessage);
         }
 
-        if (!_cryptoService.VerifyPassword(credential.SecretHash, request.Password))
-        {
-            await _passwordLoginAbuseService.RecordFailureAsync(attempt, "invalid_password", cancellationToken);
-            throw new InvalidOperationException(SqlOSPasswordLoginAbuseService.PublicFailureMessage);
-        }
-
-        credential.LastUsedAt = DateTime.UtcNow;
-
-        var user = await _context.Set<SqlOSUser>().FirstAsync(x => x.Id == email.UserId, cancellationToken);
-        var client = await _adminService.RequireClientAsync(request.ClientId, null, cancellationToken);
+        var user = await _context.Set<SqlOSUser>().AsNoTracking().FirstAsync(x => x.Id == email!.UserId, cancellationToken);
         await _passwordLoginAbuseService.RecordSuccessAsync(attempt, cancellationToken);
+        var storedCredential = await _context.Set<SqlOSCredential>().FirstAsync(x => x.Id == credential.Id, cancellationToken);
+        storedCredential.LastUsedAt = DateTime.UtcNow;
         await _context.SaveChangesAsync(cancellationToken);
         return await FinalizeClientLoginAsync(user, client, request.OrganizationId, "password", httpContext, cancellationToken);
     }

--- a/src/SqlOS/AuthServer/Services/SqlOSAuthorizationServerService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSAuthorizationServerService.cs
@@ -302,49 +302,52 @@ public sealed class SqlOSAuthorizationServerService
             clientKey,
             authorizationRequestId,
             surface ?? "authorization");
-        await _passwordLoginAbuseService.EnsureAllowedAsync(attempt, cancellationToken);
 
         var emailRecord = await _context.Set<SqlOSUserEmail>()
+            .AsNoTracking()
             .FirstOrDefaultAsync(x => x.NormalizedEmail == normalizedEmail, cancellationToken);
-        if (emailRecord == null)
-        {
-            await _passwordLoginAbuseService.RecordFailureAsync(attempt, "unknown_email", cancellationToken);
-            throw new InvalidOperationException(SqlOSPasswordLoginAbuseService.PublicFailureMessage);
-        }
+        attempt = attempt with { UserId = emailRecord?.UserId };
 
-        attempt = attempt with { UserId = emailRecord.UserId };
-        await _passwordLoginAbuseService.EnsureAllowedAsync(attempt, cancellationToken);
-
-        if (_options.RequireVerifiedEmailForPasswordLogin && !emailRecord.IsVerified && !allowUnverifiedEmailForInvitation)
+        if (emailRecord != null
+            && _options.RequireVerifiedEmailForPasswordLogin
+            && !emailRecord.IsVerified
+            && !allowUnverifiedEmailForInvitation)
         {
             throw new InvalidOperationException("Email must be verified before password login.");
         }
 
-        var credential = await _context.Set<SqlOSCredential>()
-            .FirstOrDefaultAsync(x => x.UserId == emailRecord.UserId && x.Type == "password" && x.RevokedAt == null, cancellationToken);
-        if (credential == null)
+        var credential = emailRecord == null
+            ? null
+            : await _context.Set<SqlOSCredential>()
+                .AsNoTracking()
+                .FirstOrDefaultAsync(x => x.UserId == emailRecord.UserId && x.Type == "password" && x.RevokedAt == null, cancellationToken);
+        await _passwordLoginAbuseService.ReserveAsync(attempt, cancellationToken);
+        var passwordMatches = _cryptoService.VerifyPassword(
+            credential?.SecretHash ?? SqlOSClientAuthenticationService.DummyCredentialHash,
+            password);
+        if (credential == null || !passwordMatches)
         {
-            await _passwordLoginAbuseService.RecordFailureAsync(attempt, "missing_password_credential", cancellationToken);
-            throw new InvalidOperationException(SqlOSPasswordLoginAbuseService.PublicFailureMessage);
-        }
-
-        if (!_cryptoService.VerifyPassword(credential.SecretHash, password))
-        {
-            await _passwordLoginAbuseService.RecordFailureAsync(attempt, "invalid_password", cancellationToken);
+            var failureReason = emailRecord == null
+                ? "unknown_email"
+                : credential == null
+                    ? "missing_password_credential"
+                    : "invalid_password";
+            await _passwordLoginAbuseService.RecordFailureAsync(attempt, failureReason, cancellationToken);
             throw new InvalidOperationException(SqlOSPasswordLoginAbuseService.PublicFailureMessage);
         }
 
         var user = await _context.Set<SqlOSUser>()
             .AsNoTracking()
-            .FirstOrDefaultAsync(x => x.Id == emailRecord.UserId, cancellationToken);
+            .FirstOrDefaultAsync(x => x.Id == emailRecord!.UserId, cancellationToken);
         if (user == null || !user.IsActive)
         {
             await _passwordLoginAbuseService.RecordFailureAsync(attempt, "inactive_user", cancellationToken);
             throw new InvalidOperationException(SqlOSPasswordLoginAbuseService.PublicFailureMessage);
         }
 
-        credential.LastUsedAt = DateTime.UtcNow;
         await _passwordLoginAbuseService.RecordSuccessAsync(attempt, cancellationToken);
+        var storedCredential = await _context.Set<SqlOSCredential>().FirstAsync(x => x.Id == credential.Id, cancellationToken);
+        storedCredential.LastUsedAt = DateTime.UtcNow;
         await _context.SaveChangesAsync(cancellationToken);
 
         var organizations = await _adminService.GetUserOrganizationsAsync(user.Id, cancellationToken);

--- a/src/SqlOS/AuthServer/Services/SqlOSPasswordLoginAbuseService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSPasswordLoginAbuseService.cs
@@ -68,49 +68,23 @@ public sealed class SqlOSPasswordLoginAbuseService
         }
 
         var outcome = await ExecuteAtomicAsync(() => ReserveCoreAsync(attempt, cancellationToken), cancellationToken);
-        if (outcome.Rejection != null)
+        if (outcome.Rejection == null)
         {
-            await RecordPasswordAuditAsync(
-                "password.login.rate_limit_rejected",
-                attempt,
-                data: new
-                {
-                    scope = outcome.Rejection.Scope,
-                    retryAfter = outcome.Rejection.LockedUntil,
-                    failureCount = outcome.Rejection.FailureCount,
-                    reason = outcome.Rejection.LockoutReason ?? "active_lockout"
-                },
-                cancellationToken);
-            throw new InvalidOperationException(PublicFailureMessage);
+            return;
         }
 
-        foreach (var bucket in outcome.NewlyLocked.Where(static x => x.Scope is "email" or "user"))
-        {
-            await RecordPasswordAuditAsync(
-                "password.login.locked",
-                attempt,
-                data: new
-                {
-                    scope = bucket.Scope,
-                    retryAfter = bucket.LockedUntil,
-                    failureCount = bucket.FailureCount
-                },
-                cancellationToken);
-        }
-
-        foreach (var bucket in outcome.NewlyLocked.Where(static x => x.Scope is "ip" or "client" or "device"))
-        {
-            await RecordPasswordAuditAsync(
-                "password.login.suspicious_pattern",
-                attempt,
-                data: new
-                {
-                    scope = bucket.Scope,
-                    retryAfter = bucket.LockedUntil,
-                    failureCount = bucket.FailureCount
-                },
-                cancellationToken);
-        }
+        await RecordPasswordAuditAsync(
+            "password.login.rate_limit_rejected",
+            attempt,
+            data: new
+            {
+                scope = outcome.Rejection.Scope,
+                retryAfter = outcome.Rejection.LockedUntil,
+                failureCount = outcome.Rejection.FailureCount,
+                reason = outcome.Rejection.LockoutReason ?? "active_lockout"
+            },
+            cancellationToken);
+        throw new InvalidOperationException(PublicFailureMessage);
     }
 
     [Obsolete("Use ReserveAsync before password verification.")]
@@ -132,12 +106,46 @@ public sealed class SqlOSPasswordLoginAbuseService
             return;
         }
 
-        await ExecuteAtomicAsync(() => RecordFailureCoreAsync(attempt, cancellationToken), cancellationToken);
+        var locked = await ExecuteAtomicAsync(
+            () => RecordFailureCoreAsync(attempt, cancellationToken),
+            cancellationToken);
         await RecordPasswordAuditAsync(
             "password.login.failed",
             attempt,
-            data: new { failureReason },
+            data: new
+            {
+                failureReason,
+                lockedScopes = locked.Select(static x => x.Scope).ToArray()
+            },
             cancellationToken);
+
+        foreach (var bucket in locked.Where(static x => x.Scope is "email" or "user"))
+        {
+            await RecordPasswordAuditAsync(
+                "password.login.locked",
+                attempt,
+                data: new
+                {
+                    scope = bucket.Scope,
+                    retryAfter = bucket.LockedUntil,
+                    failureCount = bucket.FailureCount
+                },
+                cancellationToken);
+        }
+
+        foreach (var bucket in locked.Where(static x => x.Scope is "ip" or "client" or "device"))
+        {
+            await RecordPasswordAuditAsync(
+                "password.login.suspicious_pattern",
+                attempt,
+                data: new
+                {
+                    scope = bucket.Scope,
+                    retryAfter = bucket.LockedUntil,
+                    failureCount = bucket.FailureCount
+                },
+                cancellationToken);
+        }
     }
 
     /// <summary>
@@ -191,8 +199,7 @@ public sealed class SqlOSPasswordLoginAbuseService
             {
                 await _context.SaveChangesAsync(cancellationToken);
                 return new ReservationOutcome(
-                    new RejectedBucket(bucket.Scope, bucket.FailureCount, lockedUntil, bucket.LockoutReason),
-                    []);
+                    new RejectedBucket(bucket.Scope, bucket.FailureCount, lockedUntil, bucket.LockoutReason));
             }
         }
 
@@ -204,7 +211,6 @@ public sealed class SqlOSPasswordLoginAbuseService
         };
         _context.Set<SqlOSPasswordLoginReservation>().Add(reservation);
 
-        var newlyLocked = new List<LockedBucket>();
         foreach (var (identity, bucket) in buckets)
         {
             bucket.FailureCount++;
@@ -220,7 +226,6 @@ public sealed class SqlOSPasswordLoginAbuseService
             {
                 bucket.LockedUntil = now.Add(_options.LockoutDuration);
                 bucket.LockoutReason = "failed_attempt_threshold";
-                newlyLocked.Add(new LockedBucket(bucket.Scope, bucket.FailureCount, bucket.LockedUntil.Value));
             }
 
             reservation.Buckets.Add(new SqlOSPasswordLoginReservationBucket
@@ -233,10 +238,10 @@ public sealed class SqlOSPasswordLoginAbuseService
         }
 
         await _context.SaveChangesAsync(cancellationToken);
-        return new ReservationOutcome(null, newlyLocked);
+        return ReservationOutcome.Admitted;
     }
 
-    private async Task<bool> RecordFailureCoreAsync(
+    private async Task<IReadOnlyList<LockedBucket>> RecordFailureCoreAsync(
         SqlOSPasswordLoginAttempt attempt,
         CancellationToken cancellationToken)
     {
@@ -247,19 +252,24 @@ public sealed class SqlOSPasswordLoginAbuseService
             .SingleOrDefaultAsync(x => x.Id == attempt.ReservationId, cancellationToken);
         if (reservation == null)
         {
-            return false;
+            return [];
         }
 
+        var locked = new List<LockedBucket>();
         foreach (var link in reservation.Buckets)
         {
             var bucket = link.Bucket!;
             bucket.LastFailureAt = now;
             bucket.UpdatedAt = now;
+            if (bucket.LockedUntil is { } lockedUntil && lockedUntil > now)
+            {
+                locked.Add(new LockedBucket(bucket.Scope, bucket.FailureCount, lockedUntil));
+            }
         }
 
         _context.Set<SqlOSPasswordLoginReservation>().Remove(reservation);
         await _context.SaveChangesAsync(cancellationToken);
-        return true;
+        return locked;
     }
 
     private async Task<IReadOnlyList<string>> RecordSuccessCoreAsync(
@@ -628,9 +638,9 @@ public sealed class SqlOSPasswordLoginAbuseService
     private sealed record PasswordBucketIdentity(string Scope, string Key, int Threshold);
     private sealed record RejectedBucket(string Scope, int FailureCount, DateTime LockedUntil, string? LockoutReason);
     private sealed record LockedBucket(string Scope, int FailureCount, DateTime LockedUntil);
-    private sealed record ReservationOutcome(RejectedBucket? Rejection, IReadOnlyList<LockedBucket> NewlyLocked)
+    private sealed record ReservationOutcome(RejectedBucket? Rejection)
     {
-        public static ReservationOutcome Admitted { get; } = new(null, []);
+        public static ReservationOutcome Admitted { get; } = new((RejectedBucket?)null);
     }
 }
 

--- a/src/SqlOS/AuthServer/Services/SqlOSPasswordLoginAbuseService.cs
+++ b/src/SqlOS/AuthServer/Services/SqlOSPasswordLoginAbuseService.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using System.Security.Cryptography;
 using System.Text;
 using Microsoft.AspNetCore.Http;
@@ -12,6 +13,8 @@ namespace SqlOS.AuthServer.Services;
 public sealed class SqlOSPasswordLoginAbuseService
 {
     public const string PublicFailureMessage = "Invalid email or password.";
+    private const int ExpiredReservationCleanupBatchSize = 100;
+    private static readonly TimeSpan ReservationTtl = TimeSpan.FromMinutes(2);
 
     private readonly ISqlOSAuthServerDbContext _context;
     private readonly SqlOSAdminService _adminService;
@@ -46,47 +49,73 @@ public sealed class SqlOSPasswordLoginAbuseService
             authorizationRequestId,
             string.IsNullOrWhiteSpace(surface) ? "unknown" : surface.Trim(),
             NormalizeIpAddress(httpContext),
-            HashUserAgent(userAgent));
+            HashUserAgent(userAgent))
+        {
+            ReservationId = _cryptoService.GenerateId("pla")
+        };
     }
 
-    public async Task EnsureAllowedAsync(SqlOSPasswordLoginAttempt attempt, CancellationToken cancellationToken = default)
+    /// <summary>
+    /// Atomically reserves capacity in every applicable bucket before a password hash comparison.
+    /// The SQL transaction completes before hashing. Abandoned reservations remain fail-closed for
+    /// two minutes.
+    /// </summary>
+    public async Task ReserveAsync(SqlOSPasswordLoginAttempt attempt, CancellationToken cancellationToken = default)
     {
         if (!_options.Enabled)
         {
             return;
         }
 
-        var now = DateTime.UtcNow;
-        foreach (var identity in GetBucketIdentities(attempt, includeUserBucket: true))
+        var outcome = await ExecuteAtomicAsync(() => ReserveCoreAsync(attempt, cancellationToken), cancellationToken);
+        if (outcome.Rejection != null)
         {
-            var bucket = await FindBucketAsync(identity, cancellationToken);
-            if (bucket == null)
-            {
-                continue;
-            }
+            await RecordPasswordAuditAsync(
+                "password.login.rate_limit_rejected",
+                attempt,
+                data: new
+                {
+                    scope = outcome.Rejection.Scope,
+                    retryAfter = outcome.Rejection.LockedUntil,
+                    failureCount = outcome.Rejection.FailureCount,
+                    reason = outcome.Rejection.LockoutReason ?? "active_lockout"
+                },
+                cancellationToken);
+            throw new InvalidOperationException(PublicFailureMessage);
+        }
 
-            if (ResetExpired(bucket, now))
-            {
-                await _context.SaveChangesAsync(cancellationToken);
-            }
+        foreach (var bucket in outcome.NewlyLocked.Where(static x => x.Scope is "email" or "user"))
+        {
+            await RecordPasswordAuditAsync(
+                "password.login.locked",
+                attempt,
+                data: new
+                {
+                    scope = bucket.Scope,
+                    retryAfter = bucket.LockedUntil,
+                    failureCount = bucket.FailureCount
+                },
+                cancellationToken);
+        }
 
-            if (bucket.LockedUntil is { } lockedUntil && lockedUntil > now)
-            {
-                await RecordPasswordAuditAsync(
-                    "password.login.rate_limit_rejected",
-                    attempt,
-                    data: new
-                    {
-                        scope = bucket.Scope,
-                        retryAfter = lockedUntil,
-                        failureCount = bucket.FailureCount,
-                        reason = bucket.LockoutReason ?? "active_lockout"
-                    },
-                    cancellationToken);
-                throw new InvalidOperationException(PublicFailureMessage);
-            }
+        foreach (var bucket in outcome.NewlyLocked.Where(static x => x.Scope is "ip" or "client" or "device"))
+        {
+            await RecordPasswordAuditAsync(
+                "password.login.suspicious_pattern",
+                attempt,
+                data: new
+                {
+                    scope = bucket.Scope,
+                    retryAfter = bucket.LockedUntil,
+                    failureCount = bucket.FailureCount
+                },
+                cancellationToken);
         }
     }
+
+    [Obsolete("Use ReserveAsync before password verification.")]
+    public Task EnsureAllowedAsync(SqlOSPasswordLoginAttempt attempt, CancellationToken cancellationToken = default)
+        => ReserveAsync(attempt, cancellationToken);
 
     public async Task RecordFailureAsync(
         SqlOSPasswordLoginAttempt attempt,
@@ -103,17 +132,83 @@ public sealed class SqlOSPasswordLoginAbuseService
             return;
         }
 
-        var now = DateTime.UtcNow;
-        var newlyLocked = new List<SqlOSPasswordLoginBucket>();
+        await ExecuteAtomicAsync(() => RecordFailureCoreAsync(attempt, cancellationToken), cancellationToken);
+        await RecordPasswordAuditAsync(
+            "password.login.failed",
+            attempt,
+            data: new { failureReason },
+            cancellationToken);
+    }
 
-        foreach (var identity in GetBucketIdentities(attempt, includeUserBucket: true))
+    /// <summary>
+    /// Clears historical account failures while preserving other in-flight account reservations.
+    /// Shared IP, client, and device buckets release only this comparison.
+    /// </summary>
+    public async Task RecordSuccessAsync(SqlOSPasswordLoginAttempt attempt, CancellationToken cancellationToken = default)
+    {
+        IReadOnlyList<string> resetScopes = [];
+        if (_options.Enabled)
         {
-            var bucket = await GetOrCreateBucketAsync(identity, attempt, now, cancellationToken);
-            ResetExpired(bucket, now);
+            resetScopes = await ExecuteAtomicAsync(() => RecordSuccessCoreAsync(attempt, cancellationToken), cancellationToken);
+        }
 
+        await RecordPasswordAuditAsync(
+            "password.login.succeeded",
+            attempt,
+            data: new { resetScopes },
+            cancellationToken);
+    }
+
+    private async Task<ReservationOutcome> ReserveCoreAsync(
+        SqlOSPasswordLoginAttempt attempt,
+        CancellationToken cancellationToken)
+    {
+        var now = DateTime.UtcNow;
+        var priorReservation = await _context.Set<SqlOSPasswordLoginReservation>()
+            .AsNoTracking()
+            .AnyAsync(x => x.Id == attempt.ReservationId, cancellationToken);
+        if (priorReservation)
+        {
+            return ReservationOutcome.Admitted;
+        }
+
+        var identities = GetBucketIdentities(attempt, includeUserBucket: true).ToArray();
+        var buckets = new List<(PasswordBucketIdentity Identity, SqlOSPasswordLoginBucket Bucket)>(identities.Length);
+        foreach (var identity in identities)
+        {
+            buckets.Add((identity, await GetOrCreateBucketAsync(identity, attempt, now, cancellationToken)));
+        }
+
+        await CleanupExpiredReservationsForBucketsAsync(
+            buckets.Select(static x => x.Bucket.Id).ToArray(),
+            now,
+            cancellationToken);
+
+        foreach (var (identity, bucket) in buckets)
+        {
+            await RebaseIfExpiredAsync(bucket, identity.Threshold, now, cancellationToken);
+            if (bucket.LockedUntil is { } lockedUntil && lockedUntil > now)
+            {
+                await _context.SaveChangesAsync(cancellationToken);
+                return new ReservationOutcome(
+                    new RejectedBucket(bucket.Scope, bucket.FailureCount, lockedUntil, bucket.LockoutReason),
+                    []);
+            }
+        }
+
+        var reservation = new SqlOSPasswordLoginReservation
+        {
+            Id = attempt.ReservationId,
+            CreatedAt = now,
+            ExpiresAt = now.Add(ReservationTtl)
+        };
+        _context.Set<SqlOSPasswordLoginReservation>().Add(reservation);
+
+        var newlyLocked = new List<LockedBucket>();
+        foreach (var (identity, bucket) in buckets)
+        {
             bucket.FailureCount++;
             bucket.WindowStartedAt ??= now;
-            bucket.LastFailureAt = now;
             bucket.UpdatedAt = now;
             bucket.NormalizedEmail ??= attempt.NormalizedEmail;
             bucket.UserId ??= attempt.UserId;
@@ -125,85 +220,265 @@ public sealed class SqlOSPasswordLoginAbuseService
             {
                 bucket.LockedUntil = now.Add(_options.LockoutDuration);
                 bucket.LockoutReason = "failed_attempt_threshold";
-                newlyLocked.Add(bucket);
+                newlyLocked.Add(new LockedBucket(bucket.Scope, bucket.FailureCount, bucket.LockedUntil.Value));
             }
-        }
 
-        await RecordPasswordAuditAsync(
-            "password.login.failed",
-            attempt,
-            data: new
+            reservation.Buckets.Add(new SqlOSPasswordLoginReservationBucket
             {
-                failureReason,
-                lockedScopes = newlyLocked.Select(static x => x.Scope).ToArray()
-            },
-            cancellationToken);
-
-        foreach (var bucket in newlyLocked.Where(static x => x.Scope is "email" or "user"))
-        {
-            await RecordPasswordAuditAsync(
-                "password.login.locked",
-                attempt,
-                data: new
-                {
-                    scope = bucket.Scope,
-                    retryAfter = bucket.LockedUntil,
-                    failureCount = bucket.FailureCount
-                },
-                cancellationToken);
+                ReservationId = reservation.Id,
+                BucketId = bucket.Id,
+                Reservation = reservation,
+                Bucket = bucket
+            });
         }
 
-        foreach (var bucket in newlyLocked.Where(static x => x.Scope is "ip" or "client" or "device"))
-        {
-            await RecordPasswordAuditAsync(
-                "password.login.suspicious_pattern",
-                attempt,
-                data: new
-                {
-                    scope = bucket.Scope,
-                    retryAfter = bucket.LockedUntil,
-                    failureCount = bucket.FailureCount
-                },
-                cancellationToken);
-        }
+        await _context.SaveChangesAsync(cancellationToken);
+        return new ReservationOutcome(null, newlyLocked);
     }
 
-    public async Task RecordSuccessAsync(SqlOSPasswordLoginAttempt attempt, CancellationToken cancellationToken = default)
+    private async Task<bool> RecordFailureCoreAsync(
+        SqlOSPasswordLoginAttempt attempt,
+        CancellationToken cancellationToken)
     {
-        if (_options.Enabled)
+        var now = DateTime.UtcNow;
+        var reservation = await _context.Set<SqlOSPasswordLoginReservation>()
+            .Include(x => x.Buckets)
+            .ThenInclude(x => x.Bucket)
+            .SingleOrDefaultAsync(x => x.Id == attempt.ReservationId, cancellationToken);
+        if (reservation == null)
         {
-            var now = DateTime.UtcNow;
-            foreach (var identity in GetAccountBucketIdentities(attempt))
+            return false;
+        }
+
+        foreach (var link in reservation.Buckets)
+        {
+            var bucket = link.Bucket!;
+            bucket.LastFailureAt = now;
+            bucket.UpdatedAt = now;
+        }
+
+        _context.Set<SqlOSPasswordLoginReservation>().Remove(reservation);
+        await _context.SaveChangesAsync(cancellationToken);
+        return true;
+    }
+
+    private async Task<IReadOnlyList<string>> RecordSuccessCoreAsync(
+        SqlOSPasswordLoginAttempt attempt,
+        CancellationToken cancellationToken)
+    {
+        var now = DateTime.UtcNow;
+        var reservation = await _context.Set<SqlOSPasswordLoginReservation>()
+            .Include(x => x.Buckets)
+            .ThenInclude(x => x.Bucket)
+            .SingleOrDefaultAsync(x => x.Id == attempt.ReservationId, cancellationToken);
+        if (reservation == null)
+        {
+            throw new InvalidOperationException("The password comparison reservation is no longer active.");
+        }
+
+        var resetScopes = new List<string>();
+        foreach (var link in reservation.Buckets.ToArray())
+        {
+            var bucket = link.Bucket!;
+            if (bucket.Scope is "email" or "user")
             {
-                var bucket = await FindBucketAsync(identity, cancellationToken);
-                if (bucket == null)
+                var pendingCount = await _context.Set<SqlOSPasswordLoginReservationBucket>()
+                    .CountAsync(x => x.BucketId == bucket.Id && x.ReservationId != reservation.Id, cancellationToken);
+                bucket.FailureCount = pendingCount;
+                bucket.WindowStartedAt = pendingCount == 0 ? null : bucket.WindowStartedAt ?? now;
+                ApplyLockState(bucket, GetThreshold(bucket.Scope), now);
+                resetScopes.Add(bucket.Scope);
+            }
+            else
+            {
+                await ReleaseSharedReservationAsync(bucket, reservation.Id, now, cancellationToken);
+            }
+
+            bucket.LastSuccessAt = now;
+            bucket.UpdatedAt = now;
+        }
+
+        _context.Set<SqlOSPasswordLoginReservation>().Remove(reservation);
+        await _context.SaveChangesAsync(cancellationToken);
+        return resetScopes;
+    }
+
+    private async Task CleanupExpiredReservationsForBucketsAsync(
+        IReadOnlyCollection<string> bucketIds,
+        DateTime now,
+        CancellationToken cancellationToken)
+    {
+        if (bucketIds.Count == 0)
+        {
+            return;
+        }
+
+        while (true)
+        {
+            var expired = await _context.Set<SqlOSPasswordLoginReservation>()
+                .Where(x => x.ExpiresAt <= now && x.Buckets.Any(b => bucketIds.Contains(b.BucketId)))
+                .OrderBy(x => x.ExpiresAt)
+                .Take(ExpiredReservationCleanupBatchSize)
+                .Include(x => x.Buckets)
+                .ThenInclude(x => x.Bucket)
+                .ToListAsync(cancellationToken);
+            if (expired.Count == 0)
+            {
+                break;
+            }
+
+            foreach (var reservation in expired)
+            {
+                foreach (var link in reservation.Buckets)
                 {
-                    continue;
+                    var bucket = link.Bucket!;
+                    bucket.FailureCount = Math.Max(0, bucket.FailureCount - 1);
+                    if (bucket.FailureCount == 0)
+                    {
+                        bucket.WindowStartedAt = null;
+                    }
+
+                    ApplyLockState(bucket, GetThreshold(bucket.Scope), now);
+                    bucket.UpdatedAt = now;
                 }
 
-                bucket.FailureCount = 0;
-                bucket.WindowStartedAt = null;
-                bucket.LockedUntil = null;
-                bucket.LockoutReason = null;
-                bucket.LastSuccessAt = now;
-                bucket.UpdatedAt = now;
+                _context.Set<SqlOSPasswordLoginReservation>().Remove(reservation);
             }
-        }
 
-        await RecordPasswordAuditAsync(
-            "password.login.succeeded",
-            attempt,
-            data: new { resetScopes = GetAccountBucketIdentities(attempt).Select(static x => x.Scope).ToArray() },
-            cancellationToken);
+            await _context.SaveChangesAsync(cancellationToken);
+        }
     }
 
-    private async Task<SqlOSPasswordLoginBucket?> FindBucketAsync(
-        PasswordBucketIdentity identity,
+    private async Task RebaseIfExpiredAsync(
+        SqlOSPasswordLoginBucket bucket,
+        int threshold,
+        DateTime now,
         CancellationToken cancellationToken)
-        => await _context.Set<SqlOSPasswordLoginBucket>()
-            .FirstOrDefaultAsync(
-                x => x.Scope == identity.Scope && x.BucketKey == identity.Key,
+    {
+        if (bucket.LockedUntil is { } lockedUntil && lockedUntil > now)
+        {
+            return;
+        }
+
+        var lockExpired = bucket.LockedUntil is { } expiredLock && expiredLock <= now;
+        var windowExpired = bucket.WindowStartedAt is { } windowStartedAt
+                            && now - windowStartedAt >= _options.FailureWindow;
+        if (!lockExpired && !windowExpired)
+        {
+            return;
+        }
+
+        var activeCount = await _context.Set<SqlOSPasswordLoginReservationBucket>()
+            .CountAsync(
+                x => x.BucketId == bucket.Id && x.Reservation!.ExpiresAt > now,
                 cancellationToken);
+        bucket.FailureCount = activeCount;
+        bucket.WindowStartedAt = activeCount == 0 ? null : now;
+        ApplyLockState(bucket, threshold, now);
+        bucket.UpdatedAt = now;
+    }
+
+    private async Task ReleaseSharedReservationAsync(
+        SqlOSPasswordLoginBucket bucket,
+        string reservationId,
+        DateTime now,
+        CancellationToken cancellationToken)
+    {
+        bucket.FailureCount = Math.Max(0, bucket.FailureCount - 1);
+        ApplyLockState(bucket, GetThreshold(bucket.Scope), now);
+
+        var otherActive = await _context.Set<SqlOSPasswordLoginReservationBucket>()
+            .AnyAsync(x => x.BucketId == bucket.Id && x.ReservationId != reservationId, cancellationToken);
+        if (bucket.FailureCount == 0 && !otherActive)
+        {
+            _context.Set<SqlOSPasswordLoginBucket>().Remove(bucket);
+            return;
+        }
+
+        if (bucket.FailureCount == 0)
+        {
+            bucket.WindowStartedAt = null;
+        }
+    }
+
+    private void ApplyLockState(SqlOSPasswordLoginBucket bucket, int threshold, DateTime now)
+    {
+        if (bucket.FailureCount >= threshold)
+        {
+            if (bucket.LockedUntil is null || bucket.LockedUntil <= now)
+            {
+                bucket.LockedUntil = now.Add(_options.LockoutDuration);
+            }
+
+            bucket.LockoutReason ??= "failed_attempt_threshold";
+            return;
+        }
+
+        bucket.LockedUntil = null;
+        bucket.LockoutReason = null;
+    }
+
+    private async Task<T> ExecuteAtomicAsync<T>(Func<Task<T>> operation, CancellationToken cancellationToken)
+    {
+        if (!_context.Database.IsRelational())
+        {
+            ClearTrackedAbuseState();
+            return await operation();
+        }
+
+        if (_context.Database.CurrentTransaction != null)
+        {
+            throw new InvalidOperationException(
+                "Password-login admission cannot run inside a host-managed database transaction.");
+        }
+
+        var strategy = _context.Database.CreateExecutionStrategy();
+        return await strategy.ExecuteAsync(async () =>
+        {
+            ClearTrackedAbuseState();
+            await using var transaction = await _context.Database.BeginTransactionAsync(
+                IsolationLevel.Serializable,
+                cancellationToken);
+            await AcquireAdmissionLockAsync(cancellationToken);
+            var result = await operation();
+            await transaction.CommitAsync(cancellationToken);
+            return result;
+        });
+    }
+
+    private Task AcquireAdmissionLockAsync(CancellationToken cancellationToken)
+    {
+        if (!string.Equals(_context.Database.ProviderName, "Microsoft.EntityFrameworkCore.SqlServer", StringComparison.Ordinal))
+        {
+            return Task.CompletedTask;
+        }
+
+        return _context.Database.ExecuteSqlRawAsync("""
+            DECLARE @result int;
+            EXEC @result = sys.sp_getapplock
+                @Resource = N'SqlOS:PasswordLoginAdmission',
+                @LockMode = N'Exclusive',
+                @LockOwner = N'Transaction',
+                @LockTimeout = 10000;
+            IF @result < 0 THROW 51000, 'Could not acquire the SqlOS password-login admission lock.', 1;
+            """, cancellationToken);
+    }
+
+    private void ClearTrackedAbuseState()
+    {
+        if (_context is not DbContext dbContext)
+        {
+            return;
+        }
+
+        foreach (var entry in dbContext.ChangeTracker.Entries().Where(x =>
+                     x.Entity is SqlOSPasswordLoginBucket
+                         or SqlOSPasswordLoginReservation
+                         or SqlOSPasswordLoginReservationBucket).ToArray())
+        {
+            entry.State = EntityState.Detached;
+        }
+    }
 
     private async Task<SqlOSPasswordLoginBucket> GetOrCreateBucketAsync(
         PasswordBucketIdentity identity,
@@ -211,7 +486,8 @@ public sealed class SqlOSPasswordLoginAbuseService
         DateTime now,
         CancellationToken cancellationToken)
     {
-        var bucket = await FindBucketAsync(identity, cancellationToken);
+        var bucket = await _context.Set<SqlOSPasswordLoginBucket>()
+            .SingleOrDefaultAsync(x => x.Scope == identity.Scope && x.BucketKey == identity.Key, cancellationToken);
         if (bucket != null)
         {
             return bucket;
@@ -250,7 +526,10 @@ public sealed class SqlOSPasswordLoginAbuseService
 
         if (!string.IsNullOrWhiteSpace(attempt.ClientKey) && _options.MaxFailedAttemptsPerClient > 0)
         {
-            yield return new PasswordBucketIdentity("client", attempt.ClientKey, _options.MaxFailedAttemptsPerClient);
+            yield return new PasswordBucketIdentity(
+                "client",
+                BoundBucketKey(attempt.ClientKey),
+                _options.MaxFailedAttemptsPerClient);
         }
 
         if (!string.IsNullOrWhiteSpace(attempt.UserAgentHash) && _options.MaxFailedAttemptsPerDevice > 0)
@@ -274,36 +553,14 @@ public sealed class SqlOSPasswordLoginAbuseService
         }
     }
 
-    private bool ResetExpired(SqlOSPasswordLoginBucket bucket, DateTime now)
+    private int GetThreshold(string scope) => scope switch
     {
-        if (bucket.LockedUntil is { } lockedUntil)
-        {
-            if (lockedUntil > now)
-            {
-                return false;
-            }
-
-            ResetBucket(bucket, now);
-            return true;
-        }
-
-        if (bucket.WindowStartedAt is { } windowStartedAt && now - windowStartedAt >= _options.FailureWindow)
-        {
-            ResetBucket(bucket, now);
-            return true;
-        }
-
-        return false;
-    }
-
-    private static void ResetBucket(SqlOSPasswordLoginBucket bucket, DateTime now)
-    {
-        bucket.FailureCount = 0;
-        bucket.WindowStartedAt = null;
-        bucket.LockedUntil = null;
-        bucket.LockoutReason = null;
-        bucket.UpdatedAt = now;
-    }
+        "email" or "user" => _options.MaxFailedAttemptsPerAccount,
+        "ip" => _options.MaxFailedAttemptsPerIp,
+        "client" => _options.MaxFailedAttemptsPerClient,
+        "device" => _options.MaxFailedAttemptsPerDevice,
+        _ => int.MaxValue
+    };
 
     private async Task RecordPasswordAuditAsync(
         string eventType,
@@ -334,6 +591,16 @@ public sealed class SqlOSPasswordLoginAbuseService
     private static string? NormalizeClientKey(string? clientKey)
         => string.IsNullOrWhiteSpace(clientKey) ? null : clientKey.Trim();
 
+    private static string BoundBucketKey(string key)
+    {
+        if (key.Length <= 512)
+        {
+            return key;
+        }
+
+        return "sha256:" + Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(key)));
+    }
+
     private static string? HashUserAgent(string? userAgent)
     {
         if (string.IsNullOrWhiteSpace(userAgent))
@@ -359,6 +626,12 @@ public sealed class SqlOSPasswordLoginAbuseService
     }
 
     private sealed record PasswordBucketIdentity(string Scope, string Key, int Threshold);
+    private sealed record RejectedBucket(string Scope, int FailureCount, DateTime LockedUntil, string? LockoutReason);
+    private sealed record LockedBucket(string Scope, int FailureCount, DateTime LockedUntil);
+    private sealed record ReservationOutcome(RejectedBucket? Rejection, IReadOnlyList<LockedBucket> NewlyLocked)
+    {
+        public static ReservationOutcome Admitted { get; } = new(null, []);
+    }
 }
 
 public sealed record SqlOSPasswordLoginAttempt(
@@ -368,4 +641,7 @@ public sealed record SqlOSPasswordLoginAttempt(
     string? AuthorizationRequestId,
     string Surface,
     string? IpAddress,
-    string? UserAgentHash);
+    string? UserAgentHash)
+{
+    public string ReservationId { get; init; } = $"pla_{Guid.NewGuid():N}"[..28];
+}

--- a/src/SqlOS/Dashboard/SqlOSDashboardLoginThrottlingService.cs
+++ b/src/SqlOS/Dashboard/SqlOSDashboardLoginThrottlingService.cs
@@ -20,6 +20,52 @@ public sealed class SqlOSDashboardLoginThrottlingService
         _store = store;
     }
 
+    /// <summary>
+    /// Reserves both global and per-IP password-comparison capacity before hashing in one short
+    /// transaction. An abandoned reservation remains fail-closed until the window or lockout expires.
+    /// </summary>
+    public async Task<SqlOSDashboardLoginReservationResult> ReserveAsync(
+        string? clientIp,
+        SqlOSDashboardLoginThrottlingOptions options,
+        DateTimeOffset now,
+        CancellationToken cancellationToken = default)
+    {
+        var normalizedIp = NormalizeClientIp(clientIp);
+        if (!options.Enabled)
+        {
+            return new SqlOSDashboardLoginReservationResult(
+                new SqlOSDashboardLoginReservation(normalizedIp, null, null),
+                null);
+        }
+
+        var state = await _store.ReservePairAsync(
+            new SqlOSRateLimitBucketRequest(
+                GlobalScope, GlobalKey, options.MaxGlobalFailures, options.Window, options.LockoutDuration),
+            new SqlOSRateLimitBucketRequest(
+                IpScope, normalizedIp, options.MaxFailuresPerIp, options.Window, options.LockoutDuration),
+            now,
+            cancellationToken);
+        if (!state.Admitted)
+        {
+            return new SqlOSDashboardLoginReservationResult(
+                null,
+                new SqlOSDashboardLoginThrottleRejection(
+                    state.RejectedIndex == 0 ? "global" : "ip",
+                    state.RejectedLockedUntil!.Value));
+        }
+
+        var globalState = state.First!;
+        var ipState = state.Second!;
+        return new SqlOSDashboardLoginReservationResult(
+            new SqlOSDashboardLoginReservation(
+                normalizedIp,
+                ipState.LockedUntil,
+                globalState.LockedUntil,
+                ipState.WindowStartedAt!.Value,
+                globalState.WindowStartedAt!.Value),
+            null);
+    }
+
     public async Task<SqlOSDashboardLoginThrottleRejection?> GetRejectionAsync(
         string? clientIp,
         SqlOSDashboardLoginThrottlingOptions options,
@@ -60,32 +106,12 @@ public sealed class SqlOSDashboardLoginThrottlingService
         DateTimeOffset now,
         CancellationToken cancellationToken = default)
     {
-        if (!options.Enabled)
-        {
-            return SqlOSDashboardLoginLockoutResult.None;
-        }
-
-        var normalizedIp = NormalizeClientIp(clientIp);
-        var ipState = await _store.IncrementAsync(
-            IpScope,
-            normalizedIp,
-            options.MaxFailuresPerIp,
-            options.Window,
-            options.LockoutDuration,
-            now,
-            cancellationToken);
-        var globalState = await _store.IncrementAsync(
-            GlobalScope,
-            GlobalKey,
-            options.MaxGlobalFailures,
-            options.Window,
-            options.LockoutDuration,
-            now,
-            cancellationToken);
-
-        return new SqlOSDashboardLoginLockoutResult(
-            ipState.LockedUntil,
-            globalState.LockedUntil);
+        var result = await ReserveAsync(clientIp, options, now, cancellationToken);
+        return result.Reservation is { } reservation
+            ? new SqlOSDashboardLoginLockoutResult(
+                reservation.PerIpLockedUntil,
+                reservation.GlobalLockedUntil)
+            : SqlOSDashboardLoginLockoutResult.None;
     }
 
     public async Task RecordSuccessAsync(
@@ -104,11 +130,49 @@ public sealed class SqlOSDashboardLoginThrottlingService
         await _store.DecrementAsync(GlobalScope, GlobalKey, now, cancellationToken);
     }
 
+    public async Task RecordSuccessAsync(
+        SqlOSDashboardLoginReservation reservation,
+        SqlOSDashboardLoginThrottlingOptions options,
+        DateTimeOffset now,
+        CancellationToken cancellationToken = default)
+    {
+        if (!options.Enabled)
+        {
+            return;
+        }
+
+        await _store.ReleaseAsync(
+            IpScope,
+            reservation.ClientIp,
+            options.MaxFailuresPerIp,
+            reservation.PerIpWindowStartedAt,
+            now,
+            cancellationToken);
+        await _store.ReleaseAsync(
+            GlobalScope,
+            GlobalKey,
+            options.MaxGlobalFailures,
+            reservation.GlobalWindowStartedAt,
+            now,
+            cancellationToken);
+    }
+
     private static string NormalizeClientIp(string? clientIp)
         => string.IsNullOrWhiteSpace(clientIp) ? SqlOSClientIpAddress.Unknown : clientIp.Trim();
 }
 
 public sealed record SqlOSDashboardLoginThrottleRejection(string Scope, DateTimeOffset RetryAfter);
+
+public sealed record SqlOSDashboardLoginReservation(
+    string ClientIp,
+    DateTimeOffset? PerIpLockedUntil,
+    DateTimeOffset? GlobalLockedUntil,
+    DateTimeOffset PerIpWindowStartedAt = default,
+    DateTimeOffset GlobalWindowStartedAt = default);
+
+public sealed record SqlOSDashboardLoginReservationResult(
+    SqlOSDashboardLoginReservation? Reservation,
+    SqlOSDashboardLoginThrottleRejection? Rejection);
 
 public sealed record SqlOSDashboardLoginLockoutResult(DateTimeOffset? PerIpLockedUntil, DateTimeOffset? GlobalLockedUntil)
 {

--- a/src/SqlOS/Dashboard/SqlOSDashboardLoginThrottlingService.cs
+++ b/src/SqlOS/Dashboard/SqlOSDashboardLoginThrottlingService.cs
@@ -107,11 +107,21 @@ public sealed class SqlOSDashboardLoginThrottlingService
         CancellationToken cancellationToken = default)
     {
         var result = await ReserveAsync(clientIp, options, now, cancellationToken);
-        return result.Reservation is { } reservation
-            ? new SqlOSDashboardLoginLockoutResult(
+        if (result.Reservation is { } reservation)
+        {
+            return new SqlOSDashboardLoginLockoutResult(
                 reservation.PerIpLockedUntil,
-                reservation.GlobalLockedUntil)
-            : SqlOSDashboardLoginLockoutResult.None;
+                reservation.GlobalLockedUntil);
+        }
+
+        if (result.Rejection is { } rejection)
+        {
+            return rejection.Scope == "ip"
+                ? new SqlOSDashboardLoginLockoutResult(rejection.RetryAfter, null)
+                : new SqlOSDashboardLoginLockoutResult(null, rejection.RetryAfter);
+        }
+
+        return SqlOSDashboardLoginLockoutResult.None;
     }
 
     public async Task RecordSuccessAsync(

--- a/src/SqlOS/Dashboard/SqlOSDashboardMiddleware.cs
+++ b/src/SqlOS/Dashboard/SqlOSDashboardMiddleware.cs
@@ -196,12 +196,12 @@ public sealed class SqlOSDashboardMiddleware
 
             var clientIp = GetClientIpAddress(context);
             var now = DateTimeOffset.UtcNow;
-            var rejection = await loginThrottlingService.GetRejectionAsync(
+            var reservationResult = await loginThrottlingService.ReserveAsync(
                 clientIp,
                 _options.LoginThrottling,
                 now,
                 context.RequestAborted);
-            if (rejection != null)
+            if (reservationResult.Rejection is { } rejection)
             {
                 await RecordDashboardAuditAsync(
                     context,
@@ -224,11 +224,10 @@ public sealed class SqlOSDashboardMiddleware
                     clientIp,
                     new { reason = "invalid_password" });
 
-                var lockout = await loginThrottlingService.RecordFailureAsync(
-                    clientIp,
-                    _options.LoginThrottling,
-                    now,
-                    context.RequestAborted);
+                var reservation = reservationResult.Reservation!;
+                var lockout = new SqlOSDashboardLoginLockoutResult(
+                    reservation.PerIpLockedUntil,
+                    reservation.GlobalLockedUntil);
                 if (lockout.PerIpLockedUntil is { } perIpLockedUntil)
                 {
                     await RecordDashboardAuditAsync(
@@ -262,7 +261,7 @@ public sealed class SqlOSDashboardMiddleware
             }
 
             await loginThrottlingService.RecordSuccessAsync(
-                clientIp,
+                reservationResult.Reservation!,
                 _options.LoginThrottling,
                 now,
                 context.RequestAborted);

--- a/src/SqlOS/Security/ISqlOSRateLimitStore.cs
+++ b/src/SqlOS/Security/ISqlOSRateLimitStore.cs
@@ -11,6 +11,12 @@ internal interface ISqlOSRateLimitStore
         DateTimeOffset now,
         CancellationToken cancellationToken = default);
 
+    Task<SqlOSRateLimitPairReservationState> ReservePairAsync(
+        SqlOSRateLimitBucketRequest first,
+        SqlOSRateLimitBucketRequest second,
+        DateTimeOffset now,
+        CancellationToken cancellationToken = default);
+
     Task<SqlOSRateLimitBucketState?> GetAsync(
         string scope,
         string key,
@@ -28,6 +34,34 @@ internal interface ISqlOSRateLimitStore
         string key,
         DateTimeOffset now,
         CancellationToken cancellationToken = default);
+
+    Task ReleaseAsync(
+        string scope,
+        string key,
+        int lockThreshold,
+        DateTimeOffset windowStartedAt,
+        DateTimeOffset now,
+        CancellationToken cancellationToken = default);
 }
 
-internal sealed record SqlOSRateLimitBucketState(int Count, DateTimeOffset? LockedUntil);
+internal sealed record SqlOSRateLimitBucketState(
+    int Count,
+    DateTimeOffset? LockedUntil,
+    bool Admitted = true,
+    DateTimeOffset? WindowStartedAt = null);
+
+internal sealed record SqlOSRateLimitBucketRequest(
+    string Scope,
+    string Key,
+    int LockThreshold,
+    TimeSpan Window,
+    TimeSpan LockoutDuration);
+
+internal sealed record SqlOSRateLimitPairReservationState(
+    SqlOSRateLimitBucketState? First,
+    SqlOSRateLimitBucketState? Second,
+    int? RejectedIndex,
+    DateTimeOffset? RejectedLockedUntil)
+{
+    public bool Admitted => RejectedIndex == null;
+}

--- a/src/SqlOS/Security/SqlOSDistributedRateLimitStore.cs
+++ b/src/SqlOS/Security/SqlOSDistributedRateLimitStore.cs
@@ -36,6 +36,8 @@ internal sealed class SqlOSDistributedRateLimitStore : ISqlOSRateLimitStore
             SET NOCOUNT ON;
             BEGIN TRANSACTION;
 
+            DECLARE @admitted BIT = 0;
+
             DECLARE @applicationLockResult INT;
             DECLARE @applicationLockResource NVARCHAR(255) =
                 N'SqlOS:rate-limit:' + CONVERT(NVARCHAR(64), HASHBYTES('SHA2_256', @scope + N':' + @key), 2);
@@ -58,6 +60,14 @@ internal sealed class SqlOSDistributedRateLimitStore : ISqlOSRateLimitStore
                 FROM [{_schema}].[SqlOSRateLimitBuckets] WITH (UPDLOCK, HOLDLOCK)
                 WHERE [Scope] = @scope AND [BucketKey] = @key)
             BEGIN
+                IF EXISTS (
+                    SELECT 1
+                    FROM [{_schema}].[SqlOSRateLimitBuckets]
+                    WHERE [Scope] = @scope
+                      AND [BucketKey] = @key
+                      AND ([LockedUntil] IS NULL OR [LockedUntil] <= @now))
+                    SET @admitted = 1;
+
                 UPDATE [{_schema}].[SqlOSRateLimitBuckets]
                 SET
                     [Count] = CASE WHEN [LockedUntil] IS NOT NULL AND [LockedUntil] > @now
@@ -73,6 +83,7 @@ internal sealed class SqlOSDistributedRateLimitStore : ISqlOSRateLimitStore
             END
             ELSE
             BEGIN
+                SET @admitted = 1;
                 INSERT INTO [{_schema}].[SqlOSRateLimitBuckets]
                     ([Scope], [BucketKey], [WindowStartedAt], [Count], [LockedUntil], [UpdatedAt])
                 VALUES
@@ -95,7 +106,7 @@ internal sealed class SqlOSDistributedRateLimitStore : ISqlOSRateLimitStore
               AND [UpdatedAt] < @staleBefore
               AND ([LockedUntil] IS NULL OR [LockedUntil] <= @now);
 
-            SELECT [Count], [LockedUntil]
+            SELECT [Count], [LockedUntil], @admitted
             FROM [{_schema}].[SqlOSRateLimitBuckets]
             WHERE [Scope] = @scope AND [BucketKey] = @key;
 
@@ -112,6 +123,96 @@ internal sealed class SqlOSDistributedRateLimitStore : ISqlOSRateLimitStore
             now,
             cancellationToken)
             ?? throw new InvalidOperationException("SqlOS rate-limit state was not returned by SQL Server.");
+    }
+
+    public async Task<SqlOSRateLimitPairReservationState> ReservePairAsync(
+        SqlOSRateLimitBucketRequest first,
+        SqlOSRateLimitBucketRequest second,
+        DateTimeOffset now,
+        CancellationToken cancellationToken = default)
+    {
+        var sql = $"""
+            SET XACT_ABORT ON;
+            SET NOCOUNT ON;
+            BEGIN TRANSACTION;
+
+            DECLARE @applicationLockResult INT;
+            EXEC @applicationLockResult = sys.sp_getapplock
+                @Resource = N'SqlOS:rate-limit-pair-reservation',
+                @LockMode = 'Exclusive',
+                @LockOwner = 'Transaction',
+                @LockTimeout = 10000;
+            IF @applicationLockResult < 0
+                THROW 51000, 'Unable to acquire the SqlOS rate-limit pair lock.', 1;
+
+            DELETE FROM [{_schema}].[SqlOSRateLimitBuckets]
+            WHERE ([Scope] = @firstScope AND [BucketKey] = @firstKey
+                   AND ([LockedUntil] IS NULL OR [LockedUntil] <= @now)
+                   AND [WindowStartedAt] <= @firstWindowStartedBefore)
+               OR ([Scope] = @secondScope AND [BucketKey] = @secondKey
+                   AND ([LockedUntil] IS NULL OR [LockedUntil] <= @now)
+                   AND [WindowStartedAt] <= @secondWindowStartedBefore);
+
+            DECLARE @rejectedIndex INT = NULL;
+            DECLARE @rejectedLockedUntil DATETIME2 = NULL;
+            SELECT TOP (1) @rejectedIndex = 0, @rejectedLockedUntil = [LockedUntil]
+            FROM [{_schema}].[SqlOSRateLimitBuckets] WITH (UPDLOCK, HOLDLOCK)
+            WHERE [Scope] = @firstScope AND [BucketKey] = @firstKey AND [LockedUntil] > @now;
+            IF @rejectedIndex IS NULL
+                SELECT TOP (1) @rejectedIndex = 1, @rejectedLockedUntil = [LockedUntil]
+                FROM [{_schema}].[SqlOSRateLimitBuckets] WITH (UPDLOCK, HOLDLOCK)
+                WHERE [Scope] = @secondScope AND [BucketKey] = @secondKey AND [LockedUntil] > @now;
+
+            IF @rejectedIndex IS NULL
+            BEGIN
+                UPDATE [{_schema}].[SqlOSRateLimitBuckets]
+                SET [Count] = [Count] + 1,
+                    [LockedUntil] = CASE WHEN [Count] + 1 >= @firstThreshold
+                        THEN @firstLockedUntil ELSE NULL END,
+                    [UpdatedAt] = @now
+                WHERE [Scope] = @firstScope AND [BucketKey] = @firstKey;
+                IF @@ROWCOUNT = 0
+                    INSERT INTO [{_schema}].[SqlOSRateLimitBuckets]
+                        ([Scope], [BucketKey], [WindowStartedAt], [Count], [LockedUntil], [UpdatedAt])
+                    VALUES (@firstScope, @firstKey, @now, 1,
+                        CASE WHEN @firstThreshold <= 1 THEN @firstLockedUntil ELSE NULL END, @now);
+
+                UPDATE [{_schema}].[SqlOSRateLimitBuckets]
+                SET [Count] = [Count] + 1,
+                    [LockedUntil] = CASE WHEN [Count] + 1 >= @secondThreshold
+                        THEN @secondLockedUntil ELSE NULL END,
+                    [UpdatedAt] = @now
+                WHERE [Scope] = @secondScope AND [BucketKey] = @secondKey;
+                IF @@ROWCOUNT = 0
+                    INSERT INTO [{_schema}].[SqlOSRateLimitBuckets]
+                        ([Scope], [BucketKey], [WindowStartedAt], [Count], [LockedUntil], [UpdatedAt])
+                    VALUES (@secondScope, @secondKey, @now, 1,
+                        CASE WHEN @secondThreshold <= 1 THEN @secondLockedUntil ELSE NULL END, @now);
+            END
+
+            ;WITH staleBuckets AS (
+                SELECT TOP (@cleanupBatchSize) *
+                FROM [{_schema}].[SqlOSRateLimitBuckets]
+                WHERE [Scope] IN (@firstScope, @secondScope)
+                  AND [UpdatedAt] < @staleBefore
+                  AND ([LockedUntil] IS NULL OR [LockedUntil] <= @now)
+                ORDER BY [UpdatedAt]
+            )
+            DELETE FROM staleBuckets;
+
+            SELECT @rejectedIndex, @rejectedLockedUntil,
+                   firstBucket.[Count], firstBucket.[LockedUntil], firstBucket.[WindowStartedAt],
+                   secondBucket.[Count], secondBucket.[LockedUntil], secondBucket.[WindowStartedAt]
+            FROM (VALUES (1)) AS anchor([Value])
+            LEFT JOIN [{_schema}].[SqlOSRateLimitBuckets] firstBucket
+              ON firstBucket.[Scope] = @firstScope AND firstBucket.[BucketKey] = @firstKey
+            LEFT JOIN [{_schema}].[SqlOSRateLimitBuckets] secondBucket
+              ON secondBucket.[Scope] = @secondScope AND secondBucket.[BucketKey] = @secondKey;
+
+            COMMIT TRANSACTION;
+            """;
+
+        return await ExecutePairStateAsync(sql, first, second, now, cancellationToken);
     }
 
     public async Task<SqlOSRateLimitBucketState?> GetAsync(
@@ -180,12 +281,59 @@ internal sealed class SqlOSDistributedRateLimitStore : ISqlOSRateLimitStore
             now,
             cancellationToken);
 
+    public Task ReleaseAsync(
+        string scope,
+        string key,
+        int lockThreshold,
+        DateTimeOffset windowStartedAt,
+        DateTimeOffset now,
+        CancellationToken cancellationToken = default)
+        => ExecuteNonQueryAsync(
+            $"""
+            SET XACT_ABORT ON;
+            SET NOCOUNT ON;
+            BEGIN TRANSACTION;
+
+            DECLARE @applicationLockResult INT;
+            DECLARE @applicationLockResource NVARCHAR(255) =
+                N'SqlOS:rate-limit:' + CONVERT(NVARCHAR(64), HASHBYTES('SHA2_256', @scope + N':' + @key), 2);
+            EXEC @applicationLockResult = sys.sp_getapplock
+                @Resource = @applicationLockResource,
+                @LockMode = 'Exclusive',
+                @LockOwner = 'Transaction',
+                @LockTimeout = 10000;
+            IF @applicationLockResult < 0
+                THROW 51000, 'Unable to acquire the SqlOS rate-limit lock.', 1;
+
+            UPDATE [{_schema}].[SqlOSRateLimitBuckets]
+            SET [Count] = CASE WHEN [Count] > 0 THEN [Count] - 1 ELSE 0 END,
+                [LockedUntil] = CASE WHEN [Count] - 1 < @lockThreshold THEN NULL ELSE [LockedUntil] END,
+                [UpdatedAt] = @now
+            WHERE [Scope] = @scope AND [BucketKey] = @key
+              AND [WindowStartedAt] = @windowStartedAt;
+
+            DELETE FROM [{_schema}].[SqlOSRateLimitBuckets]
+            WHERE [Scope] = @scope AND [BucketKey] = @key
+              AND [WindowStartedAt] = @windowStartedAt
+              AND [Count] = 0;
+
+            COMMIT TRANSACTION;
+            """,
+            scope,
+            key,
+            now,
+            cancellationToken,
+            lockThreshold,
+            windowStartedAt);
+
     private async Task ExecuteNonQueryAsync(
         string sql,
         string scope,
         string key,
         DateTimeOffset? now,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        int? lockThreshold = null,
+        DateTimeOffset? windowStartedAt = null)
     {
         var connection = _context.Database.GetDbConnection();
         var wasOpen = connection.State == ConnectionState.Open;
@@ -203,6 +351,14 @@ internal sealed class SqlOSDistributedRateLimitStore : ISqlOSRateLimitStore
             if (now.HasValue)
             {
                 AddParameter(command, "@now", now.Value.UtcDateTime);
+            }
+            if (lockThreshold.HasValue)
+            {
+                AddParameter(command, "@lockThreshold", lockThreshold.Value);
+            }
+            if (windowStartedAt.HasValue)
+            {
+                AddParameter(command, "@windowStartedAt", windowStartedAt.Value.UtcDateTime);
             }
 
             await command.ExecuteNonQueryAsync(cancellationToken);
@@ -262,7 +418,11 @@ internal sealed class SqlOSDistributedRateLimitStore : ISqlOSRateLimitStore
                 reader.GetInt32(0),
                 reader.IsDBNull(1)
                     ? null
-                    : new DateTimeOffset(DateTime.SpecifyKind(reader.GetDateTime(1), DateTimeKind.Utc)));
+                    : new DateTimeOffset(DateTime.SpecifyKind(reader.GetDateTime(1), DateTimeKind.Utc)),
+                reader.FieldCount < 3 || reader.GetBoolean(2),
+                reader.FieldCount < 4 || reader.IsDBNull(3)
+                    ? null
+                    : new DateTimeOffset(DateTime.SpecifyKind(reader.GetDateTime(3), DateTimeKind.Utc)));
         }
         finally
         {
@@ -272,6 +432,78 @@ internal sealed class SqlOSDistributedRateLimitStore : ISqlOSRateLimitStore
             }
         }
     }
+
+    private async Task<SqlOSRateLimitPairReservationState> ExecutePairStateAsync(
+        string sql,
+        SqlOSRateLimitBucketRequest first,
+        SqlOSRateLimitBucketRequest second,
+        DateTimeOffset now,
+        CancellationToken cancellationToken)
+    {
+        var connection = _context.Database.GetDbConnection();
+        var wasOpen = connection.State == ConnectionState.Open;
+        if (!wasOpen)
+        {
+            await connection.OpenAsync(cancellationToken);
+        }
+
+        try
+        {
+            await using var command = connection.CreateCommand();
+            command.CommandText = sql;
+            AddPairParameters(command, "first", first, now);
+            AddPairParameters(command, "second", second, now);
+            AddParameter(command, "@now", now.UtcDateTime);
+            AddParameter(command, "@cleanupBatchSize", CleanupBatchSize);
+            AddParameter(command, "@staleBefore", now.Subtract(StaleBucketRetention).UtcDateTime);
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+            if (!await reader.ReadAsync(cancellationToken))
+            {
+                throw new InvalidOperationException("SqlOS paired rate-limit state was not returned by SQL Server.");
+            }
+
+            int? rejectedIndex = reader.IsDBNull(0) ? null : reader.GetInt32(0);
+            var rejectedUntil = ReadDateTimeOffset(reader, 1);
+            return new SqlOSRateLimitPairReservationState(
+                ReadPairBucketState(reader, 2),
+                ReadPairBucketState(reader, 5),
+                rejectedIndex,
+                rejectedUntil);
+        }
+        finally
+        {
+            if (!wasOpen)
+            {
+                await connection.CloseAsync();
+            }
+        }
+    }
+
+    private static void AddPairParameters(
+        DbCommand command,
+        string prefix,
+        SqlOSRateLimitBucketRequest request,
+        DateTimeOffset now)
+    {
+        AddParameter(command, $"@{prefix}Scope", request.Scope);
+        AddParameter(command, $"@{prefix}Key", NormalizeKey(request.Key));
+        AddParameter(command, $"@{prefix}Threshold", request.LockThreshold);
+        AddParameter(command, $"@{prefix}WindowStartedBefore", now.Subtract(request.Window).UtcDateTime);
+        AddParameter(command, $"@{prefix}LockedUntil", now.Add(request.LockoutDuration).UtcDateTime);
+    }
+
+    private static SqlOSRateLimitBucketState? ReadPairBucketState(DbDataReader reader, int offset)
+        => reader.IsDBNull(offset)
+            ? null
+            : new SqlOSRateLimitBucketState(
+                reader.GetInt32(offset),
+                ReadDateTimeOffset(reader, offset + 1),
+                WindowStartedAt: ReadDateTimeOffset(reader, offset + 2));
+
+    private static DateTimeOffset? ReadDateTimeOffset(DbDataReader reader, int ordinal)
+        => reader.IsDBNull(ordinal)
+            ? null
+            : new DateTimeOffset(DateTime.SpecifyKind(reader.GetDateTime(ordinal), DateTimeKind.Utc));
 
     private static void AddParameter(DbCommand command, string name, object value)
     {

--- a/src/SqlOS/Security/SqlOSInMemoryRateLimitStore.cs
+++ b/src/SqlOS/Security/SqlOSInMemoryRateLimitStore.cs
@@ -26,7 +26,8 @@ internal sealed class SqlOSInMemoryRateLimitStore : ISqlOSRateLimitStore
                 {
                     return Task.FromResult(new SqlOSRateLimitBucketState(
                         lockThreshold,
-                        now.Add(lockoutDuration)));
+                        now.Add(lockoutDuration),
+                        Admitted: false));
                 }
 
                 bucket = new Bucket(now);
@@ -38,7 +39,8 @@ internal sealed class SqlOSInMemoryRateLimitStore : ISqlOSRateLimitStore
                 _buckets[bucketKey] = bucket;
             }
 
-            if (bucket.LockedUntil is null || bucket.LockedUntil <= now)
+            var admitted = bucket.LockedUntil is null || bucket.LockedUntil <= now;
+            if (admitted)
             {
                 bucket.Count++;
                 bucket.LockedUntil = bucket.Count >= lockThreshold
@@ -47,7 +49,49 @@ internal sealed class SqlOSInMemoryRateLimitStore : ISqlOSRateLimitStore
             }
 
             bucket.UpdatedAt = now;
-            return Task.FromResult(new SqlOSRateLimitBucketState(bucket.Count, bucket.LockedUntil));
+            return Task.FromResult(new SqlOSRateLimitBucketState(
+                bucket.Count, bucket.LockedUntil, admitted, bucket.WindowStartedAt));
+        }
+    }
+
+    public Task<SqlOSRateLimitPairReservationState> ReservePairAsync(
+        SqlOSRateLimitBucketRequest first,
+        SqlOSRateLimitBucketRequest second,
+        DateTimeOffset now,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        lock (_sync)
+        {
+            EvictExpired(now);
+            var firstBucket = GetActiveBucket(first, now);
+            if (firstBucket?.LockedUntil is { } firstLockedUntil && firstLockedUntil > now)
+            {
+                return Task.FromResult(new SqlOSRateLimitPairReservationState(
+                    null, null, 0, firstLockedUntil));
+            }
+
+            var secondBucket = GetActiveBucket(second, now);
+            if (secondBucket?.LockedUntil is { } secondLockedUntil && secondLockedUntil > now)
+            {
+                return Task.FromResult(new SqlOSRateLimitPairReservationState(
+                    null, null, 1, secondLockedUntil));
+            }
+
+            var requiredCapacity = (firstBucket == null ? 1 : 0) + (secondBucket == null ? 1 : 0);
+            if (!EnsurePairCapacity(first, second, requiredCapacity, now))
+            {
+                return Task.FromResult(new SqlOSRateLimitPairReservationState(
+                    null, null, 0, now.Add(first.LockoutDuration)));
+            }
+
+            firstBucket ??= AddBucket(first.Scope, first.Key, now);
+            secondBucket ??= AddBucket(second.Scope, second.Key, now);
+
+            IncrementBucket(firstBucket, first.LockThreshold, first.LockoutDuration, now);
+            IncrementBucket(secondBucket, second.LockThreshold, second.LockoutDuration, now);
+            return Task.FromResult(new SqlOSRateLimitPairReservationState(
+                ToState(firstBucket), ToState(secondBucket), null, null));
         }
     }
 
@@ -73,7 +117,8 @@ internal sealed class SqlOSInMemoryRateLimitStore : ISqlOSRateLimitStore
             }
 
             return Task.FromResult<SqlOSRateLimitBucketState?>(
-                new SqlOSRateLimitBucketState(bucket.Count, bucket.LockedUntil));
+                new SqlOSRateLimitBucketState(
+                    bucket.Count, bucket.LockedUntil, WindowStartedAt: bucket.WindowStartedAt));
         }
     }
 
@@ -115,6 +160,33 @@ internal sealed class SqlOSInMemoryRateLimitStore : ISqlOSRateLimitStore
         return Task.CompletedTask;
     }
 
+    public Task ReleaseAsync(
+        string scope,
+        string key,
+        int lockThreshold,
+        DateTimeOffset windowStartedAt,
+        DateTimeOffset now,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        lock (_sync)
+        {
+            if (_buckets.TryGetValue((scope, key), out var bucket)
+                && bucket.WindowStartedAt == windowStartedAt)
+            {
+                bucket.Count = Math.Max(0, bucket.Count - 1);
+                bucket.LockedUntil = bucket.Count >= lockThreshold ? bucket.LockedUntil : null;
+                bucket.UpdatedAt = now;
+                if (bucket.Count == 0)
+                {
+                    _buckets.Remove((scope, key));
+                }
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
     internal int BucketCount
     {
         get
@@ -144,6 +216,68 @@ internal sealed class SqlOSInMemoryRateLimitStore : ISqlOSRateLimitStore
         _buckets.Remove(oldest.Key);
         return true;
     }
+
+    private Bucket? GetActiveBucket(SqlOSRateLimitBucketRequest request, DateTimeOffset now)
+    {
+        if (!_buckets.TryGetValue((request.Scope, request.Key), out var bucket))
+        {
+            return null;
+        }
+
+        if (!IsExpired(bucket, now, request.Window))
+        {
+            return bucket;
+        }
+
+        _buckets.Remove((request.Scope, request.Key));
+        return null;
+    }
+
+    private Bucket AddBucket(string scope, string key, DateTimeOffset now)
+    {
+        var bucket = new Bucket(now);
+        _buckets[(scope, key)] = bucket;
+        return bucket;
+    }
+
+    private bool EnsurePairCapacity(
+        SqlOSRateLimitBucketRequest first,
+        SqlOSRateLimitBucketRequest second,
+        int requiredCapacity,
+        DateTimeOffset now)
+    {
+        while (_buckets.Count + requiredCapacity > MaximumBuckets)
+        {
+            var evictable = _buckets
+                .Where(entry => entry.Key != (first.Scope, first.Key)
+                                && entry.Key != (second.Scope, second.Key)
+                                && (entry.Value.LockedUntil is null || entry.Value.LockedUntil <= now))
+                .ToArray();
+            if (evictable.Length == 0)
+            {
+                return false;
+            }
+
+            var oldest = evictable.MinBy(entry => entry.Value.UpdatedAt);
+            _buckets.Remove(oldest.Key);
+        }
+
+        return true;
+    }
+
+    private static void IncrementBucket(
+        Bucket bucket,
+        int lockThreshold,
+        TimeSpan lockoutDuration,
+        DateTimeOffset now)
+    {
+        bucket.Count++;
+        bucket.LockedUntil = bucket.Count >= lockThreshold ? now.Add(lockoutDuration) : null;
+        bucket.UpdatedAt = now;
+    }
+
+    private static SqlOSRateLimitBucketState ToState(Bucket bucket)
+        => new(bucket.Count, bucket.LockedUntil, WindowStartedAt: bucket.WindowStartedAt);
 
     private void EvictExpired(DateTimeOffset now)
     {

--- a/tests/SqlOS.IntegrationTests/DistributedRateLimitIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/DistributedRateLimitIntegrationTests.cs
@@ -110,6 +110,9 @@ public class DistributedRateLimitIntegrationTests
             var perIpRejection = await first.GetRejectionAsync(ip, options, now.AddSeconds(2));
             perIpRejection.Should().NotBeNull();
             perIpRejection!.Scope.Should().Be("ip");
+            var alreadyLocked = await first.RecordFailureAsync(ip, options, now.AddSeconds(2));
+            alreadyLocked.PerIpLocked.Should().BeTrue(
+                "legacy RecordFailureAsync should surface an existing lockout instead of None");
 
             var globalResult = await first.RecordFailureAsync(otherIp, options, now.AddSeconds(3));
             globalResult.GlobalLocked.Should().BeTrue();
@@ -119,6 +122,11 @@ public class DistributedRateLimitIntegrationTests
                 now.AddSeconds(4));
             globalRejection.Should().NotBeNull();
             globalRejection!.Scope.Should().Be("global");
+            var alreadyGloballyLocked = await second.RecordFailureAsync(
+                $"ip-{Guid.NewGuid():N}",
+                options,
+                now.AddSeconds(5));
+            alreadyGloballyLocked.GlobalLocked.Should().BeTrue();
         }
         finally
         {

--- a/tests/SqlOS.IntegrationTests/DistributedRateLimitIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/DistributedRateLimitIntegrationTests.cs
@@ -128,6 +128,43 @@ public class DistributedRateLimitIntegrationTests
         }
     }
 
+    [TestMethod]
+    public async Task DashboardPasswordReservations_AdmitExactCapAcrossApplicationInstances()
+    {
+        var connectionString = GetConnectionString();
+        var authOptions = Options.Create(new SqlOSAuthServerOptions());
+        var options = new SqlOSDashboardLoginThrottlingOptions
+        {
+            MaxFailuresPerIp = 2,
+            MaxGlobalFailures = 20,
+            Window = TimeSpan.FromMinutes(5),
+            LockoutDuration = TimeSpan.FromMinutes(10)
+        };
+        var ip = $"ip-{Guid.NewGuid():N}";
+        var now = DateTimeOffset.UtcNow;
+        var start = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var attempts = Enumerable.Range(0, 10).Select(async _ =>
+        {
+            await using var context = CreateContext(connectionString);
+            var service = new SqlOSDashboardLoginThrottlingService(
+                new SqlOSDistributedRateLimitStore(context, authOptions));
+            await start.Task;
+            return await service.ReserveAsync(ip, options, now);
+        }).ToArray();
+
+        start.SetResult();
+        var results = await Task.WhenAll(attempts);
+
+        results.Count(x => x.Reservation != null).Should().Be(2);
+        results.Count(x => x.Rejection?.Scope == "ip").Should().Be(8);
+
+        await using var cleanupContext = CreateContext(connectionString);
+        var cleanup = new SqlOSDistributedRateLimitStore(cleanupContext, authOptions);
+        await cleanup.DeleteAsync("dashboard-ip", ip);
+        await cleanup.DeleteAsync("dashboard-global", "all");
+    }
+
     private static string GetConnectionString()
         => AspireFixture.SharedContext?.Database.GetConnectionString()
            ?? throw new InvalidOperationException("The integration database has no connection string.");

--- a/tests/SqlOS.IntegrationTests/PasswordLoginAdmissionIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/PasswordLoginAdmissionIntegrationTests.cs
@@ -1,0 +1,349 @@
+using System.Net;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SqlOS.AuthServer.Configuration;
+using SqlOS.AuthServer.Contracts;
+using SqlOS.AuthServer.Models;
+using SqlOS.AuthServer.Services;
+using SqlOS.IntegrationTests.Infrastructure;
+
+namespace SqlOS.IntegrationTests;
+
+[TestClass]
+public sealed class PasswordLoginAdmissionIntegrationTests
+{
+    [TestMethod]
+    public async Task ParallelWrongPasswords_AdmitExactlyTheAccountCapAcrossInstances()
+    {
+        await using var database = await PasswordAdmissionDatabase.CreateAsync(options =>
+        {
+            options.PasswordLogin.MaxFailedAttemptsPerAccount = 3;
+            options.PasswordLogin.MaxFailedAttemptsPerIp = 20;
+            options.PasswordLogin.MaxFailedAttemptsPerClient = 20;
+            options.PasswordLogin.MaxFailedAttemptsPerDevice = 20;
+        });
+        var user = await database.Admin.CreateUserAsync(new SqlOSCreateUserRequest(
+            "Parallel Password User",
+            $"parallel-{Guid.NewGuid():N}@example.com",
+            "P@ssword123!"));
+
+        var start = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var attempts = Enumerable.Range(0, 10).Select(async index =>
+        {
+            await using var actor = database.CreateActor();
+            await start.Task;
+            var act = async () => await actor.Auth.LoginWithPasswordAsync(
+                new SqlOSPasswordLoginRequest(user.DefaultEmail!, "wrong-password", "test-client", null),
+                CreateHttpContext($"203.0.113.{100 + index}", $"parallel-{index}"));
+            await act.Should().ThrowAsync<InvalidOperationException>()
+                .WithMessage(SqlOSPasswordLoginAbuseService.PublicFailureMessage);
+        }).ToArray();
+
+        start.SetResult();
+        await Task.WhenAll(attempts);
+
+        database.Context.ChangeTracker.Clear();
+        var auditTypes = await database.Context.Set<SqlOSAuditEvent>()
+            .Where(x => x.DataJson != null
+                        && x.DataJson.Contains(SqlOSAdminService.NormalizeEmail(user.DefaultEmail!)))
+            .Select(x => x.EventType)
+            .ToListAsync();
+        auditTypes.Count(x => x == "password.login.failed").Should().Be(3);
+        auditTypes.Count(x => x == "password.login.rate_limit_rejected").Should().Be(7);
+        (await database.Context.Set<SqlOSSession>().CountAsync(x => x.UserId == user.Id)).Should().Be(0);
+    }
+
+    [TestMethod]
+    public async Task CorrectPasswordAfterThresholdReservations_IsRejectedWithoutSession()
+    {
+        await using var database = await PasswordAdmissionDatabase.CreateAsync(options =>
+        {
+            options.PasswordLogin.MaxFailedAttemptsPerAccount = 2;
+            options.PasswordLogin.MaxFailedAttemptsPerIp = 20;
+            options.PasswordLogin.MaxFailedAttemptsPerClient = 20;
+            options.PasswordLogin.MaxFailedAttemptsPerDevice = 20;
+        });
+        var user = await database.Admin.CreateUserAsync(new SqlOSCreateUserRequest(
+            "Threshold Race User",
+            $"threshold-{Guid.NewGuid():N}@example.com",
+            "P@ssword123!"));
+        var normalizedEmail = SqlOSAdminService.NormalizeEmail(user.DefaultEmail!);
+
+        await using var first = database.CreateActor();
+        await using var second = database.CreateActor();
+        var firstAttempt = first.Abuse.CreateAttempt(
+            normalizedEmail,
+            CreateHttpContext("203.0.113.140", "threshold-one"),
+            "test-client",
+            surface: "api",
+            userId: user.Id);
+        var secondAttempt = second.Abuse.CreateAttempt(
+            normalizedEmail,
+            CreateHttpContext("203.0.113.141", "threshold-two"),
+            "test-client",
+            surface: "api",
+            userId: user.Id);
+        await first.Abuse.ReserveAsync(firstAttempt);
+        await second.Abuse.ReserveAsync(secondAttempt);
+
+        await using var correctGuess = database.CreateActor();
+        var act = async () => await correctGuess.Auth.LoginWithPasswordAsync(
+            new SqlOSPasswordLoginRequest(user.DefaultEmail!, "P@ssword123!", "test-client", null),
+            CreateHttpContext("203.0.113.142", "threshold-correct"));
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage(SqlOSPasswordLoginAbuseService.PublicFailureMessage);
+        database.Context.ChangeTracker.Clear();
+        (await database.Context.Set<SqlOSSession>().CountAsync(x => x.UserId == user.Id)).Should().Be(0);
+        (await database.Context.Set<SqlOSRefreshToken>().CountAsync()).Should().Be(0);
+
+        await first.Abuse.RecordFailureAsync(firstAttempt, "invalid_password");
+        await second.Abuse.RecordFailureAsync(secondAttempt, "invalid_password");
+    }
+
+    [TestMethod]
+    public async Task OverlappingAccountAndIpBuckets_AdmitOnlyTheLowestCap()
+    {
+        await using var database = await PasswordAdmissionDatabase.CreateAsync(options =>
+        {
+            options.PasswordLogin.MaxFailedAttemptsPerAccount = 10;
+            options.PasswordLogin.MaxFailedAttemptsPerIp = 3;
+            options.PasswordLogin.MaxFailedAttemptsPerClient = 20;
+            options.PasswordLogin.MaxFailedAttemptsPerDevice = 20;
+        });
+        var users = new List<SqlOSUser>();
+        for (var index = 0; index < 8; index++)
+        {
+            users.Add(await database.Admin.CreateUserAsync(new SqlOSCreateUserRequest(
+                $"Overlap User {index}",
+                $"overlap-{index}-{Guid.NewGuid():N}@example.com",
+                "P@ssword123!")));
+        }
+
+        var start = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var attempts = users.Select(async (user, index) =>
+        {
+            await using var actor = database.CreateActor();
+            await start.Task;
+            var act = async () => await actor.Auth.LoginWithPasswordAsync(
+                new SqlOSPasswordLoginRequest(user.DefaultEmail!, "wrong-password", "test-client", null),
+                CreateHttpContext("203.0.113.150", $"overlap-{index}"));
+            await act.Should().ThrowAsync<InvalidOperationException>()
+                .WithMessage(SqlOSPasswordLoginAbuseService.PublicFailureMessage);
+        }).ToArray();
+
+        start.SetResult();
+        await Task.WhenAll(attempts);
+
+        database.Context.ChangeTracker.Clear();
+        (await database.Context.Set<SqlOSAuditEvent>()
+                .CountAsync(x => x.EventType == "password.login.failed" && x.IpAddress == "203.0.113.150"))
+            .Should().Be(3);
+        (await database.Context.Set<SqlOSAuditEvent>()
+                .CountAsync(x => x.EventType == "password.login.rate_limit_rejected" && x.IpAddress == "203.0.113.150"))
+            .Should().Be(5);
+    }
+
+    [TestMethod]
+    public async Task UnknownAccounts_AreDummyVerifiedOnlyUpToTheConfiguredCap()
+    {
+        await using var database = await PasswordAdmissionDatabase.CreateAsync(options =>
+        {
+            options.PasswordLogin.MaxFailedAttemptsPerAccount = 2;
+            options.PasswordLogin.MaxFailedAttemptsPerIp = 20;
+            options.PasswordLogin.MaxFailedAttemptsPerClient = 20;
+            options.PasswordLogin.MaxFailedAttemptsPerDevice = 20;
+        });
+        var email = $"unknown-{Guid.NewGuid():N}@example.com";
+        var start = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var attempts = Enumerable.Range(0, 6).Select(async index =>
+        {
+            await using var actor = database.CreateActor();
+            await start.Task;
+            var act = async () => await actor.Auth.LoginWithPasswordAsync(
+                new SqlOSPasswordLoginRequest(email, "anything", "test-client", null),
+                CreateHttpContext($"203.0.113.{160 + index}", $"unknown-{index}"));
+            await act.Should().ThrowAsync<InvalidOperationException>()
+                .WithMessage(SqlOSPasswordLoginAbuseService.PublicFailureMessage);
+        }).ToArray();
+
+        start.SetResult();
+        await Task.WhenAll(attempts);
+
+        database.Context.ChangeTracker.Clear();
+        var normalizedEmail = SqlOSAdminService.NormalizeEmail(email);
+        var audits = await database.Context.Set<SqlOSAuditEvent>()
+            .Where(x => x.DataJson != null && x.DataJson.Contains(normalizedEmail))
+            .Select(x => new { x.EventType, x.DataJson })
+            .ToListAsync();
+        audits.Count(x => x.EventType == "password.login.failed"
+                          && x.DataJson!.Contains("unknown_email", StringComparison.Ordinal)).Should().Be(2);
+        audits.Count(x => x.EventType == "password.login.rate_limit_rejected").Should().Be(4);
+    }
+
+    [TestMethod]
+    public async Task ExpiredAndRetriedReservations_RepairCountersWithoutDoubleAdmission()
+    {
+        await using var database = await PasswordAdmissionDatabase.CreateAsync(options =>
+        {
+            options.PasswordLogin.MaxFailedAttemptsPerAccount = 1;
+            options.PasswordLogin.MaxFailedAttemptsPerIp = 20;
+            options.PasswordLogin.MaxFailedAttemptsPerClient = 20;
+            options.PasswordLogin.MaxFailedAttemptsPerDevice = 20;
+        });
+        var email = $"reservation-{Guid.NewGuid():N}@example.com";
+        var normalizedEmail = SqlOSAdminService.NormalizeEmail(email);
+        await using var first = database.CreateActor();
+        var attempt = first.Abuse.CreateAttempt(
+            normalizedEmail,
+            CreateHttpContext("203.0.113.180", "reservation"),
+            "test-client",
+            surface: "api");
+
+        await first.Abuse.ReserveAsync(attempt);
+        await using (var retry = database.CreateActor())
+        {
+            await retry.Abuse.ReserveAsync(attempt);
+        }
+
+        database.Context.ChangeTracker.Clear();
+        var bucket = await database.Context.Set<SqlOSPasswordLoginBucket>()
+            .SingleAsync(x => x.Scope == "email" && x.BucketKey == normalizedEmail);
+        bucket.FailureCount.Should().Be(1);
+
+        var reservation = await database.Context.Set<SqlOSPasswordLoginReservation>()
+            .SingleAsync(x => x.Id == attempt.ReservationId);
+        reservation.ExpiresAt = DateTime.UtcNow.AddSeconds(-1);
+        await database.Context.SaveChangesAsync();
+
+        await using var afterExpiry = database.CreateActor();
+        var replacement = afterExpiry.Abuse.CreateAttempt(
+            normalizedEmail,
+            CreateHttpContext("203.0.113.181", "replacement"),
+            "test-client",
+            surface: "api");
+        await afterExpiry.Abuse.ReserveAsync(replacement);
+
+        database.Context.ChangeTracker.Clear();
+        var repaired = await database.Context.Set<SqlOSPasswordLoginBucket>()
+            .SingleAsync(x => x.Scope == "email" && x.BucketKey == normalizedEmail);
+        repaired.FailureCount.Should().Be(1);
+        (await database.Context.Set<SqlOSPasswordLoginReservation>()
+                .CountAsync(x => x.Id == replacement.ReservationId))
+            .Should().Be(1);
+    }
+
+    private static DefaultHttpContext CreateHttpContext(string ipAddress, string userAgent)
+    {
+        var context = new DefaultHttpContext();
+        context.Connection.RemoteIpAddress = IPAddress.Parse(ipAddress);
+        context.Request.Headers.UserAgent = userAgent;
+        return context;
+    }
+
+    private sealed class PasswordAdmissionDatabase : IAsyncDisposable
+    {
+        private readonly string _connectionString;
+        private readonly SqlOSAuthServerOptions _options;
+
+        private PasswordAdmissionDatabase(
+            TestSqlOSDbContext context,
+            string connectionString,
+            SqlOSAuthServerOptions options,
+            SqlOSAdminService admin)
+        {
+            Context = context;
+            _connectionString = connectionString;
+            _options = options;
+            Admin = admin;
+        }
+
+        public TestSqlOSDbContext Context { get; }
+        public SqlOSAdminService Admin { get; }
+
+        public static async Task<PasswordAdmissionDatabase> CreateAsync(
+            Action<SqlOSAuthServerOptions> configure)
+        {
+            var context = await AspireFixture.CreateIsolatedAuthContextAsync("PasswordAdmission");
+            var connectionString = context.Database.GetConnectionString()
+                ?? throw new InvalidOperationException("The password-admission database has no connection string.");
+            var options = new SqlOSAuthServerOptions
+            {
+                Issuer = "https://tests/sqlos/auth",
+                BasePath = "/sqlos/auth"
+            };
+            options.SeedBrowserClient("test-client", "Test Client", "https://client.example.test/callback");
+            configure(options);
+            var actor = BuildActor(context, options, ownsContext: false);
+            await actor.Crypto.EnsureActiveSigningKeyAsync();
+            await actor.Admin.UpsertSeededClientsAsync();
+            _ = await actor.Settings.GetAuthPageSettingsAsync();
+            return new PasswordAdmissionDatabase(context, connectionString, options, actor.Admin);
+        }
+
+        public PasswordAdmissionActor CreateActor()
+        {
+            var context = new TestSqlOSDbContext(
+                new DbContextOptionsBuilder<TestSqlOSDbContext>()
+                    .UseSqlServer(_connectionString)
+                    .Options);
+            return BuildActor(context, _options, ownsContext: true);
+        }
+
+        private static PasswordAdmissionActor BuildActor(
+            TestSqlOSDbContext context,
+            SqlOSAuthServerOptions optionsValue,
+            bool ownsContext)
+        {
+            var options = Options.Create(optionsValue);
+            var crypto = new SqlOSCryptoService(context, options, AspireFixture.DataProtectionProvider);
+            var admin = new SqlOSAdminService(context, options, crypto);
+            var sender = new TestAuthEmailSender { IsConfigured = true };
+            var settings = new SqlOSSettingsService(context, options, sender);
+            var emailOtp = new SqlOSEmailOtpService(context, admin, crypto, settings, sender, options);
+            var abuse = new SqlOSPasswordLoginAbuseService(context, admin, crypto, options);
+            var auth = new SqlOSAuthService(
+                context,
+                options,
+                admin,
+                crypto,
+                settings,
+                emailOtp,
+                passwordLoginAbuseService: abuse);
+            return new PasswordAdmissionActor(context, admin, crypto, settings, auth, abuse, ownsContext);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await Context.Database.EnsureDeletedAsync();
+            await Context.DisposeAsync();
+        }
+    }
+
+    private sealed class PasswordAdmissionActor(
+        TestSqlOSDbContext context,
+        SqlOSAdminService admin,
+        SqlOSCryptoService crypto,
+        SqlOSSettingsService settings,
+        SqlOSAuthService auth,
+        SqlOSPasswordLoginAbuseService abuse,
+        bool ownsContext) : IAsyncDisposable
+    {
+        public SqlOSAdminService Admin { get; } = admin;
+        public SqlOSCryptoService Crypto { get; } = crypto;
+        public SqlOSSettingsService Settings { get; } = settings;
+        public SqlOSAuthService Auth { get; } = auth;
+        public SqlOSPasswordLoginAbuseService Abuse { get; } = abuse;
+
+        public async ValueTask DisposeAsync()
+        {
+            if (ownsContext)
+            {
+                await context.DisposeAsync();
+            }
+        }
+    }
+}

--- a/tests/SqlOS.IntegrationTests/PasswordLoginAdmissionIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/PasswordLoginAdmissionIntegrationTests.cs
@@ -105,6 +105,38 @@ public sealed class PasswordLoginAdmissionIntegrationTests
     }
 
     [TestMethod]
+    public async Task SuccessfulThresholdReservation_DoesNotEmitLockoutAudit()
+    {
+        await using var database = await PasswordAdmissionDatabase.CreateAsync(options =>
+        {
+            options.PasswordLogin.MaxFailedAttemptsPerAccount = 1;
+            options.PasswordLogin.MaxFailedAttemptsPerIp = 20;
+            options.PasswordLogin.MaxFailedAttemptsPerClient = 20;
+            options.PasswordLogin.MaxFailedAttemptsPerDevice = 20;
+        });
+        var user = await database.Admin.CreateUserAsync(new SqlOSCreateUserRequest(
+            "Success Threshold User",
+            $"success-threshold-{Guid.NewGuid():N}@example.com",
+            "P@ssword123!"));
+
+        await using var actor = database.CreateActor();
+        var result = await actor.Auth.LoginWithPasswordAsync(
+            new SqlOSPasswordLoginRequest(user.DefaultEmail!, "P@ssword123!", "test-client", null),
+            CreateHttpContext("203.0.113.145", "success-threshold"));
+
+        result.Tokens.Should().NotBeNull();
+        database.Context.ChangeTracker.Clear();
+        var auditTypes = await database.Context.Set<SqlOSAuditEvent>()
+            .Where(x => x.DataJson != null
+                        && x.DataJson.Contains(SqlOSAdminService.NormalizeEmail(user.DefaultEmail!)))
+            .Select(x => x.EventType)
+            .ToListAsync();
+        auditTypes.Should().Contain("password.login.succeeded");
+        auditTypes.Should().NotContain("password.login.locked");
+        auditTypes.Should().NotContain("password.login.suspicious_pattern");
+    }
+
+    [TestMethod]
     public async Task OverlappingAccountAndIpBuckets_AdmitOnlyTheLowestCap()
     {
         await using var database = await PasswordAdmissionDatabase.CreateAsync(options =>

--- a/tests/SqlOS.IntegrationTests/SchemaInitializerIntegrationTests.cs
+++ b/tests/SqlOS.IntegrationTests/SchemaInitializerIntegrationTests.cs
@@ -14,7 +14,7 @@ namespace SqlOS.IntegrationTests;
 [TestClass]
 public sealed class SchemaInitializerIntegrationTests
 {
-    private const int CurrentSchemaVersion = 38;
+    private const int CurrentSchemaVersion = 39;
 
     [TestMethod]
     public async Task EnsureSchema_CreatesCoreTables()
@@ -34,6 +34,8 @@ public sealed class SchemaInitializerIntegrationTests
                      "SqlOSUserPhoneNumbers",
                      "SqlOSCredentials",
                      "SqlOSPasswordLoginBuckets",
+                     "SqlOSPasswordLoginReservations",
+                     "SqlOSPasswordLoginReservationBuckets",
                      "SqlOSMemberships",
                      "SqlOSSsoConnections",
                      "SqlOSExternalIdentities",
@@ -112,11 +114,14 @@ public sealed class SchemaInitializerIntegrationTests
             await context.Database.ExecuteSqlRawAsync("""
                 DROP TABLE [dbo].[SqlOSEmailDeliveries];
                 DROP TABLE [dbo].[SqlOSEmailTemplates];
+                DROP TABLE [dbo].[SqlOSPasswordLoginReservationBuckets];
+                DROP TABLE [dbo].[SqlOSPasswordLoginReservations];
                 DROP TABLE [dbo].[SqlOSPasswordLoginBuckets];
                 DELETE FROM [dbo].[SqlOSAppliedMigrations]
                 WHERE [ScriptName] IN (
                     'SqlOS.AuthServer.Schema.017_PasswordLoginAbuse.sql',
-                    'SqlOS.AuthServer.Schema.017_TransactionalEmail.sql');
+                    'SqlOS.AuthServer.Schema.017_TransactionalEmail.sql',
+                    'SqlOS.AuthServer.Schema.039_AtomicPasswordLoginAdmission.sql');
                 UPDATE [dbo].[SqlOSSchema] SET [Version] = 17;
                 """);
 
@@ -126,6 +131,15 @@ public sealed class SchemaInitializerIntegrationTests
                 "SELECT COUNT(*) FROM [dbo].[SqlOSAppliedMigrations] WHERE [Version] = 17"));
             Assert.AreEqual(1, await ScalarIntAsync(context,
                 "SELECT COUNT(*) FROM sys.tables WHERE [name] = 'SqlOSPasswordLoginBuckets'"));
+            Assert.AreEqual(1, await ScalarIntAsync(context,
+                "SELECT COUNT(*) FROM sys.tables WHERE [name] = 'SqlOSPasswordLoginReservations'"));
+            Assert.AreEqual(1, await ScalarIntAsync(context,
+                "SELECT COUNT(*) FROM sys.tables WHERE [name] = 'SqlOSPasswordLoginReservationBuckets'"));
+            Assert.AreEqual(0, await ScalarIntAsync(context, """
+                SELECT COUNT(*) FROM sys.indexes
+                WHERE [name] = 'IX_SqlOSPasswordLoginBuckets_ClientKey_UpdatedAt'
+                  AND [object_id] = OBJECT_ID('[dbo].[SqlOSPasswordLoginBuckets]')
+                """));
             Assert.AreEqual(1, await ScalarIntAsync(context,
                 "SELECT COUNT(*) FROM sys.tables WHERE [name] = 'SqlOSEmailTemplates'"));
             Assert.AreEqual(1, await ScalarIntAsync(context,

--- a/tests/SqlOS.Tests/SqlOSInMemoryRateLimitStoreTests.cs
+++ b/tests/SqlOS.Tests/SqlOSInMemoryRateLimitStoreTests.cs
@@ -58,4 +58,31 @@ public class SqlOSInMemoryRateLimitStoreTests
         (await store.GetAsync("test", "locked-0", now, TimeSpan.FromDays(2)))
             .Should().NotBeNull();
     }
+
+    [TestMethod]
+    public async Task ReservePair_WhenStoreIsFullOfLockedBuckets_FailsClosedWithoutThrowing()
+    {
+        var store = new SqlOSInMemoryRateLimitStore();
+        var now = DateTimeOffset.UtcNow;
+        for (var i = 0; i < SqlOSInMemoryRateLimitStore.MaximumBuckets; i++)
+        {
+            await store.IncrementAsync(
+                "test",
+                $"locked-{i}",
+                lockThreshold: 1,
+                window: TimeSpan.FromDays(2),
+                lockoutDuration: TimeSpan.FromDays(2),
+                now);
+        }
+
+        var result = await store.ReservePairAsync(
+            new SqlOSRateLimitBucketRequest("dashboard-global", "all", 10, TimeSpan.FromMinutes(5), TimeSpan.FromMinutes(5)),
+            new SqlOSRateLimitBucketRequest("dashboard-ip", "203.0.113.50", 2, TimeSpan.FromMinutes(5), TimeSpan.FromMinutes(5)),
+            now);
+
+        result.Admitted.Should().BeFalse();
+        result.RejectedIndex.Should().Be(0);
+        result.RejectedLockedUntil.Should().NotBeNull();
+        store.BucketCount.Should().Be(SqlOSInMemoryRateLimitStore.MaximumBuckets);
+    }
 }

--- a/web/content/docs/authserver/dashboard-overview.mdx
+++ b/web/content/docs/authserver/dashboard-overview.mdx
@@ -28,7 +28,7 @@ The password can come from user secrets, an environment variable, or another con
 
 `/sqlos` and `/sqlos/admin` are administrative endpoints for users, organizations, memberships, clients, OIDC/SAML connections, security settings, sessions, audit events, and FGA data. In production, keep them on a trusted network or place them behind HTTPS, reverse-proxy or edge rate limiting, and an admin access layer such as VPN, identity-aware proxy, SSO, or MFA.
 
-Password mode includes dashboard-specific per-IP throttling, global backoff for distributed failures, temporary lockout, and audit events for login success, login failure, rate-limit rejection, lockout, and logout. Treat those built-in controls as a baseline, not as the only protection for a publicly reachable admin surface.
+Password mode includes dashboard-specific per-IP throttling, global backoff for distributed failures, temporary lockout, and audit events for login success, login failure, rate-limit rejection, lockout, and logout. Dashboard password comparisons reserve per-IP and global capacity together before hashing; successful comparisons release that generation, and abandoned reservations remain fail-closed. Treat those built-in controls as a baseline, not as the only protection for a publicly reachable admin surface.
 
 ## Authenticate operator API calls
 

--- a/web/content/docs/authserver/password-login.mdx
+++ b/web/content/docs/authserver/password-login.mdx
@@ -176,7 +176,9 @@ builder.AddSqlOS<AppDbContext>(options =>
 });
 ```
 
-SqlOS stores password-login throttle state in `SqlOSPasswordLoginBuckets`. Failed password attempts count against the normalized email, user ID when known, source IP, client, and user-agent fingerprint. Account buckets reset after a successful password login. IP, client, and device buckets expire through the configured failure window so one successful login cannot clear a password-spray pattern.
+SqlOS stores password-login throttle state in `SqlOSPasswordLoginBuckets`. Before hashing, each attempt atomically reserves capacity in every applicable normalized-email, user-ID, source-IP, client, and user-agent bucket under a short SQL transaction. The reservation commits before the password comparison, so replicas cannot collectively admit more comparisons than the lowest overlapping cap and no database lock is held during hashing.
+
+A failed comparison keeps the reserved capacity as a failure. A successful comparison clears prior account failures while preserving other in-flight account reservations; it releases only its own capacity from shared IP, client, and device buckets so one successful login cannot erase a password-spray pattern. An abandoned reservation remains fail-closed for two minutes, then a later attempt drains it.
 
 Unknown-email, wrong-password, locked-account, and rate-limited password attempts return the same public failure message. Operators can distinguish them internally through `SqlOSAuditEvents` entries such as `password.login.failed`, `password.login.locked`, `password.login.rate_limit_rejected`, `password.login.suspicious_pattern`, and `password.login.succeeded`.
 


### PR DESCRIPTION
## Summary
- Replace check-then-record password lockout with reserve-before-hash admission under a short `sp_getapplock` transaction (no lock held during hashing)
- Persist a minimal 2-minute reservation ledger so abandoned comparisons stay fail-closed; success clears account capacity while preserving in-flight reservations and releases one shared IP/client/device slot
- Move dashboard password throttling to atomic `ReservePairAsync` with generation-scoped release on success
- Deliberately omits the overbuilt rebase watermarks, threshold-owner hashing, success tombstones, and review-only edge machinery from #278

## Test plan
- [x] `./scripts/build.sh`
- [x] `./scripts/unit-tests.sh` (686 passed)
- [x] `./scripts/docs-check.sh`
- [x] `git diff --check`
- [x] Focused real-SQL admission tests (exact account/IP caps, correct-password threshold race, unknown accounts, expiry/retry)
- [x] SchemaInitializerIntegrationTests (18/18 after schema v39 bump)
- [ ] Full `./scripts/integration-tests.sh` / PR CI

Closes #233
Supersedes #278


Made with [Cursor](https://cursor.com)